### PR TITLE
flux-rdltool: update optparse_t usage

### DIFF
--- a/rdl/flux-rdltool.c
+++ b/rdl/flux-rdltool.c
@@ -33,7 +33,7 @@
 #include "rdl.h"
 
 struct prog_ctx {
-    optparse_t p;
+    optparse_t *p;
     const char *filename;
     char *cmd;
     char **args;


### PR DESCRIPTION
optparse_t was redefined as a struct rather than a pointer to one
per RFC 7.  The single use in flux-sched also needs to be updated.