### PR TITLE
resrc: conform to RFC 7

### DIFF
--- a/resrc/resrc.h
+++ b/resrc/resrc.h
@@ -8,10 +8,10 @@
 #include <uuid/uuid.h>
 #include "src/common/libutil/shortjson.h"
 
-typedef struct resource_list *resource_list_t;
-typedef struct resources *resources_t;
-typedef struct resrc *resrc_t;
-typedef struct resrc_tree *resrc_tree_t;
+typedef struct resource_list resource_list_t;
+typedef struct resources resources_t;
+typedef struct resrc resrc_t;
+typedef struct resrc_tree resrc_tree_t;
 
 typedef enum {
     RESOURCE_INVALID,
@@ -27,47 +27,47 @@ typedef enum {
 /*
  * Return the type of the resouce
  */
-char *resrc_type (resrc_t resrc);
+char *resrc_type (resrc_t *resrc);
 
 /*
  * Return the name of the resouce
  */
-char *resrc_name (resrc_t resrc);
+char *resrc_name (resrc_t *resrc);
 
 /*
  * Return the id of the resouce
  */
-int64_t resrc_id (resrc_t resrc);
+int64_t resrc_id (resrc_t *resrc);
 
 /*
  * Return the size of the resource
  */
-size_t resrc_size (resrc_t resrc);
+size_t resrc_size (resrc_t *resrc);
 
 /*
  * Return the resource state as a string
  */
-char* resrc_state (resrc_t resrc);
+char* resrc_state (resrc_t *resrc);
 
 /*
  * Return the physical tree for the resouce
  */
-resrc_tree_t resrc_phys_tree (resrc_t resrc);
+resrc_tree_t *resrc_phys_tree (resrc_t *resrc);
 
 /*
  * Create a list of resource keys
  */
-resource_list_t resrc_new_id_list ();
+resource_list_t *resrc_new_id_list ();
 
 /*
  * Destroy a list of resource keys
  */
-void resrc_id_list_destroy (resource_list_t resrc_ids);
+void resrc_id_list_destroy (resource_list_t *resrc_ids);
 
 /*
  * Get the first element in the resource id list
  */
-char *resrc_list_first (resource_list_t rl);
+char *resrc_list_first (resource_list_t *rl);
 
 /*
  * Get the next element in the resource id list
@@ -82,13 +82,13 @@ size_t resrc_list_size ();
 /*
  * Create a new resource object
  */
-resrc_t resrc_new_resource (const char *type, const char *name, int64_t id,
-                            uuid_t uuid, size_t size);
+resrc_t *resrc_new_resource (const char *type, const char *name, int64_t id,
+                             uuid_t uuid, size_t size);
 
 /*
  * Create a copy of a resource object
  */
-resrc_t resrc_copy_resource (resrc_t resrc);
+resrc_t *resrc_copy_resource (resrc_t *resrc);
 
 /*
  * Destroy a resource object
@@ -99,32 +99,32 @@ void resrc_resource_destroy (void *object);
  * Create a hash table of all resources described by a configuration
  * file
  */
-resources_t resrc_generate_resources (const char *path, char*resource);
+resources_t *resrc_generate_resources (const char *path, char*resource);
 
 /*
  * Lookup a resource by id
  */
-resrc_t resrc_lookup (resources_t resrcs, char *resrc_id);
+resrc_t *resrc_lookup (resources_t *resrcs, char *resrc_id);
 
 /*
  * De-allocate the resources handle
  */
-void resrc_destroy_resources (resources_t resources);
+void resrc_destroy_resources (resources_t *resrcs);
 
 /*
  * Add the input resource to the json object
  */
-int resrc_to_json (JSON o, resrc_t resrc);
+int resrc_to_json (JSON o, resrc_t *resrc);
 
 /*
  * Print details of a specific resource
  */
-void resrc_print_resource (resrc_t resrc);
+void resrc_print_resource (resrc_t *resrc);
 
 /*
  * Provide a listing to stdout of every resource in hash table
  */
-void resrc_print_resources (resources_t resrcs);
+void resrc_print_resources (resources_t *resrcs);
 
 /*
  * Determine whether a specific resource has the required characteristics
@@ -134,7 +134,7 @@ void resrc_print_resources (resources_t resrcs);
  *                      otherwise find all possible resources matching type
  * Returns: true if the input resource has the required characteristics
  */
-bool resrc_match_resource (resrc_t resrc, resrc_t sample, bool available);
+bool resrc_match_resource (resrc_t *resrc, resrc_t *sample, bool available);
 
 /*
  * Search a table of resources for the requested type
@@ -147,56 +147,56 @@ bool resrc_match_resource (resrc_t resrc, resrc_t sample, bool available);
  *          found     - any resources found are added to this list
  *
  */
-int resrc_search_flat_resources (resources_t resrcs, resource_list_t found,
+int resrc_search_flat_resources (resources_t *resrcs, resource_list_t *found,
                                  JSON req_res, bool available);
 
 /*
  * Stage size elements of a resource
  */
-void resrc_stage_resrc(resrc_t resrc, size_t size);
+void resrc_stage_resrc(resrc_t *resrc, size_t size);
 
 /*
  * Allocate a resource to a job
  */
-int resrc_allocate_resource (resrc_t resrc, int64_t job_id);
+int resrc_allocate_resource (resrc_t *resrc, int64_t job_id);
 
 /*
  * Allocate a set of resources to a job
  */
-int resrc_allocate_resources (resources_t resrcs, resource_list_t resrc_ids,
+int resrc_allocate_resources (resources_t *resrcs, resource_list_t *resrc_ids,
                               int64_t job_id);
 
 /*
  * Reserve a resource for a job
  */
-int resrc_reserve_resource (resrc_t resrc, int64_t job_id);
+int resrc_reserve_resource (resrc_t *resrc, int64_t job_id);
 
 /*
  * Reserve a set of resources to a job
  */
-int resrc_reserve_resources (resources_t resrcs, resource_list_t resrc_ids,
+int resrc_reserve_resources (resources_t *resrcs, resource_list_t *resrc_ids,
                              int64_t job_id);
 
 /*
  * Create a json object containing the resources present in the input
  * list
  */
-JSON resrc_id_serialize (resources_t resrcs, resource_list_t resrc_ids);
+JSON resrc_id_serialize (resources_t *resrcs, resource_list_t *resrc_ids);
 
 /*
  * Remove a job allocation from a resource
  */
-int resrc_release_resource (resrc_t resrc, int64_t rel_job);
+int resrc_release_resource (resrc_t *resrc, int64_t rel_job);
 
 /*
  * Remove a job allocation from a set of resources
  */
-int resrc_release_resources (resources_t resrcs, resource_list_t resrc_ids,
+int resrc_release_resources (resources_t *resrcs, resource_list_t *resrc_ids,
                              int64_t rel_job);
 
 /*
  * Create a resrc_t object from a json object
  */
-resrc_t resrc_new_from_json (JSON o, resrc_t parent);
+resrc_t *resrc_new_from_json (JSON o, resrc_t *parent);
 
 #endif /* !FLUX_RESRC_H */

--- a/resrc/resrc_reqst.c
+++ b/resrc/resrc_reqst.c
@@ -38,43 +38,43 @@ struct resrc_reqst_list {
 };
 
 struct resrc_reqst {
-    resrc_reqst_t parent;
-    resrc_t resrc;
+    resrc_reqst_t *parent;
+    resrc_t *resrc;
     int64_t reqrd;
     int64_t nfound;
-    resrc_reqst_list_t children;
+    resrc_reqst_list_t *children;
 };
 
-static bool match_children (resrc_tree_list_t r_trees,
-                            resrc_reqst_list_t req_trees,
-                            resrc_tree_t parent_tree, bool available);
+static bool match_children (resrc_tree_list_t *r_trees,
+                            resrc_reqst_list_t *req_trees,
+                            resrc_tree_t *parent_tree, bool available);
 
 /***********************************************************************
  * Resource request
  ***********************************************************************/
 
-resrc_t resrc_reqst_resrc (resrc_reqst_t resrc_reqst)
+resrc_t *resrc_reqst_resrc (resrc_reqst_t *resrc_reqst)
 {
     if (resrc_reqst)
-        return (resrc_t)resrc_reqst->resrc;
+        return resrc_reqst->resrc;
     return NULL;
 }
 
-int64_t resrc_reqst_reqrd (resrc_reqst_t resrc_reqst)
+int64_t resrc_reqst_reqrd (resrc_reqst_t *resrc_reqst)
 {
     if (resrc_reqst)
         return resrc_reqst->reqrd;
     return -1;
 }
 
-int64_t resrc_reqst_nfound (resrc_reqst_t resrc_reqst)
+int64_t resrc_reqst_nfound (resrc_reqst_t *resrc_reqst)
 {
     if (resrc_reqst)
         return resrc_reqst->nfound;
     return -1;
 }
 
-int64_t resrc_reqst_add_found (resrc_reqst_t resrc_reqst, int64_t nfound)
+int64_t resrc_reqst_add_found (resrc_reqst_t *resrc_reqst, int64_t nfound)
 {
     if (resrc_reqst) {
         resrc_reqst->nfound += nfound;
@@ -83,14 +83,13 @@ int64_t resrc_reqst_add_found (resrc_reqst_t resrc_reqst, int64_t nfound)
     return -1;
 }
 
-void resrc_reqst_clear_found (resrc_reqst_t resrc_reqst)
+void resrc_reqst_clear_found (resrc_reqst_t *resrc_reqst)
 {
-    resrc_reqst_t child;
-
     if (resrc_reqst) {
         resrc_reqst->nfound = 0;
         if (resrc_reqst_num_children (resrc_reqst)) {
-            child = resrc_reqst_list_first (resrc_reqst->children);
+            resrc_reqst_t *child = resrc_reqst_list_first
+                (resrc_reqst->children);
             while (child) {
                 resrc_reqst_clear_found (child);
                 child = resrc_reqst_list_next (resrc_reqst->children);
@@ -99,21 +98,21 @@ void resrc_reqst_clear_found (resrc_reqst_t resrc_reqst)
     }
 }
 
-size_t resrc_reqst_num_children (resrc_reqst_t resrc_reqst)
+size_t resrc_reqst_num_children (resrc_reqst_t *resrc_reqst)
 {
     if (resrc_reqst)
-        return zlist_size (resrc_reqst->children->list);
+        return resrc_reqst_list_size (resrc_reqst->children);
     return 0;
 }
 
-resrc_reqst_list_t resrc_reqst_children (resrc_reqst_t resrc_reqst)
+resrc_reqst_list_t *resrc_reqst_children (resrc_reqst_t *resrc_reqst)
 {
     if (resrc_reqst)
         return resrc_reqst->children;
     return NULL;
 }
 
-int resrc_reqst_add_child (resrc_reqst_t parent, resrc_reqst_t child)
+int resrc_reqst_add_child (resrc_reqst_t *parent, resrc_reqst_t *child)
 {
     int rc = -1;
     if (parent) {
@@ -124,30 +123,28 @@ int resrc_reqst_add_child (resrc_reqst_t parent, resrc_reqst_t child)
     return rc;
 }
 
-resrc_reqst_t resrc_reqst_new (resrc_t resrc, int64_t qty)
+resrc_reqst_t *resrc_reqst_new (resrc_t *resrc, int64_t qty)
 {
-    resrc_reqst_t resrc_reqst = xzmalloc (sizeof (struct resrc_reqst));
+    resrc_reqst_t *resrc_reqst = xzmalloc (sizeof (resrc_reqst_t));
     if (resrc_reqst) {
         resrc_reqst->parent = NULL;
         resrc_reqst->resrc = resrc;
         resrc_reqst->reqrd = qty;
         resrc_reqst->nfound = 0;
-        resrc_reqst->children = resrc_reqst_new_list ();
-    } else {
-        oom ();
+        resrc_reqst->children = resrc_reqst_list_new ();
     }
 
     return resrc_reqst;
 }
 
-resrc_reqst_t resrc_reqst_from_json (JSON o, resrc_t parent)
+resrc_reqst_t *resrc_reqst_from_json (JSON o, resrc_t *parent)
 {
     int qty = 0;
     JSON ca = NULL;     /* array of child json objects */
     JSON co = NULL;     /* child json object */
-    resrc_t resrc = NULL;
-    resrc_reqst_t child_reqst = NULL;
-    resrc_reqst_t resrc_reqst = NULL;
+    resrc_t *resrc = NULL;
+    resrc_reqst_t *child_reqst = NULL;
+    resrc_reqst_t *resrc_reqst = NULL;
 
     if (!Jget_int (o, "req_qty", &qty) && (qty < 1))
         goto ret;
@@ -177,15 +174,41 @@ ret:
     return resrc_reqst;
 }
 
-void resrc_reqst_print (resrc_reqst_t resrc_reqst)
+void resrc_reqst_free (resrc_reqst_t *resrc_reqst)
 {
-    resrc_reqst_t child;
+    if (resrc_reqst) {
+        zlist_destroy (&(resrc_reqst->children->list));
+        free (resrc_reqst->children);
+        resrc_resource_destroy (resrc_reqst->resrc);
+        free (resrc_reqst);
+    }
+}
 
+void resrc_reqst_destroy (resrc_reqst_t *resrc_reqst)
+{
+    if (resrc_reqst) {
+        if (resrc_reqst->parent)
+            resrc_reqst_list_remove (resrc_reqst->parent->children, resrc_reqst);
+        if (resrc_reqst_num_children (resrc_reqst)) {
+            resrc_reqst_t *child = resrc_reqst_list_first
+                (resrc_reqst->children);
+            while (child) {
+                resrc_reqst_destroy (child);
+                child = resrc_reqst_list_next (resrc_reqst->children);
+            }
+        }
+        resrc_reqst_free (resrc_reqst);
+    }
+}
+
+void resrc_reqst_print (resrc_reqst_t *resrc_reqst)
+{
     if (resrc_reqst) {
         printf ("%ld of %ld ", resrc_reqst->nfound, resrc_reqst->reqrd);
         resrc_print_resource (resrc_reqst->resrc);
         if (resrc_reqst_num_children (resrc_reqst)) {
-            child = resrc_reqst_list_first (resrc_reqst->children);
+            resrc_reqst_t *child = resrc_reqst_list_first
+                (resrc_reqst->children);
             while (child) {
                 resrc_reqst_print (child);
                 child = resrc_reqst_list_next (resrc_reqst->children);
@@ -194,93 +217,71 @@ void resrc_reqst_print (resrc_reqst_t resrc_reqst)
     }
 }
 
-void resrc_reqst_destroy (resrc_reqst_t resrc_reqst)
-{
-    resrc_reqst_t child;
-
-    if (resrc_reqst) {
-        if (resrc_reqst->parent)
-            resrc_reqst_list_remove (resrc_reqst->parent->children, resrc_reqst);
-        if (resrc_reqst_num_children (resrc_reqst)) {
-            child = resrc_reqst_list_first (resrc_reqst->children);
-            while (child) {
-                resrc_reqst_destroy (child);
-                child = resrc_reqst_list_next (resrc_reqst->children);
-            }
-        }
-        resrc_reqst_list_destroy (resrc_reqst->children);
-        resrc_resource_destroy (resrc_reqst->resrc);
-        free (resrc_reqst);
-    }
-}
-
 /***********************************************************************
  * Resource request list
  ***********************************************************************/
 
-resrc_reqst_list_t resrc_reqst_new_list ()
+resrc_reqst_list_t *resrc_reqst_list_new ()
 {
-    resrc_reqst_list_t new_list = xzmalloc (sizeof (struct resrc_reqst_list));
+    resrc_reqst_list_t *new_list = xzmalloc (sizeof (resrc_reqst_list_t));
     new_list->list = zlist_new ();
     return new_list;
 }
 
-int resrc_reqst_list_append (resrc_reqst_list_t rrl, resrc_reqst_t rr)
+int resrc_reqst_list_append (resrc_reqst_list_t *rrl, resrc_reqst_t *rr)
 {
     if (rrl && rrl->list && rr)
         return zlist_append  (rrl->list, (void *) rr);
     return -1;
 }
 
-resrc_reqst_t resrc_reqst_list_first (resrc_reqst_list_t rrl)
+resrc_reqst_t *resrc_reqst_list_first (resrc_reqst_list_t *rrl)
 {
     if (rrl && rrl->list)
         return zlist_first (rrl->list);
     return NULL;
 }
 
-resrc_reqst_t resrc_reqst_list_next (resrc_reqst_list_t rrl)
+resrc_reqst_t *resrc_reqst_list_next (resrc_reqst_list_t *rrl)
 {
     if (rrl && rrl->list)
         return zlist_next (rrl->list);
     return NULL;
 }
 
-size_t resrc_reqst_list_size (resrc_reqst_list_t rrl)
+size_t resrc_reqst_list_size (resrc_reqst_list_t *rrl)
 {
     if (rrl && rrl->list)
         return zlist_size (rrl->list);
     return 0;
 }
 
-void resrc_reqst_list_remove (resrc_reqst_list_t rrl, resrc_reqst_t rr)
+void resrc_reqst_list_remove (resrc_reqst_list_t *rrl, resrc_reqst_t *rr)
 {
     zlist_remove (rrl->list, rr);
 }
 
-void resrc_reqst_list_destroy (resrc_reqst_list_t resrc_reqst_list)
+void resrc_reqst_list_destroy (resrc_reqst_list_t *resrc_reqst_list)
 {
-    zlist_t *child;
-
     if (resrc_reqst_list) {
-        if (zlist_size (resrc_reqst_list->list)) {
-            child = zlist_first (resrc_reqst_list->list);
+        if (resrc_reqst_list_size (resrc_reqst_list)) {
+            resrc_reqst_t *child = resrc_reqst_list_first (resrc_reqst_list);
             while (child) {
-                resrc_reqst_destroy ((resrc_reqst_t) child);
-                child = zlist_next (resrc_reqst_list->list);
+                resrc_reqst_destroy (child);
+                child = resrc_reqst_list_next (resrc_reqst_list);
             }
         }
-        zlist_destroy (&resrc_reqst_list->list);
+        zlist_destroy (&(resrc_reqst_list->list));
         free (resrc_reqst_list);
     }
 }
 
 
-static bool match_child (resrc_tree_list_t r_trees, resrc_reqst_t resrc_reqst,
-                         resrc_tree_t parent_tree, bool available)
+static bool match_child (resrc_tree_list_t *r_trees, resrc_reqst_t *resrc_reqst,
+                         resrc_tree_t *parent_tree, bool available)
 {
-    resrc_tree_t resrc_tree = NULL;
-    resrc_tree_t child_tree = NULL;
+    resrc_tree_t *resrc_tree = NULL;
+    resrc_tree_t *child_tree = NULL;
     bool found = false;
     bool success = false;
 
@@ -288,14 +289,14 @@ static bool match_child (resrc_tree_list_t r_trees, resrc_reqst_t resrc_reqst,
     while (resrc_tree) {
         found = false;
         if (resrc_match_resource (resrc_tree_resrc (resrc_tree),
-                                  resrc_reqst->resrc, available)) {
+                                  resrc_reqst_resrc (resrc_reqst), available)) {
             if (resrc_reqst_num_children (resrc_reqst)) {
                 if (resrc_tree_num_children (resrc_tree)) {
                     child_tree = resrc_tree_new (parent_tree,
                                                  resrc_tree_resrc (resrc_tree));
                     if (match_children (resrc_tree_children (resrc_tree),
-                                        resrc_reqst->children, child_tree,
-                                        available)) {
+                                        resrc_reqst_children (resrc_reqst),
+                                        child_tree, available)) {
                         resrc_reqst->nfound++;
                         found = true;
                         success = true;
@@ -338,11 +339,11 @@ static bool match_child (resrc_tree_list_t r_trees, resrc_reqst_t resrc_reqst,
  * cycles through all of the resource children and returns true if all
  * of the requested children were found
  */
-static bool match_children (resrc_tree_list_t r_trees,
-                            resrc_reqst_list_t req_trees,
-                            resrc_tree_t parent_tree, bool available)
+static bool match_children (resrc_tree_list_t *r_trees,
+                            resrc_reqst_list_t *req_trees,
+                            resrc_tree_t *parent_tree, bool available)
 {
-    resrc_reqst_t resrc_reqst = resrc_reqst_list_first (req_trees);
+    resrc_reqst_t *resrc_reqst = resrc_reqst_list_first (req_trees);
     bool found = false;
 
     while (resrc_reqst) {
@@ -363,12 +364,12 @@ static bool match_children (resrc_tree_list_t r_trees,
 }
 
 /* returns the number of composites found */
-int resrc_tree_search (resrc_tree_list_t resrcs_in, resrc_reqst_t resrc_reqst,
-                       resrc_tree_list_t found_trees, bool available)
+int resrc_tree_search (resrc_tree_list_t *resrcs_in, resrc_reqst_t *resrc_reqst,
+                       resrc_tree_list_t *found_trees, bool available)
 {
     int64_t nfound = 0;
-    resrc_tree_t new_tree = NULL;
-    resrc_tree_t resrc_tree;
+    resrc_tree_t *new_tree = NULL;
+    resrc_tree_t *resrc_tree;
 
     if (!resrcs_in || !found_trees || !resrc_reqst) {
         goto ret;

--- a/resrc/resrc_reqst.h
+++ b/resrc/resrc_reqst.h
@@ -9,8 +9,8 @@
 #include "resrc_tree.h"
 
 
-typedef struct resrc_reqst *resrc_reqst_t;
-typedef struct resrc_reqst_list *resrc_reqst_list_t;
+typedef struct resrc_reqst resrc_reqst_t;
+typedef struct resrc_reqst_list resrc_reqst_list_t;
 
 /***********************************************************************
  * Composite resource request
@@ -19,62 +19,67 @@ typedef struct resrc_reqst_list *resrc_reqst_list_t;
 /*
  * Return the resrc_t associated with this request
  */
-resrc_t resrc_reqst_resrc (resrc_reqst_t resrc_reqst);
+resrc_t *resrc_reqst_resrc (resrc_reqst_t *resrc_reqst);
 
 /*
  * Return the required number of resources in this request
  */
-int64_t resrc_reqst_reqrd (resrc_reqst_t resrc_reqst);
+int64_t resrc_reqst_reqrd (resrc_reqst_t *resrc_reqst);
 
 /*
  * Return the number of resources found for this request
  */
-int64_t resrc_reqst_nfound (resrc_reqst_t resrc_reqst);
+int64_t resrc_reqst_nfound (resrc_reqst_t *resrc_reqst);
 
 /*
  * Increment the number of resources found for this request
  */
-int64_t resrc_reqst_add_found (resrc_reqst_t resrc_reqst, int64_t nfound);
+int64_t resrc_reqst_add_found (resrc_reqst_t *resrc_reqst, int64_t nfound);
 
 /*
  * Clear the number of resources found for this request
  */
-void resrc_reqst_clear_found (resrc_reqst_t resrc_reqst);
+void resrc_reqst_clear_found (resrc_reqst_t *resrc_reqst);
 
 /*
  * Return the number of children in the resource request
  */
-size_t resrc_reqst_num_children (resrc_reqst_t resrc_reqst);
+size_t resrc_reqst_num_children (resrc_reqst_t *resrc_reqst);
 
 /*
  * Return the list of child resource requests for the resouce request input
  */
-resrc_reqst_list_t resrc_reqst_children (resrc_reqst_t resrc_reqst);
+resrc_reqst_list_t *resrc_reqst_children (resrc_reqst_t *resrc_reqst);
 
 /*
  * Add a child resource request to the input resource request
  */
-int resrc_reqst_add_child (resrc_reqst_t parent, resrc_reqst_t child);
+int resrc_reqst_add_child (resrc_reqst_t *parent, resrc_reqst_t *child);
 
 /*
  * Create a new resrc_reqst_t object
  */
-resrc_reqst_t resrc_reqst_new (resrc_t resrc, int64_t qty);
+resrc_reqst_t *resrc_reqst_new (resrc_t *resrc, int64_t qty);
 
 /*
  * Create a resrc_reqst_t object from a json object
  */
-resrc_reqst_t resrc_reqst_from_json (JSON o, resrc_t parent);
+resrc_reqst_t *resrc_reqst_from_json (JSON o, resrc_t *parent);
 
 /*
- * Print the resources in a resrc_reqst_t object
+ * Free a resrc_reqst_t object
  */
-void resrc_reqst_print (resrc_reqst_t resrc_reqst);
+void resrc_reqst_free (resrc_reqst_t *resrc_reqst);
 
 /*
  * Destroy a resrc_reqst_t object
  */
-void resrc_reqst_destroy (resrc_reqst_t resrc_reqst);
+void resrc_reqst_destroy (resrc_reqst_t *resrc_reqst);
+
+/*
+ * Print the resources in a resrc_reqst_t object
+ */
+void resrc_reqst_print (resrc_reqst_t *resrc_reqst);
 
 /***********************************************************************
  * Resource request list
@@ -82,37 +87,37 @@ void resrc_reqst_destroy (resrc_reqst_t resrc_reqst);
 /*
  * Create a new list of resrc_reqst_t objects
  */
-resrc_reqst_list_t resrc_reqst_new_list ();
+resrc_reqst_list_t *resrc_reqst_list_new ();
 
 /*
  * Append a resource reqst to the resource reqst list
  */
-int resrc_reqst_list_append (resrc_reqst_list_t rrl, resrc_reqst_t rr);
+int resrc_reqst_list_append (resrc_reqst_list_t *rrl, resrc_reqst_t *rr);
 
 /*
  * Get the first element in the resource reqst list
  */
-resrc_reqst_t resrc_reqst_list_first (resrc_reqst_list_t rrl);
+resrc_reqst_t *resrc_reqst_list_first (resrc_reqst_list_t *rrl);
 
 /*
  * Get the next element in the resource reqst list
  */
-resrc_reqst_t resrc_reqst_list_next (resrc_reqst_list_t rrl);
+resrc_reqst_t *resrc_reqst_list_next (resrc_reqst_list_t *rrl);
 
 /*
  * Get the number of elements in the resource reqst list
  */
-size_t resrc_reqst_list_size (resrc_reqst_list_t rrl);
+size_t resrc_reqst_list_size (resrc_reqst_list_t *rrl);
 
 /*
  * Remove an item from the resource reqst list
  */
-void resrc_reqst_list_remove (resrc_reqst_list_t rrl, resrc_reqst_t rr);
+void resrc_reqst_list_remove (resrc_reqst_list_t *rrl, resrc_reqst_t *rr);
 
 /*
  * Destroy a resrc_reqst_list_t object
  */
-void resrc_reqst_list_destroy (resrc_reqst_list_t rrl);
+void resrc_reqst_list_destroy (resrc_reqst_list_t *rrl);
 
 /*
  * Search a list of resource trees for a specific, composite resource
@@ -124,9 +129,9 @@ void resrc_reqst_list_destroy (resrc_reqst_list_t rrl);
  * Returns: the number of matching resource composites found
  *          found       - any resources found are added to this list
  */
-int resrc_tree_search (resrc_tree_list_t resrc_trees,
-                       resrc_reqst_t sample_tree,
-                       resrc_tree_list_t found_trees, bool available);
+int resrc_tree_search (resrc_tree_list_t *resrc_trees,
+                       resrc_reqst_t *sample_tree,
+                       resrc_tree_list_t *found_trees, bool available);
 
 
 #endif /* !FLUX_RESRC_REQST_H */

--- a/resrc/resrc_tree.h
+++ b/resrc/resrc_tree.h
@@ -7,7 +7,7 @@
 
 #include "resrc.h"
 
-typedef struct resrc_tree_list *resrc_tree_list_t;
+typedef struct resrc_tree_list resrc_tree_list_t;
 
 /***********************************************************************
  * Resource tree API
@@ -15,67 +15,67 @@ typedef struct resrc_tree_list *resrc_tree_list_t;
 /*
  * Return the resrc_t associated with this tree
  */
-resrc_t resrc_tree_resrc (resrc_tree_t resrc_tree);
+resrc_t *resrc_tree_resrc (resrc_tree_t *resrc_tree);
 
 /*
  * Return the number of children in the resource tree
  */
-size_t resrc_tree_num_children (resrc_tree_t resrc_tree);
+size_t resrc_tree_num_children (resrc_tree_t *resrc_tree);
 
 /*
  * Return the list of child resource trees for the resouce tree input
  */
-resrc_tree_list_t resrc_tree_children (resrc_tree_t resrc_tree);
+resrc_tree_list_t *resrc_tree_children (resrc_tree_t *resrc_tree);
 
 /*
  * Add a child resource tree to the input resource tree
  */
-int resrc_tree_add_child (resrc_tree_t parent, resrc_tree_t child);
+int resrc_tree_add_child (resrc_tree_t *parent, resrc_tree_t *child);
 
 /*
  * Create a new resrc_tree_t object
  */
-resrc_tree_t resrc_tree_new (resrc_tree_t parent, resrc_t resrc);
+resrc_tree_t *resrc_tree_new (resrc_tree_t *parent, resrc_t *resrc);
 
 /*
  * Return a copy of the input resource tree
  */
-resrc_tree_t resrc_tree_copy (resrc_tree_t resrc_tree);
+resrc_tree_t *resrc_tree_copy (resrc_tree_t *resrc_tree);
 
 /*
  * Free a resrc_tree_t object
  */
-void resrc_tree_free (resrc_tree_t resrc_tree);
+void resrc_tree_free (resrc_tree_t *resrc_tree);
 
 /*
  * Destroy an entire tree of resrc_tree_t objects
  */
-void resrc_tree_destroy (resrc_tree_t resrc_tree);
+void resrc_tree_destroy (resrc_tree_t *resrc_tree);
 
 /*
  * Print the resources in a resrc_tree_t object
  */
-void resrc_tree_print (resrc_tree_t resrc_tree);
+void resrc_tree_print (resrc_tree_t *resrc_tree);
 
 /*
  * Add the input resource tree to the json object
  */
-int resrc_tree_serialize (JSON o, resrc_tree_t rt);
+int resrc_tree_serialize (JSON o, resrc_tree_t *resrc_tree);
 
 /*
  * Allocate all the resources in a resource tree
  */
-int resrc_tree_allocate (resrc_tree_t rt, int64_t job_id);
+int resrc_tree_allocate (resrc_tree_t *resrc_tree, int64_t job_id);
 
 /*
  * Reserve all the resources in a resource tree
  */
-int resrc_tree_reserve (resrc_tree_t rt, int64_t job_id);
+int resrc_tree_reserve (resrc_tree_t *resrc_tree, int64_t job_id);
 
 /*
  * Release all the resources in a resource tree
  */
-int resrc_tree_release (resrc_tree_t rt, int64_t job_id);
+int resrc_tree_release (resrc_tree_t *resrc_tree, int64_t job_id);
 
 /***********************************************************************
  * Resource tree list
@@ -83,58 +83,63 @@ int resrc_tree_release (resrc_tree_t rt, int64_t job_id);
 /*
  * Create a new list of resrc_tree_t objects
  */
-resrc_tree_list_t resrc_tree_list_new ();
+resrc_tree_list_t *resrc_tree_list_new ();
 
 /*
  * Append a resource tree to the resource tree list
  */
-int resrc_tree_list_append (resrc_tree_list_t rtl, resrc_tree_t rt);
+int resrc_tree_list_append (resrc_tree_list_t *rtl, resrc_tree_t *rt);
 
 /*
  * Get the first element in the resource tree list
  */
-resrc_tree_t resrc_tree_list_first (resrc_tree_list_t rtl);
+resrc_tree_t *resrc_tree_list_first (resrc_tree_list_t *rtl);
 
 /*
  * Get the next element in the resource tree list
  */
-resrc_tree_t resrc_tree_list_next (resrc_tree_list_t rtl);
+resrc_tree_t *resrc_tree_list_next (resrc_tree_list_t *rtl);
 
 /*
  * Get the number of elements in the resource tree list
  */
-size_t resrc_tree_list_size (resrc_tree_list_t rtl);
+size_t resrc_tree_list_size (resrc_tree_list_t *rtl);
+
+/*
+ * Remove an item from the resource tree list
+ */
+void resrc_tree_list_remove (resrc_tree_list_t *rtl, resrc_tree_t *rt);
 
 /*
  * Free memory of a resrc_tree_list_t object
  * Does not recursively free
  */
-void resrc_tree_list_free (resrc_tree_list_t resrc_tree_list);
+void resrc_tree_list_free (resrc_tree_list_t *resrc_tree_list);
 
 /*
  * Destroy a resrc_tree_list_t object including all children
  */
-void resrc_tree_list_destroy (resrc_tree_list_t rtl);
+void resrc_tree_list_destroy (resrc_tree_list_t *rtl);
 
 /*
  * Add the input list of resource trees to the json object
  */
-int resrc_tree_list_serialize (JSON o, resrc_tree_list_t rtl);
+int resrc_tree_list_serialize (JSON o, resrc_tree_list_t *rtl);
 
 /*
  * Allocate all the resources in a list of resource trees
  */
-int resrc_tree_list_allocate (resrc_tree_list_t rtl, int64_t job_id);
+int resrc_tree_list_allocate (resrc_tree_list_t *rtl, int64_t job_id);
 
 /*
  * Reserve all the resources in a list of resource trees
  */
-int resrc_tree_list_reserve (resrc_tree_list_t rtl, int64_t job_id);
+int resrc_tree_list_reserve (resrc_tree_list_t *rtl, int64_t job_id);
 
 /*
  * Release all the resources in a list of resource trees
  */
-int resrc_tree_list_release (resrc_tree_list_t rtl, int64_t job_id);
+int resrc_tree_list_release (resrc_tree_list_t *rtl, int64_t job_id);
 
 
 #endif /* !FLUX_RESRC_TREE_H */

--- a/resrc/test/tresrc.c
+++ b/resrc/test/tresrc.c
@@ -47,20 +47,21 @@ u_int64_t get_time() {
         + (t.tv_usec - start_time.tv_usec);
 }
 
-static void test_select_children (resrc_tree_t rt)
+static void test_select_children (resrc_tree_t *rt)
 {
     if (rt) {
-        resrc_t resrc = resrc_tree_resrc (rt);
+        resrc_t *resrc = resrc_tree_resrc (rt);
         if (strcmp (resrc_type(resrc), "memory")) {
             resrc_stage_resrc (resrc, 1);
         } else {
             resrc_stage_resrc (resrc, 100);
         }
         if (resrc_tree_num_children (rt)) {
-            resrc_tree_t child = resrc_tree_list_first (resrc_tree_children(rt));
+            resrc_tree_t *child = resrc_tree_list_first (
+                resrc_tree_children (rt));
             while (child) {
                 test_select_children (child);
-                child = resrc_tree_list_next (resrc_tree_children(rt));
+                child = resrc_tree_list_next (resrc_tree_children (rt));
             }
         }
     }
@@ -69,11 +70,11 @@ static void test_select_children (resrc_tree_t rt)
 /*
  * Select some resources from the found trees
  */
-static resrc_tree_list_t test_select_resources (resrc_tree_list_t found_trees,
-                                                int select)
+static resrc_tree_list_t *test_select_resources (resrc_tree_list_t *found_trees,
+                                                 int select)
 {
-    resrc_tree_list_t selected_res = resrc_tree_list_new ();
-    resrc_tree_t rt;
+    resrc_tree_list_t *selected_res = resrc_tree_list_new ();
+    resrc_tree_t *rt;
     int count = 1;
 
     rt = resrc_tree_list_first (found_trees);
@@ -104,13 +105,13 @@ int main (int argc, char *argv[])
     JSON memory = NULL;
     JSON o = NULL;
     JSON req_res = NULL;
-    resources_t resrcs = NULL;
-    resrc_t resrc = NULL;
-    resrc_reqst_t resrc_reqst = NULL;
-    resrc_tree_list_t found_trees = resrc_tree_list_new ();
-    resrc_tree_list_t selected_trees;
-    resrc_tree_t found_tree = NULL;
-    resrc_tree_t resrc_tree = NULL;
+    resources_t *resrcs = NULL;
+    resrc_t *resrc = NULL;
+    resrc_reqst_t *resrc_reqst = NULL;
+    resrc_tree_list_t *found_trees = resrc_tree_list_new ();
+    resrc_tree_list_t *selected_trees;
+    resrc_tree_t *found_tree = NULL;
+    resrc_tree_t *resrc_tree = NULL;
 
     plan (14);
     if (filename == NULL || *filename == '\0')

--- a/sched/schedplugin1.c
+++ b/sched/schedplugin1.c
@@ -47,10 +47,13 @@
 #include "resrc_reqst.h"
 #include "schedsrv.h"
 
+//TODO: this plugin inherently must know the inner structure of the opaque
+//types, something we need to think about
+typedef struct zhash_t resources;
 
-static bool select_children (flux_t h, resrc_tree_list_t found_children,
-                             resrc_reqst_list_t reqst_children,
-                             resrc_tree_t parent_tree);
+static bool select_children (flux_t h, resrc_tree_list_t *found_children,
+                             resrc_reqst_list_t *reqst_children,
+                             resrc_tree_t *parent_tree);
 
 /*
  * find_resources() identifies the all of the resource candidates for
@@ -63,13 +66,13 @@ static bool select_children (flux_t h, resrc_tree_list_t found_children,
  * Returns: a list of resource trees satisfying the job's request,
  *                   or NULL if none (or not enough) are found
  */
-resrc_tree_list_t find_resources (flux_t h, resources_t resrcs,
-                                  resrc_reqst_t resrc_reqst)
+resrc_tree_list_t *find_resources (flux_t h, resources_t *resrcs,
+                                   resrc_reqst_t *resrc_reqst)
 {
     int64_t nfound = 0;
-    resrc_t resrc = NULL;
-    resrc_tree_list_t found_trees = NULL;
-    resrc_tree_t resrc_tree = NULL;
+    resrc_t *resrc = NULL;
+    resrc_tree_list_t *found_trees = NULL;
+    resrc_tree_t *resrc_tree = NULL;
 
     if (!resrcs || !resrc_reqst) {
         flux_log (h, LOG_ERR, "%s: invalid arguments", __FUNCTION__);
@@ -101,12 +104,12 @@ ret:
     return found_trees;
 }
 
-static bool select_child (flux_t h, resrc_tree_list_t found_children,
-                          resrc_reqst_t child_reqst,
-                          resrc_tree_t parent_tree)
+static bool select_child (flux_t h, resrc_tree_list_t *found_children,
+                          resrc_reqst_t *child_reqst,
+                          resrc_tree_t *parent_tree)
 {
-    resrc_tree_t resrc_tree = NULL;
-    resrc_tree_t child_tree = NULL;
+    resrc_tree_t *resrc_tree = NULL;
+    resrc_tree_t *child_tree = NULL;
     bool selected = false;
 
     resrc_tree = resrc_tree_list_first (found_children);
@@ -167,11 +170,11 @@ ret:
 }
 
 
-static bool select_children (flux_t h, resrc_tree_list_t found_children,
-                             resrc_reqst_list_t reqst_children,
-                             resrc_tree_t parent_tree)
+static bool select_children (flux_t h, resrc_tree_list_t *found_children,
+                             resrc_reqst_list_t *reqst_children,
+                             resrc_tree_t *parent_tree)
 {
-    resrc_reqst_t child_reqst = resrc_reqst_list_first (reqst_children);
+    resrc_reqst_t *child_reqst = resrc_reqst_list_first (reqst_children);
     bool selected = false;
 
     while (child_reqst) {
@@ -203,14 +206,14 @@ static bool select_children (flux_t h, resrc_tree_list_t found_children,
  * Returns: a list of selected resource trees, or null if none (or not enough)
  *          are selected
  */
-resrc_tree_list_t select_resources (flux_t h, resrc_tree_list_t found_trees,
-                                    resrc_reqst_t resrc_reqst)
+resrc_tree_list_t *select_resources (flux_t h, resrc_tree_list_t *found_trees,
+                                     resrc_reqst_t *resrc_reqst)
 {
     int64_t reqrd;
-    resrc_t resrc;
-    resrc_tree_list_t selected_res = NULL;
-    resrc_tree_t new_tree = NULL;
-    resrc_tree_t rt;
+    resrc_t *resrc;
+    resrc_tree_list_t *selected_res = NULL;
+    resrc_tree_t *new_tree = NULL;
+    resrc_tree_t *rt;
 
     if (!resrc_reqst) {
         flux_log (h, LOG_ERR, "%s: called with empty request", __FUNCTION__);
@@ -254,7 +257,7 @@ resrc_tree_list_t select_resources (flux_t h, resrc_tree_list_t found_trees,
         resrc_tree_list_destroy (selected_res);
     }
 
-    return (resrc_tree_list_t)selected_res;
+    return selected_res;
 }
 
 MOD_NAME ("sched.plugin1");

--- a/sched/schedsrv.c
+++ b/sched/schedsrv.c
@@ -65,12 +65,11 @@ static int job_status_cb (JSON jcb, void *arg, int errnum);
  *                                                                            *
  ******************************************************************************/
 
-typedef resrc_tree_list_t (*find_f) (flux_t h, resources_t resrcs,
-                                            resrc_reqst_t resrc_reqst);
+typedef resrc_tree_list_t *(*find_f) (flux_t h, resources_t *resrcs,
+                                      resrc_reqst_t *resrc_reqst);
 
-typedef resrc_tree_list_t (*sel_f) (flux_t h,
-                                              resrc_tree_list_t resrc_trees,
-                                              resrc_reqst_t resrc_reqst);
+typedef resrc_tree_list_t *(*sel_f) (flux_t h, resrc_tree_list_t *resrc_trees,
+                                     resrc_reqst_t *resrc_reqst);
 
 typedef struct sched_ops {
     void         *dso;                /* Scheduler plug-in DSO handle */
@@ -79,7 +78,7 @@ typedef struct sched_ops {
 } sched_ops_t;
 
 typedef struct {
-    resources_t   root_resrcs;        /* resrcs object pointing to the root */
+    resources_t  *root_resrcs;        /* resrcs object pointing to the root */
     char         *root_uri;           /* Name of the root of the RDL hierachy */
 } rdlctx_t;
 
@@ -609,9 +608,9 @@ int schedule_job (ssrvctx_t *ctx, flux_lwj_t *job)
     flux_t h = ctx->h;
     int rc = -1;
     int64_t nnodes = 0;
-    resrc_reqst_t resrc_reqst = NULL;
-    resrc_tree_list_t found_trees = NULL;
-    resrc_tree_list_t selected_trees = NULL;
+    resrc_reqst_t *resrc_reqst = NULL;
+    resrc_tree_list_t *found_trees = NULL;
+    resrc_tree_list_t *selected_trees = NULL;
 
     /*
      * Require at least one task per node, and

--- a/sched/schedsrv.h
+++ b/sched/schedsrv.h
@@ -58,7 +58,7 @@ typedef struct {
     job_state_t state;   /*!< current job state */
     bool        reserve; /*!< reserve resources for job if true */
     flux_res_t *req;     /*!< resources requested by this LWJ */
-    resrc_tree_list_t resrc_trees; /*!< resources allocated to this LWJ */
+    resrc_tree_list_t *resrc_trees; /*!< resources allocated to this LWJ */
 } flux_lwj_t;
 
 #endif /* SCHEDSRV_H */


### PR DESCRIPTION
Essentially undoes the 6bdf47c2cf36b3d5826dbf70dceabc3b3167b7ae commit
and changes the resrc and sched code to comply with the decision in
RFC7 that abstract types SHOULD NOT be defined as pointers to
incomplete types.