### PR TITLE
jsc/etc: beefing up the jsc tests and adjusting for a recent lua binding churn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - eval `luarocks path`
   - wget https://raw.githubusercontent.com/flux-framework/flux-core/master/src/test/travis-dep-builder.sh
   - bash ./travis-dep-builder.sh --cachedir=$HOME/local/.cache
-  - eval $(./travis-dep-builder.sh --printenv)
+  - bash ./travis-dep-builder.sh --printenv
   - pip install --user cffi coverage
 
 script:

--- a/rdl/RDL.lua
+++ b/rdl/RDL.lua
@@ -27,7 +27,7 @@
 --
 -- First, load some useful modules:
 --
-local hostlist = require 'hostlist'
+local hostlist = require 'flux.hostlist'
 
 --
 -- Get the base path for this module to use in searching for
@@ -104,7 +104,7 @@ local function rdl_parse_environment ()
     ---
     -- Load extra functions defined in RDL/lib/?.lua
     ---
-    local glob = require 'posix'.glob
+    local glob = require 'flux.posix'.glob
     for _,path in pairs (glob (basepath .. "RDL/lib/*.lua")) do
         local f = assert (loadfile (path))
         local name = path:match("([^/]+)%.lua")

--- a/rdl/RDL/lib/ListOf.lua
+++ b/rdl/RDL/lib/ListOf.lua
@@ -1,4 +1,4 @@
-
+local hostlist = require 'flux.hostlist'
 local function ListOf (arg)
     local ids = arg.ids or arg.hostids
     local T = arg.type or arg[1]

--- a/rdl/RDL/memstore.lua
+++ b/rdl/RDL/memstore.lua
@@ -815,7 +815,7 @@ local function do_find (r, dst, args)
 end
 
 function MemStore:find (arg)
-    local hostlist = require 'hostlist'
+    local hostlist = require 'flux.hostlist'
     local a = self:resource_accumulator ()
 
     if arg.name then

