### PR TITLE
test: clean up waitjob and jsc tests

### DIFF
--- a/t/scripts/waitfile.lua
+++ b/t/scripts/waitfile.lua
@@ -1,0 +1,201 @@
+#!/usr/bin/lua
+--
+--  waitfile.lua : Wait until a named file appears and contains a pattern
+--
+local usage = [[
+Usage: waitfile.lua [OPTIONS] FILE
+Wait for FILE to appear with optional pattern and number of lines.
+Options:
+ -h, --help       Display this message
+ -q, --quiet      Do not print file lines on stdout
+ -v, --verbose    Print extra information about program operation
+ -p, --pattern=P  Only match lines with Lua pattern P. Default is the
+                  empty pattern (therefore anything or nothing matches)
+ -c, --count=N    Wait until pattern has matched on N lines (Default: 1)
+ -t, --timeout=T  Timeout and exit with nonzero status after T seconds.
+                  (Default is to wait forever)
+]]
+
+local getopt = require 'flux.alt_getopt' .get_opts
+local posix  = require 'flux.posix'
+local flux   = require 'flux'
+
+local opts, optind = getopt (arg, "hvqc:t:p:",
+                             { timeout = 't',
+                               pattern = 'p',
+                               count = 'c',
+                               quiet = 'q',
+                               verbose = 'v',
+                               help = 'h'
+                             })
+if opts.h then print (usage); os.exit (0) end
+
+local f, err = flux.new()
+if not f then error (err) end
+
+local timeout = opts.t or 0
+local pattern = opts.p or ""
+local count = opts.c or 1
+local file = arg[optind]
+
+local function printf (m, ...)
+    io.stderr:write (string.format ("waitfile: "..m, ...))
+end
+
+local function log_verbose (m, ...)
+    if opts.v then
+        printf (m, ...)
+    end
+end
+
+if not timeout or not pattern or not file then
+    io.stderr:write (usage)
+    os.exit (1)
+end
+
+local filewatcher = {}
+filewatcher.__index = filewatcher
+
+function filewatcher:check_line (line)
+    if line:match (self.pattern) then
+        self.nmatch = self.nmatch + 1
+        log_verbose ("Got match (%d/%d)\n", self.nmatch, self.count)
+        return self.nmatch == self.count
+    end
+    return false
+end
+
+function filewatcher:checklines ()
+    if self.st.st_size == 0 then
+        -- Check if empty file is a match
+        return self:check_line ("")
+    end
+
+    local fp, err = io.open (self.filename, "r")
+    if not fp then return nil, err end
+    local p, err = fp:seek ("set", self.position)
+    log_verbose ("%s seek set to %d\n", self.filename, self.position)
+    for line in fp:lines() do
+        if self.printlines then io.stdout:write (line.."\n") end
+        if self:check_line (line) then
+            return true
+        end
+    end
+    self.position = fp:seek()
+    log_verbose ("leaving checklines() position=%d\n", self.position)
+    return false
+end
+
+-- Make older posix stat table look like new
+local stat = {
+ __index = function (t, k)
+    local k2 = k:match ("st_(.+)")
+    local v = rawget (t, k)
+    return v and v or rawget (t, k2)
+ end
+}
+
+function filewatcher:changed ()
+    local st = self.st
+    local prev = self.prev
+    if not st then
+        log_verbose ("No file yet\n")
+        return false
+    end
+    if not prev then
+        log_verbose ("File appeared with size %d\n", st.st_size)
+        return true
+    end
+    if st.st_mtime > prev.st_mtime then
+        log_verbose ("File changed\n")
+        if st.st_size < prev.st_size then
+            printf ("truncated!\n")
+            self.position = 0 -- reread
+        end
+        return true
+    end
+    return false
+end
+
+function filewatcher:check ()
+    if self:changed () and self:checklines () then
+        log_verbose ("Got match. Calling self:on_match()\n")
+        self:on_match ()
+        return true
+    end
+    self.prev = self.st
+    return false
+end
+
+function filewatcher:start ()
+    local st = posix.stat (self.filename)
+    if st then
+        self.st = setmetatable (st, stat)
+    end
+    self.flux:statwatcher {
+        path = self.filename,
+        interval = self.interval,
+        handler = function (w, st, prev)
+            printf ("wakeup\n")
+            self.st = setmetatable (st, stat)
+            self:check ()
+            log_verbose ("back to sleep\n")
+        end
+    }
+    self:check ()
+end
+
+setmetatable (filewatcher, { __call = function (t, arg)
+    if not arg.filename or not arg.pattern then
+        return nil, "Error: required argument missing"
+    end
+    if not arg.flux then
+        return nil, "Error: flux handle missing"
+    end
+    local w = {
+        flux =     arg.flux,
+        filename = arg.filename,
+        pattern  = arg.pattern,
+	count    = tonumber (arg.count) or 1,
+        interval = arg.interval and arg.interval or .25,
+        on_match = arg.on_match,
+        position = 0,
+        nmatch   = 0,
+        printlines =  not arg.quiet,
+    }
+    setmetatable (w, filewatcher)
+    if not w.on_match then
+        w.on_match = function ()
+	    log_verbose ("Exiting\n")
+            os.exit (0)
+        end
+    end
+    return w
+end
+})
+
+local fw, err = filewatcher { flux = f,
+                              filename = file,
+                              pattern = pattern,
+                              count = count,
+                              quiet = opts.q }
+if not fw then printf ("%s\n", err); os.exit (1) end
+
+-- Exit with non-zero status after timeout:
+--
+if timeout then
+    f:timer {
+      timeout = timeout * 1000,
+      handler = function ()
+        printf ("Timeout after %ds\n", timeout)
+        os.execute ("ls -l "..file)
+        os.exit (1)
+      end
+    }
+end
+
+-- Start reactor to do the work. It is an error if we exit the reactor.
+fw:start ()
+f:reactor ()
+printf ("Unexpectedly exited reactor\n")
+os.exit (1)

