### PR TITLE
resrc: add to_string to print a resrc's state to a string

### DIFF
--- a/resrc/resrc.h
+++ b/resrc/resrc.h
@@ -113,7 +113,12 @@ resrc_t *resrc_generate_xml_resources (resrc_t *host_resrc, const char *buf,
 int resrc_to_json (JSON o, resrc_t *resrc);
 
 /*
- * Print details of a specific resource
+ * Print details of a specific resource to a string buffer
+ * and return to the caller. The caller must free it.
+ */
+char *resrc_to_string (resrc_t *resrc);
+/*
+ * Print details of a specific resource to stdout
  */
 void resrc_print_resource (resrc_t *resrc);
 


### PR DESCRIPTION
Add resrc_to_string so that a resrc's state can be printed to a string which then can be directed to `flux_log ()`. For now, the debug print function (`resrc_print_resource ()`) prints the state stdout, which gets lost when used in a comms module (e.g., `schedsrv`). `resrc_print_resource ()` is now a thin wrapper on top of `resrc_to_string ()`.