### PR TITLE
testsuite: fix non-POSIX warning from automake

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -14,12 +14,16 @@ T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 #  $FLUX_SCHED_TEST_INSTALLED is set in the current environment,
 #  skip the export of the PREPEND variables.
 #
+#  (XXX: the only way I've found to portably do this is to substitute
+#   the required path iff FLUX_SCHED_TEST_INSTALLED is not set, otherwise we
+#   substitute the *value* of FLUX_SCHED_TEST_INSTALLED, which might
+#   be `1` or `t`, but at least this doesn't point to build directory
+#   Lua PATH)
+#
 TESTS_ENVIRONMENT = \
     LUA_PATH="$(FLUX_PREFIX)/share/lua/5.1/?.lua;$(LUA_PATH);;" \
-    $(if $(FLUX_SCHED_TEST_INSTALLED),, \
-      FLUX_LUA_PATH_PREPEND="$(abs_top_srcdir)/rdl/?.lua" \
-      FLUX_LUA_CPATH_PREPEND="$(abs_top_builddir)/rdl/?.so" \
-    ) \
+    FLUX_LUA_PATH_PREPEND="$${FLUX_SCHED_TEST_INSTALLED:-$(abs_top_srcdir)/rdl/?.lua}" \
+    FLUX_LUA_CPATH_PREPEND="$${FLUX_SCHED_TEST_INSTALLED:-$(abs_top_builddir)/rdl/?.so}" \
     PATH="$(FLUX_PREFIX)/bin:$(PATH)"
 
 TESTS = \


### PR DESCRIPTION
Fix use of non-POSIX $(if ...) usage in t/Makefile.am to keep automake
from complaining. The replacement uses POSIX variable substitution to
substitute the build-tree LUA_PATH and LUA_CPATH to the PREPEND variables
iff FLUX_SCHED_TEST_INSTALLED *is not* set.

When FLUX_SCHED_TEST_INSTALLED *is* set, then the value of that variable
(`t` or maybe `1`) is substituted, which still isn't quite right, but at least
the build-tree Lua modules will not be used. Unfortunately, this was the
best that we could do at this time.

If this isn't acceptable, then we can take some other approach like discussed in #136,
or we could add the `-Wno-portability` flag to automake, since we probably don't support
non-GNU systems anyway. (However, it might be useful to keep portability warnings for
the rest of the build files)

Fixes #136