### PR TITLE
resrc: modify the serialized resources

### DIFF
--- a/resrc/resrc.h
+++ b/resrc/resrc.h
@@ -31,6 +31,11 @@ typedef enum {
 char *resrc_type (resrc_t *resrc);
 
 /*
+ * Return the fully qualified name of the resouce
+ */
+char *resrc_path (resrc_t *resrc);
+
+/*
  * Return the name of the resouce
  */
 char *resrc_name (resrc_t *resrc);
@@ -58,8 +63,9 @@ resrc_tree_t *resrc_phys_tree (resrc_t *resrc);
 /*
  * Create a new resource object
  */
-resrc_t *resrc_new_resource (const char *type, const char *name, int64_t id,
-                             uuid_t uuid, size_t size);
+resrc_t *resrc_new_resource (const char *type, const char *path,
+                             const char *name, int64_t id, uuid_t uuid,
+                             size_t size);
 
 /*
  * Create a copy of a resource object


### PR DESCRIPTION
Change the name to only include the name without the id appended.  Add
id, path, and uuid to the list of serialized (and deserialized)
resource members.
Addresses https://github.com/flux-framework/flux-sched/issues/74