--- a/t/sharness.d/sched-sharness.sh
+++ b/t/sharness.d/sched-sharness.sh
@@ -1,0 +1,283 @@
+
+#
+# project-local sharness code for flux-sched
+#
+
+sched_instance_size=0
+sched_test_session=0
+sched_start_jobid=0
+sched_end_jobid=0
+sched_test_dir=""
+
+#
+# Internal subroutines
+#
+sched_debug_to_file () {
+    local fn=$1
+    local str=$2
+cat > $fn <<-HEREDOC
+    $str
+HEREDOC
+}
+
+submit_1N_sleep_jobs () {
+    local procs=$1
+    local origprocs=$1
+    local s_amnt=$2
+    local opt=$3
+    local rc=0
+
+    if [ $procs -lt 1 ]
+    then
+        return 48
+    fi
+
+    for i in `seq $sched_start_jobid $sched_end_jobid`
+    do
+        flux submit -N 1 -n $procs sleep $s_amnt
+        if [ $? -ne 0 ]
+        then
+            return 48
+        fi
+        case $opt in
+            cons)
+                ;;
+            decr) 
+                procs=$((procs - 1))
+                ;;
+            fflop) 
+                if [ `expr $i % 2` -eq 0 ]
+                then
+                    procs=1
+                else
+                    procs=$origprocs
+                fi
+                ;;
+            *)     
+                procs=0
+                ;;
+        esac    
+        if [ $procs -lt 1 ]
+        then
+            return 48
+        fi
+    done
+    return 0
+}
+
+verify_1N_sleep_jobs () {
+    local cores=$1
+    local origcores=$1
+    local opt=$2
+    local rank=0
+    for i in `seq $sched_start_jobid $sched_end_jobid`
+    do
+        flux kvs get lwj.$i.rank.$rank.cores \
+            > $sched_test_session.$i.out
+        grep $cores $sched_test_session.$i.out
+
+        if [ $? -ne 0 ]
+        then
+            return 48
+        fi
+        case $opt in
+            cons)
+                ;;
+            decr)
+                cores=$((cores - 1))
+                ;;
+            fflop) 
+                if [ `expr $i % 2` -eq 0 ]
+                then
+                    cores=1
+                else
+                    cores=$origcores
+                fi
+                ;;
+            *)
+                cores=0
+                ;;
+        esac
+        if [ $cores -lt 1 ]
+        then
+            return 48
+        fi
+        rank=$((rank + 1))
+    done
+    return 0
+}
+
+
+# PUBLIC:
+#   Accessors 
+#
+get_instance_size () {
+    echo $sched_instance_size
+}
+
+get_session () {
+    echo $sched_test_session
+}
+
+get_start_jobid () {
+    echo $sched_start_jobid
+}
+
+get_end_jobid () {
+    echo $sched_end_jobid
+}
+
+set_instance_size () {
+    sched_instance_size=$1
+}
+
+set_session () {
+    sched_test_session=$1
+}
+
+set_start_jobid () {
+    sched_start_jobid=$1
+}
+
+set_end_jobid () {
+    sched_end_jobid=$1
+}
+
+set_tdir () {
+    sched_test_dir=$1
+}
+
+adjust_session_info () {
+    local njobs=$1
+    set_session $(($(get_session) + 1))
+    set_start_jobid $(($(get_end_jobid) + 1))
+    set_end_jobid $(($(get_start_jobid) + $njobs - 1))
+    return 0
+}
+
+# PUBLIC:
+#   Run flux-jstat in background. Wait up to 2 seconds 
+#   until flux-jstat gets ready to receive JSC events. 
+#   jstat's output will be printed to $1.<session id>
+#
+timed_run_flux_jstat () {
+    local fn=$1
+    ofile=${fn}.$sched_test_session
+    rm -f ${ofile}
+    flux jstat -o ${ofile} notify >/dev/null &
+    echo $! &&
+    $SHARNESS_TEST_SRCDIR/scripts/waitfile.lua --timeout 2 ${ofile} >&2
+}
+
+# PUBLIC:
+#   Run flux-waitjob in background. Wait up to $1 seconds
+#   until flux-waitjob gets ready to receive JSC events. 
+#   waitjob creates wo.st.<session id> to signal its readiness
+#   and wo.end.<session id> to indicate the specified job
+#   has completed.
+#
+timed_wait_job () {
+    local tout=$1
+    flux -x$sched_test_dir/sched waitjob -s wo.st.$sched_test_session \
+         -c wo.end.$sched_test_session $sched_end_jobid &
+    $SHARNESS_TEST_SRCDIR/scripts/waitfile.lua --timeout ${tout} \
+        wo.st.$sched_test_session >&2
+    return $?
+}
+
+# PUBLIC:
+#   Wait up to $1 seconds until the previously invoked flux-waitjob
+#   detects the final job has completed.
+#
+timed_sync_wait_job () {
+    local tout=$1
+    $SHARNESS_TEST_SRCDIR/scripts/waitfile.lua --timeout ${tout} \
+        wo.end.$sched_test_session >&2
+    return $?
+}
+
+# PUBLIC: 
+#   Submit 1-node sleep jobs to flux back to back.
+#   Each job sleeps for $2 seconds.
+#   The first job is to run at $1 processes and the
+#   second job at $1-1 processes and so forth.
+#
+#   The user script should already have updated
+#   sched_start_jobid and sched_end_jobid so that
+#   this script submits that many number of jobs.
+#
+submit_1N_decr_nproc_sleep_jobs () {
+    submit_1N_sleep_jobs $1 $2 "decr"
+    return $?
+}
+
+# PUBLIC:
+#   Submit 1-node sleep jobs to flux back to back.
+#   Each job sleeps for $2 seconds.
+#   Unlike submit_1N_decr_nproc_sleep_jobs, the first
+#   job is to run at $1 processes and the second job
+#   at 1 process and as such this pattern repeats 
+#
+#   The user script should already have updated
+#   sched_start_jobid and sched_end_jobid so that
+#   this script submits that many number of jobs.
+#
+submit_1N_fflop_nproc_sleep_jobs () {
+    submit_1N_sleep_jobs $1 $2 "fflop" 
+    return $?
+}
+
+# PUBLIC:
+#   Submit 1-node sleep jobs at $1 processes
+#   to flux back to back.
+#
+#   The user script should already have updated
+#   sched_start_jobid and sched_end_jobid so that
+#   this script submits that many number of jobs.
+#
+submit_1N_nproc_sleep_jobs () {
+    submit_1N_sleep_jobs $1 $2 "cons"
+    return $?
+}
+
+# PUBLIC:
+#   Verify that submit_1N_decr_nproc_sleep_jobs
+#   successfully targeted the right set of ranks
+#   to launch the application processes in the correct
+#   locations. 
+#
+#   Currently, we assume the resources under ranks are
+#   scheduled in rank order. This assumption may break
+#   when resrc traversing for scheduling change at which
+#   point we will need a bit more advanced verification 
+#   mechanism.
+#
+verify_1N_decr_nproc_sleep_jobs () {
+    verify_1N_sleep_jobs $1 "decr"
+    return $?
+}
+
+# PUBLIC:
+#   Verify that submit_1N_fflop_nproc_sleep_jobs
+#   successfully targeted the right set of ranks.
+#
+#   Currently, we assume the resources under ranks are
+#   scheduled in rank order. This assumption may break
+#   when resrc traversing for scheduling change at which
+#   point we need a bit more advanced verification 
+#   mechanism.
+#
+verify_1N_fflop_nproc_sleep_jobs () {
+    verify_1N_sleep_jobs $1 "fflop"
+    return $?
+}
+
+# PUBLIC:
+#   Verify that submit_1N_nproc_sleep_jobs
+#   successfully targeted the right set of ranks.
+#
+verify_1N_nproc_sleep_jobs () {
+    verify_1N_sleep_jobs $1 "cons"
+    return $?
+}
+


### PR DESCRIPTION
This PR has two items:

1) Remove the redundant heartbeat-based synchronization logic from flux-waitjob.c. This was discussed in `flux-core` issue [#505](https://github.com/flux-framework/flux-core/issues/505) and [#498](https://github.com/flux-framework/flux-core/issues/498) 

2) Clean up waitjob and jsc tests:
- Specifically refactor test session management and synchronization management into the subroutines in the project-local sharness script (t/sharness.d/sched-sharness.sh);
- Copy @grondo's waitfile.lua into t/scripts/ as part of it;
- waitjob and jsc test scripts now use the new support;
- Finally, the local sharness test script also contains submit-and-verification subroutines that will ease writing some of my future test scripts.

