### PR TITLE
Resource name disambiguity

### DIFF
--- a/conf/cab.lua
+++ b/conf/cab.lua
@@ -5,7 +5,7 @@ Hierarchy "default" {
     Resource{ "cluster", name = "cab",
     children = { ListOf{ Node,
                   ids = "1-1232",
-                  args = { name = "cab", sockets = {"0-7", "8-15"} }
+                  args = { basename = "cab", sockets = {"0-7", "8-15"} }
                  },
                }
     }

--- a/conf/hype-io.lua
+++ b/conf/hype-io.lua
@@ -6,7 +6,7 @@ Hierarchy "default"
    Resource{ "cluster", name = "hype", tags = { max_bw = 10000 },
              children = { ListOf{ Node,
                                   ids = "201-354",
-                                  args = { name = "hype",
+                                  args = { basename = "hype",
                                            sockets = {"0-7", "8-15"},
                                            memory_per_socket = 15000,
                                            tags = { max_bw = 144 }

--- a/conf/hype.lua
+++ b/conf/hype.lua
@@ -5,7 +5,7 @@ Hierarchy "default" {
     Resource{ "cluster", name = "hype",
     children = { ListOf{ Node,
                   ids = "201-354",
-                  args = { name = "hype",
+                  args = { basename = "hype",
                            sockets = {"0-7", "8-15"},
                            memory_per_socket = 15000 }
                  },

--- a/rdl/RDL/ResourceData.lua
+++ b/rdl/RDL/ResourceData.lua
@@ -60,9 +60,8 @@ local function copy_list_from_args (arg, name)
 end
 
 function ResourceData:__tostring()
-    local name = rawget (self, "name") or rawget (self, "type")
-    local id = rawget (self, "id") or ""
-    return string.format ("%s%s", name, id)
+    local name = rawget (self, "name") or error ("Resource name not assigned!")
+    return name
 end
 
 function ResourceData:create (args)
@@ -70,17 +69,20 @@ function ResourceData:create (args)
     -- Type given as { type = <t>, ... } or { <t>, ...}
     local t = args.type or args[1]
 
-    -- Name given as { name = <n>, ... } or { <t>, <n>, ... }
-    local name = args.name or args[2] or t
-
-    -- Type is required, if no resource name, then name = type
+    -- Type is required
     if not t then return nil, "Resource type required" end
+
+    -- Basename given as { basename = <n>, ... } or { <t>, <n>, ... }
+    -- If no resource basename, then basename = type
+    local basename = args.basename or args[2] or t
+    local id = args.id
 
     local R = {
         type = t,
         uuid = args.uuid or require 'RDL.uuid'(),
-        name = name,
-        id = args.id or nil,
+        basename = basename,
+        id = id,
+        name = args.name or string.format ("%s%s", basename, id or ""),
         properties = copy_list_from_args (args, "properties"),
         tags = copy_list_from_args (args, "tags"),
 

--- a/rdl/RDL/memstore.lua
+++ b/rdl/RDL/memstore.lua
@@ -235,7 +235,7 @@ end
 function MemStore:resource_name (id)
     local r = self:get (id)
     if not r then return nil end
-    return r.name .. (r.id or "")
+    return r.name
 end
 
 function MemStore:ids ()
@@ -1016,7 +1016,10 @@ local function resource_proxy_create (store, res)
         if index == "name" then
             return store:resource_name (res.id)
         elseif index == "basename" then
-            return resource.name or resource.type
+            return resource.basename or resource.type
+        elseif index == "name" then
+            return resource.name or string.format ("%s%s", resource.basename,
+             resource.id or "")
         elseif index == "tags" then
             return deepcopy_no_metatable (resource.tags)
         elseif index == "type" then

--- a/rdl/RDL/types/Node.lua
+++ b/rdl/RDL/types/Node.lua
@@ -26,18 +26,21 @@ uses "Socket"
 
 Node = Resource:subclass ('Node')
 function Node:initialize (arg)
-    local basename = arg.name or arg.basename
-    assert (basename, "Required Node arg `name' missing")
+    local basename = arg.basename
+    assert (basename, "Required Node arg `basename' missing")
 
     local id = arg.id
     assert (arg.sockets, "Required Node arg `sockets' missing")
     assert (type (arg.sockets) == "table",
             "Node argument sockets must be a table of core ids")
 
+    local name = arg.name or string.format ("%s%s", basename, id or "")
+
     Resource.initialize (self,
         { "node",
+          basename = basename,
           id = id,
-          name = basename,
+          name = name,
           properties = arg.properties or {},
           tags = arg.tags or {}
         }

--- a/rdl/rdl.h
+++ b/rdl/rdl.h
@@ -131,6 +131,11 @@ void rdl_resource_destroy (struct resource *r);
 const char *rdl_resource_path (struct resource *r);
 
 /*
+ *  Get the string representation of the basename for resource [r].
+ */
+const char *rdl_resource_basename (struct resource *r);
+
+/*
  *  Get the string representation of the name for resource [r].
  */
 const char *rdl_resource_name (struct resource *r);
@@ -170,6 +175,7 @@ void rdl_resource_delete_tag (struct resource *r, const char *tag);
  *
  *  Format is a dictionary of name and values something like:
  *    { type: "string",
+ *      basename: "string",
  *      name: "string",
  *      id:   number,
  *      properties: { list of key/value pairs },

--- a/rdl/test/test-rdl.lua
+++ b/rdl/test/test-rdl.lua
@@ -54,7 +54,7 @@ end
 
 function test_rdl()
     local rdl = RDL.eval([[
-Hierarchy "default" { Resource {"node", name="foo", id=0, tags = { "bar" } }}
+Hierarchy "default" { Resource {"node", basename="foo", id=0, tags = { "bar" } }}
 ]])
     assert_not_nil (rdl)
     assert_true (is_table (rdl))
@@ -102,7 +102,7 @@ function test_children()
     local rdl = RDL.eval([[
 uses "Socket"
 Hierarchy "default" {
-  Resource {"node", name="foo", id=0,
+  Resource {"node", basename="foo", id=0,
    children = {
       Socket { id=0, cpus="0-3" },
       Socket { id=1, cpus="4-7" }
@@ -191,7 +191,7 @@ function test_copy ()
     local rdl = RDL.eval([[
 uses "Socket"
 Hierarchy "default" {
-  Resource {"node", name="foo", id=0,
+  Resource {"node", basename="foo", id=0,
    children = {
       Socket { id=0, cpus="0-3" },
       Socket { id=1, cpus="4-7" }
@@ -352,7 +352,7 @@ Hierarchy "default" {
     Resource{
         "foo",
         children = { ListOf{ Node, ids="0-10",
-                             args = { name="bar",
+                             args = { basename="bar",
                                       sockets = { "0-7", "8-16"}
                                     }
                            }
@@ -448,7 +448,7 @@ Hierarchy "default" {
     Resource{
         "foo",
         children = { ListOf{ Node, ids="0-10",
-                             args = { name="bar",
+                             args = { basename="bar",
                                       sockets = { "0-7", "8-16"}
                                     }
                            }
@@ -494,11 +494,11 @@ function test_conf()
     local rdl = assert (RDL.eval ([[
 uses "Node"
 Hierarchy "default" {
-    Resource{ "foo", children = { Node{ name="bar", id=0, sockets={ "0-1" }}}}
+    Resource{ "foo", children = { Node{ basename="bar", id=0, sockets={ "0-1" }}}}
 }
 
 Hierarchy "default:/foo" {
-    Node{ name="bar", id=1, sockets={ "0-1" }}
+    Node{ basename="bar", id=1, sockets={ "0-1" }}
 }
 Hierarchy "default:/foo/bar0" { Resource{ "gpu", id=0 } }
 ]]))
@@ -513,7 +513,7 @@ function test_pool ()
 uses "Node"
 Hierarchy "default" {
     Resource{ "foo",
-        children = { Node{ name="bar", id=0, sockets={ "0-1", "2-3" } } }
+        children = { Node{ basename="bar", id=0, sockets={ "0-1", "2-3" } } }
     }
 }
 Hierarchy "default:/foo/bar0/socket0" { Resource{ "memory", count = 1024}}
@@ -551,7 +551,7 @@ Hierarchy "default:/foo/bar0/socket1" { Resource{ "memory", count = 1024}}
     -- Now ensure this socket is not found with rdl_find("available")
     r:alloc()
     assert (r.available == 0)
-    
+
     local rdl2 = assert (rdl:find{ available=true })
     assert (nil == rdl2:resource ("default:/foo/bar0/socket0"))
     r:free()

--- a/rdl/test/trdl.c
+++ b/rdl/test/trdl.c
@@ -111,11 +111,12 @@ int main (int argc, char *argv[])
     Jadd_str (args, "type", "node");
     Jadd_int (args, "id", 300);
     rdl2 = rdl_find (rdl1, args);
+    if (rdl2 == NULL)
+        err_exit ("rdl_find");
     json_object_put (args);
     r = rdl_resource_get (rdl2, "default");
     if (r == NULL)
         exit (1);
-
 
     c = rdl_resource_next_child (r);
     printf ("found %s\n", rdl_resource_name (c));

--- a/resrc/resrc.h
+++ b/resrc/resrc.h
@@ -36,6 +36,11 @@ char *resrc_type (resrc_t *resrc);
 char *resrc_path (resrc_t *resrc);
 
 /*
+ * Return the basename of the resouce
+ */
+char *resrc_basename (resrc_t *resrc);
+
+/*
  * Return the name of the resouce
  */
 char *resrc_name (resrc_t *resrc);
@@ -88,8 +93,9 @@ resrc_tree_t *resrc_phys_tree (resrc_t *resrc);
  * Create a new resource object
  */
 resrc_t *resrc_new_resource (const char *type, const char *path,
-                             const char *name, const char *sig,
-                             int64_t id, uuid_t uuid, size_t size);
+                             const char *basename, const char *name,
+                             const char *sig, int64_t id, uuid_t uuid,
+                             size_t size);
 
 /*
  * Create a copy of a resource object

--- a/resrc/test/tresrc.c
+++ b/resrc/test/tresrc.c
@@ -103,8 +103,8 @@ static void test_temporal_allocation ()
 {
     int rc = 0;
     size_t available;
-    resrc_t *resource = resrc_new_resource ("custom", "/test", "test", NULL, 1,
-                                            NULL, 10);
+    resrc_t *resource = resrc_new_resource ("custom", "/test", "test", "test1",
+                                            NULL, 1, NULL, 10);
 
     available = resrc_available_at_time (resource, 0);
     rc = (rc || !(available == 10));

--- a/t/data/hwloc-data/004N/exclusive/cab.hwloc1.lua
+++ b/t/data/hwloc-data/004N/exclusive/cab.hwloc1.lua
@@ -5,7 +5,7 @@ Hierarchy "default" {
     Resource{ "cluster", name = "cab",
     children = { ListOf{ Node,
                   ids = "1234-1237",
-                  args = { name = "cab", sockets = {"0-7", "8-15"} }
+                  args = { basename = "cab", sockets = {"0-7", "8-15"} }
                  },
                }
     }

--- a/t/data/hwloc-data/004N/exclusive/cab.hwloc2.lua
+++ b/t/data/hwloc-data/004N/exclusive/cab.hwloc2.lua
@@ -5,7 +5,7 @@ Hierarchy "default" {
     Resource{ "cluster", name = "cab",
     children = { ListOf{ Node,
                   ids = "1235-1238",
-                  args = { name = "cab", sockets = {"0-7"} }
+                  args = { basename = "cab", sockets = {"0-7"} }
                  },
                }
     }

--- a/t/data/hwloc-data/004N/exclusive/cab.hwloc3.lua
+++ b/t/data/hwloc-data/004N/exclusive/cab.hwloc3.lua
@@ -5,7 +5,7 @@ Hierarchy "default" {
     Resource{ "cluster", name = "cab",
     children = { ListOf{ Node,
                   ids = "1-2",
-                  args = { name = "cab", sockets = {"0-7", "8-16"} }
+                  args = { basename = "cab", sockets = {"0-7", "8-16"} }
                  },
                }
     }

--- a/t/lua/t0001-rdl-basic.t
+++ b/t/lua/t0001-rdl-basic.t
@@ -9,7 +9,7 @@ t:say ("Load a very simple RDL Hierarchy:\n")
 
 local rdl, err = RDL.eval ([[
  Hierarchy "default" {
-   Resource{ "foo", name = "bar", id = 0, tags = { "test_tag" } }
+   Resource{ "foo", basename = "bar", id = 0, tags = { "test_tag" } }
  }
 ]])
 

--- a/t/lua/t0002-multilevel.t
+++ b/t/lua/t0002-multilevel.t
@@ -12,7 +12,7 @@ uses "Node"
    Resource{ "cluster", name = "foo",
              children = {
                ListOf{ Node, ids="1-4",
-                 args = { name = "bar", sockets = { "0-1", "2-3" } }
+                 args = { basename = "bar", sockets = { "0-1", "2-3" } }
                }
 	     }
    }

--- a/t/lua/t0003-default-tags.t
+++ b/t/lua/t0003-default-tags.t
@@ -44,7 +44,7 @@ rdl, err = RDL.eval ([[
  Node:default_tags { "test" }
  Hierarchy "default" {
    Resource{ "foo", name = "bar",
-    children = { Node{ name="node", id=1, sockets = { "0" } } }
+    children = { Node{ basename="node", id=1, sockets = { "0" } } }
   }
  }
 ]])
@@ -69,7 +69,7 @@ rdl, err = RDL.eval ([[
  Resource:default_tags { "test" }
  Hierarchy "default" {
    Resource{ "foo", name = "bar",
-    children = { Node{ name="node", id=1, sockets = { "0" } } }
+    children = { Node{ basename="node", id=1, sockets = { "0" } } }
   }
  }
 ]])
@@ -88,7 +88,7 @@ rdl, err = RDL.eval ([[
  Node:default_tags { "test2" }
  Hierarchy "default" {
    Resource{ "foo", name = "bar",
-    children = { Node{ name="node", id=1, sockets = { "0" } } }
+    children = { Node{ basename="node", id=1, sockets = { "0" } } }
   }
  }
 ]])
@@ -108,7 +108,7 @@ rdl, err = RDL.eval ([[
  Node:default_tags {}
  Hierarchy "default" {
    Resource{ "foo", name = "bar",
-    children = { Node{ name="node", id=1, sockets = { "0" } } }
+    children = { Node{ basename="node", id=1, sockets = { "0" } } }
   }
  }
 ]])
@@ -130,7 +130,7 @@ rdl, err = RDL.eval ([[
  uses "Node" :default_tags { "set-a-tag" }
  Hierarchy "default" {
    Resource{ "foo", name = "bar",
-    children = { Node{ name="node", id=1, sockets = { "0" } } }
+    children = { Node{ basename="node", id=1, sockets = { "0" } } }
   }
  }
 ]])

--- a/t/lua/t0004-derived-type.t
+++ b/t/lua/t0004-derived-type.t
@@ -11,8 +11,8 @@ local rdl, err = RDL.eval ([[
 
  Foo = Resource:subclass 'Foo'
  function Foo:initialize (arg)
-   local name = arg.name or arg[1]
-   Resource.initialize (self, { "foo", name = name, id = arg.id })
+   local basename = arg.basename or arg[1]
+   Resource.initialize (self, { "foo", basename = basename, id = arg.id })
  end
 
  Hierarchy "default" { Foo {"bar", id = 0} }


### PR DESCRIPTION
Tracks the changes made in [PR 41](https://github.com/flux-framework/rfc/pull/41) to [RFC 4](https://github.com/flux-framework/rfc/blob/master/spec_4.adoc) as a result of the discussion in [Issue 157](https://github.com/flux-framework/flux-sched/issues/157).  Modifies the rdl and resrc code to add separate members for name and basename.  Provides the groundwork for the resolution of [Issue 155](https://github.com/flux-framework/flux-sched/pull/155).  The result is better consistency between the rdl and resrc code with regard to resource naming conventions.