### PR TITLE
runlevel: Add runlevel support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = src rdl resrc simulator sched t
+SUBDIRS = src rdl resrc simulator sched etc t
 
 EXTRA_DIST= \
 	conf \

--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,11 @@ AC_SUBST(schedplugindir)
 AS_VAR_SET(fluxschedincludedir, $includedir/flux/sched)
 AC_SUBST(fluxschedincludedir)
 
+AS_VAR_SET(fluxschedrc1dir, $sysconfdir/flux/rc1.d)
+AC_SUBST(fluxschedrc1dir)
+
+AS_VAR_SET(fluxschedrc3dir, $sysconfdir/flux/rc3.d)
+AC_SUBST(fluxschedrc3dir)
 
 ##
 # Macros to avoid repetition in Makefiles.am's
@@ -85,18 +90,19 @@ fluxlib_ldflags="-shared -export-dynamic --disable-static -Wl,--no-undefined"
 AC_SUBST(fluxlib_ldflags)
 
 AC_CONFIG_FILES([Makefile
-		 src/Makefile
-		 src/common/Makefile
-		 src/common/libtap/Makefile
-		 src/common/liblsd/Makefile
-		 src/common/libutil/Makefile
-                 rdl/Makefile
-                 rdl/test/Makefile
-                 resrc/Makefile
-                 resrc/test/Makefile
-                 sched/Makefile
-                 simulator/Makefile
-                 t/Makefile])
+  src/Makefile
+  src/common/Makefile
+  src/common/libtap/Makefile
+  src/common/liblsd/Makefile
+  src/common/libutil/Makefile
+  rdl/Makefile
+  rdl/test/Makefile
+  resrc/Makefile
+  resrc/test/Makefile
+  sched/Makefile
+  simulator/Makefile
+  etc/Makefile
+  t/Makefile])
 AC_OUTPUT
 
 echo "

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -1,0 +1,2 @@
+dist_fluxschedrc1_SCRIPTS = sched-start
+dist_fluxschedrc3_SCRIPTS = sched-stop

--- a/etc/sched-start
+++ b/etc/sched-start
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+#
+# If sched is not installed into flux-core's $prefix,
+# one should set FLUX_RC_EXTRA environment variable to flux-sched's $prefix/etc/flux
+# so that flux start can automatically execute sched's runlevel 1 and 3.
+#
+# In addition, users can set FLUX_SCHED_OPTIONS if they want flux
+# to load in the sched module with non-default options.
+# (e.g., FLUX_SCHED_OPTIONS="plugin=sched.backfill" will cause
+# flux to load the sched module with the backfil scheduling plugin.
+#
+# Finally, if FLUX_SCHED_RC_NOOP=1, flux-core
+# won't load in or remove sched as part of runlevel 1 and 3.
+#
+
+if [ -z ${FLUX_SCHED_RC_NOOP} ]; then
+    flux module load -r 0 sched ${FLUX_SCHED_OPTIONS}
+fi
+

--- a/etc/sched-stop
+++ b/etc/sched-stop
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+if [ -z ${FLUX_SCHED_RC_NOOP} ]; then
+    flux module remove sched
+fi
+

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -12,36 +12,42 @@ T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 #  modules are found instead of the lua modules in the path
 #  of the flux installation we're using for testing. If
 #  $FLUX_SCHED_TEST_INSTALLED is set in the current environment,
-#  skip the export of the PREPEND variables.
+#  export the $(prefix) PREPEND variables so that they can
+#  be picked up from the sched install directiories which
+#  may or may not be the same as $(FLUX_PREFIX).
 #
-#  (XXX: the only way I've found to portably do this is to substitute
-#   the required path iff FLUX_SCHED_TEST_INSTALLED is not set, otherwise we
-#   substitute the *value* of FLUX_SCHED_TEST_INSTALLED, which might
-#   be `1` or `t`, but at least this doesn't point to build directory
-#   Lua PATH)
+# FLUX_SCHED_CO_INST is exported so that runlevel-install
+# test can conditionally set FLUX_RC_EXTRA.
 #
 TESTS_ENVIRONMENT = \
     LUA_PATH="$(FLUX_PREFIX)/share/lua/5.1/?.lua;$(LUA_PATH);;" \
