### PR TITLE
travis-ci: add install target for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ compiler:
   - gcc
   - clang
   - gcc+coverage
+  - gcc+install
 
 cache:
   directories:
@@ -34,6 +35,9 @@ before_install:
   # If CC has "+coverage" appended then turn on code coverage for this build
   - case "$CC" in *+coverage) CC=${CC//+*}; export COVERAGE=t;; esac
 
+  # If CC has "+install" appended then test "make install"
+  - case "$CC" in *+install)  CC=${CC//+*}; export TEST_INSTALL=t;; esac
+
   - wget https://raw.githubusercontent.com/flux-framework/flux-core/master/src/test/travis-dep-builder.sh
   - eval $(bash ./travis-dep-builder.sh --printenv)
   - export PKG_CONFIG_PATH=$HOME/local2/lib/pkgconfig:${PKG_CONFIG_PATH}
@@ -56,6 +60,9 @@ script:
 
  # Enable coverage for $CC+coverage build
  - if test "$COVERAGE" = "t" ; then ARGS=--enable-code-coverage; MAKECMDS="make && make check-code-coverage && lcov -l flux-*coverage.info" ; fi
+ 
+ # Use "make install" and set FLUX_SCHED_TEST_INSTALLED in environment for installed testing:
+ - if test "$TEST_INSTALL" = "t"; then ARGS=--prefix=$HOME/local2; MAKECMDS="make && make install && FLUX_SCHED_TEST_INSTALLED=t make check"; fi
 
  - autoreconf -i && ./configure ${ARGS} && eval ${MAKECMDS}
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ flag to each flux command below.
 Create a comms session comprised of 3 brokers:
 ```
 export LUA_PATH="$HOME/flux-sched/rdl/?.lua;${LUA_PATH};;"
-export LUA_CPATH="$HOME/flux-sched/rdl/.libs/?.so;${LUA_CPATH};;"
+export LUA_CPATH="$HOME/flux-sched/rdl/?.so;${LUA_CPATH};;"
 export FLUX_MODULE_PATH=$HOME/flux-sched/sched
 $HOME/local/bin/flux start -s3
 ```

--- a/rdl/Makefile.am
+++ b/rdl/Makefile.am
@@ -27,14 +27,17 @@ nobase_dist_lua_SCRIPTS = \
 	RDL/uuid.lua
 
 lib_LTLIBRARIES = libflux-rdl.la
-fluxluaexec_LTLIBRARIES = flux-cpuset.la
+fluxluaexec_LTLIBRARIES = \
+    flux/cpuset.la
 
 fluxschedinclude_HEADERS = rdl.h
 
 flux_cpuset_la_SOURCES = lua-cpuset.c cpuset-str.c cpuset-str.h
 flux_cpuset_la_CFLAGS = $(LUA_INCLUDE)
 flux_cpuset_la_LIBADD = $(LUA_LIB)
-flux_cpuset_la_LDFLAGS = $(luamod_ldflags)
+flux_cpuset_la_LDFLAGS = \
+    $(luamod_ldflags) \
+    -Wl,--defsym=luaopen_flux_cpuset=luaopen_cpuset
 
 libflux_rdl_la_SOURCES = rdl.c json-lua.c json-lua.h
 libflux_rdl_la_LIBADD = $(FLUX_CORE_LIBS) $(LUA_LIB) $(JSON_LIBS) $(CZMQ_LIBS) \
@@ -49,3 +52,34 @@ flux_rdltool_CFLAGS = $(AM_CFLAGS)
 flux_rdltool_LDADD = libflux-rdl.la $(LUA_LIB) $(JSON_LIBS)
 
 EXTRA_DIST = rdl_version.map
+
+# Copy any Lua modules in flux/.libs to ${top_builddir}/flux/*.so so that
+#  they can be used as require 'flux.<name>' in-tree
+#
+.PHONY: convenience-link clean-convenience-link
+
+convenience-link: $(fluxluaexec_LTLIBRARIES)
+	@for f in $^; do \
+	  soname=`$(GREP) "^dlname=" $$f | $(SED) -e "s|^dlname='\(.*\)'|\1|"`; \
+	  dirname=`dirname $(abs_builddir)/$$f `; \
+	  target=$$dirname/.libs/$$soname; link=$$dirname/$$soname; \
+	  shortdir=`echo $$f | $(SED) -e 's|[^/]*.la||'`; \
+	  shorttarget="$${shortdir}.libs/$$soname"; \
+	  echo "  LN       $$shortdir$$soname -> $$shorttarget"; \
+	  rm -f  $$link; \
+	  $(LN_S) $$target $$link; \
+	done
+
+
+clean-convenience-link:
+	@for f in $^; do \
+	  soname=`$(GREP) "^dlname=" $$f | $(SED) -e "s|^dlname='\(.*\)'|\1|"`; \
+	  dirname=`echo $(abs_builddir)/$$f | $(SED) -e 's|/[^/]*.la||'`; \
+	  target=$$dirname/.libs/$$soname; link=$$dirname/$$soname; \
+	  echo "  RM       $$link"; \
+	  rm -f $$link; \
+	done
+
+all-local:: convenience-link
+
+clean-local:: clean-convenience-link

--- a/rdl/RDL/types/Socket.lua
+++ b/rdl/RDL/types/Socket.lua
@@ -25,7 +25,7 @@
 Socket = Resource:subclass ('Socket')
 
 function Socket:initialize (arg)
-    local cpuset = require 'flux-cpuset'.new
+    local cpuset = require 'flux.cpuset'.new
 
     assert (tonumber(arg.id),   "Required Socket arg `id' missing")
     assert (type(arg.cpus) == "string", "Required Socket arg `cpus' missing")

--- a/rdl/test/Makefile.am
+++ b/rdl/test/Makefile.am
@@ -5,7 +5,7 @@ AM_CPPFLAGS = -I$(top_srcdir) $(JSON_CFLAGS)
 
 TESTS_ENVIRONMENT = \
     LUA_PATH="$(abs_top_srcdir)/rdl/?.lua;$(FLUX_PREFIX)/share/lua/5.1/?.lua;$(LUA_PATH);;" \
-    LUA_CPATH="$(abs_top_builddir)/rdl/.libs/?.so;$(FLUX_PREFIX)/lib64/lua/5.1/?.so;$(LUA_CPATH);;" \
+    LUA_CPATH="$(abs_top_builddir)/rdl/?.so;$(FLUX_PREFIX)/lib64/lua/5.1/?.so;$(LUA_CPATH);;" \
     TESTRDL_INPUT_FILE="$(abs_top_srcdir)/conf/hype.lua"
 
 TESTS = trdl

--- a/resrc/test/Makefile.am
+++ b/resrc/test/Makefile.am
@@ -6,7 +6,7 @@ AM_CPPFLAGS = -I$(top_srcdir) $(JSON_CFLAGS) $(CZMQ_CFLAGS)
 TESTS_ENVIRONMENT = \
     TESTRESRC_INPUT_FILE="$(abs_top_srcdir)/conf/hype.lua" \
     LUA_PATH="$(abs_top_srcdir)/rdl/?.lua;$(FLUX_PREFIX)/share/lua/5.1/?.lua;$(LUA_PATH);;" \
-    LUA_CPATH="$(abs_top_builddir)/rdl/.libs/?.so;$(FLUX_PREFIX)/lib64/lua/5.1/?.so;$(LUA_CPATH);;"
+    LUA_CPATH="$(abs_top_builddir)/rdl/?.so;$(FLUX_PREFIX)/lib64/lua/5.1/?.so;$(LUA_CPATH);;"
 
 TESTS = tresrc
 

--- a/sched/Makefile.am
+++ b/sched/Makefile.am
@@ -10,7 +10,7 @@ schedplugin_ldflags = $(fluxlib_ldflags) -avoid-version -module \
 CONF = $(abs_top_srcdir)/conf/hype.lua
 FLUX_MODULE_PATH = $(top_srcdir)/sched
 LUA_PATH = $(abs_top_srcdir)/rdl/?.lua;$(FLUX_PREFIX)/share/lua/5.1/?.lua;$${LUA_PATH};;
-LUA_CPATH = $(abs_top_builddir)/rdl/.libs/?.so;$${LUA_CPATH};;
+LUA_CPATH = $(abs_top_builddir)/rdl/?.so;$${LUA_CPATH};;
 
 fluxmod_LTLIBRARIES = schedsrv.la
 

--- a/simulator/Makefile.am
+++ b/simulator/Makefile.am
@@ -12,7 +12,7 @@ TESTS = tsched_lib
 TESTS_ENVIRONMENT = \
     TESTSIM_INPUT_FILE="$(abs_top_srcdir)/conf/hype-io.lua" \
     LUA_PATH="$(abs_top_srcdir)/rdl/?.lua;$(FLUX_PREFIX)/share/lua/5.1/?.lua;$(LUA_PATH);;" \
-    LUA_CPATH="$(abs_top_builddir)/rdl/.libs/?.so;$(FLUX_PREFIX)/lib64/lua/5.1/?.so;$(LUA_CPATH);;"
+    LUA_CPATH="$(abs_top_builddir)/rdl/?.so;$(FLUX_PREFIX)/lib64/lua/5.1/?.so;$(LUA_CPATH);;"
 
 check_PROGRAMS = $(TESTS)
 tsched_lib_SOURCES = test/tsched_lib.c scheduler.c

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -6,11 +6,16 @@ T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 	$(top_srcdir)/m4/tap-driver.sh
 
 #
-# These are required by the lua tests
+# Set up paths for fluxometer-based Lua tests.
+# LUA_PATH is set to find fluxometer.lua itself.
+# The PREPEND versions are required so that in-tree versions of
+#  modules are found instead of the lua modules in the path
+#  of the flux installation we're using for testing.
 #
 TESTS_ENVIRONMENT = \
-    LUA_PATH="$(abs_top_srcdir)/rdl/?.lua;$(FLUX_PREFIX)/share/lua/5.1/?.lua;$(LUA_PATH);;" \
-    LUA_CPATH="$(abs_top_builddir)/rdl/.libs/?.so;$(FLUX_PREFIX)/lib64/lua/5.1/?.so;$(LUA_CPATH);;" \
+    LUA_PATH="$(FLUX_PREFIX)/share/lua/5.1/?.lua;$(LUA_PATH);;" \
+    FLUX_LUA_PATH_PREPEND="$(abs_top_srcdir)/rdl/?.lua" \
+    FLUX_LUA_CPATH_PREPEND="$(abs_top_builddir)/rdl/?.so" \
     PATH="$(FLUX_PREFIX)/bin:$(PATH)"
 
 TESTS = \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -10,12 +10,16 @@ T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 # LUA_PATH is set to find fluxometer.lua itself.
 # The PREPEND versions are required so that in-tree versions of
 #  modules are found instead of the lua modules in the path
-#  of the flux installation we're using for testing.
+#  of the flux installation we're using for testing. If
+#  $FLUX_SCHED_TEST_INSTALLED is set in the current environment,
+#  skip the export of the PREPEND variables.
 #
 TESTS_ENVIRONMENT = \
     LUA_PATH="$(FLUX_PREFIX)/share/lua/5.1/?.lua;$(LUA_PATH);;" \
-    FLUX_LUA_PATH_PREPEND="$(abs_top_srcdir)/rdl/?.lua" \
-    FLUX_LUA_CPATH_PREPEND="$(abs_top_builddir)/rdl/?.so" \
+    $(if $(FLUX_SCHED_TEST_INSTALLED),, \
+      FLUX_LUA_PATH_PREPEND="$(abs_top_srcdir)/rdl/?.lua" \
+      FLUX_LUA_CPATH_PREPEND="$(abs_top_builddir)/rdl/?.so" \
+    ) \
     PATH="$(FLUX_PREFIX)/bin:$(PATH)"
 
 TESTS = \

--- a/t/sharness.d/sched-sharness.sh
+++ b/t/sharness.d/sched-sharness.sh
@@ -3,11 +3,19 @@
 # project-local sharness code for flux-sched
 #
 
-# Set up environment so that we find flux-sched modules, commands, and Lua libs:
-FLUX_LUA_PATH_PREPEND="${SHARNESS_TEST_SRCDIR}/../rdl/?.lua"
-FLUX_LUA_CPATH_PREPEND="${SHARNESS_BUILD_DIRECTORY}/rdl/?.so"
-FLUX_MODULE_PATH_PREPEND="${SHARNESS_BUILD_DIRECTORY}/sched/.libs"
-FLUX_EXEC_PATH_PREPEND="${SHARNESS_BUILD_DIRECTORY}/sched"
+if test -n "$FLUX_SCHED_TEST_INSTALLED"; then
+  # Test against installed flux-sched, installed under same prefix as
+  #   flux-core.
+  # (Assume sched modules installed under PREFIX/lib/flux/sched-plugin)
+  FLUX_MODULE_PATH_PREPEND=$(which flux | sed -s 's|/bin/flux|/lib/flux/sched-plugin|')
+else
+  # Set up environment so that we find flux-sched modules,
+  #  commands, and Lua libs from the build directories:
+  FLUX_LUA_PATH_PREPEND="${SHARNESS_TEST_SRCDIR}/../rdl/?.lua"
+  FLUX_LUA_CPATH_PREPEND="${SHARNESS_BUILD_DIRECTORY}/rdl/?.so"
+  FLUX_MODULE_PATH_PREPEND="${SHARNESS_BUILD_DIRECTORY}/sched/.libs"
+  FLUX_EXEC_PATH_PREPEND="${SHARNESS_BUILD_DIRECTORY}/sched"
+fi
 
 ## Set up environment using flux(1) in PATH
 flux --help >/dev/null 2>&1 || error "Failed to find flux in PATH"

--- a/t/sharness.d/sched-sharness.sh
+++ b/t/sharness.d/sched-sharness.sh
@@ -5,7 +5,7 @@
 
 # Set up environment so that we find flux-sched modules, commands, and Lua libs:
 FLUX_LUA_PATH_PREPEND="${SHARNESS_TEST_SRCDIR}/../rdl/?.lua"
-FLUX_LUA_CPATH_PREPEND="${SHARNESS_BUILD_DIRECTORY}/rdl/.libs/?.so"
+FLUX_LUA_CPATH_PREPEND="${SHARNESS_BUILD_DIRECTORY}/rdl/?.so"
 FLUX_MODULE_PATH_PREPEND="${SHARNESS_BUILD_DIRECTORY}/sched/.libs"
 FLUX_EXEC_PATH_PREPEND="${SHARNESS_BUILD_DIRECTORY}/sched"
 


### PR DESCRIPTION
This PR adds support for an "install" target for travis-ci testing. This target builds flux-sched with `--prefix=$HOME/local2` (same prefix as flux-core), does `make install`, and then runs `make check` against the *installed* flux-sched components via a newly supported `FLUX_SCHED_TEST_INSTALLED` env var.

