### PR TITLE
resrc: Change resrc_match_resource() to match a request

### DIFF
--- a/resrc/resrc.h
+++ b/resrc/resrc.h
@@ -11,6 +11,7 @@
 #define TIME_MAX INT64_MAX
 
 typedef struct resrc resrc_t;
+typedef struct resrc_reqst resrc_reqst_t;
 typedef struct resrc_tree resrc_tree_t;
 
 typedef enum {
@@ -124,17 +125,13 @@ resrc_t *resrc_create_cluster (char *cluster);
 /*
  * Determine whether a specific resource has the required characteristics
  * Inputs:  resrc     - the specific resource under evaluation
- *          sample    - sample resource with the required characteristics
+ *          request   - resource request with the required characteristics
  *          available - when true, consider only idle resources
  *                      otherwise find all possible resources matching type
- *          starttime - start of period the resource needs to be available
- *                      When the starttime is 0, only the current resource
- *                      availability will be considered (now-based match).
- *          endtime   - end of period the resource needs to be available
  * Returns: true if the input resource has the required characteristics
  */
-bool resrc_match_resource (resrc_t *resrc, resrc_t *sample, bool available,
-                           int64_t starttime, int64_t endtime);
+bool resrc_match_resource (resrc_t *resrc, resrc_reqst_t *request,
+                           bool available);
 
 /*
  * Stage size elements of a resource

--- a/resrc/resrc_reqst.c
+++ b/resrc/resrc_reqst.c
@@ -357,10 +357,8 @@ static bool match_child (resrc_tree_list_t *r_trees, resrc_reqst_t *resrc_reqst,
     resrc_tree = resrc_tree_list_first (r_trees);
     while (resrc_tree) {
         found = false;
-        if (resrc_match_resource (resrc_tree_resrc (resrc_tree),
-                                  resrc_reqst->resrc, available,
-                                  resrc_reqst->starttime,
-                                  resrc_reqst->endtime)) {
+        if (resrc_match_resource (resrc_tree_resrc (resrc_tree), resrc_reqst,
+                                  available)) {
             if (resrc_reqst_num_children (resrc_reqst)) {
                 if (resrc_tree_num_children (resrc_tree)) {
                     child_tree = resrc_tree_new (parent_tree,
@@ -448,10 +446,8 @@ int resrc_tree_search (resrc_tree_list_t *resrcs_in, resrc_reqst_t *resrc_reqst,
 
     resrc_tree = resrc_tree_list_first (resrcs_in);
     while (resrc_tree) {
-        if (resrc_match_resource (resrc_tree_resrc (resrc_tree),
-                                  resrc_reqst->resrc, available,
-                                  resrc_reqst->starttime,
-                                  resrc_reqst->endtime)) {
+        if (resrc_match_resource (resrc_tree_resrc (resrc_tree), resrc_reqst,
+                                  available)) {
             if (resrc_reqst_num_children (resrc_reqst)) {
                 if (resrc_tree_num_children (resrc_tree)) {
                     new_tree = resrc_tree_new (NULL,

--- a/resrc/resrc_reqst.h
+++ b/resrc/resrc_reqst.h
@@ -9,7 +9,6 @@
 #include "resrc_tree.h"
 
 
-typedef struct resrc_reqst resrc_reqst_t;
 typedef struct resrc_reqst_list resrc_reqst_list_t;
 
 /***********************************************************************

--- a/sched/backfillplugin1.c
+++ b/sched/backfillplugin1.c
@@ -127,10 +127,8 @@ static bool select_child (flux_t h, resrc_tree_list_t *found_children,
     resrc_tree = resrc_tree_list_first (found_children);
     while (resrc_tree) {
         selected = false;
-        if (resrc_match_resource (resrc_tree_resrc (resrc_tree),
-                                  resrc_reqst_resrc (child_reqst), true,
-                                  resrc_reqst_starttime (child_reqst),
-                                  resrc_reqst_endtime (child_reqst))) {
+        if (resrc_match_resource (resrc_tree_resrc (resrc_tree), child_reqst,
+                                  true)) {
             if (resrc_reqst_num_children (child_reqst)) {
                 if (resrc_tree_num_children (resrc_tree)) {
                     child_tree = resrc_tree_new (parent_tree,
@@ -242,9 +240,7 @@ resrc_tree_list_t *select_resources (flux_t h, resrc_tree_list_t *found_trees,
     rt = resrc_tree_list_first (found_trees);
     while (reqrd && rt) {
         resrc = resrc_tree_resrc (rt);
-        if (resrc_match_resource (resrc, resrc_reqst_resrc (resrc_reqst), true,
-                                  resrc_reqst_starttime (resrc_reqst),
-                                  resrc_reqst_endtime (resrc_reqst))) {
+        if (resrc_match_resource (resrc, resrc_reqst, true)) {
             new_tree = resrc_tree_new (NULL, resrc);
             if (resrc_reqst_num_children (resrc_reqst)) {
                 if (resrc_tree_num_children (rt)) {

--- a/sched/schedplugin1.c
+++ b/sched/schedplugin1.c
@@ -106,8 +106,8 @@ static bool select_child (flux_t h, resrc_tree_list_t *found_children,
     resrc_tree = resrc_tree_list_first (found_children);
     while (resrc_tree) {
         selected = false;
-        if (resrc_match_resource (resrc_tree_resrc (resrc_tree),
-                                  resrc_reqst_resrc (child_reqst), true, 0, 0)) {
+        if (resrc_match_resource (resrc_tree_resrc (resrc_tree), child_reqst,
+                                  true)) {
             if (resrc_reqst_num_children (child_reqst)) {
                 if (resrc_tree_num_children (resrc_tree)) {
                     child_tree = resrc_tree_new (parent_tree,
@@ -214,13 +214,17 @@ resrc_tree_list_t *select_resources (flux_t h, resrc_tree_list_t *found_trees,
     }
 
     reqrd = resrc_reqst_reqrd (resrc_reqst);
+    /*
+     * A start time of zero means that we are only interested in
+     * if the resource is available now.
+     */
+    resrc_reqst_set_starttime (resrc_reqst, 0);
     selected_res = resrc_tree_list_new ();
 
     rt = resrc_tree_list_first (found_trees);
     while (reqrd && rt) {
         resrc = resrc_tree_resrc (rt);
-        if (resrc_match_resource (resrc, resrc_reqst_resrc (resrc_reqst), true,
-                                  0, 0)) {
+        if (resrc_match_resource (resrc, resrc_reqst, true)) {
             new_tree = resrc_tree_new (NULL, resrc);
             if (resrc_reqst_num_children (resrc_reqst)) {
                 if (resrc_tree_num_children (rt)) {


### PR DESCRIPTION
The old argument to resrc_match_resource() matched a specified
resource against a sample resource.  The sample resource was the
resource part of a resource request object.  This proved to be
combersome as we proceed with the next round of changes.  So, now we
pass the whole request to resrc_match_resource().

This complies with a request made in https://github.com/flux-framework/flux-sched/pull/103#issuecomment-164945235 to break [PR 103](https://github.com/flux-framework/flux-sched/pull/103) into two pieces.