-    FLUX_LUA_PATH_PREPEND="$${FLUX_SCHED_TEST_INSTALLED:-$(abs_top_srcdir)/rdl/?.lua}" \
-    FLUX_LUA_CPATH_PREPEND="$${FLUX_SCHED_TEST_INSTALLED:-$(abs_top_builddir)/rdl/?.so}" \
+    FLUX_LUA_PATH_PREPEND="$${FLUX_SCHED_TEST_INSTALLED:+$(prefix)/share/lua/5.1/?.lua}" \
+    FLUX_LUA_PATH_PREPEND="$${FLUX_LUA_PATH_PREPEND:-$(abs_top_srcdir)/rdl/?.lua}" \
+    FLUX_LUA_CPATH_PREPEND="$${FLUX_SCHED_TEST_INSTALLED:+$(prefix)/lib64/lua/5.1/?.so}" \
+    FLUX_LUA_CPATH_PREPEND="$${FLUX_LUA_CPATH_PREPEND:-$(abs_top_builddir)/rdl/?.so}" \
+    FLUX_EXEC_PATH_PREPEND="$${FLUX_SCHED_TEST_INSTALLED:+$(prefix)/libexec/flux/cmd}" \
+    FLUX_MODULE_PATH_PREPEND="$${FLUX_SCHED_TEST_INSTALLED:+$(prefix)/lib/flux/modules}" \
+    FLUX_SCHED_RC_PATH="$${FLUX_SCHED_TEST_INSTALLED:+$(sysconf)/flux}" \
+    FLUX_SCHED_CO_INST=$(shell if [ $(FLUX_PREFIX) = $(prefix) ]; then echo co; fi) \
     PATH="$(FLUX_PREFIX)/bin:$(PATH)"
 
 TESTS = \
