### PR TITLE
update travis-ci to new container build infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ compiler:
 
 cache:
   directories:
+    - $HOME/flux-core
     - $HOME/local
     - $HOME/.luarocks
     - $HOME/.ccache
@@ -40,9 +41,9 @@ before_install:
 
 script:
  - export CC="ccache $CC"
- - git clone https://github.com/flux-framework/flux-core ../flux-core
- - (cd ../flux-core && pwd && ./autogen.sh && ./configure && make -j 2)
- - (cd ../flux-core/src/common/libtap && make check)
- - ./config ../flux-core && make check
+ - test -d  $HOME/flux-core/.git || git clone https://github.com/flux-framework/flux-core $HOME/flux-core
+ - (cd $HOME/flux-core && git pull && ./autogen.sh && ./configure && make -j 2)
+ - (cd $HOME/flux-core/src/common/libtap && make check)
+ - ./config $HOME/flux-core && make check
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,48 @@
 language: c
 
+sudo: false
+
 compiler:
   - gcc
   - clang
 
-install:
-  - sudo sh -c 'echo "/usr/local/lib" >/etc/ld.so.conf.d/build'
-  - sudo apt-get update -q
-  - sudo apt-get install -y lua5.1 liblua5.1-0-dev luarocks munge libmunge-dev uuid-dev aspell
-  - sudo luarocks install luaposix
-  - git clone https://github.com/grondo/lua-hostlist
-  - (export CC=gcc; cd lua-hostlist && make LUA_VER=5.1 && sudo make install LUA_VER=5.1)
-  - wget http://download.zeromq.org/zeromq-4.0.4.tar.gz
-  - tar -xvf zeromq-4.0.4.tar.gz
-  - wget http://download.zeromq.org/czmq-3.0.0-rc1.tar.gz
-  - tar -xvf czmq-3.0.0-rc1.tar.gz
-  - wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.0.tar.gz
-  - tar -xvf libsodium-1.0.0.tar.gz
-  - wget https://s3.amazonaws.com/json-c_releases/releases/json-c-0.11.tar.gz
-  - tar -xvf  json-c-0.11.tar.gz
-  - ( export CC=gcc; cd json-c-0.11 && ./configure && make && sudo make install)
-  - (cd libsodium-1.0.0 && ./configure && make -j2 && sudo make install)
-  - (cd zeromq-4.0.4 && ./configure --with-libsodium && make -j2 && sudo make install)
-  - (cd czmq-3.0.0 && ./configure && make -j2 && sudo make install)
-  - sudo ldconfig
+cache:
+  directories:
+    - $HOME/local
+    - $HOME/.luarocks
+    - $HOME/.ccache
+
+addons:
+  apt:
+    sources:
+    packages:
+      - lua5.1
+      - liblua5.1-0-dev
+      - luarocks
+      - uuid-dev
+      - aspell
+      - libopenmpi-dev
+      - ccache
+      - libmunge-dev
+      - munge
+
+before_install:
+  - export LD_LIBRARY_PATH=$HOME/local/lib
+  - export CPPFLAGS=-I$HOME/local/include
+  - export LDFLAGS=-L$HOME/local/lib
+  - export PKG_CONFIG_PATH=$HOME/local/lib/pkgconfig
+  - test "$TRAVIS_PULL_REQUEST" == "false" || export CCACHE_READONLY=1
+  - if test "$CC" = "clang"; then export CCACHE_CPP2=1; fi
+  - eval `luarocks path`
+  - wget https://raw.githubusercontent.com/flux-framework/flux-core/master/src/test/travis-dep-builder.sh
+  - bash ./travis-dep-builder.sh --cachedir=$HOME/local/.cache
+
 
 script:
-  - git clone https://github.com/flux-framework/flux-core ../flux-core
-  - (cd ../flux-core && pwd && ./autogen.sh && ./configure && make -j 2)
-  - (cd ../flux-core/src/common/libtap && make check)
-  - ./config ../flux-core && make check
+ - export CC="ccache $CC"
+ - git clone https://github.com/flux-framework/flux-core ../flux-core
+ - (cd ../flux-core && pwd && ./autogen.sh && ./configure && make -j 2)
+ - (cd ../flux-core/src/common/libtap && make check)
+ - ./config ../flux-core && make check
 
 

--- a/resrc/test/Makefile
+++ b/resrc/test/Makefile
@@ -5,8 +5,8 @@ LIBS = $(FLUX_LIBS) $(RDL_LIBS) $(RESRC_LIBS)
 
 TESTRESRC_INPUT_FILE := $(abs_topdir)/conf/hype.lua
 
-LUA_PATH = $(abs_topdir)/rdl/?.lua;$(FLUX_SRCDIR)/src/bindings/lua/?.lua;;;
-LUA_CPATH = $(abs_topdir)/rdl/?.so;$(FLUX_SRCDIR)/src/bindings/lua/.libs/?.so;;;
+LUA_PATH := $(LUA_PATH);$(abs_topdir)/rdl/?.lua;$(FLUX_SRCDIR)/src/bindings/lua/?.lua;;;
+LUA_CPATH := $(LUA_CPATH);$(abs_topdir)/rdl/?.so;$(FLUX_SRCDIR)/src/bindings/lua/.libs/?.so;;;
 
 export CFLAGS TESTRESRC_INPUT_FILE LUA_PATH LUA_CPATH
 

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -67,7 +67,7 @@ test_under_flux() {
 
     TEST_UNDER_FLUX_ACTIVE=t \
     TERM=${ORIGINAL_TERM} \
-      exec flux -M${tdir}/sched -C${tdir}/rdl/?.so -L${tdir}/rdl/?.lua start --size=${size} ${quiet} "sh $0 ${flags}"
+      exec flux -M${tdir}/sched start --size=${size} ${quiet} "sh $0 ${flags}"
 }
 
 

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -47,11 +47,13 @@ run_timeout() {
 test_under_flux() {
     size=$1
     tdir=$2
+    log_file="$TEST_NAME.broker.log"
     if test -n "$TEST_UNDER_FLUX_ACTIVE" ; then
+        cleanup rm "${SHARNESS_TEST_DIRECTORY:-..}/$log_file"
         unset TEST_UNDER_FLUX_ACTIVE
         return
     fi
-    quiet="-o -q"
+    quiet="-o -q,-L${log_file}"
     if test "$verbose" = "t"; then
         flags="${flags} --verbose"
         quiet=""


### PR DESCRIPTION
As in flux-framework/flux-core#265, update `.travis.yml` to use the new container builds for much faster build times (and fix some minor items along the way).

For flux-sched, we also cache the flux-core git directory to speed things up.