### PR TITLE
Time component to resrc

### DIFF
--- a/resrc/resrc.c
+++ b/resrc/resrc.c
@@ -507,7 +507,7 @@ bool resrc_walltime_match (resrc_t *resrc, resrc_t *sample)
 
     /* fix job start and end time from now */
     jstarttime = time_now;
-    jendtime = time_now + jwalltime;
+    jendtime = jstarttime + jwalltime;
     tstarttime = TIME_MAX;
 
     /* Iterate over resrc's twindow and find if it sample fits from now */

--- a/resrc/resrc.c
+++ b/resrc/resrc.c
@@ -489,6 +489,7 @@ bool resrc_walltime_match (resrc_t *resrc, resrc_t *sample)
     int64_t jwalltime;
     int64_t tstarttime;
     int64_t rstarttime;
+    int64_t lendtime;
 
     char *json_str_walltime = NULL;
     char *json_str_window = NULL;
@@ -509,6 +510,15 @@ bool resrc_walltime_match (resrc_t *resrc, resrc_t *sample)
     jstarttime = time_now;
     jendtime = jstarttime + jwalltime;
     tstarttime = TIME_MAX;
+
+    /* If jendtime is greater than the lifetime of the resource, then falst */
+    json_str_window = zhash_lookup (resrc->twindow, "0");
+    JSON lt = Jfromstr (json_str_window);
+    Jget_int64 (lt, "endtime", &lendtime);
+    Jput (lt);
+    if (jendtime > (lendtime - 10)) {
+        return false;
+    }
 
     /* Iterate over resrc's twindow and find if it sample fits from now */
     json_str_window = zhash_first (resrc->twindow);

--- a/resrc/resrc.c
+++ b/resrc/resrc.c
@@ -61,13 +61,13 @@ struct resrc {
     zhash_t *tags;
     zhash_t *allocs;
     zhash_t *reservtns;
+    zhash_t *twindow;
 };
 
 
 /***************************************************************************
  *  API
  ***************************************************************************/
-
 char *resrc_type (resrc_t *resrc)
 {
     if (resrc)
@@ -190,6 +190,7 @@ resrc_t *resrc_new_resource (const char *type, const char *name, int64_t id,
         resrc->reservtns = zhash_new ();
         resrc->properties = zhash_new ();
         resrc->tags = zhash_new ();
+        resrc->twindow = zhash_new ();
     }
 
     return resrc;
@@ -211,6 +212,7 @@ resrc_t *resrc_copy_resource (resrc_t *resrc)
         new_resrc->reservtns = zhash_dup (resrc->reservtns);
         new_resrc->properties = zhash_dup (resrc->properties);
         new_resrc->tags = zhash_dup (resrc->tags);
+        new_resrc->twindow = zhash_dup (resrc->twindow);
     }
 
     return new_resrc;
@@ -235,6 +237,7 @@ void resrc_resource_destroy (void *object)
         zhash_destroy (&resrc->reservtns);
         zhash_destroy (&resrc->properties);
         zhash_destroy (&resrc->tags);
+        zhash_destroy (&resrc->twindow);
         free (resrc);
     }
 }
@@ -312,6 +315,15 @@ static resrc_t *resrc_add_resource (zhash_t *resrcs, resrc_t *parent,
                 zhash_freefn (resrc->tags, iter.key, free);
                 Jput (jtago);
             }
+        }
+
+        /* add twindow */
+        if ((!strncmp (type, "node", 5)) || (!strncmp (type, "core", 5))) {
+            JSON j = Jnew ();
+            Jadd_int64 (j, "start", epochtime ());
+            Jadd_int64 (j, "end", TIME_MAX); 
+            zhash_insert (resrc->twindow, "0", (void *)Jtostr (j));
+            Jput (j);
         }
 
         while ((c = rdl_resource_next_child (r))) {
@@ -460,6 +472,63 @@ void resrc_print_resources (resources_t *resrcs)
     zlist_destroy (&resrc_ids);
 }
 
