### PR TITLE
rdl: fix crash in rdl_destroy

### DIFF
--- a/rdl/rdl.c
+++ b/rdl/rdl.c
@@ -412,11 +412,6 @@ static struct rdl * rdl_new (struct rdllib *rl)
      */
     list_append (rl->rdl_list, rdl);
 
-    /*
-     *  Link this rdl to rdllib rdl list:
-     */
-    list_append (rl->rdl_list, rdl);
-
     /* Leave rdl instance on top of stack */
     return (rdl);
 }
@@ -478,8 +473,6 @@ static struct rdl * loadfn (struct rdllib *rl, const char *fn, const char *s)
         return (NULL);
     }
     lua_setglobal (rdl->L, "rdl");
-    lua_settop (rdl->L, 0);
-
     lua_settop (rdl->L, 0);
     return (rdl);
 }


### PR DESCRIPTION
A cherry-picked commit was inadvertently applied twice to rdl.c,
resulting in rdl objects being duplicated on the rdllib rdl_list.
This caused double-free of any rdl object and a crash during
rdl_destroy().

This commit cleans up the damage introduced by the stray commit.
Note: The commit could not simply be reverted since it was a dup,
the revert failed with conflicts.

Fixes #1
