### PR TITLE
sim & sched: fix segfaults when running in sim

### DIFF
--- a/sched/sched.c
+++ b/sched/sched.c
@@ -213,7 +213,7 @@ static void freectx (void *arg)
     ssrvarg_free (&(ctx->arg));
     resrc_resource_destroy (ctx->rctx.root_resrc);
     free (ctx->rctx.root_uri);
-    free (ctx->sctx.sim_state);
+    free_simstate (ctx->sctx.sim_state);
     if (ctx->sctx.res_queue)
         zlist_destroy (&(ctx->sctx.res_queue));
     if (ctx->sctx.jsc_queue)

--- a/simulator/simulator.c
+++ b/simulator/simulator.c
@@ -54,8 +54,6 @@ void free_simstate (sim_state_t *sim_state)
             zhash_destroy (&(sim_state->timers));
         }
         free (sim_state);
-    } else {
-        fprintf (stderr, "free_simstate called on a NULL pointer\n");
     }
 }
 
@@ -124,7 +122,6 @@ void free_job (job_t *job)
     free (job->user);
     free (job->jobname);
     free (job->account);
-    kvsdir_destroy (job->kvs_dir);
     free (job);
 }
 


### PR DESCRIPTION
Minor fixes to some free'ing that causes a segfault when running under the simulator.
The problem only occurs when the simulator is being shutdown.