### PR TITLE
build/test: Update flux commandline options

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -50,5 +50,8 @@ KVS_LIBS = -Wl,-rpath,$(FLUX_BUILDDIR)/src/modules/kvs/.libs \
 #
 # When we invoke flux we need to provide additional LUA paths for RDL
 #
-FLUX = flux -C$(RDL_LUA_CPATH) -L$(RDL_LUA_PATH) -M$(SCHED_MODULE_PATH) -x$(SUBMIT_EXEC_PATH)
+FLUX = LUA_PATH="$(RDL_LUA_PATH);$$LUA_PATH;;" \
+       LUA_CPATH="$(RDL_LUA_CPATH);$$LUA_CPATH;;" \
+       FLUX_MODULE_PATH=$(SCHED_MODULE_PATH) \
+       flux -x$(SUBMIT_EXEC_PATH)
 COMMON_CFLAGS = -g -Wall -Werror -Wno-error=deprecated-declarations -fPIC -D_GNU_SOURCE=1

--- a/README.md
+++ b/README.md
@@ -87,13 +87,16 @@ below.
 Create a comms session within SLURM across 3 nodes with one rank per
 node:
 ```
-srun -N3 --pty ~/flux-core/src/cmd/flux -M ~/flux-sched/sched -C ~/flux-sched/rdl/\?.so -L ~/flux-sched/rdl/\?.lua broker
+export LUA_PATH="${LUA_PATH};~/flux-sched/rdl/?.lua"
+export LUA_PATH="${LUA_CPATH};~/flux-sched/rdl/?.so"
+export FLUX_MODULE_PATH=~/flux-sched/sched
+srun -N3 --pty ~/flux-core/src/cmd/flux broker
 ```
 
 Load the sched module specifying the appropriate rdl configuration
 file:
 ```
-flux -M ~/flux-sched/sched -C ~/flux-sched/rdl/\?.so -L ~/flux-sched/rdl/\?.lua module load sched rdl-conf=../conf/hype.lua
+flux module load sched rdl-conf=../conf/hype.lua
 ```
 
 Check to see whether the sched module loaded:

--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -29,7 +29,7 @@ sim_sched_%.so: sim_sched_%.c $(COMMON_OBJS) $(SCHEDULER_OBJS) libsim.so
 	$(CC) $(CFLAGS) -shared -o $@ $^ $(ALL_LIBS)
 
 start:
-	$(FLUX) -B ../.build/src/broker/flux-broker start -o -l 7
+	$(FLUX) start -o -l 7
 load:
 	$(FLUX) module load ./simsrv.so exit-on-complete=false
 	$(FLUX) module load ./submitsrv.so job-csv=$(JOBDATA)

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -70,10 +70,10 @@ test_under_flux() {
 
     TEST_UNDER_FLUX_ACTIVE=t \
     TERM=${ORIGINAL_TERM} \
-      exec flux -M${tdir}/sched \
-        -C"${tdir}/rdl/?.so;${FLUX_SOURCE_DIR}/src/bindings/lua/?.so" \
-        -L"${tdir}/rdl/?.lua;${FLUX_SOURCE_DIR}/src/bindings/lua/?.lua" \
-        start --size=${size} ${quiet} "sh $0 ${flags}"
+    LUA_PATH="$LUA_PATH;${tdir}/rdl/?.lua;;" \
+    LUA_CPATH="$LUA_CPATH;${tdir}/rdl/?.so;;" \
+    FLUX_MODULE_PATH="${tdir}/sched" \
+      exec flux start --size=${size} ${quiet} "sh $0 ${flags}"
 }
 
 mock_bootstrap_instance() {


### PR DESCRIPTION
flux(1) utility command line options --module-path (-M), --lua-path (-L),
--lua-cpath (-C), and --python-path (-P) will be removed from upstream
flux-core. This commit removes use of those options from flux-sched
build and test infrastructure, in preference for environment variables
that perform a a similar function.

This change should be applied immediately after flux-framework/flux-core#516
is merged. It cannot be applied beforehand because `flux(1)` does not currently
support extending `FLUX_MODULE_PATH` from the environment.

If we'd rather not temporarily break flux-sched, we could break this into parts

 1. flux-core: Add `FLUX_MODULE_PATH` environment support to `flux(1)`
 2. flux-sched: Merge this PR
 3. flux-core: Remove -M, -P, -L, -C 