### PR TITLE
avoid cast to FluxFreeFn

### DIFF
--- a/sched/schedsrv.c
+++ b/sched/schedsrv.c
@@ -97,8 +97,9 @@ typedef struct {
  *                                 Utilities                                  *
  *                                                                            *
  ******************************************************************************/
-static void freectx (ssrvctx_t *ctx)
+static void freectx (void *arg)
 {
+    ssrvctx_t *ctx = arg;
     /* FIXME: we probably need some item free hooked into the lists
      * ignore this for a while.
      */
@@ -125,7 +126,7 @@ static ssrvctx_t *getctx (flux_t h)
         ctx->sops.dso = NULL;
         ctx->sops.find_resources = NULL;
         ctx->sops.select_resources = NULL;
-        flux_aux_set (h, "schedsrv", ctx, (FluxFreeFn)freectx);
+        flux_aux_set (h, "schedsrv", ctx, freectx);
     }
     return ctx;
 }

--- a/simulator/sim_execsrv.c
+++ b/simulator/sim_execsrv.c
@@ -47,8 +47,9 @@ typedef struct {
 	double prev_sim_time;
 } ctx_t;
 
-static void freectx (ctx_t *ctx)
+static void freectx (void *arg)
 {
+    ctx_t *ctx = arg;
 	free_simstate (ctx->sim_state);
 
 	while (zlist_size (ctx->queued_events) > 0)
@@ -73,7 +74,7 @@ static ctx_t *getctx (flux_t h)
 		ctx->queued_events = zlist_new ();
 		ctx->running_jobs = zlist_new ();
 		ctx->prev_sim_time = 0;
-        flux_aux_set (h, "simsrv", ctx, (FluxFreeFn)freectx);
+        flux_aux_set (h, "simsrv", ctx, freectx);
     }
 
     return ctx;

--- a/simulator/simsrv.c
+++ b/simulator/simsrv.c
@@ -47,8 +47,9 @@ typedef struct {
     int rank;
 } ctx_t;
 
-static void freectx (ctx_t *ctx)
+static void freectx (void *arg)
 {
+    ctx_t *ctx = arg;
 	free_simstate (ctx->sim_state);
     free (ctx);
 }
@@ -63,7 +64,7 @@ static ctx_t *getctx (flux_t h)
         ctx->master = flux_treeroot (h);
         ctx->rank = flux_rank (h);
 		ctx->sim_state = new_simstate ();
-        flux_aux_set (h, "simsrv", ctx, (FluxFreeFn)freectx);
+        flux_aux_set (h, "simsrv", ctx, freectx);
     }
 
     return ctx;


### PR DESCRIPTION
FluxFreeFn is being renamed to flux_free_f upstream.
Change the function signature to avoid the cast, and thus the
reference to this name, in the three places in flux-sched
where this was done.