### PR TITLE
rdl enhancements and testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+language: c
+
+compiler:
+  - gcc
+  - clang
+
+install:
+  - sudo sh -c 'echo "/usr/local/lib" >/etc/ld.so.conf.d/build'
+  - sudo apt-get update -q
+  - sudo apt-get install -y lua5.1 liblua5.1-0-dev luarocks munge libmunge-dev uuid-dev aspell
+  - sudo luarocks install luaposix
+  - git clone https://github.com/grondo/lua-hostlist
+  - (export CC=gcc; cd lua-hostlist && make LUA_VER=5.1 && sudo make install LUA_VER=5.1)
+  - wget http://download.zeromq.org/zeromq-4.0.4.tar.gz
+  - tar -xvf zeromq-4.0.4.tar.gz
+  - wget http://download.zeromq.org/czmq-2.2.0.tar.gz
+  - tar -xvf czmq-2.2.0.tar.gz
+  - wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.0.tar.gz
+  - tar -xvf libsodium-1.0.0.tar.gz
+  - wget https://s3.amazonaws.com/json-c_releases/releases/json-c-0.11.tar.gz
+  - tar -xvf  json-c-0.11.tar.gz
+  - ( export CC=gcc; cd json-c-0.11 && ./configure && make && sudo make install)
+  - (cd libsodium-1.0.0 && ./configure && make -j2 && sudo make install)
+  - (cd zeromq-4.0.4 && ./configure --with-libsodium && make -j2 && sudo make install)
+  - (cd czmq-2.2.0 && ./configure && make -j2 && sudo make install)
+  - sudo ldconfig
+
+script: 
+  - git clone https://github.com/flux-framework/flux-core ../flux-core
+  - (cd ../flux-core && pwd && ./autogen.sh && ./configure && make -j 2)
+  - ./config ../flux-core && make check
+
+

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ include Makefile.inc
 
 SUBDIRS = rdl sched simulator t
 
+check: all
+
 all clean install check:
 	for subdir in $(SUBDIRS); do make -C $$subdir $@; done
 

--- a/rdl/RDL.lua
+++ b/rdl/RDL.lua
@@ -47,6 +47,7 @@ local function rdl_parse_environment ()
         pairs = pairs,
         tonumber = tonumber,
         assert = assert,
+        unpack = unpack,
         table = table,
         hostlist = hostlist
     }

--- a/rdl/RDL.lua
+++ b/rdl/RDL.lua
@@ -78,6 +78,7 @@ local function rdl_parse_environment ()
             return nil, r
         end
         env [t] = r
+        return r
     end
 
     ---
@@ -112,6 +113,7 @@ local function rdl_parse_environment ()
         end
         env[name] = r
     end
+
 
     env.rdl = rdl
     return env

--- a/rdl/RDL.lua
+++ b/rdl/RDL.lua
@@ -27,7 +27,6 @@
 --
 -- First, load some useful modules:
 --
-local Resource = require 'RDL.Resource'
 local hostlist = require 'hostlist'
 
 --
@@ -49,7 +48,6 @@ local function rdl_parse_environment ()
         tonumber = tonumber,
         assert = assert,
         table = table,
-        Resource = Resource,
         hostlist = hostlist
     }
     local rdl = require 'RDL.memstore'.new()
@@ -61,8 +59,9 @@ local function rdl_parse_environment ()
     -- the "uses" function is like 'require' but loads a resource definition
     --  file from the current resource types path
     --
-    function env.uses (t)
-        local filename = basepath .. "RDL/types/" .. t .. ".lua"
+    function env.uses (t, dir)
+        local dir = dir or basepath .. "RDL/types"
+        local filename = dir .. "/" .. t .. ".lua"
         if env[t] then return end
         local f = assert (loadfile (filename))
 
@@ -94,6 +93,11 @@ local function rdl_parse_environment ()
             rdl:hierarchy_put (name, resource)
         end
     end
+
+    ---
+    -- Load 'Resource' base class by default (i.e. use "Resource")
+    ---
+    env.uses ('Resource', basepath .. "RDL")
 
     ---
     -- Load extra functions defined in RDL/lib/?.lua

--- a/rdl/RDL/Resource.lua
+++ b/rdl/RDL/Resource.lua
@@ -30,6 +30,18 @@ local class = require "middleclass"
 --
 local Resource = class ('Resource')
 
+Resource._defaultTags = {}
+
+-- Set a list of default tags for this class:
+function Resource:default_tags (t)
+    local tags = {}
+    for k,v in pairs (t) do
+        if type(v) == 'table' then error ("tags value cannot be a table!") end
+        tags[k] = v
+    end
+    self._defaultTags = tags
+end
+
 function Resource:initialize (args)
     self.children = {}
     if args.children then
