### PR TITLE
rdl: resurrect the rdl test suite

### DIFF
--- a/rdl/Makefile
+++ b/rdl/Makefile
@@ -1,5 +1,6 @@
 include ../Makefile.inc
 
+SUBDIRS = test
 CFLAGS = $(COMMON_CFLAGS) $(FLUX_CFLAGS)
 LIBS = $(FLUX_LIBS)
 
@@ -9,6 +10,7 @@ X_OBJS_LIB = json-lua.o list.o
 BUILD = flux-rdltool librdl.so.0 cpuset.so
 
 all: $(BUILD)
+	for subdir in $(SUBDIRS); do make -C $$subdir $@; done
 
 flux-rdltool: flux-rdltool.o $(X_OBJS_CMD) librdl.so.0
 	$(CC) -o $@ $^ $(LIBS) $(RDL_LIBS)
@@ -22,6 +24,7 @@ cpuset.so: lua-cpuset.o cpuset-str.o
 
 clean:
 	rm -f *.so *.o $(BUILD)
+	for subdir in $(SUBDIRS); do make -C $$subdir $@; done
 
 dump:
 	$(FLUX) ./flux-rdltool -f ../conf/hype.lua  tree

--- a/rdl/test/Makefile
+++ b/rdl/test/Makefile
@@ -1,0 +1,27 @@
+include ../../Makefile.inc
+
+CFLAGS = $(COMMON_CFLAGS) $(FLUX_CFLAGS) $(RDL_CFLAGS)
+LIBS = $(FLUX_LIBS) $(RDL_LIBS)
+
+TESTRDL_INPUT_FILE := $(abs_topdir)/conf/hype.lua
+
+LUA_PATH = $(abs_topdir)/rdl/?.lua;$(FLUX_SRCDIR)/src/bindings/lua/?.lua;;;
+LUA_CPATH = $(abs_topdir)/rdl/?.so;$(FLUX_SRCDIR)/src/bindings/lua/.libs/?.so;;;
+
+export CFLAGS TESTRDL_INPUT_FILE LUA_PATH LUA_CPATH
+
+LDADD_CLI = $(FLUX_SRCDIR)/src/common/libutil/.libs/libutil.a
+
+BUILD = trdl
+
+all: $(BUILD)
+
+trdl: trdl.o
+	$(CC) -o $@ $^ $(LIBS) $(LDADD_CLI)
+
+check:
+	./trdl
+
+clean:
+	rm -f *.o a.out
+	rm -f $(BUILD)

--- a/rdl/test/trdl.c
+++ b/rdl/test/trdl.c
@@ -27,9 +27,10 @@
 #include <libgen.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdbool.h>
 
-#include "log.h"
-#include "util.h"
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/jsonutil.h"
 #include "rdl.h"
 
 static void perr (void *ctx, const char *fmt, ...)


### PR DESCRIPTION
The rdl test app was the only ngrm test that was not moved to
flux-core.  This change fixes the build and operation of the trdl
test.
