### PR TITLE
Issue153: Better resource unmatch test and etc

### DIFF
--- a/sched/rsreader.c
+++ b/sched/rsreader.c
@@ -196,10 +196,11 @@ done:
     return rc;
 }
 
-int rsreader_link2rank (machs_t *machs, resrc_t *r_resrc)
+int rsreader_link2rank (machs_t *machs, resrc_t *r_resrc, char **err_str)
 {
     int rc = -1;
     size_t ncnt = 0;
+    char *e_str = NULL;
     resrc_tree_t *rt = NULL;
     int nsocks = 0, ncs = 0;
     const char *digest = NULL;
@@ -216,12 +217,19 @@ int rsreader_link2rank (machs_t *machs, resrc_t *r_resrc)
          */
         digest = rs2rank_tab_eq_by_count (machs, resrc_name (resrc_tree_resrc (rt)),
                                           nsocks, ncs);
-        if (!digest)
+        if (!digest) {
+            e_str = xasprintf ("%s: Can't find a matching resrc for <%s,%d,%d>",
+                __FUNCTION__, resrc_name (resrc_tree_resrc (rt)), nsocks, ncs);
             goto done;
+        }
         resrc_set_digest (resrc_tree_resrc (rt), xasprintf ("%s", digest));
     }
     rc = 0;
 done:
+    if (err_str)
+        *err_str = e_str;
+    else
+        free (e_str);
     return rc;
 }
 

--- a/sched/rsreader.h
+++ b/sched/rsreader.h
@@ -70,9 +70,10 @@ int rsreader_hwloc_load (const char *hw_xml, size_t len, uint32_t rank,
 /* Traverse the entire resrc hierarchy and link each node-type
  * resrc_t object with a broker rank by filling in its digest field.
  * Its hostname and digest of the resrc object are later used
- * to determine the managing broker.
+ * to determine the managing broker. If err_str is not null,
+ * this routine returns an error message along with a non-zero rc.
  */
-int rsreader_link2rank (machs_t *machs, resrc_t *root);
+int rsreader_link2rank (machs_t *machs, resrc_t *root, char **err_str);
 
 /* For testing such as emulation whereby no real mapping may
  * exist between the physcal broker rank and testing resource

--- a/sched/sched.c
+++ b/sched/sched.c
@@ -101,6 +101,7 @@ typedef struct {
     char         *userplugin;
     bool          sim;
     bool          schedonce;          /* Use resources only once */
+    bool          fail_on_error;      /* Fail immediately on error */
     int           verbosity;
     rsreader_t    r_mode;
 } ssrvarg_t;
@@ -131,6 +132,7 @@ static inline void ssrvarg_init (ssrvarg_t *arg)
     arg->userplugin = NULL;
     arg->sim = false;
     arg->schedonce = false;
+    arg->fail_on_error = false;
     arg->verbosity = 0;
 }
 
