### PR TITLE
sched: simplify two lines of flux-submit

### DIFF
--- a/sched/flux-submit
+++ b/sched/flux-submit
@@ -105,9 +105,7 @@ lwj:commit()
 --  Here, this doesn't have to wait for its own event because 
 --  the schedsrv will not change the state until it sees this event.
 --
-local pl = {}
-pl["lwj"] = resp.jobid
-local rc,err = f:sendevent (pl, "wreck.state.submitted", resp.jobid)
+local rc,err = f:sendevent ({lwj = resp.jobid}, "wreck.state.submitted")
 if not rc then wreck:die ("sendevent: %s\n", err) end
 
 os.exit (0)


### PR DESCRIPTION
Acts on suggestion:  https://github.com/flux-framework/flux-sched/commit/89df88f7a69568ec6b583515c50050f64c2eb6da#commitcomment-13078867
