### PR TITLE
minor test suite fixes

### DIFF
--- a/t/Makefile
+++ b/t/Makefile
@@ -4,7 +4,7 @@ CFLAGS = $(COMMON_CFLAGS) $(FLUX_CFLAGS) $(RDL_CFLAGS)
 LIBS = $(FLUX_LIBS) $(RDL_LIBS)
 
 #
-# The following variables are used by shareness.d/flux-shareness.sh
+# The following variables are used by sharness.d/flux-sharness.sh
 #
 #
 export FLUX_BUILD_DIR=$(FLUX_BUILDDIR)
@@ -19,7 +19,8 @@ all: $(BUILD)
 
 check: $(TESTS)
 	for t in $(TESTS); do \
-	$$t; done 
+		./$$t; \
+	done 
 
 clean:
 	rm -rf *.o $(BUILD) test-results trash-directory*

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -52,7 +52,7 @@ test_expect_failure 'this flux-module load should fail' '
 	test_must_fail flux module load ${schedsrv} 
 '
 
-test_expect_failure 'flux-module load works after a load faiure' '
+test_expect_success 'flux-module load works after a load failure' '
 	flux module load ${schedsrv} rdl-conf=${rdlconf}
 '
 

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -30,7 +30,7 @@ test_debug '
 '
 
 #
-# test_under_flux is under shareness.d/
+# test_under_flux is under sharness.d/
 #
 test_under_flux 1 $tdir
 


### PR DESCRIPTION
After some API changes to flux-core I wanted to make sure flux-sched still built and ran OK. 
I ran into a couple minor issues with the test suite which are fixed below.

After these changes, I'm able to successfully build and run `make check' with the current flux-core master.