@@ -148,6 +150,7 @@ static inline int ssrvarg_process_args (int argc, char **argv, ssrvarg_t *a)
 {
     int i = 0, rc = 0;
     char *schedonce = NULL;
+    char *immediate = NULL;
     char *vlevel= NULL;
     char *sim = NULL;
     for (i = 0; i < argc; i++) {
@@ -155,6 +158,9 @@ static inline int ssrvarg_process_args (int argc, char **argv, ssrvarg_t *a)
             a->path = xstrdup (strstr (argv[i], "=") + 1);
         } else if (!strncmp ("sched-once=", argv[i], sizeof ("sched-once"))) {
             schedonce = xstrdup (strstr (argv[i], "=") + 1);
+        } else if (!strncmp ("fail-on-error=", argv[i],
+                    sizeof ("fail-on-error"))) {
+            immediate = xstrdup (strstr (argv[i], "=") + 1);
         } else if (!strncmp ("verbosity=", argv[i], sizeof ("verbosity"))) {
             vlevel = xstrdup (strstr (argv[i], "=") + 1);
         } else if (!strncmp ("rdl-resource=", argv[i], sizeof ("rdl-resource"))) {
@@ -180,6 +186,10 @@ static inline int ssrvarg_process_args (int argc, char **argv, ssrvarg_t *a)
     if (schedonce && !strncmp (schedonce, "true", sizeof ("true"))) {
         a->schedonce = true;
         free (schedonce);
+    }
+    if (immediate && !strncmp (immediate, "true", sizeof ("true"))) {
+        a->fail_on_error = true;
+        free (immediate);
     }
     if (vlevel) {
          a->verbosity = strtol(vlevel, (char **)NULL, 10);
@@ -526,8 +536,14 @@ static int load_resources (ssrvctx_t *ctx)
             flux_log (ctx->h, LOG_INFO, "resrc state after resrc read");
             dump_resrc_state (ctx->h, resrc_phys_tree (tres));
         }
-        if (rsreader_link2rank (ctx->machs, tres) != 0) {
-            flux_log (ctx->h, LOG_ERR, "RDL(%s) inconsistent w/ hwloc!", path);
+        if (rsreader_link2rank (ctx->machs, tres, &e_str) != 0) {
+            flux_log (ctx->h, LOG_INFO, "RDL(%s) inconsistent w/ hwloc!", path);
+            if (e_str) {
+                flux_log (ctx->h, LOG_INFO, "%s", e_str);
+                free (e_str);
+            }
+            if (ctx->arg.fail_on_error)
+                goto done;
             flux_log (ctx->h, LOG_INFO, "rebuild resrc using hwloc");
             if (turi)
                 free (turi);

--- a/sched/sched.c
+++ b/sched/sched.c
@@ -498,6 +498,7 @@ static void dump_resrc_state (flux_t h, resrc_tree_t *rt)
 static int load_resources (ssrvctx_t *ctx)
 {
     int rc = -1;
+    char *e_str = NULL;
     char *turi = NULL;
     resrc_t *tres = NULL;
     char *path = ctx->arg.path;

--- a/t/sharness.d/sched-sharness.sh
+++ b/t/sharness.d/sched-sharness.sh
@@ -33,9 +33,6 @@ sched_src_path () {
     readlink -e "${SHARNESS_TEST_SRCDIR}/../${1}"
 }
 
-# Add explicit path to default rdl.conf
-RDL_CONF_DEFAULT=$(sched_src_path "conf/hype.lua")
-
 export FLUX_EXEC_PATH_PREPEND
 export FLUX_SCHED_RC_NOOP
 export FLUX_SCHED_RC_PATH

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -19,7 +19,7 @@ test_under_flux ${SIZE}
 
 
 test_expect_success 'sched: module load works' '
-	flux module load sched rdl-conf=${RDL_CONF_DEFAULT}
+	flux module load sched
 '
 
 test_expect_success 'sched: module remove works' '
@@ -27,7 +27,7 @@ test_expect_success 'sched: module remove works' '
 '
 
 test_expect_success 'sched: flux-module load works after a successful unload' '
-	flux module load sched rdl-conf=${RDL_CONF_DEFAULT} &&
+	flux module load sched &&
 	flux module remove sched
 '
 
@@ -37,7 +37,7 @@ test_expect_success 'sched: module load should fail' '
 '
 
 test_expect_success 'sched: module load works after a load failure' '
-	flux module load sched rdl-conf=${RDL_CONF_DEFAULT}
+	flux module load sched
 '
 
 test_expect_success 'sched: module list works' '

--- a/t/t0002-waitjob.t
+++ b/t/t0002-waitjob.t
@@ -14,7 +14,7 @@ test_under_flux 4
 
 test_expect_success  'waitjob: works when the job has not started' '
     adjust_session_info 1 &&
-    flux module load sched rdl-conf=${RDL_CONF_DEFAULT} &&
+    flux module load sched &&
     timed_wait_job 5 &&
     flux submit -N 4 -n 4 hostname &&
     timed_sync_wait_job 5

--- a/t/t1000-jsc.t
+++ b/t/t1000-jsc.t
@@ -31,7 +31,7 @@ $tr8"
 
 test_expect_success 'jsc: expected job-event sequence for single-job scheduling' '
     adjust_session_info 1 && 
-    flux module load sched rdl-conf=${RDL_CONF_DEFAULT} &&
+    flux module load sched &&
     p=$(timed_run_flux_jstat output) &&
     timed_wait_job 5 &&
     flux submit -N 4 -n 4 hostname &&

--- a/t/t1001-rs2rank-basic.t
+++ b/t/t1001-rs2rank-basic.t
@@ -75,17 +75,6 @@ test_expect_success 'rs2rank: each manages a node exclusively' '
     verify_1N_nproc_sleep_jobs ${excl_4N4B_nc} 
 '
 
-test_expect_success 'rs2rank: works with a matched RDL' '
-    adjust_session_info 4 &&
-    flux module remove sched &&
-    flux hwloc reload ${excl_4N4B} &&
-    flux module load sched rdl-conf=${excl_4N4B_m_RDL} sched-once=true &&
-    timed_wait_job 5 &&
-    submit_1N_nproc_sleep_jobs ${excl_4N4B_nc} 0 &&
-    timed_sync_wait_job 10 &&
-    verify_1N_nproc_sleep_jobs ${excl_4N4B_nc} 
-'
-
 test_expect_success 'rs2rank: works with an inconsistent RDL (fewer cores)' '
     adjust_session_info 4 &&
     flux module remove sched &&
@@ -102,6 +91,17 @@ test_expect_success 'rs2rank: works with an inconsistent RDL (fewer nodes)' '
     flux module remove sched &&
     flux hwloc reload ${excl_4N4B} &&
     flux module load sched rdl-conf=${excl_4N4B_um_RDL2} sched-once=true &&
+    timed_wait_job 5 &&
+    submit_1N_nproc_sleep_jobs ${excl_4N4B_nc} 0 &&
+    timed_sync_wait_job 10 &&
+    verify_1N_nproc_sleep_jobs ${excl_4N4B_nc} 
+'
+
+test_expect_success 'rs2rank: works with a matched RDL' '
+    adjust_session_info 4 &&
+    flux module remove sched &&
+    flux hwloc reload ${excl_4N4B} &&
+    flux module load sched rdl-conf=${excl_4N4B_m_RDL} sched-once=true fail-on-error=true &&
     timed_wait_job 5 &&
     submit_1N_nproc_sleep_jobs ${excl_4N4B_nc} 0 &&
     timed_sync_wait_job 10 &&


### PR DESCRIPTION
Fix Issue #153. 

- Remove rdl-config=RDL-file option from the tests that are not designed to test a RDL-hwloc inconsistency
- Improve the verbosity for RDL != hwloc condition
- Add fail-on-error option to the sched module for better testing 
