### PR TITLE
travis updates and build fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,8 @@ before_install:
 script:
  - export CC="ccache $CC"
  - test -d  $HOME/flux-core/.git || git clone https://github.com/flux-framework/flux-core $HOME/flux-core
- - (cd $HOME/flux-core && git pull && ./autogen.sh && ./configure && make -j 2)
+ - (cd $HOME/flux-core && git fetch origin master && git reset --hard origin/master)
+ - (cd $HOME/flux-core && ./autogen.sh && ./configure && make -j 2)
  - (cd $HOME/flux-core/src/common/libtap && make check)
  - ./config $HOME/flux-core && make check
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache:
     - $HOME/local
     - $HOME/.luarocks
     - $HOME/.ccache
+    - $HOME/.local
 
 addons:
   apt:
@@ -37,7 +38,7 @@ before_install:
   - eval `luarocks path`
   - wget https://raw.githubusercontent.com/flux-framework/flux-core/master/src/test/travis-dep-builder.sh
   - bash ./travis-dep-builder.sh --cachedir=$HOME/local/.cache
-
+  - pip install --user cffi coverage
 
 script:
  - export CC="ccache $CC"

--- a/resrc/Makefile
+++ b/resrc/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.inc
 
 SUBDIRS = test
 CFLAGS = $(COMMON_CFLAGS) $(FLUX_CFLAGS) $(RDL_CFLAGS)
-LIBS = $(FLUX_LIBS) $(RDL_LIBS)
+LIBS = $(FLUX_LIBS) $(RDL_LIBS) -luuid
 
 X_OBJS_LIB = hostlist.o
 


### PR DESCRIPTION
The travis-ci build had a few issues which should be addressed here:
 * We weren't getting the latest flux-core/master because the git repo was being updated via `git-pull`, which was failing due to changes in the working tree. We now use a hard reset to ensure we're building against latest flux-core
 * Latest flux-core now has python dependencies and these are now installed
 * Latest flux-core removes the libuuid dependency which broke linking in `resrc`. Since resrc directly requires libuuid it should specify that on link line
 * We need to support two styles of comparator functions for zlist in simulator, depending on czmq version. (Hopefully I got the compare function correct enough, it only has build testing)