@@ -38,6 +50,23 @@ function Resource:initialize (args)
         end
         args.children = nil
     end
+
+    if not args.tags then
+        args.tags = {}
+    end
+
+    --
+    -- Set default tags from the _defaultTags class attribute.
+    --  (This table is inherited by subclasses, so setting default
+    --   tags for the "Resource" class causes all resources to get
+    --   those tags, unless overridden in a subclass)
+    --
+    for k,v in pairs (self.class._defaultTags) do
+        if not args.tags[k] then
+            args.tags[k] = v
+        end
+    end
+
     self.resource = ResourceData (args)
 end
 

--- a/t/Makefile
+++ b/t/Makefile
@@ -18,6 +18,8 @@ TESTS = \
 all: $(BUILD)
 
 check: $(TESTS)
+	@export LUA_PATH="$$LUA_PATH;$(FLUX_BUILDDIR)/t/?.lua;$(RDL_LUA_PATH);;"; \
+	export LUA_CPATH="$$LUA_CPATH;$(RDL_LUA_CPATH);;"; \
 	for t in $(TESTS); do \
 		./$$t; \
 	done 

--- a/t/Makefile
+++ b/t/Makefile
@@ -16,7 +16,8 @@ TESTS = \
 	t0001-basic.t \
 	lua/t0001-rdl-basic.t \
 	lua/t0002-multilevel.t \
-	lua/t0003-default-tags.t
+	lua/t0003-default-tags.t \
+	lua/t0004-derived-type.t
 
 all: $(BUILD)
 

--- a/t/Makefile
+++ b/t/Makefile
@@ -15,7 +15,8 @@ TESTS = \
 	t0000-sharness.t \
 	t0001-basic.t \
 	lua/t0001-rdl-basic.t \
-	lua/t0002-multilevel.t
+	lua/t0002-multilevel.t \
+	lua/t0003-default-tags.t
 
 all: $(BUILD)
 

--- a/t/Makefile
+++ b/t/Makefile
@@ -13,7 +13,9 @@ export FLUX_SOURCE_DIR=$(FLUX_SRCDIR)
 BUILD = 
 TESTS = \
 	t0000-sharness.t \
-	t0001-basic.t
+	t0001-basic.t \
+	lua/t0001-rdl-basic.t \
+	lua/t0002-multilevel.t
 
 all: $(BUILD)
 

--- a/t/lua/t0001-rdl-basic.t
+++ b/t/lua/t0001-rdl-basic.t
@@ -1,0 +1,46 @@
+#!/usr/bin/lua
+--
+--  Basic rdl testing
+--
+local t = require 'fluxometer'.init (...)
+local RDL = require_ok ('RDL')
+
+t:say ("Load a very simple RDL Hierarchy:\n")
+
+local rdl, err = RDL.eval ([[
+ Hierarchy "default" {
+   Resource{ "foo", name = "bar", id = 0, tags = { "test_tag" } }
+ }
+]])
+
+type_ok (rdl, 'table', "create rdl with single resource")
+is (err, nil, "error is nil")
+
+local r, err = rdl:resource ("default")
+type_ok (r, 'table', "get handle to resource object")
+
+is (err, nil, "error is nil")
+
+is (r.name, "bar0", "resource name")
+is (r.basename, "bar", "resource basename")
+is (r.type, "foo", "resource type")
+is (r.uri, "default:/bar0", "resource URI")
+is (r.path, "/bar0", "resource path")
+is (r.id, 0, "resource id number")
+
+local tags = r.tags
+type_ok (tags, 'table', "resource tags is a table")
+isnt (tags.test_tag, nil, "test_tag set in resource")
+
+
+-- Modify resource operations:
+--
+ok (r:tag ("test2"), "tag resource with 'test2'")
+ok (r.tags.test2, "tag now set on resource")
+ok (r:get "test2", "r:get_tag() works")
+ok (r:delete_tag ("test2"), "delete tag 'test2'")
+is (r.tags.test2, nil, "tag now unset on resource")
+
+done_testing ()
+
+-- vi: ts=4 sw=4 expandtab

