### PR TITLE
test/basic: re-enable commented out test

### DIFF
--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -32,9 +32,9 @@ test_expect_success 'schedsrv: flux-module load works after a successful unload'
 '
 
 # comment this one out for now
-#test_expect_success 'schedsrv: module load should fail' '
-#	test_expect_code 1 flux module load sched rdl-conf=foo
-#'
+test_expect_success 'schedsrv: module load should fail' '
+	test_expect_code 1 flux module load sched rdl-conf=foo
+'
 
 test_expect_success 'schedsrv: module load works after a load failure' '
 	flux module load sched rdl-conf=${RDL_CONF_DEFAULT}


### PR DESCRIPTION
Now that flux-core can return mod_main() errors to flux module load,
re-enable t0001-basic.t test 4.

Discussed in issue #13 