### PR TITLE
modules: update mod_main() prototype per RFC 5

### DIFF
--- a/simulator/sim_execsrv.c
+++ b/simulator/sim_execsrv.c
@@ -439,7 +439,7 @@ static msghandler_t htab[] = {
 };
 const int htablen = sizeof (htab) / sizeof (htab[0]);
 
-int mod_main(flux_t h, zhash_t *args)
+int mod_main(flux_t h, int argc, char **argv)
 {
 	ctx_t *ctx = getctx (h);
 	if (flux_rank (h) != 0) {

--- a/simulator/simsrv.c
+++ b/simulator/simsrv.c
@@ -343,7 +343,7 @@ static msghandler_t htab[] = {
 };
 const int htablen = sizeof (htab) / sizeof (htab[0]);
 
-int mod_main(flux_t h, zhash_t *args)
+int mod_main(flux_t h, int argc, char **argv)
 {
 	ctx_t *ctx = getctx(h);
 	if (flux_rank (h) != 0) {


### PR DESCRIPTION
This change goes along with flux-framework/flux-core#289 where the prototype of `mod_main()` changed to use argc, argv style argument passing rather than a zhash_t.

I repeated that silly `zhash_fromargv()` several times thinking that people would probably want to revise the way arguments are handled in those modules one at a time;  feel free to move that somewhere shared if you want to keep it.