### PR TITLE
clang and build fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,20 @@ include Makefile.inc
 
 SUBDIRS = rdl sched simulator t
 
-all:
+.PHONY: all clean $(SUBDIRS)
+all check clean: $(SUBDIRS)
 
+all: TARGET="all"
+clean: TARGET="clean"
 check: all
+	$(MAKE) TARGET="check"
 
-all clean install check:
-	for subdir in $(SUBDIRS); do make -C $$subdir $@; done
+$(SUBDIRS):
+	@$(MAKE) -C $@ $(TARGET)
 
+sched: rdl
+simulator: rdl
+t: rdl sched simulator
+
+.PHONY: force
+force: ;

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ include Makefile.inc
 
 SUBDIRS = rdl sched simulator t
 
+all:
+
 check: all
 
 all clean install check:

--- a/sched/schedsrv.c
+++ b/sched/schedsrv.c
@@ -257,6 +257,10 @@ int update_job_state (flux_lwj_t *job, lwj_event_e e)
     return rc;
 }
 
+/* XXX: Unused function set_event() commented out to avoid compile-time
+ *      errors with -Wunused-function
+ */
+#if 0
 static inline void
 set_event (flux_event_t *e,
            event_class_e c, int ei, flux_lwj_t *j)
@@ -276,6 +280,7 @@ set_event (flux_event_t *e,
     }
     return;
 }
+#endif
 
 
 static int

--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -42,6 +42,6 @@ check:
 
 
 clean:
-	rm -f *.a *.o
+	rm -f *.a *.o *.so
 
 .PHONY: all clean load unload start

--- a/simulator/sim_execsrv.c
+++ b/simulator/sim_execsrv.c
@@ -37,7 +37,7 @@
 #include "simulator.h"
 #include "rdl.h"
 
-static const char const *module_name = "sim_exec";
+static const char *module_name = "sim_exec";
 
 typedef struct {
 	sim_state_t *sim_state;

--- a/simulator/sim_schedsrv.c
+++ b/simulator/sim_schedsrv.c
@@ -313,6 +313,7 @@ int update_job_state (flux_lwj_t *job, lwj_event_e e)
     return rc;
 }
 
+#if 0
 static inline void
 set_event (flux_event_t *e,
            event_class_e c, int ei, flux_lwj_t *j)
@@ -332,6 +333,7 @@ set_event (flux_event_t *e,
     }
     return;
 }
+#endif
 
 
 static int

--- a/simulator/sim_schedsrv.c
+++ b/simulator/sim_schedsrv.c
@@ -43,7 +43,7 @@
 
 #define MAX_STR_LEN 128
 
-static const char const *module_name = "sim_sched";
+static const char *module_name = "sim_sched";
 
 /****************************************************************
  *

--- a/simulator/submitsrv.c
+++ b/simulator/submitsrv.c
@@ -35,7 +35,7 @@
 #include "src/common/libutil/shortjson.h"
 #include "simulator.h"
 
-static const char const *module_name = "submit";
+static const char *module_name = "submit";
 static zlist_t *jobs;  //TODO: remove from "global" scope
 
 //Compare two job_t's based on submit time

--- a/t/Makefile
+++ b/t/Makefile
@@ -20,9 +20,12 @@ all: $(BUILD)
 check: $(TESTS)
 	@export LUA_PATH="$$LUA_PATH;$(FLUX_BUILDDIR)/t/?.lua;$(RDL_LUA_PATH);;"; \
 	export LUA_CPATH="$$LUA_CPATH;$(RDL_LUA_CPATH);;"; \
+        rc=0; \
 	for t in $(TESTS); do \
 		./$$t; \
-	done 
+		if test $$? -ne 0; then rc=1; fi; \
+	done; \
+	exit $$rc
 
 clean:
 	rm -rf *.o $(BUILD) test-results trash-directory*


### PR DESCRIPTION
This PR contains fixes for a couple warnings when building with `clang` in travis-ci (which are hard errors due to -Werror), and also rectifies an issue with commit 826a3b48f6906336ea392228a0efeedbcc2dcb48 wherein `check` was accidentally made the default target of `make` instead of `all`.