--- a/t/lua/t0002-multilevel.t
+++ b/t/lua/t0002-multilevel.t
@@ -1,0 +1,68 @@
+#!/usr/bin/lua
+--
+--  Basic rdl testing. Multi-level hierarchy
+--
+local t = require 'fluxometer'.init (...)
+local RDL = require_ok ('RDL')
+
+local rdl, err = RDL.eval ([[
+uses "Node"
+
+ Hierarchy "default" {
+   Resource{ "cluster", name = "foo",
+             children = {
+               ListOf{ Node, ids="1-4",
+                 args = { name = "bar", sockets = { "0-1", "2-3" } }
+               }
+	     }
+   }
+ }
+]])
+
+type_ok (rdl, 'table', "load RDL")
+is (err, nil, "error is nil")
+
+local r, err = rdl:resource ("default")
+type_ok (r, 'table', "get handle to top of default hierarchy")
+is (r.name, "foo", "Got a handle to resource default:/foo")
+
+local agg = { cluster = 1, node = 4, socket = 8, core = 16 }
+is_deeply (r:aggregate(), agg, "RDL aggregate checks out")
+
+-- iterate over children
+for c in r:children () do
+    t:say ("child "..c.uri)
+    type_ok (c, 'table', "Got a valid child")
+    is (c.type, 'node',  "child is a Node")
+    is (c.basename, 'bar', "child has basename bar")
+    like (c.name, 'bar%d', "child name is "..c.name)
+end
+
+-- Now get a node and check sockets:
+local r, err = rdl:resource ("default:/foo/bar1")
+
+-- iterate over children
+for c in r:children () do
+    t:say ("child "..c.uri)
+    type_ok (c, 'table', "Got a valid child")
+    is (c.type, 'socket',  "child is a "..c.type)
+    is (c.basename, 'socket', "child has basename "..c.basename)
+    like (c.name, 'socket%d', "child name is "..c.name)
+end
+
+-- Now get a socket and check cores
+local r, err = rdl:resource ("default:/foo/bar1/socket0")
+
+for c in r:children () do
+    t:say ("child "..c.uri)
+    type_ok (c, 'table', "Got a valid child")
+    is (c.type, 'core',  "child is a "..c.type)
+    is (c.basename, 'core', "child has basename "..c.basename)
+    like (c.name, 'core%d', "child name is "..c.name)
+end
+
+
+
+done_testing ()
+
+-- vi: ts=4 sw=4 expandtab

--- a/t/lua/t0003-default-tags.t
+++ b/t/lua/t0003-default-tags.t
@@ -1,0 +1,148 @@
+#!/usr/bin/lua
+--
+--  Basic rdl testing
+--
+local t = require 'fluxometer'.init (...)
+local RDL = require_ok ('RDL')
+
+t:say ("Check basic functionality of default tags\n")
+
+local rdl, err = RDL.eval ([[
+ Resource:default_tags { "tag1" }
+ Hierarchy "default" {
+   Resource{ "foo", name = "bar", id = 0 }
+ }
+]])
+
+type_ok (rdl, 'table', "create rdl with single resource and default tags")
+is (err, nil, "error is nil")
+
+local r, err = rdl:resource ("default")
+type_ok (r, 'table', "get handle to resource object")
+
+is (r.tags.tag1, 1, "Got default tag")
+
+t:say ("Resource:default_tags should be reset for each eval")
+rdl, err = RDL.eval ([[
+ Hierarchy "default" {
+   Resource{ "foo", name = "bar", id = 0 }
+ }
+]])
+
+type_ok (rdl, 'table', "create rdl with single resource, no default tags")
+is (err, nil, "error is nil")
+
+local r, err = rdl:resource ("default")
+type_ok (r, 'table', "get handle to resource object")
+
+is (r.tags.tag1, nil, "no default tag")
+
+
+t:say ("default tags work on a subclass of Resource type")
+rdl, err = RDL.eval ([[
+ uses "Node"
+ Node:default_tags { "test" }
+ Hierarchy "default" {
+   Resource{ "foo", name = "bar",
+    children = { Node{ name="node", id=1, sockets = { "0" } } }
+  }
+ }
+]])
+
+type_ok (rdl, 'table', "create rdl with generic resource and Node")
+is (err, nil, "error is nil")
+
+local r, err = rdl:resource ("default")
+type_ok (r, 'table', "get handle to resource object")
+is (r.tags.tag1, nil, "no default tag on Resource class")
+
+local r, err = rdl:resource ("default:/bar/node1")
+type_ok (r, 'table', "get handle to resource object")
+is (err, nil, "no error")
+is (r.type, "node", "got Node object as expected")
+is (r.tags.test, 1, "default tag on Node class works")
+
+
+t:say ("default tags inherited by Resource subclass")
+rdl, err = RDL.eval ([[
+ uses "Node"
+ Resource:default_tags { "test" }
+ Hierarchy "default" {
+   Resource{ "foo", name = "bar",
+    children = { Node{ name="node", id=1, sockets = { "0" } } }
+  }
+ }
+]])
+
+local r, err = rdl:resource ("default:/bar/node1")
+type_ok (r, 'table', "get handle to resource object")
+is (err, nil, "no error")
+is (r.type, "node", "got Node object as expected")
+is (r.tags.test, 1, "default tag on Node class works")
+
+
+t:say ("Override default_tags on Resource subclass")
+rdl, err = RDL.eval ([[
+ uses "Node"
+ Resource:default_tags { "test" }
+ Node:default_tags { "test2" }
+ Hierarchy "default" {
+   Resource{ "foo", name = "bar",
+    children = { Node{ name="node", id=1, sockets = { "0" } } }
+  }
+ }
+]])
+
+local r, err = rdl:resource ("default:/bar/node1")
+type_ok (r, 'table', "get handle to resource object")
+is (err, nil, "no error")
+is (r.type, "node", "got Node object as expected")
+is (r.tags.test, nil, "first  tag on Node class not set")
+is (r.tags.test2, 1, "overridden tag on Node class is set")
+
+--
+t:say ("Override default tags with empty list")
+rdl, err = RDL.eval ([[
+ uses "Node"
+ Resource:default_tags { "test" }
+ Node:default_tags {}
+ Hierarchy "default" {
+   Resource{ "foo", name = "bar",
+    children = { Node{ name="node", id=1, sockets = { "0" } } }
+  }
+ }
+]])
+
+local r, err = rdl:resource ("default:/bar/node1")
+type_ok (r, 'table', "get handle to resource object")
+is (err, nil, "no error")
+is (r.type, "node", "got Node object as expected")
+is_deeply (r.tags, {}, "No tags on node instance")
+
+local r, err = rdl:resource ("default:/bar")
+type_ok (r, 'table', "get handle to resource object")
+is (err, nil, "no error")
+is (r.tags.test, 1, "Tag on resource object still set")
+
+--
+t:say ("Set default tags on 'uses' line")
+rdl, err = RDL.eval ([[
+ uses "Node" :default_tags { "set-a-tag" }
+ Hierarchy "default" {
+   Resource{ "foo", name = "bar",
+    children = { Node{ name="node", id=1, sockets = { "0" } } }
+  }
+ }
+]])
+type_ok (rdl, 'table', "RDL eval success")
+is (err, nil, "no error")
+
+local r, err = rdl:resource ("default:/bar/node1")
+type_ok (r, 'table', "get handle to resource object")
+is (err, nil, "no error")
+is (r.type, "node", "got Node object as expected")
+is (r.tags['set-a-tag'], 1, "tag is set on node instance")
+
+done_testing ()
+
+-- vi: ts=4 sw=4 expandtab

