### PR TITLE
Versatile Scheduling

### DIFF
--- a/resrc/resrc.c
+++ b/resrc/resrc.c
@@ -981,7 +981,7 @@ char *resrc_to_string (resrc_t *resrc)
         }
     }
     if (zhash_size (resrc->reservtns)) {
-        fprintf (ss, ", reserved jobs");
+        fprintf (ss, ", reserved");
         size_ptr = zhash_first (resrc->reservtns);
         while (size_ptr) {
             fprintf (ss, ", %s: %"PRIu64"",

--- a/resrc/resrc.c
+++ b/resrc/resrc.c
@@ -533,8 +533,8 @@ void resrc_resource_destroy (void *object)
             free (resrc->name);
         if (resrc->digest)
             free (resrc->digest);
-        if (resrc->phys_tree)
-            resrc_tree_destroy (resrc->phys_tree, false);
+        /* Use resrc_tree_destroy() to destroy this resource along
+         * with its physical tree */
         if (resrc->graphs)
             zlist_destroy (&resrc->graphs);
         zhash_destroy (&resrc->allocs);

--- a/resrc/resrc_reqst.c
+++ b/resrc/resrc_reqst.c
@@ -55,7 +55,7 @@ struct resrc_reqst {
 
 static bool match_children (resrc_tree_list_t *r_trees,
                             resrc_reqst_list_t *req_trees,
-                            resrc_tree_t *parent_tree, bool available);
+                            resrc_tree_t *found_parent, bool available);
 
 /***********************************************************************
  * Resource request
@@ -399,81 +399,45 @@ void resrc_reqst_list_destroy (resrc_reqst_list_t *resrc_reqst_list)
     }
 }
 
-
-static bool match_child (resrc_tree_list_t *r_trees, resrc_reqst_t *resrc_reqst,
-                         resrc_tree_t *parent_tree, bool available)
+/*
+ * cycles through all of the resource children and returns the number of
+ * requested resources found
+ */
+static int64_t match_child (resrc_tree_list_t *r_trees,
+                            resrc_reqst_t *resrc_reqst,
+                            resrc_tree_t *found_parent, bool available)
 {
+    int64_t nfound = 0;
+    resrc_t *resrc = NULL;
     resrc_tree_t *resrc_tree = NULL;
-    resrc_tree_t *child_tree = NULL;
-    bool found = false;
-    bool success = false;
 
     resrc_tree = resrc_tree_list_first (r_trees);
     while (resrc_tree) {
-        found = false;
-        if (resrc_match_resource (resrc_tree_resrc (resrc_tree), resrc_reqst,
-                                  available)) {
-            if (resrc_reqst_num_children (resrc_reqst)) {
-                if (resrc_tree_num_children (resrc_tree)) {
-                    child_tree = resrc_tree_new (parent_tree,
-                                                 resrc_tree_resrc (resrc_tree));
-                    if (match_children (resrc_tree_children (resrc_tree),
-                                        resrc_reqst_children (resrc_reqst),
-                                        child_tree, available)) {
-                        resrc_reqst->nfound++;
-                        found = true;
-                        success = true;
-                    } else {
-                        resrc_tree_destroy (child_tree, false);
-                    }
-                }
-            } else {
-                (void) resrc_tree_new (parent_tree,
-                                       resrc_tree_resrc (resrc_tree));
-                resrc_reqst->nfound++;
-                found = true;
-                success = true;
-            }
-        }
-        /*
-         * The following clause allows the resource request to be
-         * sparsely defined.  E.g., it might only stipulate a node
-         * with 4 cores and omit the intervening socket.
-         */
-        if (!found) {
-            if (resrc_tree_num_children (resrc_tree)) {
-                child_tree = resrc_tree_new (parent_tree,
-                                             resrc_tree_resrc (resrc_tree));
-                if (match_child (resrc_tree_children (resrc_tree), resrc_reqst,
-                                 child_tree, available)) {
-                    success = true;
-                } else {
-                    resrc_tree_destroy (child_tree, false);
-                }
-            }
-        }
+        resrc = resrc_tree_resrc (resrc_tree);
+        nfound += resrc_tree_search (resrc, resrc_reqst, &found_parent,
+                                     available);
         resrc_tree = resrc_tree_list_next (r_trees);
     }
 
-    return success;
+    return nfound;
 }
 
 /*
- * cycles through all of the resource children and returns true if all
+ * cycles through all of the resource requests and returns true if all
  * of the requested children were found
  */
 static bool match_children (resrc_tree_list_t *r_trees,
                             resrc_reqst_list_t *req_trees,
-                            resrc_tree_t *parent_tree, bool available)
+                            resrc_tree_t *found_parent, bool available)
 {
-    resrc_reqst_t *resrc_reqst = resrc_reqst_list_first (req_trees);
     bool found = false;
+    resrc_reqst_t *resrc_reqst = resrc_reqst_list_first (req_trees);
 
     while (resrc_reqst) {
         resrc_reqst->nfound = 0;
         found = false;
 
-        if (match_child (r_trees, resrc_reqst, parent_tree, available)) {
+        if (match_child (r_trees, resrc_reqst, found_parent, available)) {
             if (resrc_reqst->nfound >= resrc_reqst->reqrd_qty)
                 found = true;
         }
@@ -486,45 +450,61 @@ static bool match_children (resrc_tree_list_t *r_trees,
     return found;
 }
 
-/* returns the number of composites found */
-int resrc_tree_search (resrc_tree_list_t *resrcs_in, resrc_reqst_t *resrc_reqst,
-                       resrc_tree_list_t *found_trees, bool available)
+/* returns the number of resource or resource composites found */
+int64_t resrc_tree_search (resrc_t *resrc_in, resrc_reqst_t *resrc_reqst,
+                           resrc_tree_t **found_tree, bool available)
 {
     int64_t nfound = 0;
+    resrc_tree_list_t *children = NULL;
+    resrc_tree_t *child_tree;
     resrc_tree_t *new_tree = NULL;
-    resrc_tree_t *resrc_tree;
 
-    if (!resrcs_in || !found_trees || !resrc_reqst) {
+    if (!resrc_in || !found_tree || !resrc_reqst) {
         goto ret;
     }
 
-    resrc_tree = resrc_tree_list_first (resrcs_in);
-    while (resrc_tree) {
-        if (resrc_match_resource (resrc_tree_resrc (resrc_tree), resrc_reqst,
-                                  available)) {
-            if (resrc_reqst_num_children (resrc_reqst)) {
-                if (resrc_tree_num_children (resrc_tree)) {
-                    new_tree = resrc_tree_new (NULL,
-                                               resrc_tree_resrc (resrc_tree));
-                    if (match_children (resrc_tree_children (resrc_tree),
-                                        resrc_reqst->children, new_tree,
-                                        available)) {
-                        resrc_tree_list_append (found_trees, new_tree);
-                        nfound++;
-                    } else {
-                        resrc_tree_destroy (new_tree, false);
-                    }
+    if (resrc_match_resource (resrc_in, resrc_reqst, available)) {
+        if (resrc_reqst_num_children (resrc_reqst)) {
+            if (resrc_tree_num_children (resrc_phys_tree (resrc_in))) {
+                new_tree = resrc_tree_new (*found_tree, resrc_in);
+                children = resrc_tree_children (resrc_phys_tree (resrc_in));
+                if (match_children (children, resrc_reqst->children, new_tree,
+                                    available)) {
+                    nfound = 1;
+                    resrc_reqst->nfound++;
+                } else {
+                    resrc_tree_destroy (new_tree, false);
                 }
-            } else {
-                new_tree = resrc_tree_new (NULL, resrc_tree_resrc (resrc_tree));
-                resrc_tree_list_append (found_trees, new_tree);
-                nfound++;
             }
-        } else if (resrc_tree_num_children (resrc_tree)) {
-            nfound += resrc_tree_search (resrc_tree_children (resrc_tree),
-                                         resrc_reqst, found_trees, available);
+        } else {
+            (void) resrc_tree_new (*found_tree, resrc_in);
+            nfound = 1;
+            resrc_reqst->nfound++;
         }
-        resrc_tree = resrc_tree_list_next (resrcs_in);
+    } else if (resrc_tree_num_children (resrc_phys_tree (resrc_in))) {
+        /*
+         * This clause visits the children of the current resource
+         * searching for a match to the resource request.  The found
+         * tree must be extended to include this intermediate
+         * resource.
+         *
+         * This also allows the resource request to be sparsely
+         * defined.  E.g., it might only stipulate a node with 4 cores
+         * and omit the intervening socket.
+         */
+        if (*found_tree)
+            new_tree = resrc_tree_new (*found_tree, resrc_in);
+        else {
+            new_tree = resrc_tree_new (NULL, resrc_in);
+            *found_tree = new_tree;
+        }
+        children = resrc_tree_children (resrc_phys_tree (resrc_in));
+        child_tree = resrc_tree_list_first (children);
+        while (child_tree) {
+            nfound += resrc_tree_search (resrc_tree_resrc (child_tree),
+                                         resrc_reqst, &new_tree, available);
+            child_tree = resrc_tree_list_next (children);
+        }
     }
 ret:
     return nfound;

--- a/resrc/resrc_reqst.c
+++ b/resrc/resrc_reqst.c
@@ -268,10 +268,16 @@ resrc_reqst_t *resrc_reqst_from_json (JSON o, resrc_reqst_t *parent)
      */
     Jget_bool (o, "exclusive", &exclusive);
 
+    /*
+     * We use the request's start time to determine whether to request
+     * resources that are available now or in the future.  A zero
+     * starttime conveys a request for resources that are available
+     * now.
+     */
     if (parent)
         starttime = parent->starttime;
     else if (!(Jget_int64 (o, "starttime", &starttime)))
-        starttime = time (NULL);
+        starttime = 0;
 
     if (parent)
         endtime = parent->endtime;

--- a/resrc/resrc_reqst.c
+++ b/resrc/resrc_reqst.c
@@ -170,6 +170,29 @@ int resrc_reqst_clear_found (resrc_reqst_t *resrc_reqst)
     return -1;
 }
 
+bool resrc_reqst_all_found (resrc_reqst_t *resrc_reqst)
+{
+    bool all_found = false;
+
+    if (resrc_reqst) {
+        if (resrc_reqst_nfound (resrc_reqst) >=
+            resrc_reqst_reqrd_qty (resrc_reqst))
+            all_found = true;
+
+        if (resrc_reqst_num_children (resrc_reqst)) {
+            resrc_reqst_t *child = resrc_reqst_list_first(resrc_reqst->children);
+            while (child) {
+                if (!resrc_reqst_all_found (child)) {
+                    all_found = false;
+                    break;
+                }
+                child = resrc_reqst_list_next (resrc_reqst->children);
+            }
+        }
+    }
+    return all_found;
+}
+
 size_t resrc_reqst_num_children (resrc_reqst_t *resrc_reqst)
 {
     if (resrc_reqst)

--- a/resrc/resrc_reqst.c
+++ b/resrc/resrc_reqst.c
@@ -281,31 +281,14 @@ ret:
     return resrc_reqst;
 }
 
-void resrc_reqst_free (resrc_reqst_t *resrc_reqst)
-{
-    if (resrc_reqst) {
-        zlist_destroy (&(resrc_reqst->children->list));
-        free (resrc_reqst->children);
-        resrc_reqst->children = NULL;
-        resrc_resource_destroy (resrc_reqst->resrc);
-        free (resrc_reqst);
-    }
-}
-
 void resrc_reqst_destroy (resrc_reqst_t *resrc_reqst)
 {
     if (resrc_reqst) {
         if (resrc_reqst->parent)
             resrc_reqst_list_remove (resrc_reqst->parent->children, resrc_reqst);
-        if (resrc_reqst_num_children (resrc_reqst)) {
-            resrc_reqst_t *child = resrc_reqst_list_first
-                (resrc_reqst->children);
-            while (child) {
-                resrc_reqst_destroy (child);
-                child = resrc_reqst_list_next (resrc_reqst->children);
-            }
-        }
-        resrc_reqst_free (resrc_reqst);
+        resrc_reqst_list_destroy (resrc_reqst->children);
+        resrc_resource_destroy (resrc_reqst->resrc);
+        free (resrc_reqst);
     }
 }
 

--- a/resrc/resrc_reqst.h
+++ b/resrc/resrc_reqst.h
@@ -153,17 +153,16 @@ void resrc_reqst_list_destroy (resrc_reqst_list_t *rrl);
 
 /*
  * Search a list of resource trees for a specific, composite resource
- * Inputs:  resrc_trees - the list of resource trees to search
- *          found       - running list of keys to previously found resources
- *          sample_tree - the resource tree to search for
+ * Inputs:  resrc_in    - the resource at the head of the tree
+ *          resrc_reqst - the requested resource or resource composite
+ *          found_tree  - the tree that will contain found resources
  *          available   - when true, consider only idle resources
  *                        otherwise find all possible resources matching type
  * Returns: the number of matching resource composites found
- *          found       - any resources found are added to this list
+ *          found_tree  - any resources found are added to this tree
  */
-int resrc_tree_search (resrc_tree_list_t *resrc_trees,
-                       resrc_reqst_t *sample_tree,
-                       resrc_tree_list_t *found_trees, bool available);
+int64_t resrc_tree_search (resrc_t *resrc_in, resrc_reqst_t *resrc_reqst,
+                           resrc_tree_t **found_tree, bool available);
 
 
 #endif /* !FLUX_RESRC_REQST_H */

--- a/resrc/resrc_reqst.h
+++ b/resrc/resrc_reqst.h
@@ -71,6 +71,12 @@ int64_t resrc_reqst_add_found (resrc_reqst_t *resrc_reqst, int64_t nfound);
 int resrc_reqst_clear_found (resrc_reqst_t *resrc_reqst);
 
 /*
+ * Return true if the required number of resources were found for the
+ * resource request and all its children
+ */
+bool resrc_reqst_all_found (resrc_reqst_t *resrc_reqst);
+
+/*
  * Return the number of children in the resource request
  */
 size_t resrc_reqst_num_children (resrc_reqst_t *resrc_reqst);

--- a/resrc/resrc_reqst.h
+++ b/resrc/resrc_reqst.h
@@ -98,11 +98,6 @@ resrc_reqst_t *resrc_reqst_new (resrc_t *resrc, int64_t qty, int64_t size,
 resrc_reqst_t *resrc_reqst_from_json (json_object *o, resrc_reqst_t *parent);
 
 /*
- * Free a resrc_reqst_t object
- */
-void resrc_reqst_free (resrc_reqst_t *resrc_reqst);
-
-/*
  * Destroy a resrc_reqst_t object
  */
 void resrc_reqst_destroy (resrc_reqst_t *resrc_reqst);

--- a/resrc/resrc_tree.c
+++ b/resrc/resrc_tree.c
@@ -124,11 +124,7 @@ void resrc_tree_destroy (resrc_tree_t *resrc_tree, bool destroy_resrc)
             resrc_tree->children = NULL;
         }
 
-        /*
-         * Destroying a resource from a tree that is not the physical
-         * tree would corrupt the physical tree.
-         */
-        if (destroy_resrc && (resrc_tree == phys_tree))
+        if (destroy_resrc)
             resrc_resource_destroy (resrc_tree->resrc);
         free (resrc_tree);
     }

--- a/resrc/resrc_tree.c
+++ b/resrc/resrc_tree.c
@@ -289,16 +289,6 @@ void resrc_tree_list_remove (resrc_tree_list_t *rtl, resrc_tree_t *rt)
     zlist_remove (rtl->list, rt);
 }
 
-void resrc_tree_list_free (resrc_tree_list_t *resrc_tree_list)
-{
-    if (resrc_tree_list) {
-        if (resrc_tree_list->list) {
-            zlist_destroy (&(resrc_tree_list->list));
-        }
-        free (resrc_tree_list);
-    }
-}
-
 void resrc_tree_list_destroy (resrc_tree_list_t *resrc_tree_list,
                               bool destroy_resrc)
 {
@@ -310,7 +300,10 @@ void resrc_tree_list_destroy (resrc_tree_list_t *resrc_tree_list,
                 child = resrc_tree_list_next (resrc_tree_list);
             }
         }
-        resrc_tree_list_free (resrc_tree_list);
+        if (resrc_tree_list->list) {
+            zlist_destroy (&(resrc_tree_list->list));
+        }
+        free (resrc_tree_list);
     }
 }
 

--- a/resrc/resrc_tree.h
+++ b/resrc/resrc_tree.h
@@ -123,12 +123,6 @@ size_t resrc_tree_list_size (resrc_tree_list_t *rtl);
 void resrc_tree_list_remove (resrc_tree_list_t *rtl, resrc_tree_t *rt);
 
 /*
- * Free memory of a resrc_tree_list_t object
- * Does not recursively free
- */
-void resrc_tree_list_free (resrc_tree_list_t *resrc_tree_list);
-
-/*
  * Destroy a resrc_tree_list_t object including all children
  */
 void resrc_tree_list_destroy (resrc_tree_list_t *rtl, bool destroy_resrc);

--- a/resrc/test/tresrc.c
+++ b/resrc/test/tresrc.c
@@ -53,47 +53,38 @@ u_int64_t get_time() {
         + (t.tv_usec - start_time.tv_usec);
 }
 
-static void test_select_children (resrc_tree_t *rt)
+/*
+ * Select some resources from the found tree
+ * frt is found resource tree
+ * prt is selected resource tree parent
+ */
+static resrc_tree_t *test_select_resources (resrc_tree_t *frt, resrc_tree_t *prt,
+                                            int select)
 {
-    if (rt) {
-        resrc_t *resrc = resrc_tree_resrc (rt);
-        if (strcmp (resrc_type(resrc), "memory")) {
-            resrc_stage_resrc (resrc, 1);
-        } else {
+    resrc_tree_t *selected_res = NULL;
+
+    if (frt) {
+        resrc_t *resrc = resrc_tree_resrc (frt);
+
+        if (!strcmp (resrc_type(resrc), "core")) {
+            if (resrc_id (resrc) == select)
+                resrc_stage_resrc (resrc, 1);
+            else
+                goto ret;
+        } else if (!strcmp (resrc_type(resrc), "memory"))
             resrc_stage_resrc (resrc, 100);
-        }
-        if (resrc_tree_num_children (rt)) {
+
+        selected_res = resrc_tree_new (prt, resrc);
+        if (resrc_tree_num_children (frt)) {
             resrc_tree_t *child = resrc_tree_list_first (
-                resrc_tree_children (rt));
+                resrc_tree_children (frt));
             while (child) {
-                test_select_children (child);
-                child = resrc_tree_list_next (resrc_tree_children (rt));
+                (void) test_select_resources (child, selected_res, select);
+                child = resrc_tree_list_next (resrc_tree_children (frt));
             }
         }
     }
-}
-
-/*
- * Select some resources from the found trees
- */
-static resrc_tree_list_t *test_select_resources (resrc_tree_list_t *found_trees,
-                                                 int select)
-{
-    resrc_tree_list_t *selected_res = resrc_tree_list_new ();
-    resrc_tree_t *rt;
-    int count = 1;
-
-    rt = resrc_tree_list_first (found_trees);
-    while (rt) {
-        if (count == select) {
-            test_select_children (rt);
-            resrc_tree_list_append (selected_res, rt);
-            break;
-        }
-        count++;
-        rt = resrc_tree_list_next (found_trees);
-    }
-
+ret:
     return selected_res;
 }
 
@@ -243,16 +234,13 @@ static int test_a_resrc (resrc_t *resrc, bool rdl)
     int rc = 0;
     int verbose = 0;
     int64_t nowtime = epochtime ();
-    JSON child_core = NULL;
     JSON o = NULL;
     JSON req_res = NULL;
     resrc_reqst_t *resrc_reqst = NULL;
-    resrc_tree_list_t *deserialized_trees = NULL;
-    resrc_tree_list_t *found_trees = resrc_tree_list_new ();
-    resrc_tree_list_t *selected_trees;
     resrc_tree_t *deserialized_tree = NULL;
     resrc_tree_t *found_tree = NULL;
     resrc_tree_t *resrc_tree = NULL;
+    resrc_tree_t *selected_tree = NULL;
 
     resrc_tree = resrc_phys_tree (resrc);
     ok ((resrc_tree != NULL), "resource tree valid");
@@ -271,12 +259,10 @@ static int test_a_resrc (resrc_t *resrc, bool rdl)
      *  from the sample RDL file or from the hwloc.  The hwloc request
      *  does not span multiple nodes or contain the localid property.
      */
-    child_core = Jnew ();
-    Jadd_str (child_core, "type", "core");
     req_res = Jnew ();
-    Jadd_str (req_res, "type", "node");
 
     if (rdl) {
+        JSON child_core = Jnew ();
         JSON child_sock = Jnew ();
         JSON ja = Jnew_ar ();
         JSON jpropo = Jnew (); /* json property object */
@@ -291,7 +277,9 @@ static int test_a_resrc (resrc_t *resrc, bool rdl)
         Jadd_int (memory, "size", 100);
         json_object_array_add (ja, memory);
 
+        Jadd_str (child_core, "type", "core");
         Jadd_int (child_core, "req_qty", 6);
+        Jadd_bool (child_core, "exclusive", true);
         Jadd_int (jpropo, "localid", 1);
         json_object_object_add (child_core, "properties", jpropo);
         json_object_array_add (ja, child_core);
@@ -300,13 +288,15 @@ static int test_a_resrc (resrc_t *resrc, bool rdl)
         Jadd_int (child_sock, "req_qty", 2);
         json_object_object_add (child_sock, "req_children", ja);
 
+        Jadd_str (req_res, "type", "node");
         Jadd_int (req_res, "req_qty", 2);
+        Jadd_int64 (req_res, "starttime", nowtime);
         /* json_object_object_add (req_res, "tags", jtago); */
         json_object_object_add (req_res, "req_child", child_sock);
     } else {
-        Jadd_int (child_core, "req_qty", 2);
-        Jadd_int (req_res, "req_qty", 1);
-        json_object_object_add (req_res, "req_child", child_core);
+        Jadd_str (req_res, "type", "core");
+        Jadd_int (req_res, "req_qty", 2);
+        Jadd_bool (req_res, "exclusive", true);
     }
 
     resrc_reqst = resrc_reqst_from_json (req_res, NULL);
@@ -322,27 +312,22 @@ static int test_a_resrc (resrc_t *resrc, bool rdl)
     }
 
     init_time ();
-    found = resrc_tree_search (resrc_tree_children (resrc_tree), resrc_reqst,
-                               found_trees, false);
+    found = resrc_tree_search (resrc, resrc_reqst, &found_tree, true);
 
-    ok (found, "found %d composite resources in %lf", found,
+    ok (found, "found %d requested resources in %lf", found,
         ((double)get_time ())/1000000);
     if (!found)
         goto ret;
 
     if (verbose) {
-        printf ("Listing found trees\n");
-        found_tree = resrc_tree_list_first (found_trees);
-        while (found_tree) {
-            resrc_tree_print (found_tree);
-            found_tree = resrc_tree_list_next (found_trees);
-        }
-        printf ("End of found trees\n");
+        printf ("Listing found tree\n");
+        resrc_tree_print (found_tree);
+        printf ("End of found tree\n");
     }
 
-    o = Jnew_ar ();
+    o = Jnew ();
     init_time ();
-    rc = resrc_tree_list_serialize (o, found_trees);
+    rc = resrc_tree_serialize (o, found_tree);
     ok (!rc, "found resource serialization took: %lf",
         ((double)get_time ())/1000000);
 
@@ -350,39 +335,51 @@ static int test_a_resrc (resrc_t *resrc, bool rdl)
         printf ("The found resources serialized: %s\n", Jtostr (o));
     }
 
-    deserialized_trees = resrc_tree_list_deserialize (o);
+    deserialized_tree = resrc_tree_deserialize (o, NULL);
     if (verbose) {
-        printf ("Listing deserialized trees\n");
-        deserialized_tree = resrc_tree_list_first (deserialized_trees);
-        while (deserialized_tree) {
-            resrc_tree_print (deserialized_tree);
-            deserialized_tree = resrc_tree_list_next (deserialized_trees);
-       }
-        printf ("End of deserialized trees\n");
+        printf ("Listing deserialized tree\n");
+        resrc_tree_print (deserialized_tree);
+        printf ("End of deserialized tree\n");
     }
     Jput (o);
 
     init_time ();
 
-    selected_trees = test_select_resources (found_trees, 1);
-    rc = resrc_tree_list_allocate (selected_trees, 1, nowtime, nowtime + 3600);
+    /*
+     * Exercise time-based allocations for the rdl case and
+     * now-based allocations for the hwloc case
+     */
+    selected_tree = test_select_resources (found_tree, NULL, 1);
+    if (rdl)
+        rc = resrc_tree_allocate (selected_tree, 1, nowtime, nowtime + 3600);
+    else
+        rc = resrc_tree_allocate (selected_tree, 1, 0, 0);
     ok (!rc, "successfully allocated resources for job 1");
-    resrc_tree_list_free (selected_trees);
+    resrc_tree_destroy (selected_tree, false);
 
-    selected_trees = test_select_resources (found_trees, 2);
-    rc = resrc_tree_list_allocate (selected_trees, 2, nowtime, nowtime + 3600);
+    selected_tree = test_select_resources (found_tree, NULL, 2);
+    if (rdl)
+        rc = resrc_tree_allocate (selected_tree, 2, nowtime, nowtime + 3600);
+    else
+        rc = resrc_tree_allocate (selected_tree, 2, 0, 0);
     ok (!rc, "successfully allocated resources for job 2");
-    resrc_tree_list_free (selected_trees);
+    resrc_tree_destroy (selected_tree, false);
 
-    selected_trees = test_select_resources (found_trees, 3);
-    rc = resrc_tree_list_allocate (selected_trees, 3, nowtime, nowtime + 3600);
+    selected_tree = test_select_resources (found_tree, NULL, 3);
+    if (rdl)
+        rc = resrc_tree_allocate (selected_tree, 3, nowtime, nowtime + 3600);
+    else
+        rc = resrc_tree_allocate (selected_tree, 3, 0, 0);
     ok (!rc, "successfully allocated resources for job 3");
-    resrc_tree_list_free (selected_trees);
+    resrc_tree_destroy (selected_tree, false);
 
-    selected_trees = test_select_resources (found_trees, 4);
-    rc = resrc_tree_list_reserve (selected_trees, 4, nowtime, nowtime + 3600);
+    selected_tree = test_select_resources (found_tree, NULL, 4);
+    if (rdl)
+        rc = resrc_tree_reserve (selected_tree, 4, nowtime, nowtime + 3600);
+    else
+        rc = resrc_tree_reserve (selected_tree, 4, 0, 0);
     ok (!rc, "successfully reserved resources for job 4");
-    resrc_tree_list_free (selected_trees);
+    resrc_tree_destroy (selected_tree, false);
 
     printf ("        allocate and reserve took: %lf\n",
             ((double)get_time ())/1000000);
@@ -393,7 +390,7 @@ static int test_a_resrc (resrc_t *resrc, bool rdl)
     }
 
     init_time ();
-    rc = resrc_tree_list_release (found_trees, 1);
+    rc = resrc_tree_release (found_tree, 1);
     ok (!rc, "resource release of job 1 took: %lf",
         ((double)get_time ())/1000000);
 
@@ -404,8 +401,8 @@ static int test_a_resrc (resrc_t *resrc, bool rdl)
 
     init_time ();
     resrc_reqst_destroy (resrc_reqst);
-    resrc_tree_list_destroy (deserialized_trees, true);
-    resrc_tree_list_destroy (found_trees, false);
+    resrc_tree_destroy (deserialized_tree, true);
+    resrc_tree_destroy (found_tree, false);
     printf ("        destroy took: %lf\n", ((double)get_time ())/1000000);
 ret:
     return rc;

--- a/resrc/test/tresrc.c
+++ b/resrc/test/tresrc.c
@@ -440,7 +440,7 @@ int main (int argc, char *argv[])
             ((double)get_time())/1000000);
         if (resrc) {
             rc1 = test_a_resrc (resrc, true);
-            resrc_resource_destroy (resrc);
+            resrc_tree_destroy (resrc_phys_tree (resrc), true);
         }
     }
 
@@ -457,7 +457,7 @@ int main (int argc, char *argv[])
     hwloc_topology_destroy (topology);
     if (resrc) {
         rc2 = test_a_resrc (resrc, false);
-        resrc_resource_destroy (resrc);
+        resrc_tree_destroy (resrc_phys_tree (resrc), true);
     }
 
     done_testing ();

--- a/sched/plugin.h
+++ b/sched/plugin.h
@@ -12,22 +12,24 @@ struct sched_plugin {
 
     int                  (*sched_loop_setup)(flux_t h);
 
-    resrc_tree_list_t *  (*find_resources)(flux_t h,
+    int64_t              (*find_resources)(flux_t h,
                                            resrc_t *resrc,
-                                           resrc_reqst_t *resrc_reqst);
+                                           resrc_reqst_t *resrc_reqst,
+                                           resrc_tree_t **found_tree);
 
-    resrc_tree_list_t *  (*select_resources)(flux_t h,
-                                             resrc_tree_list_t *resrc_trees,
-                                             resrc_reqst_t *resrc_reqst);
+    resrc_tree_t *       (*select_resources)(flux_t h,
+                                             resrc_tree_t *found_tree,
+                                             resrc_reqst_t *resrc_reqst,
+                                             resrc_tree_t *selected_parent);
 
     int                  (*allocate_resources)(flux_t h,
-                                               resrc_tree_list_t *rtl,
+                                               resrc_tree_t *rt,
                                                int64_t job_id,
                                                int64_t starttime,
                                                int64_t endtime);
 
     int                  (*reserve_resources)(flux_t h,
-                                              resrc_tree_list_t *rtl,
+                                              resrc_tree_t **selected_tree,
                                               int64_t job_id,
                                               int64_t starttime,
                                               int64_t walltime,

--- a/sched/sched.c
+++ b/sched/sched.c
@@ -1042,10 +1042,10 @@ static inline int bridge_rs2rank_tab_query (ssrvctx_t *ctx, resrc_t *r,
         rc = rs2rank_tab_query_by_none (ctx->machs, resrc_digest (r),
                                         false, rank);
     } else {
-        flux_log (ctx->h, LOG_INFO, "hostname: %s, digest: %s\n", resrc_name (r),
+        flux_log (ctx->h, LOG_INFO, "hostname: %s, digest: %s", resrc_name (r),
                                      resrc_digest (r));
-        rc = rs2rank_tab_query_by_sign (ctx->machs, resrc_name (r), resrc_digest (r),
-                                        false, rank);
+        rc = rs2rank_tab_query_by_sign (ctx->machs, resrc_name (r),
+                                        resrc_digest (r), false, rank);
     }
     if (rc == 0)
         flux_log (ctx->h, LOG_INFO, "broker found, rank: %"PRIu32, *rank);

--- a/sched/sched.c
+++ b/sched/sched.c
@@ -218,7 +218,7 @@ static void freectx (void *arg)
     zlist_destroy (&(ctx->c_queue));
     rs2rank_tab_destroy (ctx->machs);
     ssrvarg_free (&(ctx->arg));
-    resrc_resource_destroy (ctx->rctx.root_resrc);
+    resrc_tree_destroy (resrc_phys_tree (ctx->rctx.root_resrc), true);
     free (ctx->rctx.root_uri);
     free_simstate (ctx->sctx.sim_state);
     if (ctx->sctx.res_queue)
@@ -579,7 +579,7 @@ static int load_resources (ssrvctx_t *ctx)
             if (turi)
                 free (turi);
             if (tres)
-                resrc_resource_destroy (tres);
+                resrc_tree_destroy (resrc_phys_tree (tres), true);
             r_mode = RSREADER_HWLOC;
             /* deliberate fall-through to RSREADER_HWLOC! */
         } else {

--- a/sched/sched.c
+++ b/sched/sched.c
@@ -1075,21 +1075,32 @@ static void inline build_contain_1node_req (int64_t nc, int64_t rank, JSON rarr)
  * Because the job's rdl should only contain what's allocated to the job,
  * we traverse the entire tree in the post-order walk fashion
  */
-static int build_contain_req (ssrvctx_t *ctx, flux_lwj_t *job, JSON arr)
+static int build_contain_req (ssrvctx_t *ctx, flux_lwj_t *job, resrc_tree_t *rt,
+                              JSON arr)
 {
     int rc = -1;
     uint32_t rank = 0;
-    resrc_tree_t *nd = NULL;
     resrc_t *r = NULL;
 
-    for (nd = resrc_tree_list_first (job->resrc_trees); nd;
-            nd = resrc_tree_list_next (job->resrc_trees)) {
-        r = resrc_tree_resrc (nd);
-        if (strcmp (resrc_type (r), "node") != 0
-            || bridge_rs2rank_tab_query (ctx, r, &rank) != 0)
-            goto done;
-
-        build_contain_1node_req (job->req->corespernode, rank, arr);
+    if (rt) {
+        r = resrc_tree_resrc (rt);
+        if (strcmp (resrc_type (r), "node")) {
+            if (resrc_tree_num_children (rt)) {
+                resrc_tree_list_t *children = resrc_tree_children (rt);
+                if (children) {
+                    resrc_tree_t *child = resrc_tree_list_first (children);
+                    while (child) {
+                        build_contain_req (ctx, job, child, arr);
+                        child = resrc_tree_list_next (children);
+                    }
+                }
+            }
+        } else {
+            if (bridge_rs2rank_tab_query (ctx, r, &rank))
+                goto done;
+            else
+                build_contain_1node_req (job->req->corespernode, rank, arr);
+        }
     }
     rc = 0;
 done:
@@ -1108,10 +1119,10 @@ static int req_tpexec_allocate (ssrvctx_t *ctx, flux_lwj_t *job)
     int rc = -1;
     flux_t h = ctx->h;
     JSON jcb = Jnew ();
-    JSON ro = Jnew_ar ();
+    JSON ro = Jnew ();
     JSON arr = Jnew_ar ();
 
-    if (resrc_tree_list_serialize (ro, job->resrc_trees)) {
+    if (resrc_tree_serialize (ro, job->resrc_tree)) {
         flux_log (h, LOG_ERR, "%"PRId64" resource serialization failed: %s",
                   job->lwj_id, strerror (errno));
         goto done;
@@ -1125,7 +1136,7 @@ static int req_tpexec_allocate (ssrvctx_t *ctx, flux_lwj_t *job)
     }
     Jput (jcb);
     jcb = Jnew ();
-    if (build_contain_req (ctx, job, arr) != 0) {
+    if (build_contain_req (ctx, job, job->resrc_tree, arr) != 0) {
         flux_log (h, LOG_ERR, "error requesting containment for job");
         goto done;
     }
@@ -1135,7 +1146,6 @@ static int req_tpexec_allocate (ssrvctx_t *ctx, flux_lwj_t *job)
         flux_log (h, LOG_ERR, "error updating jcb");
         goto done;
     }
-    Jput (arr);
     if ((update_state (h, job->lwj_id, job->state, J_ALLOCATED)) != 0) {
         flux_log (h, LOG_ERR, "failed to update the state of job %"PRId64"",
                   job->lwj_id);
@@ -1226,14 +1236,14 @@ static int req_tpexec_run (flux_t h, flux_lwj_t *job)
  */
 int schedule_job (ssrvctx_t *ctx, flux_lwj_t *job, int64_t starttime)
 {
-    JSON child_core = NULL;
     JSON req_res = NULL;
     flux_t h = ctx->h;
     int rc = -1;
-    int64_t nnodes = 0;
+    int64_t nfound = 0;
+    int64_t nreqrd = 0;
     resrc_reqst_t *resrc_reqst = NULL;
-    resrc_tree_list_t *found_trees = NULL;
-    resrc_tree_list_t *selected_trees = NULL;
+    resrc_tree_t *found_tree = NULL;
+    resrc_tree_t *selected_tree = NULL;
     struct sched_plugin *plugin = sched_plugin_get (ctx->loader);
 
     if (!plugin)
@@ -1242,78 +1252,115 @@ int schedule_job (ssrvctx_t *ctx, flux_lwj_t *job, int64_t starttime)
     /*
      * Require at least one task per node, and
      * Assume (for now) one task per core.
+     *
+     * At this point, our flux_lwj_t structure supplies a simple count
+     * of nodes and cores.  This is a short term solution that
+     * supports the typical request.  Until a more complex model is
+     * available, we will have to interpret the request along these
+     * most likely scenarios:
+     *
+     * - If only cores are requested, the number of nodes we find to
+     *   supply the requested cores does not matter to the user.
+     *
+     * - If only nodes are requested, we will return only nodes whose
+     *   cores are all idle.
+     *
+     * - If nodes and cores are requested, we will return the
+     *   requested number of nodes with at least the requested number
+     *   of cores on each node.  We will not attempt to provide a
+     *   balanced number of cores per node.
      */
-    job->req->nnodes = (job->req->nnodes ? job->req->nnodes : 1);
-    if (job->req->ncores < job->req->nnodes)
-        job->req->ncores = job->req->nnodes;
-    job->req->corespernode = (job->req->ncores + job->req->nnodes - 1) /
-        job->req->nnodes;
-
-    child_core = Jnew ();
-    Jadd_str (child_core, "type", "core");
-    Jadd_int64 (child_core, "req_qty", job->req->corespernode);
-    /* setting size == 1 devotes (all of) the core to the job */
-    Jadd_int64 (child_core, "req_size", 1);
-    /* setting exclusive to true prevents multiple jobs per core */
-    Jadd_bool (child_core, "exclusive", true);
-    Jadd_int64 (child_core, "starttime", starttime);
-    Jadd_int64 (child_core, "endtime", starttime + job->req->walltime);
-
     req_res = Jnew ();
-    Jadd_str (req_res, "type", "node");
-    Jadd_int64 (req_res, "req_qty", job->req->nnodes);
-    if (job->req->node_exclusive) {
+    if (job->req->nnodes > 0) {
+        JSON child_core = Jnew ();
+
+        Jadd_str (req_res, "type", "node");
+        Jadd_int64 (req_res, "req_qty", job->req->nnodes);
+        nreqrd = job->req->nnodes;
+
+        /* Since nodes are requested, make sure we look for at
+         * least one core on each node */
+        if (job->req->ncores < job->req->nnodes)
+            job->req->ncores = job->req->nnodes;
+        job->req->corespernode = (job->req->ncores + job->req->nnodes - 1) /
+            job->req->nnodes;
+        if (job->req->node_exclusive) {
+            Jadd_int64 (req_res, "req_size", 1);
+            Jadd_bool (req_res, "exclusive", true);
+        } else {
+            Jadd_int64 (req_res, "req_size", 0);
+            Jadd_bool (req_res, "exclusive", false);
+        }
+
+        Jadd_str (child_core, "type", "core");
+        Jadd_int64 (child_core, "req_qty", job->req->corespernode);
+        /* setting size == 1 devotes (all of) the core to the job */
+        Jadd_int64 (child_core, "req_size", 1);
+        /* setting exclusive to true prevents multiple jobs per core */
+        Jadd_bool (child_core, "exclusive", true);
+        Jadd_int64 (child_core, "starttime", starttime);
+        Jadd_int64 (child_core, "endtime", starttime + job->req->walltime);
+        json_object_object_add (req_res, "req_child", child_core);
+    } else if (job->req->ncores > 0) {
+        Jadd_str (req_res, "type", "core");
+        Jadd_int (req_res, "req_qty", job->req->ncores);
+        nreqrd = job->req->ncores;
+
         Jadd_int64 (req_res, "req_size", 1);
+        /* setting exclusive to true prevents multiple jobs per core */
         Jadd_bool (req_res, "exclusive", true);
-    } else {
-        Jadd_int64 (req_res, "req_size", 0);
-        Jadd_bool (req_res, "exclusive", false);
-    }
+    } else
+        goto done;
+
     Jadd_int64 (req_res, "starttime", starttime);
     Jadd_int64 (req_res, "endtime", starttime + job->req->walltime);
-
-    json_object_object_add (req_res, "req_child", child_core);
-
     resrc_reqst = resrc_reqst_from_json (req_res, NULL);
     Jput (req_res);
     if (!resrc_reqst)
         goto done;
 
-    if ((found_trees = plugin->find_resources (h, ctx->rctx.root_resrc,
-                                               resrc_reqst))) {
-        nnodes = resrc_tree_list_size (found_trees);
-        flux_log (h, LOG_DEBUG, "%"PRId64" nodes found for job %"PRId64", "
-                  "reqrd_qty: %"PRId64"", nnodes, job->lwj_id, job->req->nnodes);
+    if ((nfound = plugin->find_resources (h, ctx->rctx.root_resrc,
+                                          resrc_reqst, &found_tree))) {
+        flux_log (h, LOG_DEBUG, "Found %"PRId64" %s(s) for job %"PRId64", "
+                  "required: %"PRId64"", nfound,
+                  resrc_type (resrc_reqst_resrc (resrc_reqst)), job->lwj_id,
+                  nreqrd);
 
-        resrc_tree_list_unstage_resources (found_trees);
-        if ((selected_trees = plugin->select_resources (h, found_trees,
-                                                        resrc_reqst))) {
-            nnodes = resrc_tree_list_size (selected_trees);
-            if (nnodes == job->req->nnodes) {
-                plugin->allocate_resources (h, selected_trees, job->lwj_id,
+        resrc_tree_unstage_resources (found_tree);
+        resrc_reqst_clear_found (resrc_reqst);
+        if ((selected_tree = plugin->select_resources (h, found_tree,
+                                                       resrc_reqst, NULL))) {
+            if (resrc_reqst_all_found (resrc_reqst)) {
+                plugin->allocate_resources (h, selected_tree, job->lwj_id,
                                             starttime, starttime +
                                             job->req->walltime);
                 /* Scheduler specific job transition */
                 // TODO: handle this some other way (JSC?)
                 job->starttime = starttime;
                 job->state = J_SELECTED;
-                job->resrc_trees = selected_trees;
+                job->resrc_tree = selected_tree;
                 if (req_tpexec_allocate (ctx, job) != 0) {
                     flux_log (h, LOG_ERR,
                               "failed to request allocate for job %"PRId64"",
                               job->lwj_id);
-                    resrc_tree_list_destroy (job->resrc_trees, false);
-                    job->resrc_trees = NULL;
+                    resrc_tree_destroy (job->resrc_tree, false);
+                    job->resrc_tree = NULL;
                     goto done;
                 }
-                flux_log (h, LOG_DEBUG, "Allocated %"PRId64" nodes for job "
-                          "%"PRId64", reqrd_qty: %"PRId64"", nnodes, job->lwj_id,
-                          job->req->nnodes);
+                flux_log (h, LOG_DEBUG, "Allocated %"PRId64" %s(s) for job "
+                          "%"PRId64"", nreqrd,
+                          resrc_type (resrc_reqst_resrc (resrc_reqst)),
+                          job->lwj_id);
             } else {
-                plugin->reserve_resources (h, selected_trees, job->lwj_id,
-                                           starttime, job->req->walltime,
-                                           ctx->rctx.root_resrc,
-                                           resrc_reqst);
+                rc = plugin->reserve_resources (h, &selected_tree, job->lwj_id,
+                                                starttime, job->req->walltime,
+                                                ctx->rctx.root_resrc,
+                                                resrc_reqst);
+                if (rc) {
+                    resrc_tree_destroy (selected_tree, false);
+                    job->resrc_tree = NULL;
+                } else
+                    job->resrc_tree = selected_tree;
             }
         }
     }
@@ -1321,8 +1368,8 @@ int schedule_job (ssrvctx_t *ctx, flux_lwj_t *job, int64_t starttime)
 done:
     if (resrc_reqst)
         resrc_reqst_destroy (resrc_reqst);
-    if (found_trees)
-        resrc_tree_list_destroy (found_trees, false);
+    if (found_tree)
+        resrc_tree_destroy (found_tree, false);
 
     return rc;
 }
@@ -1429,7 +1476,7 @@ static int action (ssrvctx_t *ctx, flux_lwj_t *job, job_state_t newstate)
         q_move_to_cqueue (ctx, job);
         if (!ctx->arg.schedonce) {
             /* support testing by actually not releasing the resrc */
-            if (resrc_tree_list_release (job->resrc_trees, job->lwj_id)) {
+            if (resrc_tree_release (job->resrc_tree, job->lwj_id)) {
             flux_log (h, LOG_ERR, "%s: failed to release resources for job "
                       "%"PRId64"", __FUNCTION__, job->lwj_id);
             }
@@ -1449,6 +1496,7 @@ static int action (ssrvctx_t *ctx, flux_lwj_t *job, job_state_t newstate)
         zlist_remove (ctx->c_queue, job);
         if (job->req)
             free (job->req);
+        resrc_tree_destroy (job->resrc_tree, false);
         free (job);
         break;
     case J_COMPLETE:
@@ -1456,6 +1504,7 @@ static int action (ssrvctx_t *ctx, flux_lwj_t *job, job_state_t newstate)
         zlist_remove (ctx->c_queue, job);
         if (job->req)
             free (job->req);
+        resrc_tree_destroy (job->resrc_tree, false);
         free (job);
         break;
     case J_REAPED:

--- a/sched/sched_fcfs.c
+++ b/sched/sched_fcfs.c
@@ -42,9 +42,13 @@
 #include "scheduler.h"
 
 
-static bool select_children (flux_t h, resrc_tree_list_t *found_children,
+static bool select_children (flux_t h, resrc_tree_list_t *children,
                              resrc_reqst_list_t *reqst_children,
-                             resrc_tree_t *parent_tree);
+                             resrc_tree_t *selected_parent);
+
+resrc_tree_t *select_resources (flux_t h, resrc_tree_t *found_tree,
+                                resrc_reqst_t *resrc_reqst,
+                                resrc_tree_t *selected_parent);
 
 int sched_loop_setup (void)
 {
@@ -57,134 +61,84 @@ int sched_loop_setup (void)
  * requires.  A later call to select_resources() will cull this list
  * down to the most appropriate set for the job.
  *
- * Inputs:  resrcs - hash table of all resources
+ * Inputs:  resrcs      - hash table of all resources
  *          resrc_reqst - the resources the job requests
- * Returns: a list of resource trees satisfying the job's request,
- *                   or NULL if none (or not enough) are found
+ * Returns: nfound      - the number of resources found
+ *          found_tree  - a resource tree containing resources that satisfy the
+ *                        job's request or NULL if none are found
  */
-resrc_tree_list_t *find_resources (flux_t h, resrc_t *resrc,
-                                   resrc_reqst_t *resrc_reqst)
+int64_t find_resources (flux_t h, resrc_t *resrc, resrc_reqst_t *resrc_reqst,
+                        resrc_tree_t **found_tree)
 {
     int64_t nfound = 0;
-    resrc_tree_list_t *found_trees = NULL;
-    resrc_tree_t *resrc_tree = NULL;
 
     if (!resrc || !resrc_reqst) {
         flux_log (h, LOG_ERR, "%s: invalid arguments", __FUNCTION__);
         goto ret;
     }
-    resrc_tree = resrc_phys_tree (resrc);
-
-    found_trees = resrc_tree_list_new ();
-    if (!found_trees) {
-        flux_log (h, LOG_ERR, "%s: new tree list failed", __FUNCTION__);
-        goto ret;
-    }
-
+    /*
+     * A start time of zero is used to restrict the search to now
+     * (appropriate for FCFS) and prevent any search into the future.
+     */
     if (resrc_reqst_set_starttime (resrc_reqst, 0) ||
         resrc_reqst_set_endtime (resrc_reqst, 0))
         goto ret;
 
-    nfound = resrc_tree_search (resrc_tree_children (resrc_tree), resrc_reqst,
-                                found_trees, true);
+    *found_tree = NULL;
+    nfound = resrc_tree_search (resrc, resrc_reqst, found_tree, true);
 
-    if (!nfound) {
-        resrc_tree_list_destroy (found_trees, false);
-        found_trees = NULL;
+    if (!nfound && *found_tree) {
+        resrc_tree_destroy (*found_tree, false);
+        *found_tree = NULL;
     }
 ret:
-    return found_trees;
+    return nfound;
 }
 
-static bool select_child (flux_t h, resrc_tree_list_t *found_children,
+/*
+ * cycles through all of the resource children and returns true when
+ * the requested quantity of resources have been selected.
+ */
+static bool select_child (flux_t h, resrc_tree_list_t *children,
                           resrc_reqst_t *child_reqst,
-                          resrc_tree_t *parent_tree)
+                          resrc_tree_t *selected_parent)
 {
-    resrc_tree_t *resrc_tree = NULL;
     resrc_tree_t *child_tree = NULL;
     bool selected = false;
 
-    resrc_tree = resrc_tree_list_first (found_children);
-    while (resrc_tree) {
-        selected = false;
-        if (resrc_match_resource (resrc_tree_resrc (resrc_tree), child_reqst,
-                                  true)) {
-            if (resrc_reqst_num_children (child_reqst)) {
-                if (resrc_tree_num_children (resrc_tree)) {
-                    child_tree = resrc_tree_new (parent_tree,
-                                                 resrc_tree_resrc (resrc_tree));
-                    if (select_children (h, resrc_tree_children (resrc_tree),
-                                         resrc_reqst_children (child_reqst),
-                                         child_tree)) {
-                        resrc_reqst_add_found (child_reqst, 1);
-                        resrc_stage_resrc (resrc_tree_resrc (resrc_tree),
-                                           resrc_reqst_reqrd_size (child_reqst));
-                        selected = true;
-                        if (resrc_reqst_nfound (child_reqst) >=
-                            resrc_reqst_reqrd_qty (child_reqst))
-                            goto ret;
-                    } else {
-                        resrc_tree_destroy (child_tree, false);
-                    }
-                }
-            } else {
-                (void) resrc_tree_new (parent_tree,
-                                       resrc_tree_resrc (resrc_tree));
-                resrc_reqst_add_found (child_reqst, 1);
-                resrc_stage_resrc (resrc_tree_resrc (resrc_tree),
-                                   resrc_reqst_reqrd_size (child_reqst));
-                selected = true;
-                if (resrc_reqst_nfound (child_reqst) >=
-                    resrc_reqst_reqrd_qty (child_reqst))
-                    goto ret;
-            }
+    child_tree = resrc_tree_list_first (children);
+    while (child_tree) {
+        if (select_resources (h, child_tree, child_reqst, selected_parent) &&
+            (resrc_reqst_nfound (child_reqst) >=
+             resrc_reqst_reqrd_qty (child_reqst))) {
+            selected = true;
+            break;
         }
-        /*
-         * The following clause allows the resource request to be
-         * sparsely defined.  E.g., it might only stipulate a node
-         * with 4 cores and omit the intervening socket.
-         */
-        if (!selected) {
-            if (resrc_tree_num_children (resrc_tree)) {
-                child_tree = resrc_tree_new (parent_tree,
-                                             resrc_tree_resrc (resrc_tree));
-                if (select_child (h, resrc_tree_children (resrc_tree),
-                                  child_reqst, child_tree)) {
-                    selected = true;
-                    if (resrc_reqst_nfound (child_reqst) >=
-                        resrc_reqst_reqrd_qty (child_reqst))
-                        goto ret;
-                } else {
-                    resrc_tree_destroy (child_tree, false);
-                }
-            }
-        }
-        resrc_tree = resrc_tree_list_next (found_children);
+        child_tree = resrc_tree_list_next (children);
     }
-ret:
+
     return selected;
 }
 
-
-static bool select_children (flux_t h, resrc_tree_list_t *found_children,
+/*
+ * cycles through all of the resource requests and returns true if all
+ * of the requested children were selected
+ */
+static bool select_children (flux_t h, resrc_tree_list_t *children,
                              resrc_reqst_list_t *reqst_children,
-                             resrc_tree_t *parent_tree)
+                             resrc_tree_t *selected_parent)
 {
-    resrc_reqst_t *child_reqst = resrc_reqst_list_first (reqst_children);
+    resrc_reqst_t *child_reqst = NULL;
     bool selected = false;
 
+    child_reqst = resrc_reqst_list_first (reqst_children);
     while (child_reqst) {
         resrc_reqst_clear_found (child_reqst);
         selected = false;
 
-        if (select_child (h, found_children, child_reqst, parent_tree) &&
-            (resrc_reqst_nfound (child_reqst) >=
-             resrc_reqst_reqrd_qty (child_reqst)))
-            selected = true;
-
-        if (!selected)
+        if (!select_child (h, children, child_reqst, selected_parent))
             break;
-
+        selected = true;
         child_reqst = resrc_reqst_list_next (reqst_children);
     }
 
@@ -193,92 +147,101 @@ static bool select_children (flux_t h, resrc_tree_list_t *found_children,
 
 /*
  * select_resources() selects from the set of resource candidates the
- * best resources for the job.  If reserve is set, whatever resources
- * are selected will be reserved for the job and removed from
- * consideration as candidates for other jobs.
+ * best resources for the job.
  *
- * Inputs:  found_trees - list of resource tree candidates
- *          resrc_reqst - the resources the job requests
- * Returns: a list of selected resource trees, or null if none (or not enough)
- *          are selected
+ * Inputs:  found_tree      - tree of resource tree candidates
+ *          resrc_reqst     - the resources the job requests
+ *          selected_parent - parent of the selected resource tree
+ * Returns: a resource tree of however many resources were selected
  */
-resrc_tree_list_t *select_resources (flux_t h, resrc_tree_list_t *found_trees,
-                                     resrc_reqst_t *resrc_reqst)
+resrc_tree_t *select_resources (flux_t h, resrc_tree_t *found_tree,
+                                resrc_reqst_t *resrc_reqst,
+                                resrc_tree_t *selected_parent)
 {
-    int64_t reqrd_qty;
     resrc_t *resrc;
-    resrc_tree_list_t *selected_res = NULL;
-    resrc_tree_t *new_tree = NULL;
-    resrc_tree_t *rt;
+    resrc_tree_list_t *children = NULL;
+    resrc_tree_t *child_tree;
+    resrc_tree_t *selected_tree = NULL;
 
     if (!resrc_reqst) {
         flux_log (h, LOG_ERR, "%s: called with empty request", __FUNCTION__);
         return NULL;
     }
 
-    reqrd_qty = resrc_reqst_reqrd_qty (resrc_reqst);
     /*
-     * A start time of zero means that we are only interested in
-     * if the resource is available now.
+     * A start time of zero is used to restrict the search to now
+     * (appropriate for FCFS) and prevent any search into the future.
      */
-    resrc_reqst_set_starttime (resrc_reqst, 0);
-    selected_res = resrc_tree_list_new ();
+    if (resrc_reqst_set_starttime (resrc_reqst, 0) ||
+        resrc_reqst_set_endtime (resrc_reqst, 0))
+        return NULL;
 
-    rt = resrc_tree_list_first (found_trees);
-    while (reqrd_qty && rt) {
-        resrc = resrc_tree_resrc (rt);
-        if (resrc_match_resource (resrc, resrc_reqst, true)) {
-            new_tree = resrc_tree_new (NULL, resrc);
-            if (resrc_reqst_num_children (resrc_reqst)) {
-                if (resrc_tree_num_children (rt)) {
-                    if (select_children (h, resrc_tree_children (rt),
-                                         resrc_reqst_children (resrc_reqst),
-                                         new_tree)) {
-                        resrc_tree_list_append (selected_res, new_tree);
-                        resrc_stage_resrc (resrc,
-                                           resrc_reqst_reqrd_size (resrc_reqst));
-                        flux_log (h, LOG_DEBUG, "selected %s", resrc_name (resrc));
-                        reqrd_qty--;
-                    } else {
-                        resrc_tree_destroy (new_tree, false);
-                    }
+    resrc = resrc_tree_resrc (found_tree);
+    if (resrc_match_resource (resrc, resrc_reqst, true)) {
+        if (resrc_reqst_num_children (resrc_reqst)) {
+            if (resrc_tree_num_children (found_tree)) {
+                selected_tree = resrc_tree_new (selected_parent, resrc);
+                if (select_children (h, resrc_tree_children (found_tree),
+                                     resrc_reqst_children (resrc_reqst),
+                                     selected_tree)) {
+                    resrc_stage_resrc (resrc,
+                                       resrc_reqst_reqrd_size (resrc_reqst));
+                    resrc_reqst_add_found (resrc_reqst, 1);
+                    flux_log (h, LOG_DEBUG, "selected %s", resrc_name (resrc));
+                } else {
+                    resrc_tree_destroy (selected_tree, false);
                 }
-            } else {
-                resrc_tree_list_append (selected_res, new_tree);
-                resrc_stage_resrc (resrc, resrc_reqst_reqrd_size (resrc_reqst));
-                flux_log (h, LOG_DEBUG, "selected %s", resrc_name (resrc));
-                reqrd_qty--;
             }
+        } else {
+            selected_tree = resrc_tree_new (selected_parent, resrc);
+            resrc_stage_resrc (resrc, resrc_reqst_reqrd_size (resrc_reqst));
+            resrc_reqst_add_found (resrc_reqst, 1);
+            flux_log (h, LOG_DEBUG, "selected %s", resrc_name (resrc));
         }
-        rt = resrc_tree_list_next (found_trees);
+    } else if (resrc_tree_num_children (found_tree)) {
+        /*
+         * This clause visits the children of the current resource
+         * searching for a match to the resource request.  The selected
+         * tree must be extended to include this intermediate
+         * resource.
+         *
+         * This also allows the resource request to be sparsely
+         * defined.  E.g., it might only stipulate a node with 4 cores
+         * and omit the intervening socket.
+         */
+        selected_tree = resrc_tree_new (selected_parent, resrc);
+        children = resrc_tree_children (found_tree);
+        child_tree = resrc_tree_list_first (children);
+        while (child_tree) {
+            if (select_resources (h, child_tree, resrc_reqst, selected_tree) &&
+                resrc_reqst_nfound (resrc_reqst) >=
+                resrc_reqst_reqrd_qty (resrc_reqst))
+                break;
+            child_tree = resrc_tree_list_next (children);
+        }
     }
 
-    /* If we did not select all that was required and the selected
-     * resource list is empty, destroy the list. */
-    if (reqrd_qty && !resrc_tree_list_size (selected_res)) {
-        resrc_tree_list_destroy (selected_res, false);
-        selected_res = NULL;
-    }
-
-    return selected_res;
+    return selected_tree;
 }
 
-int allocate_resources (flux_t h, resrc_tree_list_t *rtl, int64_t job_id,
+int allocate_resources (flux_t h, resrc_tree_t *selected_tree, int64_t job_id,
                         int64_t starttime, int64_t endtime)
 {
-    int rc = resrc_tree_list_allocate (rtl, job_id, 0, 0);
+    int rc = -1;
+
+    if (selected_tree)
+        rc = resrc_tree_allocate (selected_tree, job_id, 0, 0);
     return rc;
 }
 
-int reserve_resources (flux_t h, resrc_tree_list_t *rtl, int64_t job_id,
+int reserve_resources (flux_t h, resrc_tree_t **selected_tree, int64_t job_id,
                        int64_t starttime, int64_t walltime, resrc_t *resrc,
                        resrc_reqst_t *resrc_reqst)
 {
     int rc = -1;
 
-    if (rtl && !(rc = resrc_tree_list_reserve (rtl, job_id, 0, 0)))
-        flux_log (h, LOG_DEBUG, "Reserved %"PRId64" nodes for job %"PRId64"",
-                  resrc_tree_list_size (rtl), job_id);
+    if (*selected_tree)
+        rc = resrc_tree_reserve (*selected_tree, job_id, 0, 0);
     return rc;
 }
 

--- a/sched/scheduler.h
+++ b/sched/scheduler.h
@@ -59,7 +59,7 @@ typedef struct {
     int64_t     lwj_id;  /*!< LWJ id */
     job_state_t state;   /*!< current job state */
     flux_res_t *req;     /*!< resources requested by this LWJ */
-    resrc_tree_list_t *resrc_trees; /*!< resources allocated to this LWJ */
+    resrc_tree_t *resrc_tree; /*!< resources allocated to this LWJ */
     int64_t starttime;
 } flux_lwj_t;
 


### PR DESCRIPTION
Replace tree list searches with tree searches

Modifies the resrc search code to search a resource tree instead of a resource tree list.  This has two benefits:
    
* Can now search for an isolated resource (like cores) without regard to its parent resource (like nodes).  Formally, we had to define a request that include one node and multiple cores to find resource composites of node+cores.  Now we can just search for cores.
    
* The code now conforms to the RFC 4 requirement:
"The job ID for a job that is allocated a resource in a composite hierarchy MUST be annotated not only to the resource, but to each parent up the tree of those resources allocated to the enclosing
instance"

Also in this PR are minor mods that prepared the way for the tree search changes.