### PR TITLE
update message handler API usage

### DIFF
--- a/sched/schedsrv.c
+++ b/sched/schedsrv.c
@@ -56,7 +56,7 @@
 #if ENABLE_TIMER_EVENT
 static int timer_event_cb (flux_t h, void *arg);
 #endif
-static void res_event_cb (flux_t h, flux_msg_watcher_t *w,
+static void res_event_cb (flux_t h, flux_msg_handler_t *w,
                           const flux_msg_t *msg, void *arg);
 static int job_status_cb (JSON jcb, void *arg, int errnum);
 
@@ -384,7 +384,7 @@ done:
  *                                                                            *
  ******************************************************************************/
 
-static struct flux_msghandler htab[] = {
+static struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_EVENT,     "sched.res.*", res_event_cb},
     FLUX_MSGHANDLER_TABLE_END
 };
@@ -407,7 +407,7 @@ static int inline reg_events (ssrvctx_t *ctx)
         rc = -1;
         goto done;
     }
-    if (flux_msg_watcher_addvec (h, htab, (void *)h) < 0) {
+    if (flux_msg_handler_addvec (h, htab, (void *)h) < 0) {
         flux_log (h, LOG_ERR,
                   "error registering resource event handler: %s",
                   strerror (errno));
@@ -823,7 +823,7 @@ bad_transition:
  * For now, the only resource event is raised when a job releases its
  * RDL allocation.
  */
-static void res_event_cb (flux_t h, flux_msg_watcher_t *w,
+static void res_event_cb (flux_t h, flux_msg_handler_t *w,
                           const flux_msg_t *msg, void *arg)
 {
     schedule_jobs (getctx ((flux_t)arg));

--- a/simulator/scheduler.c
+++ b/simulator/scheduler.c
@@ -169,7 +169,7 @@ void remove_job_resources_from_rdl (struct rdl *rdl,
 }
 
 void trigger_cb (flux_t h,
-                 flux_msg_watcher_t *w,
+                 flux_msg_handler_t *w,
                  const flux_msg_t *msg,
                  void *arg)
 {
@@ -284,7 +284,7 @@ int queue_kvs_cb (const char *key, const char *val, void *arg, int errnum)
 }
 
 void newlwj_rpc (flux_t h,
-                 flux_msg_watcher_t *w,
+                 flux_msg_handler_t *w,
                  const flux_msg_t *msg,
                  void *arg)
 {
@@ -1668,7 +1668,7 @@ void end_schedule_loop (ctx_t *ctx)
 
 // Received an event that a simulation is starting
 void start_cb (flux_t h,
-               flux_msg_watcher_t *w,
+               flux_msg_handler_t *w,
                const flux_msg_t *msg,
                void *arg)
 {
@@ -1705,7 +1705,7 @@ void start_cb (flux_t h,
 int init_and_start_scheduler (flux_t h,
                               ctx_t *ctx,
                               zhash_t *args,
-                              struct flux_msghandler *tab)
+                              struct flux_msg_handler_spec *tab)
 {
     int rc = 0;
     char *path;
@@ -1769,8 +1769,8 @@ int init_and_start_scheduler (flux_t h,
         rc = -1;
         goto ret;
     }
-    if (flux_msg_watcher_addvec (h, tab, NULL) < 0) {
-        flux_log (h, LOG_ERR, "flux_msg_watcher_addvec: %s", strerror (errno));
+    if (flux_msg_handler_addvec (h, tab, NULL) < 0) {
+        flux_log (h, LOG_ERR, "flux_msg_handler_addvec: %s", strerror (errno));
         return -1;
     }
 
@@ -1805,7 +1805,7 @@ skip_for_sim:
     rdllib_close (rdllib);
 
 ret:
-    flux_msg_watcher_delvec (h, tab);
+    flux_msg_handler_delvec (tab);
     return rc;
 }
 

--- a/simulator/scheduler.h
+++ b/simulator/scheduler.h
@@ -156,14 +156,14 @@ void remove_job_resources_from_rdl (struct rdl *rdl,
                                     flux_lwj_t *job);
 
 void trigger_cb (flux_t h,
-                 flux_msg_watcher_t *w,
+                 flux_msg_handler_t *w,
                  const flux_msg_t *msg,
                  void *arg);
 void handle_kvs_queue (ctx_t *ctx);
 
 int queue_kvs_cb (const char *key, const char *val, void *arg, int errnum);
 void newlwj_rpc (flux_t h,
-                 flux_msg_watcher_t *w,
+                 flux_msg_handler_t *w,
                  const flux_msg_t *msg,
                  void *arg);
 int newlwj_cb (const char *key, int64_t val, void *arg, int errnum);
@@ -247,14 +247,14 @@ bool should_run_schedule_loop (ctx_t *ctx, int time);
 void end_schedule_loop (ctx_t *ctx);
 
 void start_cb (flux_t h,
-               flux_msg_watcher_t *w,
+               flux_msg_handler_t *w,
                const flux_msg_t *msg,
                void *arg);
 
 int init_and_start_scheduler (flux_t h,
                               ctx_t *ctx,
                               zhash_t *args,
-                              struct flux_msghandler *tab);
+                              struct flux_msg_handler_spec *tab);
 
 int schedule_job (ctx_t *ctx,
                   struct rdl *rdl,

--- a/simulator/sim_execsrv.c
+++ b/simulator/sim_execsrv.c
@@ -509,7 +509,7 @@ static int handle_queued_events (ctx_t *ctx)
 
 // Received an event that a simulation is starting
 static void start_cb (flux_t h,
-                      flux_msg_watcher_t *w,
+                      flux_msg_handler_t *w,
                       const flux_msg_t *msg,
                       void *arg)
 {
@@ -528,7 +528,7 @@ static void start_cb (flux_t h,
 }
 
 static void rdl_update_cb (flux_t h,
-                           flux_msg_watcher_t *w,
+                           flux_msg_handler_t *w,
                            const flux_msg_t *msg,
                            void *arg)
 {
@@ -562,7 +562,7 @@ static void rdl_update_cb (flux_t h,
 
 // Handle trigger requests from the sim module ("sim_exec.trigger")
 static void trigger_cb (flux_t h,
-                        flux_msg_watcher_t *w,
+                        flux_msg_handler_t *w,
                         const flux_msg_t *msg,
                         void *arg)
 {
@@ -602,7 +602,7 @@ static void trigger_cb (flux_t h,
 }
 
 static void run_cb (flux_t h,
-                    flux_msg_watcher_t *w,
+                    flux_msg_handler_t *w,
                     const flux_msg_t *msg,
                     void *arg)
 {
@@ -624,7 +624,7 @@ static void run_cb (flux_t h,
     flux_log (h, LOG_DEBUG, "queued the running of jobid %d", *jobid);
 }
 
-static struct flux_msghandler htab[] = {
+static struct flux_msg_handler_spec htab[] = {
     {FLUX_MSGTYPE_EVENT, "sim.start", start_cb},
     {FLUX_MSGTYPE_EVENT, "rdl.update", rdl_update_cb},
     {FLUX_MSGTYPE_REQUEST, "sim_exec.trigger", trigger_cb},
@@ -649,8 +649,8 @@ int mod_main (flux_t h, int argc, char **argv)
         flux_log (h, LOG_ERR, "subscribing to event: %s", strerror (errno));
         return -1;
     }
-    if (flux_msg_watcher_addvec (h, htab, ctx) < 0) {
-        flux_log (h, LOG_ERR, "flux_msg_watcher_add: %s", strerror (errno));
+    if (flux_msg_handler_addvec (h, htab, ctx) < 0) {
+        flux_log (h, LOG_ERR, "flux_msg_handler_add: %s", strerror (errno));
         return -1;
     }
 

--- a/simulator/sim_sched_easy.c
+++ b/simulator/sim_sched_easy.c
@@ -306,7 +306,7 @@ int schedule_jobs (ctx_t *ctx, double sim_time)
     return rc;
 }
 
-static struct flux_msghandler htab[] = {
+static struct flux_msg_handler_spec htab[] = {
     {FLUX_MSGTYPE_EVENT, "sim.start", start_cb},
     {FLUX_MSGTYPE_REQUEST, "sim_sched.trigger", trigger_cb},
     //{ FLUX_MSGTYPE_EVENT,   "sim_sched.event",   event_cb },

--- a/simulator/sim_sched_easy_aware.c
+++ b/simulator/sim_sched_easy_aware.c
@@ -480,7 +480,7 @@ int schedule_jobs (ctx_t *ctx, double sim_time)
     return rc;
 }
 
-static struct flux_msghandler htab[] = {
+static struct flux_msg_handler_spec htab[] = {
     {FLUX_MSGTYPE_EVENT, "sim.start", start_cb},
     {FLUX_MSGTYPE_REQUEST, "sim_sched.trigger", trigger_cb},
     {FLUX_MSGTYPE_REQUEST, "sim_sched.lwj-watch", newlwj_rpc},

--- a/simulator/sim_sched_fcfs.c
+++ b/simulator/sim_sched_fcfs.c
@@ -103,7 +103,7 @@ int schedule_jobs (ctx_t *ctx, double sim_time)
     return rc;
 }
 
-static struct flux_msghandler htab[] = {
+static struct flux_msg_handler_spec htab[] = {
     {FLUX_MSGTYPE_EVENT, "sim.start", start_cb},
     {FLUX_MSGTYPE_REQUEST, "sim_sched.trigger", trigger_cb},
     {FLUX_MSGTYPE_REQUEST, "sim_sched.lwj-watch", newlwj_rpc},

--- a/simulator/sim_sched_fcfs_aware.c
+++ b/simulator/sim_sched_fcfs_aware.c
@@ -132,7 +132,7 @@ int schedule_jobs (ctx_t *ctx, double sim_time)
  *        High Level Job and Resource Event Handlers
  *
  ****************************************************************/
-static struct flux_msghandler htab[] = {
+static struct flux_msg_handler_spec htab[] = {
     {FLUX_MSGTYPE_EVENT, "sim.start", start_cb},
     {FLUX_MSGTYPE_REQUEST, "sim_sched.trigger", trigger_cb},
     //{ FLUX_MSGTYPE_EVENT,   "sim_sched.event",   event_cb },

--- a/simulator/simsrv.c
+++ b/simulator/simsrv.c
@@ -203,7 +203,7 @@ static int handle_next_event (ctx_t *ctx)
 
 // Recevied a request to join the simulation ("sim.join")
 static void join_cb (flux_t h,
-                     flux_msg_watcher_t *w,
+                     flux_msg_handler_t *w,
                      const flux_msg_t *msg,
                      void *arg)
 {
@@ -329,7 +329,7 @@ static void copy_new_state_data (ctx_t *ctx,
 }
 
 static void rdl_update_cb (flux_t h,
-                           flux_msg_watcher_t *w,
+                           flux_msg_handler_t *w,
                            const flux_msg_t *msg,
                            void *arg)
 {
@@ -356,7 +356,7 @@ static void rdl_update_cb (flux_t h,
 
 // Recevied a reply to a trigger ("sim.reply")
 static void reply_cb (flux_t h,
-                      flux_msg_watcher_t *w,
+                      flux_msg_handler_t *w,
                       const flux_msg_t *msg,
                       void *arg)
 {
@@ -391,7 +391,7 @@ static void reply_cb (flux_t h,
 }
 
 static void alive_cb (flux_t h,
-                      flux_msg_watcher_t *w,
+                      flux_msg_handler_t *w,
                       const flux_msg_t *msg,
                       void *arg)
 {
@@ -411,7 +411,7 @@ static void alive_cb (flux_t h,
     flux_log (h, LOG_DEBUG, "sending start event again");
 }
 
-static struct flux_msghandler htab[] = {
+static struct flux_msg_handler_spec htab[] = {
     {FLUX_MSGTYPE_REQUEST, "sim.join", join_cb},
     {FLUX_MSGTYPE_REQUEST, "sim.reply", reply_cb},
     {FLUX_MSGTYPE_REQUEST, "sim.alive", alive_cb},
@@ -450,8 +450,8 @@ int mod_main (flux_t h, int argc, char **argv)
         return -1;
     }
 
-    if (flux_msg_watcher_addvec (h, htab, ctx) < 0) {
-        flux_log (h, LOG_ERR, "flux_msg_watcher_add: %s", strerror (errno));
+    if (flux_msg_handler_addvec (h, htab, ctx) < 0) {
+        flux_log (h, LOG_ERR, "flux_msg_handler_add: %s", strerror (errno));
         return -1;
     }
 

--- a/simulator/submitsrv.c
+++ b/simulator/submitsrv.c
@@ -288,7 +288,7 @@ int schedule_next_job (flux_t h, sim_state_t *sim_state)
 
 // Received an event that a simulation is starting
 static void start_cb (flux_t h,
-                      flux_msg_watcher_t *w,
+                      flux_msg_handler_t *w,
                       const flux_msg_t *msg,
                       void *arg)
 {
@@ -310,7 +310,7 @@ static void start_cb (flux_t h,
 
 // Handle trigger requests from the sim module ("submit.trigger")
 static void trigger_cb (flux_t h,
-                        flux_msg_watcher_t *w,
+                        flux_msg_handler_t *w,
                         const flux_msg_t *msg,
                         void *arg)
 {
@@ -341,7 +341,7 @@ static void trigger_cb (flux_t h,
     Jput (o);
 }
 
-static struct flux_msghandler htab[] = {
+static struct flux_msg_handler_spec htab[] = {
     {FLUX_MSGTYPE_EVENT, "sim.start", start_cb},
     {FLUX_MSGTYPE_REQUEST, "submit.trigger", trigger_cb},
     FLUX_MSGHANDLER_TABLE_END,
@@ -372,8 +372,8 @@ int mod_main (flux_t h, int argc, char **argv)
         flux_log (h, LOG_ERR, "subscribing to event: %s", strerror (errno));
         return -1;
     }
-    if (flux_msg_watcher_addvec (h, htab, NULL) < 0) {
-        flux_log (h, LOG_ERR, "flux_msg_watcher_addvec: %s", strerror (errno));
+    if (flux_msg_handler_addvec (h, htab, NULL) < 0) {
+        flux_log (h, LOG_ERR, "flux_msg_handler_addvec: %s", strerror (errno));
         return -1;
     }
 


### PR DESCRIPTION
Use the new message handler interfaces that changed in flux-core.

Fixes #72 

Once PR flux-framework/flux-core#418 is merged, flux-sched should be back on its feet again.