### PR TITLE
sched:  extract the backfill scheduling code from the sched framework

### DIFF
--- a/resrc/resrc.h
+++ b/resrc/resrc.h
@@ -59,8 +59,8 @@ size_t resrc_available_at_time (resrc_t *resrc, int64_t time);
  * range
  */
 size_t resrc_available_during_range (resrc_t *resrc,
-                                     int64_t range_start_time,
-                                     int64_t range_end_time);
+                                     int64_t range_starttime,
+                                     int64_t range_endtime);
 /*
  * Return the resource state as a string
  */
@@ -127,9 +127,14 @@ resrc_t *resrc_create_cluster (char *cluster);
  *          sample    - sample resource with the required characteristics
  *          available - when true, consider only idle resources
  *                      otherwise find all possible resources matching type
+ *          starttime - start of period the resource needs to be available
+ *                      When the starttime is 0, only the current resource
+ *                      availability will be considered (now-based match).
+ *          endtime   - end of period the resource needs to be available
  * Returns: true if the input resource has the required characteristics
  */
-bool resrc_match_resource (resrc_t *resrc, resrc_t *sample, bool available);
+bool resrc_match_resource (resrc_t *resrc, resrc_t *sample, bool available,
+                           int64_t starttime, int64_t endtime);
 
 /*
  * Stage size elements of a resource
@@ -140,18 +145,25 @@ void resrc_stage_resrc(resrc_t *resrc, size_t size);
  * Allocate a resource to a job
  */
 int resrc_allocate_resource (resrc_t *resrc, int64_t job_id,
-                             int64_t time_now, int64_t walltime);
+                             int64_t starttime, int64_t endtime);
 
 /*
  * Reserve a resource for a job
  */
 int resrc_reserve_resource (resrc_t *resrc, int64_t job_id,
-                            int64_t time_now, int64_t walltime);
+                            int64_t starttime, int64_t endtime);
 
 /*
  * Remove a job allocation from a resource
+ * Supports both now and time-based allocations.
  */
-int resrc_release_resource (resrc_t *resrc, int64_t rel_job);
+int resrc_release_allocation (resrc_t *resrc, int64_t rel_job);
+
+/*
+ * Remove all reservations of a resource
+ * Supports both now and time-based reservations.
+ */
+int resrc_release_all_reservations (resrc_t *resrc);
 
 /*
  * Get epoch time

--- a/resrc/resrc_reqst.h
+++ b/resrc/resrc_reqst.h
@@ -22,6 +22,26 @@ typedef struct resrc_reqst_list resrc_reqst_list_t;
 resrc_t *resrc_reqst_resrc (resrc_reqst_t *resrc_reqst);
 
 /*
+ * Return the start time of this request
+ */
+int64_t resrc_reqst_starttime (resrc_reqst_t *resrc_reqst);
+
+/*
+ * Set the start time of this request
+ */
+int resrc_reqst_set_starttime (resrc_reqst_t *resrc_reqst, int64_t time);
+
+/*
+ * Return the end time of this request
+ */
+int64_t resrc_reqst_endtime (resrc_reqst_t *resrc_reqst);
+
+/*
+ * Set the end time of this request
+ */
+int resrc_reqst_set_endtime (resrc_reqst_t *resrc_reqst, int64_t time);
+
+/*
  * Return the required number of resources in this request
  */
 int64_t resrc_reqst_reqrd (resrc_reqst_t *resrc_reqst);
@@ -39,7 +59,7 @@ int64_t resrc_reqst_add_found (resrc_reqst_t *resrc_reqst, int64_t nfound);
 /*
  * Clear the number of resources found for this request
  */
-void resrc_reqst_clear_found (resrc_reqst_t *resrc_reqst);
+int resrc_reqst_clear_found (resrc_reqst_t *resrc_reqst);
 
 /*
  * Return the number of children in the resource request
@@ -59,12 +79,13 @@ int resrc_reqst_add_child (resrc_reqst_t *parent, resrc_reqst_t *child);
 /*
  * Create a new resrc_reqst_t object
  */
-resrc_reqst_t *resrc_reqst_new (resrc_t *resrc, int64_t qty);
+resrc_reqst_t *resrc_reqst_new (resrc_t *resrc, int64_t qty, int64_t starttime,
+                                int64_t endtime);
 
 /*
  * Create a resrc_reqst_t object from a json object
  */
