### PR TITLE
Copy gitignore over from flux-core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,71 @@
+# http://www.gnu.org/software/automake
+Makefile.in
+# http://www.gnu.org/software/autoconf
+autom4te.cache
+compile
+configure
+aclocal.m4
+stamp-h1
+aclocal.m4
+config.guess
+config.sub
+depcomp
+install-sh
+ltmain.sh
+missing
+config.log
+config.status
+config.h
+config.h.in
+config.h.in~
+libtool
+.deps/
+.libs/
+libltdl/
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+*.pyc
+*.pyo
+
+# autoconf-preprocessed
+Makefile
+*.1
+*.3
+*.5
+*.8
+*.spec
+*.pc
+
+# misc
+*.swp
+*.diff
+*.tar.gz
+*.orig
+*.core
+*.tap
+.coverage*
+*.trs
+*.log
+.dirstamp
+


### PR DESCRIPTION
My 'git status' is becoming rather unruly with all of the untracked files (mainly from autotools).  Any objections to pulling flux-core's .gitignore into flux-sched?