+/*
+ * Finds if a resrc_t *sample matches with resrc_t *resrc in terms of walltime
+ *
+ * Note: this function is working on a resource that is already AVAILABLE.
+ * Therefore it is sufficient if the walltime fits before the earliest starttime 
+ * of a reserved job.
+ */
+bool resrc_walltime_match (resrc_t *resrc, resrc_t *sample)
+{
+    bool rc = false;
+    
+    int64_t time_now = epochtime ();
+    int64_t jstarttime;
+    int64_t jendtime;
+    int64_t jwalltime;
+    int64_t tstarttime;
+    int64_t rstarttime;
+
+    char *json_str_walltime = NULL;
+    char *json_str_window = NULL;
+    
+    /* retrieve first element of twindow from request sample */
+    json_str_walltime = zhash_first (sample->twindow);
+    if (!json_str_walltime)
+        return true;
+    
+    /* retrieve the walltime information from request sample */
+    JSON jw = Jfromstr (json_str_walltime);
+    if (!(Jget_int64 (jw, "walltime", &jwalltime))) {
+        Jput (jw);
+        return true;
+    }
+
+    /* fix job start and end time from now */
+    jstarttime = time_now;
+    jendtime = time_now + jwalltime;
+    tstarttime = TIME_MAX;
+
+    /* Iterate over resrc's twindow and find if it sample fits from now */
+    json_str_window = zhash_first (resrc->twindow);
+    while (json_str_window) {
+        
+        JSON rw = Jfromstr (json_str_window);
+        Jget_int64 (rw, "starttime", &rstarttime);
+        
+        if (rstarttime > time_now)
+            tstarttime = tstarttime < rstarttime ? tstarttime : rstarttime;
+
+        json_str_window = zhash_next (resrc->twindow);
+    }
+
+    rc = jendtime <= tstarttime ? true : false;
+    
+    return rc;
+}
+
+
 bool resrc_match_resource (resrc_t *resrc, resrc_t *sample, bool available)
 {
     bool rc = false;
@@ -498,7 +567,7 @@ bool resrc_match_resource (resrc_t *resrc, resrc_t *sample, bool available)
         }
 
         if (available) {
-            if (resrc->state == RESOURCE_IDLE)
+            if ((resrc->state == RESOURCE_IDLE) && (resrc_walltime_match (resrc, sample)))
                 rc = true;
         } else
             rc = true;
@@ -574,6 +643,28 @@ ret:
     return rc;
 }
 
+int resrc_update_walltime (resrc_t *resrc, int64_t job_id, int64_t walltime)
+{
+    int rc = -1;
+
+    if (resrc && job_id) {
+
+        JSON j = Jnew ();
+        int64_t now = epochtime ();
+        char *id_ptr = NULL;
+        Jadd_int64 (j, "starttime", now);
+        Jadd_int64 (j, "endtime", now + walltime);
+        asprintf (&id_ptr, "%ld", job_id);
+        zhash_insert (resrc->twindow, id_ptr, (void *)Jtostr (j) );
+        Jput (j);
+        rc = 0;
+        free (id_ptr);       
+
+    }
+
+    return rc;
+}
+
 int resrc_allocate_resources (resources_t *resrcs, resource_list_t *resrc_ids,
                               int64_t job_id)
 {
@@ -595,6 +686,8 @@ int resrc_allocate_resources (resources_t *resrcs, resource_list_t *resrc_ids,
 ret:
     return rc;
 }
+
+
 
 /*
  * Just like resrc_allocate_resource() above, but for a reservation
@@ -731,6 +824,7 @@ resrc_t *resrc_new_from_json (JSON o, resrc_t *parent)
     json_object_iter iter;
     resrc_t *resrc = NULL;
     size_t size = 1;
+    int64_t jduration;
 
     if (!Jget_str (o, "type", &type))
         goto ret;
@@ -766,6 +860,14 @@ resrc_t *resrc_new_from_json (JSON o, resrc_t *parent)
                 Jput (jtago);
             }
         }
+
+        if (Jget_int64 (o, "walltime", &jduration)) {
+            JSON w = Jnew ();
+            Jadd_int64 (w, "walltime", jduration);
+            zhash_insert (resrc->twindow, "0", (void *)Jtostr (w));
+            Jput (w);
+        } 
+        
     }
 ret:
     return resrc;

--- a/resrc/resrc.h
+++ b/resrc/resrc.h
@@ -161,13 +161,13 @@ void resrc_stage_resrc(resrc_t *resrc, size_t size);
 /*
  * Allocate a resource to a job
  */
-int resrc_allocate_resource (resrc_t *resrc, int64_t job_id);
+int resrc_allocate_resource (resrc_t *resrc, int64_t job_id, int64_t walltime);
 
 /*
  * Allocate a set of resources to a job
  */
 int resrc_allocate_resources (resources_t *resrcs, resource_list_t *resrc_ids,
-                              int64_t job_id);
+                              int64_t job_id, int64_t walltime);
 
 /*
  * Reserve a resource for a job
@@ -210,6 +210,5 @@ static inline int64_t epochtime ()
     return (int64_t) time (NULL);
 }
 
-int resrc_update_walltime (resrc_t *resrc, int64_t job_id, int64_t walltime);
 
 #endif /* !FLUX_RESRC_H */