-resrc_reqst_t *resrc_reqst_from_json (JSON o, resrc_t *parent);
+resrc_reqst_t *resrc_reqst_from_json (JSON o, resrc_reqst_t *parent);
 
 /*
  * Free a resrc_reqst_t object

--- a/resrc/resrc_tree.h
+++ b/resrc/resrc_tree.h
@@ -71,18 +71,28 @@ resrc_tree_t *resrc_tree_deserialize (JSON o, resrc_tree_t *parent);
  * Allocate all the resources in a resource tree
  */
 int resrc_tree_allocate (resrc_tree_t *resrc_tree, int64_t job_id,
-                         int64_t time_now, int64_t walltime);
+                         int64_t starttime, int64_t endtime);
 
 /*
  * Reserve all the resources in a resource tree
  */
 int resrc_tree_reserve (resrc_tree_t *resrc_tree, int64_t job_id,
-                        int64_t time_now, int64_t walltime);
+                        int64_t starttime, int64_t endtime);
 
 /*
- * Release all the resources in a resource tree
+ * Release an allocation from a resource tree
  */
 int resrc_tree_release (resrc_tree_t *resrc_tree, int64_t job_id);
+
+/*
+ * Remove all reservations from a resource tree
+ */
+int resrc_tree_release_all_reservations (resrc_tree_t *resrc_tree);
+
+/*
+ * Unstage all resources in a resource tree
+ */
+void resrc_tree_unstage_resources (resrc_tree_t *resrc_tree);
 
 /***********************************************************************
  * Resource tree list
@@ -142,18 +152,28 @@ resrc_tree_list_t *resrc_tree_list_deserialize (JSON o);
  * Allocate all the resources in a list of resource trees
  */
 int resrc_tree_list_allocate (resrc_tree_list_t *rtl, int64_t job_id,
-                              int64_t time_now, int64_t walltime);
+                              int64_t starttime, int64_t endtime);
 
 /*
  * Reserve all the resources in a list of resource trees
  */
 int resrc_tree_list_reserve (resrc_tree_list_t *rtl, int64_t job_id,
-                             int64_t time_now, int64_t walltime);
+                             int64_t starttime, int64_t endtime);
 
 /*
- * Release all the resources in a list of resource trees
+ * Release an allocation from a list of resource trees
  */
 int resrc_tree_list_release (resrc_tree_list_t *rtl, int64_t job_id);
+
+/*
+ * Release all the reservations from a list of resource trees
+ */
+int resrc_tree_list_release_all_reservations (resrc_tree_list_t *rtl);
+
+/*
+ * Unstage all resources in a list of resource trees
+ */
+void resrc_tree_list_unstage_resources (resrc_tree_list_t *rtl);
 
 
 #endif /* !FLUX_RESRC_TREE_H */

--- a/resrc/test/tresrc.c
+++ b/resrc/test/tresrc.c
@@ -109,9 +109,9 @@ static void test_temporal_allocation ()
 
     // Setup the resource allocations for the rest of the tests
     resrc_stage_resrc (resource, 5);
-    rc = (rc || resrc_allocate_resource (resource, 1, 0, 1000));
+    rc = (rc || resrc_allocate_resource (resource, 1, 1, 1000));
     resrc_stage_resrc (resource, 10);
