### PR TITLE
Add flux-module remove, load-after-remove test, etc

### DIFF
--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -48,11 +48,11 @@ test_expect_success 'flux-module load works after a successful unload' '
 	flux module remove sched
 '
 
-test_expect_success 'this flux-module load should fail' '
+test_expect_failure 'this flux-module load should fail' '
 	test_must_fail flux module load ${schedsrv} 
 '
 
-test_expect_success 'flux-module load works after a load faiure' '
+test_expect_failure 'flux-module load works after a load faiure' '
 	flux module load ${schedsrv} rdl-conf=${rdlconf}
 '
 


### PR DESCRIPTION
Add more test cases as I merged the latest changes Don had pushed including a `flux module remove sched` fix.

`this flux-module load should fail` (4th test) doesn't fail, and this appears to be a bug where `flux module load` does not return an error code on this failure. I will create an issue for this. 
