### PR TITLE
Improved LONGTEST usage in testsuite

### DIFF
--- a/t/sharness.d/sched-sharness.sh
+++ b/t/sharness.d/sched-sharness.sh
@@ -9,6 +9,10 @@ sched_start_jobid=0
 sched_end_jobid=0
 sched_test_dir=""
 
+if test "$TEST_LONG" = "t"; then
+    test_set_prereq LONGTEST
+fi
+
 #
 # Internal subroutines
 #

--- a/t/t1002-rs2rank-64ranks.t
+++ b/t/t1002-rs2rank-64ranks.t
@@ -8,8 +8,9 @@ the nodes allocated to a job.
 '
 . `dirname $0`/sharness.sh
 
-if test "$TEST_LONG" = "t"; then
-    test_set_prereq LONGTEST
+if ! test_have_prereq LONGTEST; then
+    skip_all='LONGTEST not set, skipping...'
+    test_done
 fi
 
 tdir=`readlink -e ${SHARNESS_TEST_SRCDIR}/../`

--- a/t/t1003-stress.t
+++ b/t/t1003-stress.t
@@ -5,8 +5,9 @@ test_description='Stress the system by submitting large numbers of jobs'
 
 . `dirname $0`/sharness.sh
 
-if test "$TEST_LONG" = "t"; then
-    test_set_prereq LONGTEST
+if ! test_have_prereq LONGTEST; then
+    skip_all='LONGTEST not set, skipping...'
+    test_done
 fi
 
 tdir=`readlink -e ${SHARNESS_TEST_SRCDIR}/../`

--- a/t/t1003-stress.t
+++ b/t/t1003-stress.t
@@ -36,7 +36,7 @@ test_debug '
     echo ${excl_4N4B_nc}
 '
 
-test_expect_success LONGTEST 'stress: submit and execute 1000 sleep 0 jobs (max allowed: 1h)' '
+test_expect_success  'stress: submit and execute 1000 sleep 0 jobs (max allowed: 1h)' '
     adjust_session_info 1000 &&
     flux hwloc reload ${excl_4N4B} &&
     flux module load ${schedsrv} rdl-conf=${excl_4N4B_m_RDL} &&
@@ -47,19 +47,7 @@ test_expect_success LONGTEST 'stress: submit and execute 1000 sleep 0 jobs (max 
     date > end.$(get_session)
 '
 
-test_expect_success LONGTEST 'stress: repeat second time (max allowed: 1h)' '
-    adjust_session_info 1000 &&
-    flux module remove sched &&
-    flux hwloc reload ${excl_4N4B} &&
-    flux module load ${schedsrv} rdl-conf=${excl_4N4B_m_RDL} &&
-    date > begin.$(get_session)
-    timed_wait_job 5 &&
-    submit_1N_nproc_sleep_jobs ${excl_4N4B_nc} 0 &&
-    timed_sync_wait_job 3600 &&
-    date > end.$(get_session)
-'
-
-test_expect_success LONGTEST 'stress: repeat third time (max allowed: 1h)' '
+test_expect_success  'stress: repeat second time (max allowed: 1h)' '
     adjust_session_info 1000 &&
     flux module remove sched &&
     flux hwloc reload ${excl_4N4B} &&
@@ -71,7 +59,7 @@ test_expect_success LONGTEST 'stress: repeat third time (max allowed: 1h)' '
     date > end.$(get_session)
 '
 
-test_expect_success LONGTEST 'stress: repeat 4th time (max allowed: 1h)' '
+test_expect_success  'stress: repeat third time (max allowed: 1h)' '
     adjust_session_info 1000 &&
     flux module remove sched &&
     flux hwloc reload ${excl_4N4B} &&
@@ -83,7 +71,7 @@ test_expect_success LONGTEST 'stress: repeat 4th time (max allowed: 1h)' '
     date > end.$(get_session)
 '
 
