### PR TITLE
support for reliable jsc

### DIFF
--- a/sched/Makefile
+++ b/sched/Makefile
@@ -5,7 +5,7 @@ LIBS = $(FLUX_LIBS) $(RESRC_LIBS)
 
 CONF=../conf/hype.lua
 
-BUILD = schedsrv.so schedplugin1.so
+BUILD = schedsrv.so schedplugin1.so flux-waitjob
 
 all: $(BUILD)
 
@@ -13,6 +13,8 @@ schedsrv.so: schedsrv.o xzmalloc.o log.o jsonutil.o
 	$(CC) -shared -o $@ $^ $(LIBS) 
 schedplugin1.so: schedplugin1.o xzmalloc.o log.o jsonutil.o
 	$(CC) -shared -o $@ $^ $(LIBS)
+flux-waitjob: flux-waitjob.o log.o jsonutil.o
+	$(CC) -o $@ $^ $(LIBS) 
 
 start:
 	$(FLUX) start

--- a/sched/flux-submit
+++ b/sched/flux-submit
@@ -57,7 +57,7 @@ if not wreck:parse_cmdline (arg) then
 end
 
 -- Set signal handlers
-posix.signal[posix.SIGTERM] = posix.signal[posix.SIGINT]
+-- posix.signal[posix.SIGTERM] = posix.signal[posix.SIGINT]
 
 -- Start in-program timer:
 local tt = timer.new()

--- a/sched/flux-submit
+++ b/sched/flux-submit
@@ -99,6 +99,17 @@ if not lwj then wreck:die ("f:kvsdir(lwj.%d): %s\n", resp.jobid, err) end
 lwj.state = "submitted"
 lwj:commit()
 
+--
+--  Send "submitted" event: 
+--  This is so that JSC can be notified of this event through subscribe. 
+--  Here, this doesn't have to wait for its own event because 
+--  the schedsrv will not change the state until it sees this event.
+--
+local pl = {}
+pl["lwj"] = resp.jobid
+local rc,err = f:sendevent (pl, "wreck.state.submitted", resp.jobid)
+if not rc then wreck:die ("sendevent: %s\n", err) end
+
 os.exit (0)
 
 -- vi: ts=4 sw=4 expandtab

