### PR TITLE
resrc: eliminate the hard-coded memory pool

### DIFF
--- a/resrc/test/tresrc.c
+++ b/resrc/test/tresrc.c
@@ -155,7 +155,7 @@ int main (int argc, char *argv[])
 
     memory = Jnew ();
     Jadd_str (memory, "type", "memory");
-    Jadd_int (memory, "req_qty", 100);
+    Jadd_int (memory, "size", 100);
 
     ja = Jnew_ar ();
     json_object_array_add (ja, child_core);


### PR DESCRIPTION
Use a resource's size field to determine whether the resource is a
pool.  This is a transitional commit that provides a practical replacement for a hard-coded placeholder.  I'll be looking into streamlining this area even further.