-	t0000-sharness.t \
-	t0001-basic.t \
-	lua/t0001-rdl-basic.t \
-	lua/t0002-multilevel.t \
-	lua/t0003-default-tags.t \
-	lua/t0004-derived-type.t \
-	t0002-waitjob.t \
-	t1000-jsc.t \
-	t1001-rs2rank-basic.t \
-	t1002-rs2rank-64ranks.t \
-	t1003-stress.t \
-	t1004-module-load.t \
-	t2000-fcfs.t \
-	t2001-fcfs-aware.t \
-	t2002-easy.t
+    t0000-sharness.t \
+    t0001-basic.t \
+    lua/t0001-rdl-basic.t \
+    lua/t0002-multilevel.t \
+    lua/t0003-default-tags.t \
+    lua/t0004-derived-type.t \
+    t0002-waitjob.t \
+    t0003-basic-install.t \
+    t1000-jsc.t \
+    t1001-rs2rank-basic.t \
+    t1002-rs2rank-64ranks.t \
+    t1003-stress.t \
+    t1004-module-load.t \
+    t2000-fcfs.t \
+    t2001-fcfs-aware.t \
+    t2002-easy.t
 
 check_SCRIPTS = $(TESTS)
 

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -31,6 +31,7 @@ test_size_large() {
 #
 test_under_flux() {
     size=${1:-1}
+    personality=${2:-full}
     log_file="$TEST_NAME.broker.log"
     if test -n "$TEST_UNDER_FLUX_ACTIVE" ; then
         cleanup rm "${SHARNESS_TEST_DIRECTORY:-..}/$log_file"
@@ -49,6 +50,18 @@ test_under_flux() {
     fi
     if test -n "$SHARNESS_TEST_DIRECTORY"; then
         cd $SHARNESS_TEST_DIRECTORY
+    fi
+
+    if test "$personality" = "minimal"; then
+        export FLUX_RC1_PATH=""
+        export FLUX_RC3_PATH=""
+    elif test "$personality" != "full"; then
+        export FLUX_RC1_PATH=$FLUX_SOURCE_DIR/t/rc/rc1-$personality
+        export FLUX_RC3_PATH=""
+        test -x $FLUX_RC1_PATH || error "$FLUX_RC1_PATH"
+    else
+        unset FLUX_RC1_PATH
+        unset FLUX_RC3_PATH
     fi
 
     TEST_UNDER_FLUX_ACTIVE=t \

--- a/t/sharness.d/sched-sharness.sh
+++ b/t/sharness.d/sched-sharness.sh
@@ -2,12 +2,14 @@
 #
 # project-local sharness code for flux-sched
 #
-
+FLUX_SCHED_RC_NOOP=1
 if test -n "$FLUX_SCHED_TEST_INSTALLED"; then
   # Test against installed flux-sched, installed under same prefix as
   #   flux-core.
-  # (Assume sched modules installed under PREFIX/lib/flux/sched-plugin)
-  FLUX_MODULE_PATH_PREPEND=$(which flux | sed -s 's|/bin/flux|/lib/flux/sched-plugin|')
+  # (Assume sched modules installed under PREFIX/lib/flux/modeuls/sched)
+  # (We also support testing this when sched is installed
+  # another location, but only via make check)
+  FLUX_MODULE_PATH_PREPEND=$(which flux | sed -s 's|/bin/flux|/lib/flux/modules/sched|'):${FLUX_MODULE_PATH_PREPEND}
 else
   # Set up environment so that we find flux-sched modules,
   #  commands, and Lua libs from the build directories:
@@ -35,6 +37,9 @@ sched_src_path () {
 RDL_CONF_DEFAULT=$(sched_src_path "conf/hype.lua")
 
 export FLUX_EXEC_PATH_PREPEND
+export FLUX_SCHED_RC_NOOP
+export FLUX_SCHED_RC_PATH
+export FLUX_SCHED_CO_INST
 export FLUX_MODULE_PATH_PREPEND
 export FLUX_LUA_CPATH_PREPEND
 export FLUX_LUA_PATH_PREPEND

--- a/t/t0003-basic-install.t
+++ b/t/t0003-basic-install.t
@@ -1,0 +1,33 @@
+#!/bin/sh
+#set -x
+
+test_description='Test runlevel support with installed flux
+
+Ensure sched runlevel support works with installed flux.
+'
+#
+# source sharness from the directore where this test
+# file resides
+#
+. $(dirname $0)/sharness.sh
+
+if [ -z $FLUX_SCHED_TEST_INSTALLED ]; then
+    skip_all='FLUX_SCHED_TEST_INSTALLED not set, skipping...'
+    test_done
+fi
+
+#
+# test_under_flux is under sharness.d/
+#
+SIZE=2
+unset FLUX_SCHED_NOOP_RC
+if [ test ${FLUX_FLUX_CO_INST} = co ]; then
+    export FLUX_RC_EXTRA=${FLUX_SCHED_RC_PATH}
+fi
+test_under_flux ${SIZE}
+test_expect_success 'sched: module remove/load works with installed sched' '
+	flux module remove sched &&
+	flux module load sched
+'
+
+test_done


### PR DESCRIPTION
If sched is not installed into flux-core's $prefix,
one should set FLUX_RC_EXTRA environment variable to flux-sched's $prefix/etc/flux
so that flux start can automatically locate and execute sched's runlevel 1 and 3.

In addition, users can set FLUX_SCHED_OPTIONS if they want flux
to load in the sched module with non-default options.
(e.g., FLUX_SCHED_OPTIONS="plugin=sched.backfill" will cause
the flux session to load the sched module with the backfil scheduling plugin.

For LLNL's /opt rpm package, I plan to add FLUX_RC_EXTRA to its module script.
Also, module load flux-sched-xxx.rpm will print out available load options
of sched to console to help users to choose options to play with.