### PR TITLE
sched: replace use of flux_event_send() with flux_sendmsg()

### DIFF
--- a/sched/schedsrv.c
+++ b/sched/schedsrv.c
@@ -542,7 +542,7 @@ static int req_tpexec_exec (flux_t h, flux_lwj_t *job)
             flux_log (h, LOG_ERR, "%s: topic create failed: %s",
                       __FUNCTION__, strerror (errno));
         } else if (!(zmsg = flux_event_encode (topic, NULL))
-                   || flux_event_send (h, &zmsg) < 0) {
+                   || flux_sendmsg (h, &zmsg) < 0) {
             flux_log (h, LOG_ERR, "%s: error sending event: %s",
                       __FUNCTION__, strerror (errno));
         } else {
@@ -759,7 +759,7 @@ static int action (ssrvctx_t *ctx, flux_lwj_t *job, job_state_t newstate)
         } else {
             zmsg_t *zmsg = flux_event_encode ("sched.res.event", NULL);
 
-            if (!zmsg || flux_event_send (h, &zmsg) < 0) {
+            if (!zmsg || flux_sendmsg (h, &zmsg) < 0) {
                 flux_log (h, LOG_ERR, "%s: error sending event: %s",
                           __FUNCTION__, strerror (errno));
             } else

--- a/simulator/sim_schedsrv.c
+++ b/simulator/sim_schedsrv.c
@@ -196,9 +196,9 @@ signal_event ( )
         //send_reply_request (h, sim_state);
         goto ret;
     } else if (!(zmsg = flux_event_encode ("sim_sched.event", NULL))
-             || flux_event_send (h, &zmsg) < 0) {
+             || flux_sendmsg (h, &zmsg) < 0) {
         flux_log (h, LOG_ERR,
-                  "flux_event_send: %s", strerror (errno));
+                  "flux_sendmsg: %s", strerror (errno));
         rc = -1;
     }
 
@@ -810,7 +810,7 @@ request_run (flux_lwj_t *job)
     if (!in_sim) {
         topic = xasprintf ("rexec.run.%ld", job->lwj_id);
         if (!(zmsg = flux_event_encode (topic, NULL))
-            || flux_event_send (h, &zmsg) < 0) {
+            || flux_sendmsg (h, &zmsg) < 0) {
             flux_log (h, LOG_ERR, "request_run event send failed: %s",
                       strerror (errno));
             goto done;

--- a/simulator/simsrv.c
+++ b/simulator/simsrv.c
@@ -96,7 +96,7 @@ int send_start_event(flux_t h)
 	Jadd_int (o, "rank", flux_rank(h));
 	Jadd_int (o, "sim_time", 0);
 	if (!(zmsg = flux_event_encode ("sim.start", Jtostr (o)))
-            || flux_event_send (h, &zmsg) < 0){
+            || flux_sendmsg (h, &zmsg) < 0){
 		Jput(o);
 		zmsg_destroy (&zmsg);
 		return -1;


### PR DESCRIPTION
Tracks the latest mods to flux-core