### PR TITLE
rs2rank: add support to link resrc to broker rank, etc

### DIFF
--- a/resrc/resrc.c
+++ b/resrc/resrc.c
@@ -41,6 +41,7 @@ struct resrc {
     char *type;
     char *path;
     char *name;
+    char *digest;
     int64_t id;
     uuid_t uuid;
     size_t size;
@@ -80,6 +81,20 @@ char *resrc_name (resrc_t *resrc)
     if (resrc)
         return resrc->name;
     return NULL;
+}
+
+char *resrc_digest (resrc_t *resrc)
+{
+    if (resrc)
+        return resrc->digest;
+    return NULL;
+}
+
+char *resrc_set_digest (resrc_t *resrc, char *digest)
+{
+    char *old = resrc->digest;
+    resrc->digest = digest;
+    return old;
 }
 
 int64_t resrc_id (resrc_t *resrc)
@@ -418,6 +433,7 @@ resrc_t *resrc_new_resource (const char *type, const char *path,
         if (name)
             resrc->name = xstrdup (name);
         resrc->id = id;
+        resrc->digest = NULL;
         if (uuid)
             uuid_copy (resrc->uuid, uuid);
         resrc->size = size;
@@ -473,6 +489,8 @@ void resrc_resource_destroy (void *object)
             free (resrc->path);
         if (resrc->name)
             free (resrc->name);
+        if (resrc->digest)
+            free (resrc->digest);
         /* Don't worry about freeing resrc->phys_tree.  It will be
          * freed by resrc_tree_free()
          */

--- a/resrc/resrc.h
+++ b/resrc/resrc.h
@@ -40,6 +40,13 @@ char *resrc_path (resrc_t *resrc);
 char *resrc_name (resrc_t *resrc);
 
 /*
+ * Return the digest of resrc -- key to find corresponding
+ * broker rank
+ */
+char *resrc_digest (resrc_t *resrc);
+char *resrc_set_digest (resrc_t *resrc, char *digest);
+
+/*
  * Return the id of the resouce
  */
 int64_t resrc_id (resrc_t *resrc);

--- a/sched/Makefile
+++ b/sched/Makefile
@@ -9,8 +9,8 @@ BUILD = schedsrv.so schedplugin1.so backfillplugin1.so flux-waitjob
 
 all: $(BUILD)
 
-schedsrv.so: schedsrv.o xzmalloc.o log.o jsonutil.o
-	$(CC) -shared -o $@ $^ $(LIBS) $(SIM_LIBS)
+schedsrv.so: schedsrv.o rs2rank.o rsreader.o xzmalloc.o log.o jsonutil.o
+	$(CC) -shared -o $@ $^ $(LIBS) $(SIM_LIBS) -lhwloc
 schedplugin%.so: schedplugin%.o xzmalloc.o log.o jsonutil.o
 	$(CC) -shared -o $@ $^ $(LIBS)
 backfillplugin%.so: backfillplugin%.o xzmalloc.o log.o jsonutil.o

--- a/sched/rs2rank.c
+++ b/sched/rs2rank.c
@@ -1,0 +1,293 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <czmq.h>
+#include <hwloc.h>
+
+#include "src/common/libutil/jsonutil.h"
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/xzmalloc.h"
+#include "resrc.h"
+#include "resrc_tree.h"
+#include "resrc_reqst.h"
+#include "rs2rank.h"
+
+/* This rs2rank table is keyed by hostname. The value
+ * is another hash table keyed by the signiture of
+ * the resource partition contained within the host.
+ * (Normally there is only one resource partition per host.)
+ * Each value of the partition hash table includes an
+ * equivalent set of broker ranks that mananage that partition.
+ */
+struct machs {
+    zhash_t      *tab;
+};
+
+/* Each resource partition within a host holds an object of
+ * this resource signiture. This can be extended later if needed.
+ */
+struct rssig {
+    char         *digest;
+    int           nsockets;
+    int           ncores;
+};
+
+typedef struct partition {
+    struct rssig *sig;
+    int           rrobin;
+    zlist_t      *ranks;
+} partition_t;
+
+
+/******************************************************************************
+ *                                                                            *
+ *                             Utility functions                              *
+ *                                                                            *
+ ******************************************************************************/
+
+static inline bool host_seen (zhash_t *tab, const char *hn)
+{
+    return (hn && zhash_lookup (tab, hn)) ? true : false;
+}
+
+static inline bool partition_seen (zhash_t *partab, const char *digest)
+{
+    return (digest && zhash_lookup (partab, digest)) ? true : false;
+}
+
+static void partition_tab_freefn (void *data)
+{
+    zhash_t *tab = (zhash_t *)data;
+    zhash_destroy (&tab);
+}
+
+static void partition_freefn (void *data)
+{
+    partition_t *o = (partition_t *)data;
+    free (o->sig->digest);
+    zlist_destroy (&(o->ranks));
+}
+
+static inline void partition_tab_new (zhash_t *tab, const char *hn)
+{
+    zhash_t *partab;
+    if (!(partab  = zhash_new ()))
+        oom ();
+    zhash_insert (tab, hn, (void *)partab);
+    zhash_freefn (tab, hn, partition_tab_freefn);
+}
+
+static inline void partition_new (zhash_t *partab, rssig_t *sig)
+{
+    partition_t *nobj = (partition_t *)xzmalloc (sizeof (*nobj));
+    nobj->sig = sig;
+    nobj->rrobin = 0;
+    if (!(nobj->ranks = zlist_new ()))
+        oom ();
+    zhash_insert (partab, sig->digest, (void *)nobj);
+    zhash_freefn (partab, sig->digest, partition_freefn);
+}
+
+static int get_rank_rrobin (partition_t *part, uint32_t *rank)
+{
+    int rc = 0;
+    uint32_t *tmp;
+    if (!(part->ranks))
+        return -1;
+
+    if (part->rrobin && (tmp = zlist_next (part->ranks))) {
+        *rank = *tmp;
+        part->rrobin = 1;
+    }
+    else if ((tmp = zlist_first (part->ranks))) {
+        *rank = *tmp;
+        part->rrobin =1;
+    }
+    else
+        rc = -1;
+
+    return rc;
+}
+
+
+/******************************************************************************
+ *                                                                            *
+ *                   Resource2BrokerRank Public APIs                          *
+ *                                                                            *
+ ******************************************************************************/
+
+machs_t *rs2rank_tab_new ()
+{
+    machs_t *m;
+    m = (machs_t *) xzmalloc (sizeof (*m));
+    if (!(m->tab = zhash_new ()))
+        oom ();
+    return m;;
+}
+
+void rs2rank_tab_destroy (machs_t *m)
+{
+    if (m) {
+        if (m->tab)
+            zhash_destroy (&(m->tab));
+        free (m);
+    }
+}
+
+int rs2rank_tab_query_by_sign (machs_t *m, const char *hn, const char *digest,
+                               bool reset, uint32_t *rank)
+{
+    int rc = -1;
+    zhash_t *partab = NULL;
+    partition_t *part = NULL;
+    if (!host_seen (m->tab, hn))
+        goto done;
+    if (!(partab = zhash_lookup (m->tab, hn)))
+        goto done;
+    if (!(part = zhash_lookup (partab, digest)))
+        goto done;
+    if (reset)
+        part->rrobin = 0;
+    if (get_rank_rrobin (part, rank) != 0)
+        goto done;
+
+    rc = 0;
+done:
+    return rc;
+}
+
+int rs2rank_tab_query_by_none (machs_t *m, const char *digest,
+                               bool reset, uint32_t *rank)
+{
+    int rc = -1;
+    zhash_t *partab = NULL;
+    partition_t *part = NULL;
+    if (!(partab = zhash_first (m->tab)))
+        goto done;
+    if (!(part = zhash_lookup (partab, digest)))
+        goto done;
+    if (reset)
+        part->rrobin = 0;
+    if (get_rank_rrobin (part, rank) != 0)
+        goto done;
+    rc = 0;
+done:
+    return rc;
+}
+
+int rs2rank_tab_update (machs_t *m, const char *hn, rssig_t *sig, uint32_t rank)
+{
+    int rc = -1;
+    uint32_t *rcp = NULL;
+    partition_t *robj = NULL;
+    zhash_t *partab = NULL;
+
+    if (!hn || !sig || !m || !(m->tab))
+        goto done;
+    else if (!host_seen (m->tab, hn))
+        partition_tab_new (m->tab, hn);
+
+    if (!(partab = zhash_lookup (m->tab, hn)))
+        goto done;
+    else if (!partition_seen (partab, sig->digest))
+        partition_new (partab, sig);
+
+    if (!(robj = zhash_lookup (partab, sig->digest)))
+        goto done;
+
+    rcp = xzmalloc (sizeof (*rcp));
+    *rcp = rank;
+    if (zlist_append (robj->ranks, (void *)rcp) != 0)
+        goto done;
+    else if (!zlist_freefn (robj->ranks, (void *)rcp, free, false))
+        goto done;
+    rc = 0;
+
+done:
+    return rc;
+}
+
+const char *rs2rank_tab_eq_by_sign (machs_t *m, const char *hn,
+                                    int nsockets, int ncores)
+{
+    zhash_t *partab = NULL;
+    partition_t *part = NULL;
+    const char *rdigest = NULL;
+
+    if (!host_seen (m->tab, hn))
+        goto done;
+    if ((!(partab = zhash_lookup (m->tab, hn))))
+        goto done;
+    for (part = zhash_first (partab); part; part = zhash_next (partab)) {
+        if (part->sig->nsockets == nsockets && part->sig->ncores == ncores) {
+            rdigest = part->sig->digest;
+            break;
+        }
+    }
+done:
+    return rdigest;
+}
+
+const char *rs2rank_tab_eq_by_none (machs_t *m)
+{
+    const char *rdigest = NULL;
+    zhash_t *partab = NULL;
+    partition_t *part = NULL;
+    if ((partab = zhash_first (m->tab)) && (part = zhash_first (partab)))
+        rdigest = part->sig->digest;
+    return rdigest;
+}
+
+int rs2rank_set_signiture (char *rsbuf, size_t len, hwloc_topology_t t,
+                           rssig_t **sig)
+{
+    int rc = -1;
+    zdigest_t *digest = NULL;
+    *sig = (rssig_t *) xzmalloc (sizeof (**sig)) ;
+    if (!(digest = zdigest_new ()))
+        oom ();
+
+    zdigest_update (digest, (byte *)rsbuf, len);
+    (*sig)->digest = xasprintf ("%s", zdigest_string (digest));
+    zdigest_destroy (&(digest));
+    /* FIMXE: Why HWLOC_OBJ_NUMANODE doesn't work ? */
+    (*sig)->nsockets = hwloc_get_nbobjs_by_type (t, HWLOC_OBJ_SOCKET);
+    (*sig)->ncores = hwloc_get_nbobjs_by_type (t, HWLOC_OBJ_CORE);
+    if (((*sig)->nsockets > 0) && ((*sig)->ncores > 0))
+        rc = 0;
+
+    return rc;
+}
+
+const char *rs2rank_get_digest (rssig_t *sig)
+{
+    return sig ? sig->digest : NULL;
+}
+
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/sched/rs2rank.h
+++ b/sched/rs2rank.h
@@ -1,0 +1,91 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef RS2RANK_H
+#define RS2RANK_H 1
+
+#include <hwloc.h>
+
+typedef struct machs machs_t;
+typedef struct rssig rssig_t;
+
+/* rs2rank table (of machs_t type) c'tor/d'tors.
+ * The table is keyed by hostname and each value entry maintains
+ * the signiture of each resource partition within this host as
+ * well as one or more equivalent broker ranks that manage the
+ * resource partition.
+ */
+machs_t *rs2rank_tab_new ();
+void rs2rank_tab_destroy (machs_t *m);
+
+/* A equality matching function based on hostname, socket and core count
+ * This comparator should be used if a node-type resrc_t object can
+ * be considered to be eqqual to a hwloc object when their hostnames
+ * and socket and core counts are each identical.
+ */
+const char *rs2rank_tab_eq_by_sign (machs_t *m, const char *hn, int s, int c);
+
+/* A testing equality matching -- returns the signiture of the first partition
+ * This dumb comparator should be used if all node-type resrc_t objects
+ * must be matched with the first hwloc obj (e.g., emulation mode).
+ */
+const char *rs2rank_tab_eq_by_none (machs_t *m);
+
+/* Update the rs2rank table with hostname and resource partition signiture
+ * If multiple ranks manage the same resource partition given by s,
+ * the table maintains and treats all these ranks as "equivalent."
+ */
+int rs2rank_tab_update (machs_t *m, const char *hn, rssig_t *s, uint32_t rank);
+
+/* Return a broker rank that manages the resource partition
+ * given by hostname hn and digest. If multiple ranks manage the partition
+ * in a shared fashion, return a rank in round robin from the equivalent
+ * ranks set (wrapped to the first rank in the end).  Passing true to
+ * reset will return the first rank of this ranks set by resetting
+ * the iterator.
+ */
+int rs2rank_tab_query_by_sign (machs_t *m, const char *hn, const char *digest,
+                               bool reset, uint32_t *rank);
+
+/* A testing query -- always use the first host in m
+ * (needed for emulation testing)
+ */
+int rs2rank_tab_query_by_none (machs_t *m, const char *digest,
+                               bool reset, uint32_t *rank);
+
+
+/* Set signiture s based on the hwloc xml string rsb, its length and hwloc obj
+ * s should be freed by rs2rank_tab_destroy after it is made associated with the
+ * rs2rank table.
+ */
+int rs2rank_set_signiture (char *rsb, size_t l, hwloc_topology_t t, rssig_t **s);
+
+/* Utility function to return a stringfied SHA digest of the res partition */
+const char *rs2rank_get_digest (rssig_t *sig);
+
+#endif /* RS2RANK_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/sched/rsreader.c
+++ b/sched/rsreader.c
@@ -1,0 +1,242 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include <stdio.h>
+#include <hwloc.h>
+
+#include "src/common/libutil/jsonutil.h"
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/xzmalloc.h"
+#include "resrc.h"
+#include "resrc_tree.h"
+#include "resrc_reqst.h"
+#include "rs2rank.h"
+#include "rsreader.h"
+
+/******************************************************************************
+ *                                                                            *
+ *                             Utility functions                              *
+ *                                                                            *
+ ******************************************************************************/
+
+static inline const char *hwloc_get_hn (hwloc_topology_t topo)
+{
+    hwloc_obj_t obj;
+    const char *hn = NULL;;
+    obj = hwloc_get_obj_by_type (topo, HWLOC_OBJ_MACHINE, 0);
+    if (obj)
+        hn = hwloc_obj_get_info_by_name (obj, "HostName");
+    return hn;
+}
+
+static inline void create_req4allnodes (JSON reqobj)
+{
+    JSON req1, req2;
+    Jadd_str (reqobj, "type", "node");
+    Jadd_int (reqobj, "req_qty", 1);
+    req1 = Jnew ();
+    Jadd_str (req1, "type", "socket");
+    Jadd_int (req1, "req_qty", 1);
+    req2 = Jnew ();
+    Jadd_str (req2, "type", "core");
+    Jadd_int (req2, "req_qty", 1);
+    json_object_object_add (req1, "req_child", req2);
+    json_object_object_add (reqobj, "req_child", req1);
+}
+
+static inline void create_req4allsocks (JSON reqobj)
+{
+    JSON req1;
+    Jadd_str (reqobj, "type", "socket");
+    Jadd_int (reqobj, "req_qty", 1);
+    req1 = Jnew ();
+    Jadd_str (req1, "type", "core");
+    Jadd_int (req1, "req_qty", 1);
+    json_object_object_add (reqobj, "req_child", req1);
+}
+
+static inline void create_req4allcores (JSON reqobj)
+{
+    Jadd_str (reqobj, "type", "core");
+    Jadd_int (reqobj, "req_qty", 1);
+}
+
+static int find_all_nodes (resrc_tree_t *root,
+                           resrc_tree_list_t **ot, size_t *size)
+{
+    JSON reqobj = NULL;
+    resrc_reqst_t *req = NULL;
+
+    reqobj = Jnew ();
+    create_req4allnodes (reqobj);
+    req = resrc_reqst_from_json (reqobj, NULL);
+    *ot = resrc_tree_list_new ();
+    *size = resrc_tree_search (resrc_tree_children (root), req, *ot, false);
+    resrc_reqst_destroy (req);
+    Jput (reqobj);
+
+    return (*size > 0) ? 0 : -1;
+}
+
+static int find_all_sockets_cores (resrc_tree_t *node, int *nsocks, int *ncs)
+{
+    JSON reqobj= NULL;
+    resrc_reqst_t *req = NULL;
+    resrc_tree_list_t *st = NULL;
+    resrc_tree_list_t *ct = NULL;
+
+    reqobj = Jnew ();
+    create_req4allsocks (reqobj);
+    req = resrc_reqst_from_json (reqobj, NULL);
+    st = resrc_tree_list_new ();
+    *nsocks = resrc_tree_search (resrc_tree_children (node), req, st, false);
+    resrc_reqst_destroy (req);
+    Jput (reqobj);
+
+    reqobj = Jnew ();
+    create_req4allcores (reqobj);
+    req = resrc_reqst_from_json (reqobj, NULL);
+    ct = resrc_tree_list_new ();
+    *ncs = resrc_tree_search (resrc_tree_children (node), req, ct, false);
+    resrc_reqst_destroy (req);
+    Jput (reqobj);
+
+    return (*nsocks > 0 && *ncs > 0) ? 0 : -1;
+}
+
+
+/******************************************************************************
+ *                                                                            *
+ *                   Resource Reader Public APIs                              *
+ *                                                                            *
+ ******************************************************************************/
+
+int rsreader_resrc_bulkload (const char *path, char *uri, char **r_uri,
+                             resrc_t **r_resrc)
+{
+    *r_uri = uri ? uri : xstrdup ("default");
+    return (*r_resrc = resrc_generate_rdl_resources (path, *r_uri)) ? 0 : -1;
+}
+
+int rsreader_hwloc_bulkload (const char *buf, size_t len, rsreader_t r_mode,
+                             char **r_uri, resrc_t **r_resrc, machs_t *machs)
+{
+    /* NYI */
+    return -1;
+}
+
+int rsreader_resrc_load (const char *path, char *uri, uint32_t rank, char **r_uri,
+                         resrc_t **r_resrc)
+{
+    /* NYI */
+    return -1;
+}
+
+int rsreader_hwloc_load (const char *buf, size_t len, uint32_t rank,
+                         rsreader_t r_mode, resrc_t **r_resrc, machs_t *machs)
+{
+    int rc = -1;
+    rssig_t *sig = NULL;
+    hwloc_topology_t topo;
+
+    if (hwloc_topology_init (&topo) != 0)
+        goto done;
+    else if (hwloc_topology_set_xmlbuffer (topo, buf, len) != 0)
+        goto done;
+    else if (hwloc_topology_load (topo) != 0)
+        goto done;
+
+    if (!machs)
+        goto done;
+    else if (rs2rank_set_signiture ((char*)buf, len, topo, &sig) != 0)
+        goto done;
+    else if (rs2rank_tab_update (machs, hwloc_get_hn (topo), sig, rank) != 0)
+        goto done;
+
+    /* TODO: add a new resrc function that works w/ hwloc
+     * resrc_generate_hwloc_resources (*r_resrc, topology...
+     */
+    if (r_mode == RSREADER_HWLOC) {
+        if (!resrc_generate_xml_resources (*r_resrc, buf, len))
+            goto done;
+    }
+
+    hwloc_topology_destroy (topo);
+    rc = 0;
+done:
+    return rc;
+}
+
+int rsreader_link2rank (machs_t *machs, resrc_t *r_resrc)
+{
+    int rc = -1;
+    char *hn = NULL;
+    size_t ncnt = 0;
+    resrc_tree_t *o = NULL;
+    int nsocks = 0, ncs = 0;
+    const char *digest = NULL;
+    resrc_tree_list_t *nl = NULL;
+
+    if (find_all_nodes (resrc_phys_tree (r_resrc), &nl, &ncnt) != 0)
+        goto done;
+    for (o = resrc_tree_list_first (nl); o; o = resrc_tree_list_next (nl)) {
+        if (find_all_sockets_cores (o, &nsocks, &ncs) != 0)
+            goto done;
+        hn = xasprintf ("%s%"PRId64"", resrc_name (resrc_tree_resrc (o)),
+                                       resrc_id (resrc_tree_resrc (o)));
+        /* matches based on the hostname, number of sockets and cores */
+        digest = rs2rank_tab_eq_by_sign (machs, hn, nsocks, ncs);
+        free (hn);
+        if (!digest)
+            goto done;
+        resrc_set_digest (resrc_tree_resrc (o), xasprintf ("%s", digest));
+    }
+    rc = 0;
+done:
+    return rc;
+}
+
+int rsreader_force_link2rank (machs_t *machs, resrc_t *r_resrc)
+{
+    int rc = -1;
+    size_t ncnt = 0;
+    resrc_tree_t *o = NULL;
+    const char *digest = NULL;
+    resrc_tree_list_t *nl = NULL;
+
+    if (find_all_nodes (resrc_phys_tree (r_resrc), &nl, &ncnt) != 0)
+        goto done;
+    for (o = resrc_tree_list_first (nl); o; o = resrc_tree_list_next (nl)) {
+        if (!(digest = rs2rank_tab_eq_by_none (machs)))
+            goto done;
+        resrc_set_digest (resrc_tree_resrc (o), xasprintf ("%s", digest));
+    }
+    rc = 0;
+done:
+    return rc;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/sched/rsreader.h
+++ b/sched/rsreader.h
@@ -1,0 +1,88 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef RSREADER_H
+#define RSREADER_H 1
+
+#include <stdint.h>
+#include <hwloc.h>
+#include "resrc.h"
+#include "rs2rank.h"
+
+typedef enum {
+     RSREADER_RESRC_EMUL,
+     RSREADER_RESRC,
+     RSREADER_HWLOC,
+     RSREADER_FOR_RENT
+} rsreader_t;
+
+/* Bulk-load the resources specified in a rdl file (rdl_path) into
+ * the root resrc_t object (root). r_uri is allocated and filled
+ * with the uri of the root. uri is optional; if NULL, "default"
+ * uri is used.
+ */
+int rsreader_resrc_bulkload (const char *rdl_path, char *uri, char **r_uri,
+                             resrc_t **root);
+
+/* Placehodler for hwloc resource data bulk loading
+ * Not Yet Implemented.
+ */
+int rsreader_hwloc_bulkload (const char *hw_xml, size_t len, rsreader_t r_mode,
+                             char **r_uri, resrc_t **root, machs_t *machs);
+
+/* Placehodler for individual resrc data loading
+ * Not Yet Implemented.
+ */
+int rsreader_resrc_load (const char *path, char *uri, uint32_t rank, char **r_uri,
+                         resrc_t **root);
+
+ /* The main purpose of this function is to process the hwloc
+  * resource xml buffer of one broker rank (rank) to fill in
+  * the rs2rank table (machs: please see rs2rank.h).
+  * It also loads the hwloc resource xml buffer and make it available
+  * through the root resrc_t object (root) if r_mode is RSREADER_RESRC.
+  */
+int rsreader_hwloc_load (const char *hw_xml, size_t len, uint32_t rank,
+                         rsreader_t r_mode, resrc_t **root, machs_t *machs);
+
+/* Traverse the entire resrc hierarchy and link each node-type
+ * resrc_t object with a broker rank by filling in its digest field.
+ * Its hostname and digest of the resrc object are later used
+ * to determine the managing broker.
+ */
+int rsreader_link2rank (machs_t *machs, resrc_t *root);
+
+/* For testing such as emulation whereby no real mapping may
+ * exist between the phiscal broker rank and testing resource
+ * hierarchy, this method should be used to force to ssociate
+ * each and all of the node-type resrc_t object with a single
+ * broker rank.
+ */
+int rsreader_force_link2rank (machs_t *machs, resrc_t *root);
+
+#endif /* RSREADER_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/sched/schedsrv.c
+++ b/sched/schedsrv.c
@@ -92,22 +92,22 @@ typedef struct sched_ops {
 } sched_ops_t;
 
 typedef struct {
-    JSON jcb;
-    void *arg;
-    int errnum;
+    JSON          jcb;
+    void         *arg;
+    int           errnum;
 } jsc_event_t;
 
 typedef struct {
-    flux_t h;
-    void *arg;
+    flux_t        h;
+    void         *arg;
 } res_event_t;
 
 typedef struct {
-    bool in_sim;
-    sim_state_t *sim_state;
-    zlist_t *res_queue;
-    zlist_t *jsc_queue;
-    zlist_t *timer_queue;
+    bool          in_sim;
+    sim_state_t  *sim_state;
+    zlist_t      *res_queue;
+    zlist_t      *jsc_queue;
+    zlist_t      *timer_queue;
 } simctx_t;
 
 typedef struct {

--- a/sched/schedsrv.c
+++ b/sched/schedsrv.c
@@ -312,18 +312,12 @@ static inline bool is_newjob (JSON jcb)
     return ((os == J_NULL) && (ns == J_NULL))? true : false;
 }
 
-/* clang warning:  error: unused function */
-#if 0
-static bool inline is_node (const char *t)
-{
-    return (strcmp (t, "node") == 0)? true: false;
-}
 
-static bool inline is_core (const char *t)
-{
-    return (strcmp (t, "core") == 0)? true: false;
-}
-#endif
+/********************************************************************************
+ *                                                                              *
+ *                          Simple Job Queue Methods                            *
+ *                                                                              *
+ *******************************************************************************/
 
 static int append_to_pqueue (ssrvctx_t *ctx, JSON jcb)
 {
@@ -674,11 +668,9 @@ static void handle_res_queue (ssrvctx_t *ctx)
     }
 }
 
-
 /*
  * Simulator Callbacks
  */
-
 static void start_cb (flux_t h,
                       flux_msg_handler_t *w,
                       const flux_msg_t *msg,
@@ -790,10 +782,16 @@ static void trigger_cb (flux_t h,
     Jput (o);
 }
 
+
+/******************************************************************************
+ *                                                                            *
+ *                     Scheduler Eventing For Emulation Mode                  *
+ *                                                                            *
+ ******************************************************************************/
+
 /*
  * Simulator Initialization Functions
  */
-
 static struct flux_msg_handler_spec sim_htab[] = {
     {FLUX_MSGTYPE_EVENT, "sim.start", start_cb},
     {FLUX_MSGTYPE_REQUEST, "sched.trigger", trigger_cb},
@@ -857,9 +855,10 @@ done:
     return rc;
 }
 
+
 /******************************************************************************
  *                                                                            *
- *                     Scheduler Event Registeration                          *
+ *                     Scheduler Eventing For Normal Mode                     *
  *                                                                            *
  ******************************************************************************/
 
@@ -915,6 +914,116 @@ done:
     return rc;
 }
 
+
+/******************************************************************************
+ *                                                                            *
+ *            Mode Bridging Layer to Hide Emulation vs. Normal Mode           *
+ *                                                                            *
+ ******************************************************************************/
+
+static inline int bridge_set_execmode (ssrvctx_t *ctx)
+{
+    int rc = 0;
+    if (ctx->arg.sim && setup_sim (ctx, ctx->arg.sim) != 0) {
+        flux_log (ctx->h, LOG_ERR, "failed to setup sim mode");
+        rc = -1;
+        goto done;
+    }
+done:
+    return rc;
+}
+
+static inline int bridge_set_events (ssrvctx_t *ctx)
+{
+    int rc = -1;
+    if (ctx->sctx.in_sim) {
+        if (reg_sim_events (ctx) != 0) {
+            flux_log (ctx->h, LOG_ERR, "failed to reg sim events");
+            goto done;
+        }
+        flux_log (ctx->h, LOG_INFO, "sim events registered");
+    } else {
+        if (reg_events (ctx) != 0) {
+            flux_log (ctx->h, LOG_ERR, "failed to reg events");
+            goto done;
+        }
+        flux_log (ctx->h, LOG_INFO, "events registered");
+    }
+    rc = 0;
+
+done:
+    return rc;
+}
+
+static inline int bridge_send_runrequest (ssrvctx_t *ctx, flux_lwj_t *job)
+{
+    int rc = -1;
+    flux_t h = ctx->h;
+    char *topic = NULL;
+    flux_msg_t *msg = NULL;
+
+    if (ctx->sctx.in_sim) {
+        /* Emulation mode */
+        if (asprintf (&topic, "sim_exec.run.%"PRId64"", job->lwj_id) < 0) {
+            flux_log (h, LOG_ERR, "%s: topic create failed: %s",
+                      __FUNCTION__, strerror (errno));
+        } else if (!(msg = flux_msg_create (FLUX_MSGTYPE_REQUEST))
+                   || flux_msg_set_topic (msg, topic) < 0
+                   || flux_send (h, msg, 0) < 0) {
+            flux_log (h, LOG_ERR, "%s: request create failed: %s",
+                      __FUNCTION__, strerror (errno));
+        } else {
+            queue_timer_change (ctx, "sim_exec");
+            flux_log (h, LOG_DEBUG, "job %"PRId64" runrequest", job->lwj_id);
+            rc = 0;
+        }
+    } else {
+        /* Normal mode */
+        if (asprintf (&topic, "wrexec.run.%"PRId64"", job->lwj_id) < 0) {
+            flux_log (h, LOG_ERR, "%s: topic create failed: %s",
+                      __FUNCTION__, strerror (errno));
+        } else if (!(msg = flux_event_encode (topic, NULL))
+                   || flux_send (h, msg, 0) < 0) {
+            flux_log (h, LOG_ERR, "%s: event create failed: %s",
+                      __FUNCTION__, strerror (errno));
+        } else {
+            flux_log (h, LOG_DEBUG, "job %"PRId64" runrequest", job->lwj_id);
+            rc = 0;
+        }
+    }
+    if (msg)
+        flux_msg_destroy (msg);
+    if (topic)
+        free (topic);
+    return rc;
+}
+
+static inline void bridge_update_timer (ssrvctx_t *ctx)
+{
+    if (ctx->sctx.in_sim)
+        queue_timer_change (ctx, "sched");
+}
+
+static char *resrc_get_hostname (resrc_t *r)
+{
+    return xasprintf ("%s%"PRId64"", resrc_name (r), resrc_id (r));
+}
+
+static inline int bridge_rs2rank_tab_query (ssrvctx_t *ctx, resrc_t *r,
+                                            uint32_t *rank)
+{
+    int rc = -1;
+    if (ctx->sctx.in_sim) {
+        rc = rs2rank_tab_query_by_none (ctx->machs, resrc_digest (r),
+                                        false, rank);
+    } else {
+        char *hn = resrc_get_hostname (r);
+        rc = rs2rank_tab_query_by_sign (ctx->machs, hn, resrc_digest (r),
+                                        false, rank);
+        free (hn);
+    }
+    return rc;
+}
 
 /********************************************************************************
  *                                                                              *
@@ -999,12 +1108,8 @@ static int req_tpexec_allocate (ssrvctx_t *ctx, flux_lwj_t *job)
                   job->lwj_id);
         goto done;
     }
-    if (ctx->sctx.in_sim) {
-        queue_timer_change (ctx, "sched");
-    }
-
+    bridge_update_timer (ctx);
     rc = 0;
-
 done:
     if (jcb)
         Jput (jcb);
@@ -1041,8 +1146,6 @@ static int req_tpexec_map (flux_t h, flux_lwj_t *job)
 
 static int req_tpexec_exec (flux_t h, flux_lwj_t *job)
 {
-    char *topic = NULL;
-    flux_msg_t *msg = NULL;
     ssrvctx_t *ctx = getctx (h);
     int rc = -1;
 
@@ -1050,43 +1153,13 @@ static int req_tpexec_exec (flux_t h, flux_lwj_t *job)
         flux_log (h, LOG_ERR, "failed to update the state of job %"PRId64"",
                   job->lwj_id);
         goto done;
+    } else if (bridge_send_runrequest (ctx, job) != 0) {
+        flux_log (h, LOG_ERR, "failed to send runrequest for job %"PRId64"",
+                  job->lwj_id);
+        goto done;
     }
-
-    if (ctx->sctx.in_sim) {
-        /* Emulation mode */
-        if (asprintf (&topic, "sim_exec.run.%"PRId64"", job->lwj_id) < 0) {
-            flux_log (h, LOG_ERR, "%s: topic create failed: %s",
-                      __FUNCTION__, strerror (errno));
-        } else if (!(msg = flux_msg_create (FLUX_MSGTYPE_REQUEST))
-                   || flux_msg_set_topic (msg, topic) < 0
-                   || flux_send (h, msg, 0) < 0) {
-            flux_log (h, LOG_ERR, "%s: request create failed: %s",
-                      __FUNCTION__, strerror (errno));
-        } else {
-            queue_timer_change (ctx, "sim_exec");
-            flux_log (h, LOG_DEBUG, "job %"PRId64" runrequest", job->lwj_id);
-            rc = 0;
-        }
-    } else {
-        /* Normal mode */
-        if (asprintf (&topic, "wrexec.run.%"PRId64"", job->lwj_id) < 0) {
-            flux_log (h, LOG_ERR, "%s: topic create failed: %s",
-                      __FUNCTION__, strerror (errno));
-        } else if (!(msg = flux_event_encode (topic, NULL))
-                   || flux_send (h, msg, 0) < 0) {
-            flux_log (h, LOG_ERR, "%s: event create failed: %s",
-                      __FUNCTION__, strerror (errno));
-        } else {
-            flux_log (h, LOG_DEBUG, "job %"PRId64" runrequest", job->lwj_id);
-            rc = 0;
-        }
-    }
-
+    rc = 0;
 done:
-    if (msg)
-        flux_msg_destroy (msg);
-    if (topic)
-        free (topic);
     return rc;
 }
 
@@ -1417,27 +1490,20 @@ int mod_main (flux_t h, int argc, char **argv)
         goto done;
     }
     flux_log (h, LOG_INFO, "%s plugin loaded", ctx->arg.userplugin);
+    if (bridge_set_execmode (ctx) != 0) {
+        flux_log (h, LOG_ERR, "failed to setup execution mode");
+        goto done;
+    }
+
     if (load_resources (ctx) != 0) {
         flux_log (h, LOG_ERR, "failed to load resources");
         goto done;
     }
     flux_log (h, LOG_INFO, "resources loaded");
-    if ((sim) && setup_sim (ctx, sim) != 0) {
-        flux_log (h, LOG_ERR, "failed to setup sim");
+
+    if (bridge_set_events (ctx) != 0) {
+        flux_log (h, LOG_ERR, "failed to set events");
         goto done;
-    }
-    if (ctx->sctx.in_sim) {
-        if (reg_sim_events (ctx) != 0) {
-            flux_log (h, LOG_ERR, "failed to reg sim events");
-            goto done;
-        }
-        flux_log (h, LOG_INFO, "sim events registered");
-    } else {
-        if (reg_events (ctx) != 0) {
-            flux_log (h, LOG_ERR, "failed to reg events");
-            goto done;
-        }
-        flux_log (h, LOG_INFO, "events registered");
     }
     if (flux_reactor_start (h) < 0) {
         flux_log (h, LOG_ERR, "flux_reactor_start: %s", strerror (errno));

--- a/sched/schedsrv.c
+++ b/sched/schedsrv.c
@@ -23,11 +23,7 @@
 \*****************************************************************************/
 
 /*
- * schedsrv.c - scheduler frameowrk service comms module
- *
- * Update Log:
- *       Apr 12 2015 DHA: Code refactoring including JSC API integration
- *       May 24 2014 DHA: File created.
+ * schedsrv.c - scheduler framework service comms module
  */
 
 #include <stdio.h>
@@ -47,6 +43,8 @@
 #include "resrc.h"
 #include "resrc_tree.h"
 #include "resrc_reqst.h"
+#include "rs2rank.h"
+#include "rsreader.h"
 #include "schedsrv.h"
 #include "../simulator/simulator.h"
 
@@ -60,6 +58,7 @@ static int timer_event_cb (flux_t h, void *arg);
 static void res_event_cb (flux_t h, flux_msg_handler_t *w,
                           const flux_msg_t *msg, void *arg);
 static int job_status_cb (JSON jcb, void *arg, int errnum);
+
 
 /******************************************************************************
  *                                                                            *
@@ -115,12 +114,22 @@ typedef struct {
     char         *root_uri;           /* Name of the root of the RDL hierachy */
 } rdlctx_t;
 
+typedef struct {
+    char         *path;
+    char         *uri;
+    char         *sim;
+    char         *userplugin;
+    rsreader_t    r_mode;
+} ssrvarg_t;
+
 /* TODO: Implement prioritization function for p_queue */
 typedef struct {
     flux_t        h;
     zlist_t      *p_queue;            /* Pending job priority queue */
     zlist_t      *r_queue;            /* Running job queue */
     zlist_t      *c_queue;            /* Complete/cancelled job queue */
+    machs_t      *machs;              /* rs2rank table */
+    ssrvarg_t     arg;                /* args passed to this module */
     rdlctx_t      rctx;               /* RDL context */
     simctx_t      sctx;               /* simulator context */
     sched_ops_t   sops;               /* scheduler plugin operations */
@@ -131,12 +140,65 @@ typedef struct {
  *                                 Utilities                                  *
  *                                                                            *
  ******************************************************************************/
+
+static inline void ssrvarg_init (ssrvarg_t *arg)
+{
+    arg->path = NULL;
+    arg->uri = NULL;
+    arg->sim = NULL;
+    arg->userplugin = NULL;
+    arg->r_mode = RSREADER_FOR_RENT;
+}
+
+static inline void ssrvarg_free (ssrvarg_t *arg)
+{
+    if (arg->path)
+        free (arg->path);
+    if (arg->uri)
+        free (arg->uri);
+    if (arg->sim)
+        free (arg->sim);
+    if (arg->userplugin)
+        free (arg->userplugin);
+}
+
+static inline int ssrvarg_process_args (int argc, char **argv, ssrvarg_t *a)
+{
+    int i = 0, rc = 0;
+
+    for (i = 0; i < argc; i++) {
+        if (!strncmp ("rdl-conf=", argv[i], sizeof ("rdl-conf"))) {
+            a->path = xstrdup (strstr (argv[i], "=") + 1);
+        } else if (!strncmp ("rdl-resource=", argv[i], sizeof ("rdl-resource"))) {
+            a->uri = xstrdup (strstr (argv[i], "=") + 1);
+        } else if (!strncmp ("in-sim=", argv[i], sizeof ("in-sim"))) {
+            a->sim = xstrdup (strstr (argv[i], "=") + 1);
+        } else if (!strncmp ("plugin=", argv[i], sizeof ("plugin"))) {
+            a->userplugin = xstrdup (strstr (argv[i], "=") + 1);
+        } else {
+            rc = -1;
+            errno = EINVAL;
+            goto done;
+        }
+    }
+    if (!(a->userplugin))
+        a->userplugin = xstrdup ("sched.plugin1");
+    if (a->path)
+        a->r_mode = (a->sim)? RSREADER_RESRC_EMUL : RSREADER_RESRC;
+    else
+        a->r_mode = RSREADER_HWLOC;
+done:
+    return rc;
+}
+
 static void freectx (void *arg)
 {
     ssrvctx_t *ctx = arg;
     zlist_destroy (&(ctx->p_queue));
     zlist_destroy (&(ctx->r_queue));
     zlist_destroy (&(ctx->c_queue));
+    rs2rank_tab_destroy (ctx->machs);
+    ssrvarg_free (&(ctx->arg));
     resrc_tree_destroy (resrc_phys_tree (ctx->rctx.root_resrc), true);
     free (ctx->rctx.root_uri);
     free (ctx->sctx.sim_state);
@@ -162,6 +224,9 @@ static ssrvctx_t *getctx (flux_t h)
             oom ();
         if (!(ctx->c_queue = zlist_new ()))
             oom ();
+        if (!(ctx->machs = rs2rank_tab_new ()))
+            oom ();
+        ssrvarg_init (&(ctx->arg));
         ctx->rctx.root_resrc = NULL;
         ctx->rctx.root_uri = NULL;
         ctx->sctx.in_sim = false;
@@ -370,7 +435,7 @@ done:
     return rc;
 }
 
-static int load_sched_plugin (ssrvctx_t *ctx, const char *pin)
+static int load_sched_plugin (ssrvctx_t *ctx)
 {
     int rc = -1;
     flux_t h = ctx->h;
@@ -381,9 +446,9 @@ static int load_sched_plugin (ssrvctx_t *ctx, const char *pin)
         flux_log (h, LOG_ERR, "FLUX_MODULE_PATH not set");
         goto done;
     }
-    if (!(path = flux_modfind (searchpath, pin))) {
+    if (!(path = flux_modfind (searchpath, ctx->arg.userplugin))) {
         flux_log (h, LOG_ERR, "%s: not found in module search path %s",
-                  pin, searchpath);
+                  ctx->arg.userplugin, searchpath);
         goto done;
     }
     if (!(ctx->sops.dso = dlopen (path, RTLD_NOW | RTLD_LOCAL))) {
@@ -391,7 +456,7 @@ static int load_sched_plugin (ssrvctx_t *ctx, const char *pin)
                   dlerror ());
         goto done;
     }
-    flux_log (h, LOG_DEBUG, "loaded: %s", pin);
+    flux_log (h, LOG_DEBUG, "loaded: %s", ctx->arg.userplugin);
     rc = resolve_functions (ctx);
 
 done:
@@ -411,69 +476,129 @@ static void setup_rdl_lua (flux_t h)
     flux_log (h, LOG_DEBUG, "LUA_CPATH %s", getenv ("LUA_CPATH"));
 }
 
-static int load_resources (ssrvctx_t *ctx, char *path, char *uri)
+static int build_hwloc_rs2rank (ssrvctx_t *ctx, rsreader_t r_mode)
 {
     int rc = -1;
+    size_t len = 0;
+    uint32_t rank = 0, size = 0;
+    char *key = NULL, *rs_buf = NULL;;
 
-    setup_rdl_lua (ctx->h);
-    if (path) {
-        if (uri)
-            ctx->rctx.root_uri = uri;
-        else
-            ctx->rctx.root_uri = xstrdup ("default");
-
-        if ((ctx->rctx.root_resrc =
-             resrc_generate_rdl_resources (path, ctx->rctx.root_uri))) {
-            flux_log (ctx->h, LOG_DEBUG, "loaded %s rdl resource from %s",
-                      ctx->rctx.root_uri, path);
-            rc = 0;
-        } else {
-            flux_log (ctx->h, LOG_ERR, "failed to load %s rdl resource from %s",
-                      ctx->rctx.root_uri, path);
-        }
-    } else if ((ctx->rctx.root_resrc = resrc_create_cluster ("cluster"))) {
-        char    *buf = NULL;
-        char    *key;
-        int64_t i = 0;
-        size_t  buflen = 0;
-
-        rc = 0;
-        while (1) {
-            key = xasprintf ("resource.hwloc.xml.%"PRIu64"", i++);
-            if (kvs_get_string (ctx->h, key, &buf)) {
-                /* no more nodes to load - normal exit */
-                free (key);
-                break;
-            }
-            buflen = strlen (buf);
-            if ((resrc_generate_xml_resources (ctx->rctx.root_resrc, buf,
-                                               buflen))) {
-                flux_log (ctx->h, LOG_DEBUG, "loaded %s", key);
-            } else {
-                free (buf);
-                free (key);
-                rc = -1;
-                break;
-            }
-            free (buf);
-            free (key);
-        }
-        flux_log (ctx->h, LOG_INFO, "loaded resrc using hwloc (status %d)", rc);
+    if (flux_get_size (ctx->h, &size) == -1) {
+        flux_log (ctx->h, LOG_ERR, "can't decide the instance size");
+        goto done;
     }
+    for (rank=0; rank < size; rank++) {
+        key = xasprintf ("resource.hwloc.xml.%"PRIu32"", rank);
+        if (kvs_get_string (ctx->h, key, &rs_buf) == -1) {
+            flux_log (ctx->h, LOG_ERR, "can't get hwloc data in kvs");
+            break;
+        }
+        len = strlen (rs_buf);
+        if (rsreader_hwloc_load (rs_buf, len, rank, r_mode,
+             &(ctx->rctx.root_resrc), ctx->machs) != 0) {
+            flux_log (ctx->h, LOG_ERR, "can't load hwloc data");
+            goto done;
+        } else if (key) {
+            free (key);
+            key = NULL;
+        }
+    }
+    rc = 0;
 
+done:
+    if (key)
+        free (key);
     return rc;
 }
 
+static int load_resources (ssrvctx_t *ctx)
+{
+    int rc = -1;
+    char *turi = NULL;
+    resrc_t *tres = NULL;
+    char *path = ctx->arg.path;
+    char *uri = ctx->arg.uri;
+    rsreader_t r_mode = ctx->arg.r_mode;
+
+    setup_rdl_lua (ctx->h);
+
+    switch (r_mode) {
+    case RSREADER_RESRC_EMUL:
+        if (rsreader_resrc_bulkload (path, uri, &turi, &tres) != 0) {
+            flux_log (ctx->h, LOG_ERR, "failed to load resrc");
+            goto done;
+        } else if (build_hwloc_rs2rank (ctx, r_mode) != 0) {
+            flux_log (ctx->h, LOG_ERR, "failed to build rs2rank");
+            goto done;
+        } else if (rsreader_force_link2rank (ctx->machs, tres) != 0) {
+            flux_log (ctx->h, LOG_ERR, "failed to force a link to a rank");
+            goto done;
+        }
+        ctx->rctx.root_uri = turi;
+        ctx->rctx.root_resrc = tres;
+        flux_log (ctx->h, LOG_INFO, "loaded resrc");
+        rc = 0;
+        break;
+
+    case RSREADER_RESRC:
+        if (rsreader_resrc_bulkload (path, uri, &turi, &tres) != 0) {
+            flux_log (ctx->h, LOG_ERR, "failed to load resrc");
+            goto done;
+        } else if (build_hwloc_rs2rank (ctx, r_mode) != 0) {
+            flux_log (ctx->h, LOG_ERR, "failed to build rs2rank");
+            goto done;
+        } else if (rsreader_link2rank (ctx->machs, tres) != 0) {
+            flux_log (ctx->h, LOG_ERR, "RDL(%s) inconsistent w/ hwloc!", path);
+            flux_log (ctx->h, LOG_INFO, "rebuild resrc using hwloc");
+            if (turi)
+                free (turi);
+            if (tres)
+                resrc_tree_destroy (resrc_phys_tree (tres), true);
+            r_mode = RSREADER_HWLOC;
+            /* deliberate fall-through to RSREADER_HWLOC! */
+        }
+        else {
+            ctx->rctx.root_uri = turi;
+            ctx->rctx.root_resrc = tres;
+            flux_log (ctx->h, LOG_INFO, "loaded resrc");
+            rc = 0;
+            break;
+        }
+
+    case RSREADER_HWLOC:
+        if (!(ctx->rctx.root_resrc = resrc_create_cluster ("cluster"))) {
+            flux_log (ctx->h, LOG_ERR, "failed to create cluster resrc");
+            goto done;
+        } else if (build_hwloc_rs2rank (ctx, r_mode) != 0) {
+            flux_log (ctx->h, LOG_ERR, "failed to load resrc using hwloc");
+            goto done;
+        } else if (rsreader_link2rank (ctx->machs, ctx->rctx.root_resrc) != 0) {
+            flux_log (ctx->h, LOG_ERR, "fatal: inconsistent resrc!");
+            goto done;
+        }
+        flux_log (ctx->h, LOG_INFO, "loaded resrc using hwloc");
+        rc = 0;
+        break;
+
+    default:
+        flux_log (ctx->h, LOG_ERR, "unkwown resource reader type");
+        break;
+    }
+
+done:
+    return rc;
+}
+
+
 /******************************************************************************
  *                                                                            *
- *                         Simulator Specific Code                            *
+ *                         Emulator Specific Code                             *
  *                                                                            *
  ******************************************************************************/
 
 /*
  * Simulator Helper Functions
  */
-
 static void queue_timer_change (ssrvctx_t *ctx, const char *module)
 {
     zlist_append (ctx->sctx.timer_queue, (void *)module);
@@ -797,10 +922,11 @@ done:
  *                                                                              *
  *******************************************************************************/
 
-static void inline build_contain_1node_req (int64_t nc, JSON rarr)
+static void inline build_contain_1node_req (int64_t nc, int64_t rank, JSON rarr)
 {
     JSON e = Jnew ();
     JSON o = Jnew ();
+    Jadd_int64 (o, JSC_RDL_ALLOC_CONTAINING_RANK, rank);
     Jadd_int64 (o, JSC_RDL_ALLOC_CONTAINED_NCORES, nc);
     json_object_object_add (e, JSC_RDL_ALLOC_CONTAINED, o);
     json_object_array_add (rarr, e);
@@ -810,18 +936,26 @@ static void inline build_contain_1node_req (int64_t nc, JSON rarr)
  * Because the job's rdl should only contain what's allocated to the job,
  * this traverse the entire tree post-order walk
  */
-static int build_contain_req (flux_t h, flux_lwj_t *job, JSON rarr)
+static int build_contain_req (ssrvctx_t *ctx, flux_lwj_t *job, JSON arr)
 {
-    int rc = 0;
-    int64_t n;
+    int rc = -1;
+    uint32_t rank = 0;
+    resrc_tree_t *nd = NULL;
+    resrc_t *r = NULL;
 
-    for (n = 0; n < job->req->nnodes; n++) {
-        build_contain_1node_req (job->req->corespernode, rarr);
+    for (nd = resrc_tree_list_first (job->resrc_trees); nd;
+            nd = resrc_tree_list_next (job->resrc_trees)) {
+        r = resrc_tree_resrc (nd);
+        if (strcmp (resrc_type (r), "node") != 0
+            || bridge_rs2rank_tab_query (ctx, r, &rank) != 0)
+            goto done;
+
+        build_contain_1node_req (job->req->corespernode, rank, arr);
     }
-
+    rc = 0;
+done:
     return rc;
 }
-
 
 /*
  * Once the job gets allocated to its own copy of rdl, this
@@ -834,8 +968,8 @@ static int req_tpexec_allocate (ssrvctx_t *ctx, flux_lwj_t *job)
     int rc = -1;
     flux_t h = ctx->h;
     JSON jcb = Jnew ();
-    JSON arr = Jnew_ar ();
     JSON ro = Jnew_ar ();
+    JSON arr = Jnew_ar ();
 
     if (resrc_tree_list_serialize (ro, job->resrc_trees)) {
         flux_log (h, LOG_ERR, "%"PRId64" resource serialization failed: %s",
@@ -850,7 +984,7 @@ static int req_tpexec_allocate (ssrvctx_t *ctx, flux_lwj_t *job)
     }
     Jput (jcb);
     jcb = Jnew ();
-    if (build_contain_req (h, job, arr) != 0) {
+    if (build_contain_req (ctx, job, arr) != 0) {
         flux_log (h, LOG_ERR, "error requesting containment for job");
         goto done;
     }
@@ -1255,55 +1389,35 @@ static int job_status_cb (JSON jcb, void *arg, int errnum)
  *                                                                            *
  ******************************************************************************/
 
+
 int mod_main (flux_t h, int argc, char **argv)
 {
-    int rc = -1, i = 0;
+    int rc = -1;
     ssrvctx_t *ctx = NULL;
-    char *schedplugin = NULL, *userplugin = NULL;
-    char *uri = NULL, *path = NULL, *sim = NULL;
     uint32_t rank = 1;
 
     if (!(ctx = getctx (h))) {
         flux_log (h, LOG_ERR, "can't find or allocate the context");
         goto done;
     }
-
-    for (i = 0; i < argc; i++) {
-        if (!strncmp ("rdl-conf=", argv[i], sizeof ("rdl-conf"))) {
-            path = xstrdup (strstr (argv[i], "=") + 1);
-        } else if (!strncmp ("rdl-resource=", argv[i], sizeof ("rdl-resource"))) {
-            uri = xstrdup (strstr (argv[i], "=") + 1);
-        } else if (!strncmp ("in-sim=", argv[i], sizeof ("in-sim"))) {
-            sim = xstrdup (strstr (argv[i], "=") + 1);
-        } else if (!strncmp ("plugin=", argv[i], sizeof ("plugin"))) {
-            userplugin = xstrdup (strstr (argv[i], "=") + 1);
-        } else {
-            flux_log (ctx->h, LOG_ERR, "module load option %s invalid", argv[i]);
-            errno = EINVAL;
-            goto done;
-        }
-    }
-
-    if (userplugin == NULL) {
-        schedplugin = "sched.plugin1";
-    } else {
-        schedplugin = userplugin;
-    }
-
     if (flux_get_rank (h, &rank)) {
         flux_log (h, LOG_ERR, "failed to determine rank");
         goto done;
     } else if (rank) {
         flux_log (h, LOG_ERR, "sched module must only run on rank 0");
         goto done;
+    } else if (ssrvarg_process_args (argc, argv, &(ctx->arg)) != 0) {
+        flux_log (h, LOG_ERR, "can't process module args");
+        goto done;
     }
     flux_log (h, LOG_INFO, "sched comms module starting");
-    if (load_sched_plugin (ctx, schedplugin) != 0) {
+
+    if (load_sched_plugin (ctx) != 0) {
         flux_log (h, LOG_ERR, "failed to load scheduler plugin");
         goto done;
     }
-    flux_log (h, LOG_INFO, "%s plugin loaded", schedplugin);
-    if (load_resources (ctx, path, uri) != 0) {
+    flux_log (h, LOG_INFO, "%s plugin loaded", ctx->arg.userplugin);
+    if (load_resources (ctx) != 0) {
         flux_log (h, LOG_ERR, "failed to load resources");
         goto done;
     }
@@ -1332,10 +1446,6 @@ int mod_main (flux_t h, int argc, char **argv)
     rc = 0;
 
 done:
-    free (path);
-    free (uri);
-    free (sim);
-    free (userplugin);
     return rc;
 }
 


### PR DESCRIPTION
This is not ready to be merged. But before I turn into a pumpkin for a week, I wanted to post this to get some early feedback. This PR has two distinct items for your review:

- Fix the issue #69 where schedsrv incorrectly targets the first
k consecutive broker ranks (starting from rank 0) to launch a job
of k nodes, regardless of what nodes it is allocated to
and what broker ranks manage these nodes. For example, even if two
jobs are allocated back to back to cab[1-2] and cab[3-4], the old
scheme will end up launching both of the jobs into cab[1-2], assuming
rank 0 and 1 are running on these nodes. The detail is in the commit message. 


- Add a bridge layer into schedsrv: With the latest emulation integration,
emulation-specific code has been sprinkled through schedsrv, potentially making
the code error prone. This layer centralizes where specialized
code for either mode is used so that hopefully can improve code
maintainability and reduce errors.

This PR needs a related flux-core PR for testing, which I will post soon.