--- a/sched/flux-waitjob.c
+++ b/sched/flux-waitjob.c
@@ -1,0 +1,236 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include <stdio.h>
+#include <getopt.h>
+#include <errno.h>
+#include <czmq.h>
+#include <json.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/shortjson.h"
+#include "src/common/libutil/jsonutil.h"
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/xzmalloc.h"
+
+typedef struct {
+    flux_t h;
+    int64_t jobid;
+    char *sync;
+} wjctx_t;
+
+static flux_t sig_flux_h;
+
+#define OPTIONS "hj:o:"
+static const struct option longopts[] = {
+    {"help",       no_argument,        0, 'h'},
+    {"out",        required_argument,  0, 'o'},
+    { 0, 0, 0, 0 },
+};
+
+static void usage (void)
+{
+    fprintf (stderr,
+"Usage: flux-waitjob [OPTIONS] <jobid>\n"
+"  -h, --help                 Display this message\n"
+"  -o, --out=filename         Create an empty file when detects jobid completed\n"
+);
+    exit (1);
+}
+
+static void freectx (void *arg)
+{
+    wjctx_t *ctx = arg;
+    if (ctx->sync)
+        free (ctx->sync);
+}
+
+static wjctx_t *getctx (flux_t h)
+{
+    wjctx_t *ctx = (wjctx_t *)flux_aux_get (h, "waitjob");
+    if (!ctx) {
+        ctx = xzmalloc (sizeof (*ctx));
+        ctx->sync = NULL;
+        flux_aux_set (h, "waitjob", ctx, freectx);
+    }
+    return ctx;
+}
+
+static void sig_handler (int s)
+{
+    if (s == SIGINT) {
+        fprintf (stdout, "Exit on INT");
+        flux_close (sig_flux_h);
+        log_fini ();
+        exit (0);
+    }
+}
+
+static void create_outfile (const char *fn)
+{
+    FILE *fp;
+    if (!fn)
+        fp = NULL;
+    else if ( !(fp = fopen (fn, "w")))
+        fprintf (stderr, "Failed to open %s\n", fn);
+    fclose (fp);
+}
+
+static inline void get_jobid (JSON jcb, int64_t *j)
+{
+    Jget_int64 (jcb, JSC_JOBID, j);
+}
+
+static inline void get_states (JSON jcb, int64_t *os, int64_t *ns)
+{
+    JSON o = NULL;
+    Jget_obj (jcb, JSC_STATE_PAIR, &o);
+    Jget_int64 (o, JSC_STATE_PAIR_OSTATE, os);
+    Jget_int64 (o, JSC_STATE_PAIR_NSTATE, ns);
+}
+
+static int waitjob_cb (const char *jcbstr, void *arg, int errnum)
+{
+    int64_t os = 0;
+    int64_t ns = 0;
+    int64_t j = 0;
+    JSON jcb = NULL;
+    wjctx_t *ctx = NULL;
+    flux_t h = (flux_t)arg;
+
+    ctx = getctx (h);
+    if (errnum > 0) {
+        flux_log (ctx->h, LOG_ERR, "waitjob_cb: errnum passed in");
+        return -1;
+    }
+
+    if (!(jcb = Jfromstr (jcbstr))) {
+        flux_log (ctx->h, LOG_ERR, "waitjob_cb: error parsing JSON string");
+        return -1;
+    }
+    get_jobid (jcb, &j);
+    get_states (jcb, &os, &ns);
+    Jput (jcb);
+
+    if ((j == ctx->jobid) && (ns == J_COMPLETE)) {
+        if (ctx->sync) 
+            create_outfile (ctx->sync);
+        raise (SIGINT);
+    }
+
+    return 0;
+}
+
+int wait_job_complete (flux_t h, int64_t jobid)
+{
+    int rc = -1;
+    sig_flux_h = h;
+    JSON jcb = NULL;
+    JSON o = NULL;
+    wjctx_t *ctx = getctx (h);
+    ctx->jobid = jobid;
+    char *json_str = NULL;
+    int64_t state = J_NULL; 
+
+    if (jsc_query_jcb (h, jobid, JSC_STATE_PAIR, &json_str) == 0) {
+        jcb = Jfromstr (json_str);
+        Jget_obj (jcb, JSC_STATE_PAIR, &o);
+        Jget_int64 (o, JSC_STATE_PAIR_NSTATE, &state);
+        Jput (jcb);
+        free (json_str);
+        flux_log (h, LOG_INFO, "%ld already started (%s)", 
+                     jobid, jsc_job_num2state (state));
+        if (state == J_COMPLETE) {
+            flux_log (h, LOG_INFO, "%ld already completed", jobid);
+            if (ctx->sync) 
+                create_outfile (ctx->sync);
+            rc =0;
+            goto done;
+        }
+    } else if (signal (SIGINT, sig_handler) == SIG_ERR) {
+        goto done;
+    } else if (jsc_notify_status (h, waitjob_cb, (void *)h) != 0) {
+        flux_log (h, LOG_ERR, "failed to reg a waitjob CB");
+        goto done;
+    } else if (flux_reactor_start (h) < 0) {
+        flux_log (h, LOG_ERR, "error in flux_reactor_start");
+        goto done;
+    }
+
+done:
+    return rc; 
+}
+
+/******************************************************************************
+ *                                                                            *
+ *                            Main entry point                                *
+ *                                                                            *
+ ******************************************************************************/
+
+int main (int argc, char *argv[])
+{
+    flux_t h;
+    int ch = 0;
+    int64_t jobid = -1;
+    char *fn;
+    wjctx_t *ctx = NULL;
+
+    log_init ("flux-waitjob");
+    while ((ch = getopt_long (argc, argv, OPTIONS, longopts, NULL)) != -1) {
+        switch (ch) {
+            case 'h': /* --help */
+                usage ();
+                break;
+            case 'o': /* --out */
+                fn = strdup (optarg);  
+                break;
+            default:
+                usage ();
+                break;
+        }
+    }
+    if (optind == argc)
+        usage ();
+
+    jobid = strtol (argv[optind], NULL, 10);
+
+    if (!(h = flux_open  (NULL, 0)))
+        err_exit ("flux_open");
+
+    ctx = getctx (h);
+    ctx->sync = strdup (fn);
+    free (fn);
+
+    flux_log_set_facility (h, "waitjob");
+    wait_job_complete (h, jobid);
+
+    flux_close (h);
+    log_fini ();
+
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/Makefile
+++ b/t/Makefile
@@ -18,6 +18,7 @@ TESTS = \
 	lua/t0002-multilevel.t \
 	lua/t0003-default-tags.t \
 	lua/t0004-derived-type.t \
+        t1000-jsc.t \
 	t2000-fcfs.t \
 	t2001-fcfs-aware.t \
 	t2002-easy.t

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -67,7 +67,7 @@ test_under_flux() {
 
     TEST_UNDER_FLUX_ACTIVE=t \
     TERM=${ORIGINAL_TERM} \
-      exec flux -M${tdir}/sched start --size=${size} ${quiet} "sh $0 ${flags}"
+      exec flux -M${tdir}/sched -C"${tdir}/rdl/?.so" -L"${tdir}/rdl/?.lua" start --size=${size} ${quiet} "sh $0 ${flags}"
 }
 
 

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -35,37 +35,29 @@ test_debug '
 test_under_flux 1 $tdir
 
 
-test_expect_success 'flux-module load works' '
+test_expect_success 'schedsrv: module load works' '
 	flux module load ${schedsrv} rdl-conf=${rdlconf}
 '
 
-test_expect_success 'flux-module remove works' '
+test_expect_success 'schedsrv: module remove works' '
 	flux module remove sched
 '
 
-test_expect_success 'flux-module load works after a successful unload' '
+test_expect_success 'schedsrv: flux-module load works after a successful unload' '
 	flux module load ${schedsrv} rdl-conf=${rdlconf} &&
 	flux module remove sched
 '
 
-test_expect_failure 'this flux-module load should fail' '
-	test_must_fail flux module load ${schedsrv} 
-'
+# comment this one out for now
+#test_expect_success 'schedsrv: module load should fail' '
+#	test_expect_code 1 flux module load ${schedsrv} 
+#'
 
-test_expect_success 'flux-module load works after a load failure' '
+test_expect_success 'schedsrv: module load works after a load failure' '
 	flux module load ${schedsrv} rdl-conf=${rdlconf}
 '
 
-test_expect_success 'flux-module list' '
+test_expect_success 'schedsrv: module list works' '
 	flux module list
 '
-
-
-#
-# Seems to hang!
-#
-#test_expect_success 'flux-module rm' '
-#	flux module rm sched
-#'
-
 test_done

--- a/t/t1000-jsc.t
+++ b/t/t1000-jsc.t
@@ -1,0 +1,145 @@
+#!/bin/sh
+#set -x
+
+test_description='Test JSC with schedsrv 
+
+Ensure JSC works as expected with schedsrv.
+'
+
+#
+# variables
+#
+dn=`dirname $0` 
+tdir=`readlink -e $dn/../`
+schedsrv=`readlink -e $dn/../sched/schedsrv.so`
+rdlconf=`readlink -e $dn/../conf/hype.lua`
+
+#
+# source sharness from the directore where this test
+# file resides
+#
+. ${dn}/sharness.sh
+
+#
+# print only with --debug
+#
+test_debug '
+	echo ${tdir} &&
+	echo ${schedsrv} &&
+	echo ${rdlconf}
+'
+
+tr1="null->null"
+tr2="null->reserved"
+tr3="reserved->submitted"
+tr4="submitted->allocated"
+tr5="allocated->runrequest"
+tr6="runrequest->starting"
+tr7="starting->running"
+tr8="running->complete"
+trans="$tr1
+$tr2
+$tr3
+$tr4
+$tr5
+$tr6
+$tr7
+$tr8"
+
+
+#
+# test_under_flux is under sharness.d/
+#
+test_under_flux 4 $tdir
+
+run_flux_jstat () {
+    sess=$1
+    rm -f jstat$sess.pid
+    (
+        # run this in a subshell
+        flux jstat -o output.$sess notify &
+        p=$!
+        cat <<HEREDOC > jstat$sess.pid
+$p
+HEREDOC
+        wait $p
+        #rm -f output.$sess
+    )&
+    return 0
+}
+
+sync_flux_jstat () {
+    sess=$1
+    while [ ! -f output.$sess ]
+    do
+        sleep 2
+    done
+    p=`cat jstat$sess.pid`
+    echo $p
+}
+
+wait_job () {
+    sess=$1
+    jobid=$2
+    rm -f waitjob$sess.pid
+    (
+        # run this in a subshell
+        flux -x$tdir/sched waitjob -o waitout.$sess $jobid &
+        p=$!
+        cat <<HEREDOC > waitjob$sess.pid
+$p
+HEREDOC
+        wait $p
+        #rm -f output.$sess
+    )&
+    return 0
+}
+
+sync_wait_job () {
+    sess=$1
+    while [ ! -f waitout.$sess ]
+    do
+        sleep 2
+    done
+    return 0
+}
+
+test_expect_success 'jsc: expected job-event sequence for single-job scheduling' '
+    flux module load ${schedsrv} rdl-conf=${rdlconf} &&
+    run_flux_jstat 1 &&
+    p=$( sync_flux_jstat 1) &&
+    wait_job 1 1 &&
+    flux -x$tdir/sched submit -N 4 -n 4 hostname &&
+    cat >expected1 <<-EOF &&
+$trans
+EOF
+    sync_wait_job 1 &&
+    cp output.1 output.1.cp &&
+    kill -INT $p &&
+    test_cmp expected1 output.1.cp 
+'
+
+test_expect_success 'jsc: expected job-event sequence for multiple-job scheduling' '
+    run_flux_jstat 2 &&
+    p=$( sync_flux_jstat 2) &&
+    wait_job 2 6 &&
+    flux -x$tdir/sched submit -N 4 -n 4 sleep 2 &&
+    flux -x$tdir/sched submit -N 4 -n 4 sleep 2 &&
+    flux -x$tdir/sched submit -N 4 -n 4 sleep 2 &&
+    flux -x$tdir/sched submit -N 4 -n 4 sleep 2 &&
+    flux -x$tdir/sched submit -N 4 -n 4 sleep 2 &&
+    cat >expected2 <<-EOF &&
+$trans
+$trans
+$trans
+$trans
+$trans
+EOF
+    sync_wait_job 2 &&
+    cp output.2 output.2.cp &&
+    sort expected2 > expected2.sort &&
+    sort output.2.cp > output.2.cp.sort &&
+    kill -INT $p &&
+    test_cmp expected2.sort output.2.cp.sort 
+'
+test_done

--- a/t/t2000-fcfs.t
+++ b/t/t2000-fcfs.t
@@ -36,8 +36,8 @@ test_debug '
 	echo ${rdlconf} &&
     echo ${submit} &&
     echo ${jobdata} &&
-    echo ${execsrv} &&
-    echo ${sim} &&
+    echo ${sim_exec} &&
+    echo ${sim} 
 '
 
 #


### PR DESCRIPTION
Note that this PR should not be merged before PR #386 of flux-core is merged. This PR contains initial support for reliable jsc including a sharness test case. 

To facilitate testing, a new utility called `flux-waitjob` is added so that a shareness test can wait until all of the jobs are complete, which are submitted through `flux-submit`. 

In addition, to get notified of the “submitted” event, flux-submit now emits wreck.state.submitted as well. 

Finally, this PR also contains other minor fixes and a workaround (i.g., removing the use of posix.signal from within flux-submit).