### PR TITLE
update flux-core API usage after changes

### DIFF
--- a/sched/schedsrv.c
+++ b/sched/schedsrv.c
@@ -158,7 +158,7 @@ static inline int fill_resource_req (flux_t h, flux_lwj_t *j)
     if (!j) goto done;
 
     j->req = (flux_res_t *) xzmalloc (sizeof (flux_res_t));
-    if ((rc = jsc_query_jcb (h, j->lwj_id, JSC_RDESC, &jcb)) != 0) {
+    if ((rc = jsc_query_jcb_obj (h, j->lwj_id, JSC_RDESC, &jcb)) != 0) {
         flux_log (h, LOG_ERR, "error in jsc_query_job.");
         goto done;
     }
@@ -183,7 +183,7 @@ static int update_state (flux_t h, uint64_t jid, job_state_t os, job_state_t ns)
     Jadd_int64 (o, JSC_STATE_PAIR_NSTATE , (int64_t) ns);
     /* don't want to use Jadd_obj because I want to transfer the ownership */
     json_object_object_add (jcb, JSC_STATE_PAIR, o);
-    rc = jsc_update_jcb (h, jid, JSC_STATE_PAIR, jcb);
+    rc = jsc_update_jcb_obj (h, jid, JSC_STATE_PAIR, jcb);
     Jput (jcb);
     return rc;
 }
@@ -424,7 +424,7 @@ static int inline reg_events (ssrvctx_t *ctx)
         goto done;
     }
 #endif
-    if (jsc_notify_status (h, job_status_cb, (void *)h) != 0) {
+    if (jsc_notify_status_obj (h, job_status_cb, (void *)h) != 0) {
         flux_log (h, LOG_ERR, "error registering a job status change CB");
         rc = -1;
         goto done;
@@ -487,7 +487,7 @@ static int req_tpexec_allocate (ssrvctx_t *ctx, flux_lwj_t *job)
         goto done;
     }
     Jadd_obj (jcb, JSC_RDL, ro);
-    if (jsc_update_jcb (h, job->lwj_id, JSC_RDL, jcb) != 0) {
+    if (jsc_update_jcb_obj (h, job->lwj_id, JSC_RDL, jcb) != 0) {
         flux_log (h, LOG_ERR, "error jsc udpate: %ld (%s)", job->lwj_id,
                   strerror (errno));
         goto done;
@@ -499,7 +499,7 @@ static int req_tpexec_allocate (ssrvctx_t *ctx, flux_lwj_t *job)
         goto done;
     }
     json_object_object_add (jcb, JSC_RDL_ALLOC, arr);
-    if (jsc_update_jcb (h, job->lwj_id, JSC_RDL_ALLOC, jcb) != 0) {
+    if (jsc_update_jcb_obj (h, job->lwj_id, JSC_RDL_ALLOC, jcb) != 0) {
         flux_log (h, LOG_ERR, "error updating jcb");
         goto done;
     }

--- a/simulator/sim_execsrv.c
+++ b/simulator/sim_execsrv.c
@@ -81,7 +81,7 @@ static ctx_t *getctx (flux_t h)
 }
 
 //Given the kvs dir of a job, change the state of the job and timestamp the change
-static int update_job_state (ctx_t *ctx, kvsdir_t kvs_dir, char* state, double update_time)
+static int update_job_state (ctx_t *ctx, kvsdir_t *kvs_dir, char* state, double update_time)
 {
 	char *timer_key = NULL;
 
@@ -289,7 +289,7 @@ static int handle_queued_events (ctx_t *ctx)
 {
 	job_t *job = NULL;
 	int *jobid = NULL;
-	kvsdir_t kvs_dir;
+	kvsdir_t *kvs_dir;
 	flux_t h = ctx->h;
 	zlist_t *queued_events = ctx->queued_events;
 	zlist_t *running_jobs = ctx->running_jobs;

--- a/simulator/simulator.c
+++ b/simulator/simulator.c
@@ -202,7 +202,7 @@ int put_job_in_kvs (job_t *job)
 	return 0;
 }
 
-job_t *pull_job_from_kvs (kvsdir_t kvsdir)
+job_t *pull_job_from_kvs (kvsdir_t *kvsdir)
 {
 	job_t *job = blank_job();
 

--- a/simulator/simulator.h
+++ b/simulator/simulator.h
@@ -23,7 +23,7 @@ typedef struct {
 	int nnodes;
 	int ncpus;
 	double io_rate;
-	kvsdir_t kvs_dir;
+	kvsdir_t *kvs_dir;
 } job_t;
 
 sim_state_t *new_simstate ();
@@ -33,7 +33,7 @@ sim_state_t *json_to_sim_state(JSON o);
 int print_values (const char *key, void *item, void *argument);
 
 int put_job_in_kvs (job_t *job);
-job_t *pull_job_from_kvs (kvsdir_t kvs_dir);
+job_t *pull_job_from_kvs (kvsdir_t *kvs_dir);
 void free_job (job_t *job);
 job_t *blank_job ();
 int send_alive_request (flux_t h, const char* module_name);

--- a/simulator/submitsrv.c
+++ b/simulator/submitsrv.c
@@ -239,7 +239,7 @@ int schedule_next_job (flux_t h, sim_state_t *sim_state)
 	double *new_submit_mod_time;
 	JSON response;
 	int64_t new_jobid = -1;
-	kvsdir_t dir;
+	kvsdir_t *dir;
 	job_t *job;
 
 	//Get the next job to submit


### PR DESCRIPTION
kvsitr_t  is now a struct not a pointer to struct.

kvs callback typedefs changed names.  Eliminate places in simulator
where this was being cast, as doing so is a bit dangerous - changes
in prototype would be hidden.  Case in point, these functions are
expected to return an integer result and were declared with return
type void.

Use the (deprecated) jsc _obj interfaces