### PR TITLE
build: make deprecated function warnings non-fatal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ compiler:
 
 cache:
   directories:
-    - $HOME/flux-core
     - $HOME/local
     - $HOME/.luarocks
     - $HOME/.ccache
@@ -42,8 +41,7 @@ before_install:
 
 script:
  - export CC="ccache $CC"
- - test -d  $HOME/flux-core/.git || git clone https://github.com/flux-framework/flux-core $HOME/flux-core
- - (cd $HOME/flux-core && git fetch origin master && git reset --hard origin/master)
+ - git clone --depth=1 https://github.com/flux-framework/flux-core $HOME/flux-core
  - (cd $HOME/flux-core && ./autogen.sh && ./configure && make -j 2)
  - (cd $HOME/flux-core/src/common/libtap && make check)
  - ./config $HOME/flux-core && make check

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -47,4 +47,4 @@ RESRC_LIBS = -Wl,-rpath,$(abs_topdir)/resrc -L$(topdir)/resrc -lresrc
 # When we invoke flux we need to provide additional LUA paths for RDL
 #
 FLUX = flux -C$(RDL_LUA_CPATH) -L$(RDL_LUA_PATH) -M$(SCHED_MODULE_PATH) -x$(SUBMIT_EXEC_PATH)
-COMMON_CFLAGS = -g -Wall -Werror -fPIC -D_GNU_SOURCE=1
+COMMON_CFLAGS = -g -Wall -Werror -Wno-error=deprecated-declarations -fPIC -D_GNU_SOURCE=1


### PR DESCRIPTION
flux-core started tagging deprecated functions with the 'deprecated'
attribute, which results in a compiler warning when those functions
are used.

Add CFLAGS to make that particular warning non-fatal.