### PR TITLE
resrc: redesign pool support

### DIFF
--- a/resrc/resrc.c
+++ b/resrc/resrc.c
@@ -320,7 +320,7 @@ resources_t resrc_generate_resources (const char *path, char *resource)
     if (!(resrcs = zhash_new ()))
         goto ret;
 
-    if ((nodelist = getenv ("SLURM_JOB_NODELIST"))) {
+    if ((nodelist = getenv ("SLURM_NODELIST"))) {
         hostset = hostset_create (nodelist);
         if (hostset)
             slurm_job = true;

--- a/resrc/resrc.h
+++ b/resrc/resrc.h
@@ -40,6 +40,16 @@ char *resrc_name (resrc_t resrc);
 int64_t resrc_id (resrc_t resrc);
 
 /*
+ * Return the size of the resource
+ */
+size_t resrc_size (resrc_t resrc);
+
+/*
+ * Return the resource state as a string
+ */
+char* resrc_state (resrc_t resrc);
+
+/*
  * Return the physical tree for the resouce
  */
 resrc_tree_t resrc_phys_tree (resrc_t resrc);
@@ -78,7 +88,7 @@ size_t resrc_list_size ();
  * Create a new resource object
  */
 resrc_t resrc_new_resource (const char *type, const char *name, int64_t id,
-                                uuid_t uuid);
+                            uuid_t uuid, size_t size);
 
 /*
  * Create a copy of a resource object
@@ -141,14 +151,9 @@ int resrc_search_flat_resources (resources_t resrcs, resource_list_t found,
                                  JSON req_res, bool available);
 
 /*
- * Determine whether a resource contains a pool type
+ * Stage size elements of a resource
  */
-bool resrc_has_pool (resrc_t resrc, char* type);
-
-/*
- * Select specified items from resource pool
- */
-int resrc_select_pool_items (resrc_t resrc, char* type, int64_t items);
+void resrc_stage_resrc(resrc_t resrc, size_t size);
 
 /*
  * Allocate a resource to a job

--- a/resrc/resrc_tree.c
+++ b/resrc/resrc_tree.c
@@ -566,6 +566,7 @@ static bool match_child (zlist_t *r_trees, resrc_reqst_t resrc_reqst,
     resrc_tree_t resrc_tree = NULL;
     resrc_tree_t child_tree = NULL;
     bool found = false;
+    bool success = false;
 
     resrc_tree = zlist_first (r_trees);
     while (resrc_tree) {
@@ -581,6 +582,7 @@ static bool match_child (zlist_t *r_trees, resrc_reqst_t resrc_reqst,
                                         available)) {
                         resrc_reqst->nfound++;
                         found = true;
+                        success = true;
                     } else {
                         resrc_tree_destroy (child_tree);
                     }
@@ -589,6 +591,7 @@ static bool match_child (zlist_t *r_trees, resrc_reqst_t resrc_reqst,
                 (void) resrc_tree_new (parent_tree, resrc_tree->resrc);
                 resrc_reqst->nfound++;
                 found = true;
+                success = true;
             }
         }
         /*
@@ -601,7 +604,7 @@ static bool match_child (zlist_t *r_trees, resrc_reqst_t resrc_reqst,
                 child_tree = resrc_tree_new (parent_tree, resrc_tree->resrc);
                 if (match_child (resrc_tree->children, resrc_reqst, child_tree,
                                  available)) {
-                    found = true;
+                    success = true;
                 } else {
                     resrc_tree_destroy (child_tree);
                 }
@@ -610,7 +613,7 @@ static bool match_child (zlist_t *r_trees, resrc_reqst_t resrc_reqst,
         resrc_tree = zlist_next (r_trees);
     }
 
-    return found;
+    return success;
 }
 
 /*

--- a/resrc/test/tresrc.c
+++ b/resrc/test/tresrc.c
@@ -50,8 +50,10 @@ static void test_select_children (resrc_tree_t rt)
 {
     if (rt) {
         resrc_t resrc = resrc_tree_resrc (rt);
-        if (resrc_has_pool (resrc, "memory")) {
-            resrc_select_pool_items (resrc, "memory", 100);
+        if (strcmp (resrc_type(resrc), "memory")) {
+            resrc_stage_resrc (resrc, 1);
+        } else {
+            resrc_stage_resrc (resrc, 100);
         }
         if (zlist_size ((zlist_t*)resrc_tree_children(rt))) {
             resrc_tree_t child = zlist_first ((zlist_t*)
@@ -68,7 +70,7 @@ static void test_select_children (resrc_tree_t rt)
  * Select some resources from the found trees
  */
 static resrc_tree_list_t test_select_resources (resrc_tree_list_t found_trees,
-                                                int skip)
+                                                int select)
 {
     resrc_tree_list_t selected_res = resrc_tree_new_list ();
     resrc_tree_t rt;
@@ -76,9 +78,10 @@ static resrc_tree_list_t test_select_resources (resrc_tree_list_t found_trees,
 
     rt = resrc_tree_list_first (found_trees);
     while (rt) {
-        if (!(count % skip)) {
+        if (count == select) {
             test_select_children (rt);
             zlist_append ((zlist_t *) selected_res, rt);
+            break;
         }
         count++;
         rt = resrc_tree_list_next (found_trees);
@@ -155,6 +158,7 @@ int main (int argc, char *argv[])
 
     memory = Jnew ();
     Jadd_str (memory, "type", "memory");
+    Jadd_int (memory, "req_qty", 1);
     Jadd_int (memory, "size", 100);
 
     ja = Jnew_ar ();
@@ -235,7 +239,7 @@ int main (int argc, char *argv[])
     ok (!rc, "successfully allocated resources for job 3");
     zlist_destroy ((zlist_t**) &selected_trees);
 
-    selected_trees = test_select_resources (found_trees, 2);
+    selected_trees = test_select_resources (found_trees, 4);
     rc = resrc_tree_list_reserve (selected_trees, 4);
     ok (!rc, "successfully reserved resources for job 4");
     zlist_destroy ((zlist_t**) &selected_trees);


### PR DESCRIPTION
Eliminate the dedicated pool structure and enhance the resrc structure
to support a size component.  This makes the resrc model conform with
the design described in RFC 4.  Update the tresrc test to match the
new model.  No changes were needed to the sched module.