### PR TITLE
simple tweak to get flux-sched building with debian/ubuntu json-c packaging

### DIFF
--- a/rdl/rdl.h
+++ b/rdl/rdl.h
@@ -6,7 +6,7 @@
  */
 
 #include <stdlib.h>
-#include <json/json.h>
+#include <json.h>
 
 /*
  *  Forward declarations:

--- a/sched/schedsrv.c
+++ b/sched/schedsrv.c
@@ -35,7 +35,7 @@
 #include <errno.h>
 #include <libgen.h>
 #include <czmq.h>
-#include <json/json.h>
+#include <json.h>
 #include <dlfcn.h>
 #include <flux/core.h>
 

--- a/simulator/sim_schedsrv.c
+++ b/simulator/sim_schedsrv.c
@@ -28,7 +28,7 @@
 #include <errno.h>
 #include <libgen.h>
 #include <czmq.h>
-#include <json/json.h>
+#include <json.h>
 #include <dlfcn.h>
 #include <time.h>
 #include <inttypes.h>


### PR DESCRIPTION
Avoid including `<json/json.h>` as on some systems it is `<json-c/json.h>`.
Simply include`<json.h>` as CFLAGS from flux-core's Makefile.inc
will set -I appropriately.