### PR TITLE
stop using deprecated flux-core functions

### DIFF
--- a/simulator/sim_execsrv.c
+++ b/simulator/sim_execsrv.c
@@ -323,7 +323,8 @@ static int send_join_request(flux_t h)
 	Jadd_str (o, "mod_name", module_name);
 	Jadd_int (o, "rank", flux_rank (h));
 	Jadd_double (o, "next_event", -1);
-	if (flux_request_send (h, o, "%s", "sim.join") < 0){
+	if (flux_json_request (h, FLUX_NODEID_ANY,
+                                  FLUX_MATCHTAG_NONE, "sim.join", o) < 0) {
 		Jput (o);
 		return -1;
 	}
@@ -336,7 +337,8 @@ static int send_reply_request(flux_t h, sim_state_t *sim_state)
 {
 	JSON o = sim_state_to_json (sim_state);
 	Jadd_bool (o, "event_finished", true);
-	if (flux_request_send (h, o, "%s", "sim.reply") < 0){
+	if (flux_json_request (h, FLUX_NODEID_ANY,
+                                  FLUX_MATCHTAG_NONE, "sim.reply", o) < 0) {
 		Jput (o);
 		return -1;
 	}

--- a/simulator/sim_schedsrv.c
+++ b/simulator/sim_schedsrv.c
@@ -1322,12 +1322,10 @@ static int newlwj_rpc (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 	JSON o;
 	JSON o_resp;
 	const char *key;
-	char* tag;
 	int64_t id;
 	int rc = 0;
 
-	if (flux_msg_decode (*zmsg, &tag, &o) < 0
-		    || o == NULL
+    if (flux_json_request_decode (*zmsg, &o) < 0
 		    || !Jget_str (o, "key", &key)
 		    || !Jget_int64 (o, "val", &id)) {
 		flux_log (h, LOG_ERR, "%s: bad message", __FUNCTION__);
@@ -1368,12 +1366,11 @@ event_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 
 static int trigger_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 {
-	JSON o;
-	char *tag;
+	JSON o = NULL;
 	clock_t start, diff;
 	double seconds;
 
-	if (flux_msg_decode (*zmsg, &tag, &o) < 0 || o == NULL){
+    if (flux_json_request_decode (*zmsg, &o) < 0) {
 		flux_log (h, LOG_ERR, "%s: bad message", __FUNCTION__);
 		Jput (o);
 		return -1;

--- a/simulator/sim_schedsrv.c
+++ b/simulator/sim_schedsrv.c
@@ -1341,7 +1341,7 @@ static int newlwj_rpc (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 
 	o_resp = Jnew ();
 	Jadd_int (o_resp, "rc", rc);
-	flux_respond (h, zmsg, o_resp);
+    flux_json_respond (h, o_resp, zmsg);
 	Jput (o_resp);
 
 	if (o)

--- a/simulator/simsrv.c
+++ b/simulator/simsrv.c
@@ -74,12 +74,15 @@ static ctx_t *getctx (flux_t h)
 static int send_trigger (flux_t h, char *mod_name, sim_state_t *sim_state)
 {
 	JSON o = sim_state_to_json (sim_state);
-	if (flux_request_send (h, o, "%s.trigger", mod_name) < 0){
+	char *topic = xasprintf ("%s.trigger", mod_name);
+	if (flux_json_request (h, FLUX_NODEID_ANY,
+                                  FLUX_MATCHTAG_NONE, topic, o) < 0) {
 		flux_log (h, LOG_ERR, "failed to send trigger to %s", mod_name);
 		return -1;
 	}
 	//flux_log (h, LOG_DEBUG, "sent a trigger to %s", mod_name);
 	Jput(o);
+	free (topic);
 	return 0;
 }
 

--- a/simulator/simsrv.c
+++ b/simulator/simsrv.c
@@ -176,7 +176,7 @@ static int join_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 	ctx_t *ctx = arg;
 	sim_state_t *sim_state = ctx->sim_state;
 
-	if (flux_msg_decode (*zmsg, NULL, &request) < 0 || request == NULL
+	if (flux_json_request_decode (*zmsg, &request) < 0
 		|| !Jget_str (request, "mod_name", &mod_name)
 		|| !Jget_int (request, "rank", &mod_rank)
 		|| !Jget_double (request, "next_event", next_event)) {
@@ -283,7 +283,7 @@ static int reply_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 	sim_state_t *curr_sim_state = ctx->sim_state;
 	sim_state_t *reply_sim_state;
 
-	if (flux_msg_decode (*zmsg, NULL, &request) < 0 || request == NULL
+	if (flux_json_request_decode (*zmsg, &request) < 0
 		|| !Jget_bool (request, "event_finished", &event_finished)) {
 		flux_log (h, LOG_ERR, "%s: bad reply message", __FUNCTION__);
 		Jput(request);
@@ -311,7 +311,7 @@ static int alive_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 	JSON request = NULL;
 	const char *json_string;
 
-	if (flux_msg_decode (*zmsg, NULL, &request) < 0 || request == NULL) {
+	if (flux_json_request_decode (*zmsg, &request) < 0) {
 		flux_log (h, LOG_ERR, "%s: bad reply message", __FUNCTION__);
 		Jput(request);
 		return 0;

--- a/simulator/simulator.c
+++ b/simulator/simulator.c
@@ -229,7 +229,8 @@ int send_alive_request (flux_t h, const char* module_name)
 	JSON o = Jnew ();
 	Jadd_str (o, "mod_name", module_name);
 	Jadd_int (o, "rank", flux_rank (h));
-	if (flux_request_send (h, o, "%s", "sim.alive") < 0){
+	if (flux_json_request (h, FLUX_NODEID_ANY,
+                                  FLUX_MATCHTAG_NONE, "sim.alive", o) < 0) {
 		Jput (o);
 		return -1;
 	}

--- a/simulator/submitsrv.c
+++ b/simulator/submitsrv.c
@@ -232,7 +232,7 @@ int schedule_next_job (flux_t h, sim_state_t *sim_state)
 	Jadd_int (o, "nnodes", job->nnodes);
 	Jadd_int (o, "ntasks", job->ncpus);
 
-	response = flux_rpc (h, o, "job.create");
+	flux_json_rpc (h, FLUX_NODEID_ANY, "job.create", o, &response);
 	Jget_int64 (response, "jobid", &new_jobid);
 
 	//Update lwj.%jobid%'s state in the kvs to "submitted"

--- a/simulator/submitsrv.c
+++ b/simulator/submitsrv.c
@@ -291,9 +291,8 @@ static int trigger_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 	JSON o;
 	const char *json_string;
 	sim_state_t *sim_state;
-	char *tag;
 
-	if (flux_msg_decode (*zmsg, &tag, &o) < 0 || o == NULL){
+	if (flux_json_request_decode (*zmsg, &o) < 0) {
 		flux_log (h, LOG_ERR, "%s: bad message", __FUNCTION__);
 		Jput (o);
 		return -1;
@@ -301,7 +300,7 @@ static int trigger_cb (flux_t h, int typemask, zmsg_t **zmsg, void *arg)
 
 //Logging
 	json_string = Jtostr (o);
-	flux_log(h, LOG_DEBUG, "received a trigger (%s): %s", tag, json_string);
+	flux_log(h, LOG_DEBUG, "received a trigger (submit.trigger): %s", json_string);
 
 //Handle the trigger
 	sim_state = json_to_sim_state (o);

--- a/simulator/submitsrv.c
+++ b/simulator/submitsrv.c
@@ -183,7 +183,8 @@ int send_join_request (flux_t h)
 	Jadd_str (o, "mod_name", module_name);
 	Jadd_int (o, "rank", flux_rank (h));
 	Jadd_double (o, "next_event", get_next_submit_time());
-	if (flux_request_send (h, o, "%s", "sim.join") < 0){
+	if (flux_json_request (h, FLUX_NODEID_ANY,
+                                  FLUX_MATCHTAG_NONE, "sim.join", o) < 0) {
 		Jput (o);
 		return -1;
 	}
@@ -196,7 +197,8 @@ int send_reply_request (flux_t h, sim_state_t *sim_state)
 {
 	JSON o = sim_state_to_json (sim_state);
 	Jadd_bool (o, "event_finished", true);
-	if (flux_request_send (h, o, "%s", "sim.reply") < 0){
+	if (flux_json_request (h, FLUX_NODEID_ANY,
+                                  FLUX_MATCHTAG_NONE, "sim.reply", o) < 0) {
 		Jput (o);
 		return -1;
 	}


### PR DESCRIPTION
This update follows PR flux-framework/flux-core#182.
All changes affected only the simulator.