-test_expect_success LONGTEST 'stress: repeat 5th time (max allowed: 1h)' '
+test_expect_success  'stress: repeat 4th time (max allowed: 1h)' '
     adjust_session_info 1000 &&
     flux module remove sched &&
     flux hwloc reload ${excl_4N4B} &&
@@ -95,7 +83,7 @@ test_expect_success LONGTEST 'stress: repeat 5th time (max allowed: 1h)' '
     date > end.$(get_session)
 '
 
-test_expect_success LONGTEST 'stress: repeat 6th time (max allowed: 1h)' '
+test_expect_success  'stress: repeat 5th time (max allowed: 1h)' '
     adjust_session_info 1000 &&
     flux module remove sched &&
     flux hwloc reload ${excl_4N4B} &&
@@ -107,7 +95,7 @@ test_expect_success LONGTEST 'stress: repeat 6th time (max allowed: 1h)' '
     date > end.$(get_session)
 '
 
-test_expect_success LONGTEST 'stress: repeat 7th time (max allowed: 1h)' '
+test_expect_success  'stress: repeat 6th time (max allowed: 1h)' '
     adjust_session_info 1000 &&
     flux module remove sched &&
     flux hwloc reload ${excl_4N4B} &&
@@ -119,7 +107,7 @@ test_expect_success LONGTEST 'stress: repeat 7th time (max allowed: 1h)' '
     date > end.$(get_session)
 '
 
-test_expect_success LONGTEST 'stress: repeat 8th time (max allowed: 1h)' '
+test_expect_success  'stress: repeat 7th time (max allowed: 1h)' '
     adjust_session_info 1000 &&
     flux module remove sched &&
     flux hwloc reload ${excl_4N4B} &&
@@ -131,7 +119,7 @@ test_expect_success LONGTEST 'stress: repeat 8th time (max allowed: 1h)' '
     date > end.$(get_session)
 '
 
-test_expect_success LONGTEST 'stress: repeat 9th time (max allowed: 1h)' '
+test_expect_success  'stress: repeat 8th time (max allowed: 1h)' '
     adjust_session_info 1000 &&
     flux module remove sched &&
     flux hwloc reload ${excl_4N4B} &&
@@ -143,7 +131,19 @@ test_expect_success LONGTEST 'stress: repeat 9th time (max allowed: 1h)' '
     date > end.$(get_session)
 '
 
-test_expect_success LONGTEST 'stress: repeat 10th time (max allowed: 1h)' '
+test_expect_success  'stress: repeat 9th time (max allowed: 1h)' '
+    adjust_session_info 1000 &&
+    flux module remove sched &&
+    flux hwloc reload ${excl_4N4B} &&
+    flux module load ${schedsrv} rdl-conf=${excl_4N4B_m_RDL} &&
+    date > begin.$(get_session)
+    timed_wait_job 5 &&
+    submit_1N_nproc_sleep_jobs ${excl_4N4B_nc} 0 &&
+    timed_sync_wait_job 3600 &&
+    date > end.$(get_session)
+'
+
+test_expect_success  'stress: repeat 10th time (max allowed: 1h)' '
     adjust_session_info 1000 &&
     flux module remove sched &&
     flux hwloc reload ${excl_4N4B} &&


### PR DESCRIPTION
I was getting OOMs and EAGAIN errors from `fork` on a small VM when trying to run `make check` in flux-sched, due to the 64 rank flux session being started in `t1002-rs2rank-64ranks.t`, even when LONGTEST is not set. 

It seemed the intent here (and in `t1003-stress.t`) was to skip all tests if `--long` or `TEST_LONG` is not set, so, in addition to setting `LONGTEST` prereq in one place, this PR puts the stanza:
```sh
if ! test_have_prereq LONGTEST; then
    skip_all='LONGTEST not set, skipping...'
    test_done
 fi
```

At the top of these functions, which results in skipping these entire files, thus avoiding unnecessary launch of a flux session.