-    rc = (rc || resrc_allocate_resource (resource, 2, 2000, 1000));
+    rc = (rc || resrc_allocate_resource (resource, 2, 2000, 3000));
     ok (!rc, "Temporal allocation setup works");
     if (rc) {
         return;
@@ -122,7 +122,7 @@ static void test_temporal_allocation ()
     // This should fail
     rc = (rc || !resrc_allocate_resource (resource, 3, 10, 3000));
     // This should work
-    rc = (rc || resrc_allocate_resource (resource, 3, 10, 1989));
+    rc = (rc || resrc_allocate_resource (resource, 3, 10, 1999));
     ok (!rc, "Overlapping temporal allocations work");
     if (rc) {
         return;
@@ -130,7 +130,7 @@ static void test_temporal_allocation ()
 
     // Test "available at time"
     // Job 1
-    available = resrc_available_at_time (resource, 0);
+    available = resrc_available_at_time (resource, 1);
     rc = (rc || !(available == 5));
     // Jobs 1 & 3
     available = resrc_available_at_time (resource, 10);
@@ -249,6 +249,7 @@ int main (int argc, char *argv[])
     int found = 0;
     int rc = 0;
     int verbose = 0;
+    int64_t nowtime = epochtime ();
     JSON child_core = NULL;
     JSON o = NULL;
     JSON req_res = NULL;
@@ -406,22 +407,22 @@ int main (int argc, char *argv[])
     init_time ();
 
     selected_trees = test_select_resources (found_trees, 1);
-    rc = resrc_tree_list_allocate (selected_trees, 1, -1, 3600);
+    rc = resrc_tree_list_allocate (selected_trees, 1, nowtime, nowtime + 3600);
     ok (!rc, "successfully allocated resources for job 1");
     resrc_tree_list_free (selected_trees);
 
     selected_trees = test_select_resources (found_trees, 2);
-    rc = resrc_tree_list_allocate (selected_trees, 2, -1, 3600);
+    rc = resrc_tree_list_allocate (selected_trees, 2, nowtime, nowtime + 3600);
     ok (!rc, "successfully allocated resources for job 2");
     resrc_tree_list_free (selected_trees);
 
     selected_trees = test_select_resources (found_trees, 3);
-    rc = resrc_tree_list_allocate (selected_trees, 3, -1, 3600);
+    rc = resrc_tree_list_allocate (selected_trees, 3, nowtime, nowtime + 3600);
     ok (!rc, "successfully allocated resources for job 3");
     resrc_tree_list_free (selected_trees);
 
     selected_trees = test_select_resources (found_trees, 4);
-    rc = resrc_tree_list_reserve (selected_trees, 4, -1, 3600);
+    rc = resrc_tree_list_reserve (selected_trees, 4, nowtime, nowtime + 3600);
     ok (!rc, "successfully reserved resources for job 4");
     resrc_tree_list_free (selected_trees);
 

--- a/sched/Makefile
+++ b/sched/Makefile
@@ -5,13 +5,15 @@ LIBS = $(FLUX_LIBS) $(RESRC_LIBS)
 
 CONF=../conf/hype.lua
 
-BUILD = schedsrv.so schedplugin1.so flux-waitjob
+BUILD = schedsrv.so schedplugin1.so backfillplugin1.so flux-waitjob
 
 all: $(BUILD)
 
 schedsrv.so: schedsrv.o xzmalloc.o log.o jsonutil.o
 	$(CC) -shared -o $@ $^ $(LIBS) $(SIM_LIBS)
 schedplugin%.so: schedplugin%.o xzmalloc.o log.o jsonutil.o
+	$(CC) -shared -o $@ $^ $(LIBS)
+backfillplugin%.so: backfillplugin%.o xzmalloc.o log.o jsonutil.o
 	$(CC) -shared -o $@ $^ $(LIBS)
 flux-waitjob: flux-waitjob.o log.o jsonutil.o
 	$(CC) -o $@ $^ $(LIBS)

--- a/sched/schedsrv.h
+++ b/sched/schedsrv.h
@@ -57,8 +57,6 @@ typedef struct flux_resources {
 typedef struct {
     int64_t     lwj_id;  /*!< LWJ id */
     job_state_t state;   /*!< current job state */
-    bool        reserve; /*!< reserve resources for job if true */
-    bool        reserved; // Job has resources reserved for it
     flux_res_t *req;     /*!< resources requested by this LWJ */
     resrc_tree_list_t *resrc_trees; /*!< resources allocated to this LWJ */
     int64_t starttime;

--- a/t/t2002-easy.t
+++ b/t/t2002-easy.t
@@ -57,7 +57,7 @@ test_expect_success 'loading exec works' '
 	flux module load ${sim_exec}
 '
 test_expect_success 'loading sched works' '
-	flux module load ${sched} rdl-conf=${rdlconf} in-sim=true plugin=sched.plugin1 backfill=easy
+	flux module load ${sched} rdl-conf=${rdlconf} in-sim=true plugin=backfill.plugin1
 '
 
 while flux kvs get lwj.12.complete_time 2>&1 | grep -q "No such file"; do sleep 0.5; done


### PR DESCRIPTION
A new backfillplugin1 was added as an alternative to the original FCFS
schedplugin1 plugin.  The EASY_BACKFILL definition in this plugin
controls whether the backfill is EASY or conservative.  It's currently
defined to be EASY so as to function as an exact replacement.

3 new API's were added to the sched framework: sched_loop_setup(),
allocate_resources(), and reserve_resources().

Includes many changes across sched as well as resrc.  resrc now
includes support for time-based as well as now-based resource
matching, allocations and reservations.  The backfill scheduler uses
the time-based functionality while the schedplugin1 FCFS uses the
now-based versions.

The stage_tree_list() was removed and instead staging was moved to the
selection function.  As size elements of a resource are selected, they
are also staged.

Finally, the t2002-easy.t test was modified to load the new plugin.
The hype-test.csv file of input jobs was not modified and the
easy_expected order remains the same.

Addresses [Issue 88](https://github.com/flux-framework/flux-sched/issues/88)