### PR TITLE
test: print PASS/FAIL after each sharness test

### DIFF
--- a/t/Makefile
+++ b/t/Makefile
@@ -32,7 +32,8 @@ check: $(TESTS)
         rc=0; \
 	for t in $(TESTS); do \
 		./$$t; \
-		if test $$? -ne 0; then rc=1; fi; \
+		if test $$? -ne 0; then echo FAIL: $$t; rc=1; \
+				   else echo PASS: $$t; fi; \
 	done; \
 	exit $$rc
 


### PR DESCRIPTION
I got a little lost trying to figure out what sharness test belonged to what output, especially the ones that repeat the same tests for different scheduler algs.  This prints PASS or FAIL: and the name of the test after each test is run similar to the automake test driver.