### PR TITLE
fixed compilation error on Ubuntu 14.04.1

### DIFF
--- a/rdl/test/Makefile
+++ b/rdl/test/Makefile
@@ -17,7 +17,7 @@ BUILD = trdl
 all: $(BUILD)
 
 trdl: trdl.o
-	$(CC) -o $@ $^ $(LIBS) $(LDADD_CLI)
+	$(CC) -o $@ $^ $(LDADD_CLI) $(LIBS)
 
 check:
 	./trdl


### PR DESCRIPTION
swapped the order of the static and dynamic libraries in the compile
line.  This now compiles on both my local ubuntu installation and
hype.