--- a/rdl/test/test-rdl.lua
+++ b/rdl/test/test-rdl.lua
@@ -326,7 +326,7 @@ Hierarchy "default" {
     b = assert (rdl2:aggregate('default'))
     assert (equals (a, b), "Expected ".. i(a) .. " got ".. i(b))
 
-    local hl = require 'hostlist'.new ("bar[5-10]")
+    local hl = require 'flux.hostlist'.new ("bar[5-10]")
 
     for name in hl:next() do
         local id = tonumber (name:match ("[0-9]+$"))
@@ -363,7 +363,7 @@ Hierarchy "default" {
     assert_not_nil (rdl)
     assert_true (is_table (rdl))
 
-    local t0 = require 'timer'.new()
+    local t0 = require 'flux.timer'.new()
     local r = assert (rdl:find{ type = "core" })
     local delta = t0:get0()
     assert_true (delta < 0.02, "rdl_find took "..delta.." seconds")

--- a/resrc/test/Makefile
+++ b/resrc/test/Makefile
@@ -6,7 +6,7 @@ LIBS = $(FLUX_LIBS) $(RDL_LIBS) $(RESRC_LIBS)
 TESTRESRC_INPUT_FILE := $(abs_topdir)/conf/hype.lua
 
 LUA_PATH := $(LUA_PATH);$(abs_topdir)/rdl/?.lua;$(FLUX_SRCDIR)/src/bindings/lua/?.lua;;;
-LUA_CPATH := $(LUA_CPATH);$(abs_topdir)/rdl/?.so;$(FLUX_SRCDIR)/src/bindings/lua/.libs/?.so;;;
+LUA_CPATH := $(LUA_CPATH);$(abs_topdir)/rdl/?.so;$(FLUX_SRCDIR)/src/bindings/lua/?.so;;;
 
 export CFLAGS TESTRESRC_INPUT_FILE LUA_PATH LUA_CPATH
 

--- a/simulator/test/Makefile
+++ b/simulator/test/Makefile
@@ -24,7 +24,7 @@ tsched_lib: tsched_lib.c $(COMMON_OBJS) $(SCHEDULER_OBJS)
 
 check: tsched_lib
 	@export LUA_PATH="$(LUA_PATH);$(abs_topdir)/rdl/?.lua;$(FLUX_SRCDIR)/src/bindings/lua/?.lua;;;"; \
-	export LUA_CPATH="$(LUA_CPATH);$(abs_topdir)/rdl/?.so;$(FLUX_BUILDDIR)/src/bindings/lua/.libs/?.so;;;"; \
+	export LUA_CPATH="$(LUA_CPATH);$(abs_topdir)/rdl/?.so;$(FLUX_BUILDDIR)/src/bindings/lua/?.so;;;"; \
 	export TESTSIM_INPUT_FILE="$(TESTSIM_INPUT_FILE)"; \
 	./tsched_lib
 

--- a/t/Makefile
+++ b/t/Makefile
@@ -18,6 +18,7 @@ TESTS = \
 	lua/t0002-multilevel.t \
 	lua/t0003-default-tags.t \
 	lua/t0004-derived-type.t \
+	t0002-waitjob.t \
 	t2000-fcfs.t \
 	t2001-fcfs-aware.t \
 	t2002-easy.t

--- a/t/Makefile
+++ b/t/Makefile
@@ -19,6 +19,7 @@ TESTS = \
 	lua/t0003-default-tags.t \
 	lua/t0004-derived-type.t \
 	t0002-waitjob.t \
+	t1000-jsc.t \
 	t2000-fcfs.t \
 	t2001-fcfs-aware.t \
 	t2002-easy.t

--- a/t/Makefile
+++ b/t/Makefile
@@ -18,7 +18,6 @@ TESTS = \
 	lua/t0002-multilevel.t \
 	lua/t0003-default-tags.t \
 	lua/t0004-derived-type.t \
-#        t1000-jsc.t \
 	t2000-fcfs.t \
 	t2001-fcfs-aware.t \
 	t2002-easy.t
@@ -26,8 +25,8 @@ TESTS = \
 all: $(BUILD)
 
 check: $(TESTS)
-	@export LUA_PATH="$$LUA_PATH;$(FLUX_BUILDDIR)/t/?.lua;$(RDL_LUA_PATH);;"; \
-	export LUA_CPATH="$$LUA_CPATH;$(RDL_LUA_CPATH);;"; \
+	@export LUA_PATH="$$LUA_PATH;$(FLUX_BUILDDIR)/src/bindings/lua/?.lua;$(FLUX_BUILDDIR)/t/?.lua;$(RDL_LUA_PATH);;"; \
+	export LUA_CPATH="$$LUA_CPATH;$(FLUX_BUILDDIR)/src/bindings/lua/?.so;$(RDL_LUA_CPATH);;"; \
         rc=0; \
 	for t in $(TESTS); do \
 		./$$t; \

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -70,7 +70,10 @@ test_under_flux() {
 
     TEST_UNDER_FLUX_ACTIVE=t \
     TERM=${ORIGINAL_TERM} \
-      exec flux -M${tdir}/sched -C"${tdir}/rdl/?.so" -L"${tdir}/rdl/?.lua" start --size=${size} ${quiet} "sh $0 ${flags}"
+      exec flux -M${tdir}/sched \
+        -C"${tdir}/rdl/?.so;${FLUX_SOURCE_DIR}/src/bindings/lua/?.so" \
+        -L"${tdir}/rdl/?.lua;${FLUX_SOURCE_DIR}/src/bindings/lua/?.lua" \
+        start --size=${size} ${quiet} "sh $0 ${flags}"
 }
 
 mock_bootstrap_instance() {
@@ -120,12 +123,12 @@ TEST_NAME=$SHARNESS_TEST_NAME
 export TEST_NAME
 
 #  Test requirements for testsuite
-if ! lua -e 'require "posix"'; then
-    error "failed to find lua posix module in path"
-fi
-if ! lua -e 'require "hostlist"'; then
-    error "failed to find lua posix module in path"
-fi
+#if ! lua -e 'require "flux.posix"'; then
+#    error "failed to find lua posix module in path"
+#fi
+#if ! lua -e 'require "flux.hostlist"'; then
+#    error "failed to find lua posix module in path"
+#fi
 
 
 # vi: ts=4 sw=4 expandtab

--- a/t/t0002-waitjob.t
+++ b/t/t0002-waitjob.t
@@ -1,0 +1,86 @@
+#!/bin/sh
+#set -x
+
+test_description='Test flux-waitjob 
+
+Ensure flux-waitjob works as expected.
+'
+
+#
+# variables
+#
+dn=`dirname $0` 
+tdir=`readlink -e $dn/../`
+schedsrv=`readlink -e $dn/../sched/schedsrv.so`
+rdlconf=`readlink -e $dn/../conf/hype.lua`
+
+#
+# source sharness from the directore where this test
+# file resides
+#
+. ${dn}/sharness.sh
+
+#
+# print only with --debug
+#
+test_debug '
+	echo ${tdir} &&
+	echo ${schedsrv} &&
+	echo ${rdlconf}
+'
+#
+# test_under_flux is under sharness.d/
+#
+test_under_flux 4 $tdir
+
+timed_wait_job () {
+    sess=$1
+    jobid=$2
+    to=$3
+    rc=0
+    flux -x$tdir/sched waitjob -s wo.st.$sess -c wo.end.$sess $jobid &
+    while [ ! -f wo.st.$sess -a $to -ge 0 ]
+    do
+        sleep 1
+        to=`expr $to - 1`
+    done
+    if [ $to -lt 0 ]; then
+        rc=48 
+    fi
+    return $rc
+}
+
+timed_sync_wait_job () {
+    sess=$1
+    to=$2 
+    rc=0
+    while [ ! -f wo.end.$sess -a $to -ge 0 ]
+    do
+        sleep 1
+        to=`expr $to - 1`
+    done
+    if [ $to -lt 0 ]; then
+        rc=48 
+    fi
+    return $rc
+}
+
+test_expect_success 'waitjob: works when the job has not started' '
+    flux module load ${schedsrv} rdl-conf=${rdlconf} &&
+    timed_wait_job 1 1 5 &&
+    flux -x$tdir/sched submit -N 4 -n 4 hostname &&
+    timed_sync_wait_job 1 5
+'
+
+test_expect_success 'waitjob: works when the job has already completed' '
+    timed_wait_job 2 1 5 &&
+    timed_sync_wait_job 1 5
+'
+
+test_expect_success 'waitjob: works when the job started but has not completed' '
+    flux -x$tdir/sched submit -N 4 -n 4 sleep 5 &&
+    timed_wait_job 3 2 3 &&
+    timed_sync_wait_job 3 6
+'
+
+test_done


### PR DESCRIPTION
This PR contains fixes for two distinct issues: 1) intermittent jsc test failures and 2) Travis CI build failures because `hostlist` and `posix` have moved to the flux namespace (e.g., `src/bindings/lua/flux/hostlist.so`). 

1) is captured in PR #64 along with other issues. I suspect the issue is due to some less precise synchronization mechanisms used between `flux-waitjob` and subsequent `flux-submit`s within the test script (`t/t1000-jsc.t`). To make synchronization air-tight, better synchronization support has been added within `flux-waitjob` (along with its own test case --- `t/t0002-waitjob.t`) and `t/t1000-jsc.t` has also been improved.  

2) is captured in #76. To debug this better in the future, I've made a very minor modification to  `.travis.yml` such that I can see the environment variables that are exported by the `flux-core`'s deb builder script. And the other fixes are trivial changes in a sharness test script, Makefiles and lua files: e.g., `require 'hostlist'` to `require 'flux.hostlist'`. BTW, the reason that Travis CI has not detected these failures is that its test have been run with a cache. So occasional deleting of Travis caches should be encouraged to detection a condition like this.

I've ran this PR on Travis CI for 10 times and all succeeded. 