### PR TITLE
jsc: extend the test to cover hwloc reader mode

### DIFF
--- a/sched/flux-waitjob.c
+++ b/sched/flux-waitjob.c
@@ -43,7 +43,7 @@ typedef struct {
 
 static flux_t sig_flux_h;
 
-#define OPTIONS "h:c:s:"
+#define OPTIONS "hc:s:"
 static const struct option longopts[] = {
     {"help",          no_argument,        0, 'h'},
     {"sync-start",    required_argument,  0, 's'},

--- a/sched/schedsrv.c
+++ b/sched/schedsrv.c
@@ -446,6 +446,7 @@ static int load_resources (ssrvctx_t *ctx, char *path, char *uri)
             free (buf);
             free (key);
         }
+        flux_log (ctx->h, LOG_INFO, "loaded resrc using hwloc (status %d)", rc);
     }
 
     return rc;

--- a/t/t1000-jsc.t
+++ b/t/t1000-jsc.t
@@ -148,4 +148,44 @@ EOF
     kill -INT $p &&
     test_cmp expected2.sort output.2.cp.sort 
 '
+
+test_expect_success 'jsc: expected single-job-event sequence in hwloc read mode' '
+    flux module remove sched &&
+    flux module load ${schedsrv} &&
+    run_flux_jstat 3 &&
+    p=$( sync_flux_jstat 3) &&
+    timed_wait_job 3 7 5 &&
+    flux -x$tdir/sched submit -N 4 -n 4 hostname &&
+    cat >expected3 <<-EOF &&
+$trans
+EOF
+    timed_sync_wait_job 3 5 &&
+    cp output.3 output.3.cp &&
+    kill -INT $p &&
+    test_cmp expected3 output.3.cp 
+'
+
+test_expect_success 'jsc: expected multi-job-event sequence in hwloc read mode' '
+    run_flux_jstat 4 &&
+    p=$( sync_flux_jstat 4) &&
+    timed_wait_job 4 12 5 &&
+    flux -x$tdir/sched submit -N 4 -n 4 sleep 2 &&
+    flux -x$tdir/sched submit -N 4 -n 4 sleep 2 &&
+    flux -x$tdir/sched submit -N 4 -n 4 sleep 2 &&
+    flux -x$tdir/sched submit -N 4 -n 4 sleep 2 &&
+    flux -x$tdir/sched submit -N 4 -n 4 sleep 2 &&
+    cat >expected4 <<-EOF &&
+$trans
+$trans
+$trans
+$trans
+$trans
+EOF
+    timed_sync_wait_job 4 15 &&
+    cp output.4 output.4.cp &&
+    sort expected4 > expected4.sort &&
+    sort output.4.cp > output.4.cp.sort &&
+    kill -INT $p &&
+    test_cmp expected4.sort output.4.cp.sort 
+'
 test_done


### PR DESCRIPTION
- Add a very simple patch to the jsc sharness test to cover the new hwloc reader mode
- Add a LOG_INFO to make it easy to verify hwloc is used