--- a/resrc/resrc.h
+++ b/resrc/resrc.h
@@ -7,6 +7,9 @@
 
 #include <uuid/uuid.h>
 #include "src/common/libutil/shortjson.h"
+#include "time.h"
+
+#define TIME_MAX UINT64_MAX
 
 typedef struct resource_list resource_list_t;
 typedef struct resources resources_t;
@@ -198,5 +201,15 @@ int resrc_release_resources (resources_t *resrcs, resource_list_t *resrc_ids,
  * Create a resrc_t object from a json object
  */
 resrc_t *resrc_new_from_json (JSON o, resrc_t *parent);
+
+/* 
+ * Get epoch time
+ */
+static inline int64_t epochtime ()
+{
+    return (int64_t) time (NULL);
+}
+
+int resrc_update_walltime (resrc_t *resrc, int64_t job_id, int64_t walltime);
 
 #endif /* !FLUX_RESRC_H */

--- a/resrc/resrc_reqst.c
+++ b/resrc/resrc_reqst.c
@@ -40,6 +40,7 @@ struct resrc_reqst_list {
 struct resrc_reqst {
     resrc_reqst_t *parent;
     resrc_t *resrc;
+    int64_t walltime;
     int64_t reqrd;
     int64_t nfound;
     resrc_reqst_list_t *children;

--- a/resrc/resrc_tree.c
+++ b/resrc/resrc_tree.c
@@ -351,6 +351,39 @@ int resrc_tree_list_release (resrc_tree_list_t *rtl, int64_t job_id)
     return rc;
 }
 
+
+int resrc_tree_update_walltime (resrc_tree_t *resrc_tree, int64_t job_id, int64_t walltime)
+{
+    int rc = -1;
+    if (resrc_tree) {
+        rc = resrc_update_walltime (resrc_tree->resrc, job_id, walltime);
+        if (resrc_tree_num_children (resrc_tree)) {
+            resrc_tree_t *child = resrc_tree_list_first (resrc_tree->children);
+            while (!rc && child) {
+                rc = resrc_tree_update_walltime (child, job_id, walltime);
+                child = resrc_tree_list_next (resrc_tree->children);
+            }
+        }
+    }
+    return rc;
+}
+
+int resrc_tree_list_update_walltime (resrc_tree_list_t *rtl, int64_t job_id, int64_t walltime)
+{
+    resrc_tree_t *rt;
+    int rc = -1;
+
+    if (rtl) {
+        rc = 0;
+        rt = resrc_tree_list_first (rtl);
+        while (!rc && rt) {
+            rc = resrc_tree_update_walltime (rt, job_id, walltime);
+            rt = resrc_tree_list_next (rtl);
+        }
+    }
+
+    return rc;
+}
 /*
  * vi: ts=4 sw=4 expandtab
  */

--- a/resrc/resrc_tree.c
+++ b/resrc/resrc_tree.c
@@ -167,15 +167,15 @@ int resrc_tree_serialize (JSON o, resrc_tree_t *resrc_tree)
     return rc;
 }
 
-int resrc_tree_allocate (resrc_tree_t *resrc_tree, int64_t job_id)
+int resrc_tree_allocate (resrc_tree_t *resrc_tree, int64_t job_id, int64_t walltime)
 {
     int rc = -1;
     if (resrc_tree) {
-        rc = resrc_allocate_resource (resrc_tree->resrc, job_id);
+        rc = resrc_allocate_resource (resrc_tree->resrc, job_id, walltime);
         if (resrc_tree_num_children (resrc_tree)) {
             resrc_tree_t *child = resrc_tree_list_first (resrc_tree->children);
             while (!rc && child) {
-                rc = resrc_tree_allocate (child, job_id);
+                rc = resrc_tree_allocate (child, job_id, walltime);
                 child = resrc_tree_list_next (resrc_tree->children);
             }
         }
@@ -300,7 +300,7 @@ int resrc_tree_list_serialize (JSON o, resrc_tree_list_t *rtl)
     return rc;
 }
 
-int resrc_tree_list_allocate (resrc_tree_list_t *rtl, int64_t job_id)
+int resrc_tree_list_allocate (resrc_tree_list_t *rtl, int64_t job_id, int64_t walltime)
 {
     resrc_tree_t *rt;
     int rc = -1;
@@ -309,7 +309,7 @@ int resrc_tree_list_allocate (resrc_tree_list_t *rtl, int64_t job_id)
         rc = 0;
         rt = resrc_tree_list_first (rtl);
         while (!rc && rt) {
-            rc = resrc_tree_allocate (rt, job_id);
+            rc = resrc_tree_allocate (rt, job_id, walltime);
             rt = resrc_tree_list_next (rtl);
         }
     }
@@ -351,39 +351,6 @@ int resrc_tree_list_release (resrc_tree_list_t *rtl, int64_t job_id)
     return rc;
 }
 
-
-int resrc_tree_update_walltime (resrc_tree_t *resrc_tree, int64_t job_id, int64_t walltime)
-{
-    int rc = -1;
-    if (resrc_tree) {
-        rc = resrc_update_walltime (resrc_tree->resrc, job_id, walltime);
-        if (resrc_tree_num_children (resrc_tree)) {
-            resrc_tree_t *child = resrc_tree_list_first (resrc_tree->children);
-            while (!rc && child) {
-                rc = resrc_tree_update_walltime (child, job_id, walltime);
-                child = resrc_tree_list_next (resrc_tree->children);
-            }
-        }
-    }
-    return rc;
-}
-
-int resrc_tree_list_update_walltime (resrc_tree_list_t *rtl, int64_t job_id, int64_t walltime)
-{
-    resrc_tree_t *rt;
-    int rc = -1;
-
-    if (rtl) {
-        rc = 0;
-        rt = resrc_tree_list_first (rtl);
-        while (!rc && rt) {
-            rc = resrc_tree_update_walltime (rt, job_id, walltime);
-            rt = resrc_tree_list_next (rtl);
-        }
-    }
-
-    return rc;
-}
 /*
  * vi: ts=4 sw=4 expandtab
  */

--- a/resrc/resrc_tree.h
+++ b/resrc/resrc_tree.h
@@ -65,7 +65,7 @@ int resrc_tree_serialize (JSON o, resrc_tree_t *resrc_tree);
 /*
  * Allocate all the resources in a resource tree
  */
-int resrc_tree_allocate (resrc_tree_t *resrc_tree, int64_t job_id);
+int resrc_tree_allocate (resrc_tree_t *resrc_tree, int64_t job_id, int64_t walltime);
 
 /*
  * Reserve all the resources in a resource tree
@@ -129,7 +129,7 @@ int resrc_tree_list_serialize (JSON o, resrc_tree_list_t *rtl);
 /*
  * Allocate all the resources in a list of resource trees
  */
-int resrc_tree_list_allocate (resrc_tree_list_t *rtl, int64_t job_id);
+int resrc_tree_list_allocate (resrc_tree_list_t *rtl, int64_t job_id, int64_t walltime);
 
 /*
  * Reserve all the resources in a list of resource trees
@@ -140,10 +140,6 @@ int resrc_tree_list_reserve (resrc_tree_list_t *rtl, int64_t job_id);
  * Release all the resources in a list of resource trees
  */
 int resrc_tree_list_release (resrc_tree_list_t *rtl, int64_t job_id);
-
-
-int resrc_tree_update_walltime (resrc_tree_t *resrc_tree, int64_t job_id, int64_t walltime);
-int resrc_tree_list_update_walltime (resrc_tree_list_t *rtl, int64_t job_id, int64_t walltime);
 
 
 #endif /* !FLUX_RESRC_TREE_H */

--- a/resrc/resrc_tree.h
+++ b/resrc/resrc_tree.h
@@ -142,4 +142,8 @@ int resrc_tree_list_reserve (resrc_tree_list_t *rtl, int64_t job_id);
 int resrc_tree_list_release (resrc_tree_list_t *rtl, int64_t job_id);
 
 
+int resrc_tree_update_walltime (resrc_tree_t *resrc_tree, int64_t job_id, int64_t walltime);
+int resrc_tree_list_update_walltime (resrc_tree_list_t *rtl, int64_t job_id, int64_t walltime);
+
+
 #endif /* !FLUX_RESRC_TREE_H */

--- a/resrc/test/tresrc.c
+++ b/resrc/test/tresrc.c
@@ -231,17 +231,17 @@ int main (int argc, char *argv[])
     init_time();
 
     selected_trees = test_select_resources (found_trees, 1);
-    rc = resrc_tree_list_allocate (selected_trees, 1);
+    rc = resrc_tree_list_allocate (selected_trees, 1, 3600);
     ok (!rc, "successfully allocated resources for job 1");
     resrc_tree_list_free (selected_trees);
 
     selected_trees = test_select_resources (found_trees, 2);
-    rc = resrc_tree_list_allocate (selected_trees, 2);
+    rc = resrc_tree_list_allocate (selected_trees, 2, 3600);
     ok (!rc, "successfully allocated resources for job 2");
     resrc_tree_list_free (selected_trees);
 
     selected_trees = test_select_resources (found_trees, 3);
-    rc = resrc_tree_list_allocate (selected_trees, 3);
+    rc = resrc_tree_list_allocate (selected_trees, 3, 3600);
     ok (!rc, "successfully allocated resources for job 3");
     resrc_tree_list_free (selected_trees);
 

--- a/sched/schedsrv.c
+++ b/sched/schedsrv.c
@@ -654,8 +654,7 @@ int schedule_job (ssrvctx_t *ctx, flux_lwj_t *job)
                                                           resrc_reqst))) {
             nnodes = resrc_tree_list_size (selected_trees);
             if (nnodes == job->req->nnodes) {
-                resrc_tree_list_allocate (selected_trees, job->lwj_id);
-                resrc_tree_list_update_walltime (selected_trees, job->lwj_id, job->req->walltime);
+                resrc_tree_list_allocate (selected_trees, job->lwj_id, job->req->walltime);
                 /* Scheduler specific job transition */
                 job->state = J_SELECTED;
                 job->resrc_trees = selected_trees;

--- a/sched/schedsrv.c
+++ b/sched/schedsrv.c
@@ -164,6 +164,7 @@ static inline int fill_resource_req (flux_t h, flux_lwj_t *j)
     if (!Jget_int64 (o, JSC_RDESC_NTASKS, &nc)) goto done;
     j->req->nnodes = (uint64_t) nn;
     j->req->ncores = (uint32_t) nc;
+    j->req->walltime = (uint64_t) 3600;
     rc = 0;
 done:
     if (jcb)
@@ -627,10 +628,13 @@ int schedule_job (ssrvctx_t *ctx, flux_lwj_t *job)
     child_core = Jnew ();
     Jadd_str (child_core, "type", "core");
     Jadd_int (child_core, "req_qty", job->req->corespernode);
+    Jadd_int64 (child_core, "walltime", job->req->walltime);
 
     req_res = Jnew ();
     Jadd_str (req_res, "type", "node");
     Jadd_int (req_res, "req_qty", job->req->nnodes);
+    Jadd_int (req_res, "walltime", job->req->walltime);
+
     json_object_object_add (req_res, "req_child", child_core);
 
     resrc_reqst = resrc_reqst_from_json (req_res, NULL);
@@ -651,6 +655,7 @@ int schedule_job (ssrvctx_t *ctx, flux_lwj_t *job)
             nnodes = resrc_tree_list_size (selected_trees);
             if (nnodes == job->req->nnodes) {
                 resrc_tree_list_allocate (selected_trees, job->lwj_id);
+                resrc_tree_list_update_walltime (selected_trees, job->lwj_id, job->req->walltime);
                 /* Scheduler specific job transition */
                 job->state = J_SELECTED;
                 job->resrc_trees = selected_trees;

--- a/sched/schedsrv.h
+++ b/sched/schedsrv.h
@@ -47,7 +47,7 @@ typedef struct flux_resources {
     uint64_t nnodes; /*!< num of nodes requested by a job */
     uint64_t ncores; /*!< num of cores requested by a job */
     uint64_t corespernode; /*!< num of cores per node requested by a job */
-    uint64_t walltime /*!< walltime requested by a job */
+    uint64_t walltime; /*!< walltime requested by a job */
 } flux_res_t;
 
 

--- a/sched/schedsrv.h
+++ b/sched/schedsrv.h
@@ -47,6 +47,7 @@ typedef struct flux_resources {
     uint64_t nnodes; /*!< num of nodes requested by a job */
     uint64_t ncores; /*!< num of cores requested by a job */
     uint64_t corespernode; /*!< num of cores per node requested by a job */
+    uint64_t walltime /*!< walltime requested by a job */
 } flux_res_t;
 
 
@@ -59,6 +60,7 @@ typedef struct {
     bool        reserve; /*!< reserve resources for job if true */
     flux_res_t *req;     /*!< resources requested by this LWJ */
     resrc_tree_list_t *resrc_trees; /*!< resources allocated to this LWJ */
+
 } flux_lwj_t;
 
 #endif /* SCHEDSRV_H */


### PR DESCRIPTION
More than a PR, this is ping to get a feedback from everyone on the extending the resrc with time component (mainly for @lipari to see if the resrc extension is close to what he envisioned and @SteVwonder to check if this does seem to suit his needs). If its good, I will continue working on it after feedback and bring it to a mergable state. Otherwise, we can close the PR and I can rework differently.

Here is a summary of the changes and logic:
1. resrc is extended with another hash table "twindow". When allocated/reserved for future with jobs, this will store job_id as key and a json string as value - { "starttime" :  epoch_start_time, "endtime" : epoch_end_time }. Note that this is valid only for nodes and cores at this point. 
2. When root loads the RDL from configuration, all the resources have a default entry in twindow for job_id 0 : { "starttime" : epoch_sched_start_time, "endtime" : UNIT64_MAX }
3. flux_res_t of a job now also has a walltime component to it along with nodes, cores and corespernode. By default, this is set to 3600 seconds during fill_resource_req (sidenote: for walltime support, flux-submit and the JSC needs extension).
4. For resrc created for match_resource purpose will have twindow with key 0 and { "walltime" : walltime }. This is used by resrc_walltime_match called from within resrc_match_resource to check if that resource does is free for the required walltime.
5. When the resources are allocated for the job, the resource is updated with the twindow information. This should ideally be done in resrc_allocate_resource (by providing also a walltime parameter to it). But I didn't want to change the existing functions before I have go, and so created similar function resrc_walltime_update() which does the job. 

Let me know your feedback, so that I can work on this further. Once a consensus is reached, I can expand/modify this and also provide utility functions, for example, that will look up if a resource is free at a particular time, or the next gap in reservations etc (depending upon the need). 