--- a/t/lua/t0004-derived-type.t
+++ b/t/lua/t0004-derived-type.t
@@ -1,0 +1,38 @@
+#!/usr/bin/lua
+--
+--  RDL Derived type testing
+--
+local t = require 'fluxometer'.init (...)
+local RDL = require_ok ('RDL')
+
+t:say ("Load a simple RDL Hierarchy using a derived type:\n")
+
+local rdl, err = RDL.eval ([[
+
+ Foo = Resource:subclass 'Foo'
+ function Foo:initialize (arg)
+   local name = arg.name or arg[1]
+   Resource.initialize (self, { "foo", name = name, id = arg.id })
+ end
+
+ Hierarchy "default" { Foo {"bar", id = 0} }
+]])
+
+type_ok (rdl, 'table', "create rdl with single derived resource")
+is (err, nil, "error is nil")
+
+local r, err = rdl:resource ("default")
+type_ok (r, 'table', "get handle to resource object")
+
+is (err, nil, "error is nil")
+
+is (r.name, "bar0", "resource name")
+is (r.basename, "bar", "resource basename")
+is (r.type, "foo", "resource type")
+is (r.uri, "default:/bar0", "resource URI")
+is (r.path, "/bar0", "resource path")
+is (r.id, 0, "resource id number")
+
+done_testing ()
+
+-- vi: ts=4 sw=4 expandtab


### PR DESCRIPTION
This PR includes a small RDL enhancements including testing and Travis CI support for flux-sched.

 * Add lua-based tests for RDL under `t/lua` using `fluxometer` directly from `flux-core`
 * Add `.travis.yml` file for Travis-CI builds. We build against `flux-core/master`
 * RDL Resource classes now support a list of default tags as a class attribute, empty by default. Default tags can be set on any type and is inherited by all subtypes. (Therefore setting default tags on the Resource type will set those tags on all resources in a hierarchy). Tags can be overridden in derived types. e.g.
 ```
  Resource:default_tags { "idle" }
  Hierarchy "default" { ... } 
 ```
Default tags can also be passed directly on the `uses` line, e.g.

 ```
 uses "Node" :default_tags { "mytag" }
 ```

