### PR TITLE
Add runtime option to select backfill algorithm

### DIFF
--- a/sched/plugin.c
+++ b/sched/plugin.c
@@ -56,40 +56,50 @@ static void plugin_destroy (struct sched_plugin *plugin)
 static struct sched_plugin *plugin_create (flux_t h, void *dso)
 {
     int saved_errno;
+    char *strerr = NULL;
     struct sched_plugin *plugin = malloc (sizeof (*plugin));
+
     if (!plugin) {
         errno = ENOMEM;
         goto error;
     }
     memset (plugin, 0, sizeof (*plugin));
+    dlerror (); // Clear old dlerrors
+
     plugin->sched_loop_setup = dlsym (dso, "sched_loop_setup");
-    if (!plugin->sched_loop_setup || !*plugin->sched_loop_setup) {
-        flux_log (h, LOG_ERR, "can't load sched_loop_setup: %s", dlerror ());
+    strerr = dlerror();
+    if (strerr || !plugin->sched_loop_setup || !*plugin->sched_loop_setup) {
+        flux_log (h, LOG_ERR, "can't load sched_loop_setup: %s", strerr);
         goto error;
     }
     plugin->find_resources = dlsym (dso, "find_resources");
-    if (!plugin->find_resources || !*plugin->find_resources) {
-        flux_log (h, LOG_ERR, "can't load find_resources: %s", dlerror ());
+    strerr = dlerror();
+    if (strerr || !plugin->find_resources || !*plugin->find_resources) {
+        flux_log (h, LOG_ERR, "can't load find_resources: %s", strerr);
         goto error;
     }
     plugin->select_resources = dlsym (dso, "select_resources");
-    if (!plugin->select_resources || !*plugin->select_resources) {
-        flux_log (h, LOG_ERR, "can't load select_resources: %s", dlerror ());
+    strerr = dlerror();
+    if (strerr || !plugin->select_resources || !*plugin->select_resources) {
+        flux_log (h, LOG_ERR, "can't load select_resources: %s", strerr);
         goto error;
     }
     plugin->allocate_resources = dlsym (dso, "allocate_resources");
-    if (!plugin->allocate_resources || !*plugin->allocate_resources) {
-        flux_log (h, LOG_ERR, "can't load allocate_resources: %s", dlerror ());
+    strerr = dlerror();
+    if (strerr || !plugin->allocate_resources || !*plugin->allocate_resources) {
+        flux_log (h, LOG_ERR, "can't load allocate_resources: %s", strerr);
         goto error;
     }
     plugin->reserve_resources = dlsym (dso, "reserve_resources");
-    if (!plugin->reserve_resources || !*plugin->reserve_resources) {
-        flux_log (h, LOG_ERR, "can't load reserve_resources: %s", dlerror ());
+    strerr = dlerror();
+    if (strerr || !plugin->reserve_resources || !*plugin->reserve_resources) {
+        flux_log (h, LOG_ERR, "can't load reserve_resources: %s", strerr);
         goto error;
     }
     plugin->process_args = dlsym (dso, "process_args");
-    if (!plugin->process_args || !*plugin->process_args) {
-        flux_log (h, LOG_ERR, "can't load process_args: %s", dlerror ());
+    strerr = dlerror();
+    if (strerr || !plugin->process_args || !*plugin->process_args) {
+        flux_log (h, LOG_ERR, "can't load process_args: %s", strerr);
         goto error;
     }
     plugin->dso = dso;

--- a/sched/plugin.h
+++ b/sched/plugin.h
@@ -1,6 +1,10 @@
 #ifndef _FLUX_SCHED_PLUGIN_H
 #define _FLUX_SCHED_PLUGIN_H
 
+#include "resrc.h"
+#include "resrc_tree.h"
+#include "resrc_reqst.h"
+
 struct sched_plugin {
     void         *dso;                /* Scheduler plug-in DSO handle */
     char         *name;               /* Name of plugin */
@@ -29,6 +33,10 @@ struct sched_plugin {
                                               int64_t walltime,
                                               resrc_t *resrc,
                                               resrc_reqst_t *resrc_reqst);
+
+    int                  (*process_args)(flux_t h,
+                                         char *argz,
+                                         size_t argz_len);
 };
 
 /* Create/destroy the plugin loader apparatus.

--- a/sched/plugin_version.map
+++ b/sched/plugin_version.map
@@ -5,5 +5,6 @@
     sched_loop_setup;
     select_resources;
     mod_name;
+    process_args;
   local: *;
 };

--- a/sched/sched_backfill.c
+++ b/sched/sched_backfill.c
@@ -42,9 +42,14 @@
 #include "resrc_reqst.h"
 #include "scheduler.h"
 
+// Reservation Depth Guide:
+//     0 = All backfilling (no reservations)
+//     1 = EASY Backfill
+//    >1 = Hybrid Backfill
+//    <0 = Conservative Backfill
 
-static bool easy_backfill = false;
-static bool first_time_backfill = true;
+static int reservation_depth = 1;
+static int curr_reservation_depth = 0;
 static zlist_t *completion_times = NULL;
 
 #if CZMQ_VERSION < CZMQ_MAKE_VERSION(3, 0, 1)
@@ -71,7 +76,7 @@ static bool select_children (flux_t h, resrc_tree_list_t *found_children,
 
 int sched_loop_setup (void)
 {
-    first_time_backfill = true;
+    curr_reservation_depth = 0;
     if (!completion_times)
         completion_times = zlist_new ();
     return 0;
@@ -309,7 +314,7 @@ int reserve_resources (flux_t h, resrc_tree_list_t *rtl, int64_t job_id,
     resrc_tree_list_t *selected_trees = NULL;
     resrc_tree_t *resrc_tree = NULL;
 
-    if (easy_backfill && !first_time_backfill) {
+    if (reservation_depth > 0 && (curr_reservation_depth >= reservation_depth)) {
         goto ret;
     } else if (!resrc || !resrc_reqst) {
         flux_log (h, LOG_ERR, "%s: invalid arguments", __FUNCTION__);
@@ -347,7 +352,7 @@ int reserve_resources (flux_t h, resrc_tree_list_t *rtl, int64_t job_id,
                 rc = resrc_tree_list_reserve (selected_trees, job_id,
                                               *completion_time + 1,
                                               *completion_time + 1 + walltime);
-                first_time_backfill = false;
+                curr_reservation_depth++;
                 flux_log (h, LOG_DEBUG, "Reserved %"PRId64" nodes for job "
                           "%"PRId64" from %"PRId64" to %"PRId64"",
                           resrc_reqst_reqrd_qty (resrc_reqst), job_id,
@@ -365,15 +370,15 @@ ret:
 int process_args (flux_t h, char *argz, size_t argz_len)
 {
     int rc = 0;
-    char *easy_backfill_str = NULL;
+    char *reserve_depth_str = NULL;
     char *entry = NULL;
 
     for (entry = argz;
          entry;
          entry = argz_next (argz, argz_len, entry)) {
 
-        if (!strncmp ("easy-backfill=", entry, sizeof ("easy-backfill"))) {
-            easy_backfill_str = entry;
+        if (!strncmp ("reserve-depth=", entry, sizeof ("reserve-depth"))) {
+            reserve_depth_str = strstr (entry, "=") + 1;
         } else {
             rc = -1;
             errno = EINVAL;
@@ -381,10 +386,11 @@ int process_args (flux_t h, char *argz, size_t argz_len)
         }
     }
 
-    if (easy_backfill_str) {
-        easy_backfill = !strncmp (easy_backfill_str, "true", sizeof ("true"));
+    if (reserve_depth_str) {
+        // If atoi fails, it defaults to 0, which is fine for us
+        reservation_depth = atoi(reserve_depth_str);
     } else {
-        easy_backfill = false;
+        reservation_depth = 0;
     }
 
  done:

--- a/sched/sched_fcfs.c
+++ b/sched/sched_fcfs.c
@@ -283,6 +283,11 @@ int reserve_resources (flux_t h, resrc_tree_list_t *rtl, int64_t job_id,
 }
 
 
+int process_args (flux_t h, char *argz, size_t argz_len)
+{
+    return 0;
+}
+
 MOD_NAME ("sched.fcfs");
 
 

--- a/t/t1004-module-load.t
+++ b/t/t1004-module-load.t
@@ -51,8 +51,23 @@ test_expect_success 'module-load: sched unloads the fcfs plugin' '
     flux module list sched
 '
 
-test_expect_success 'module-load: sched loads the bacfill plugin' '
-    flux module load sched.backfill sched-once=true &&
+test_expect_success 'module-load: sched loads the backfill plugin' '
+    flux module load sched.backfill &&
+    flux module list sched
+'
+
+test_expect_success 'module-load: sched unloads the backfill plugin' '
+    flux module remove sched.backfill &&
+    flux module list sched
+'
+
+test_expect_success 'module-load: sched loads the backfill plugin with an argument meant for sched' '
+    test_must_fail flux module load sched.backfill sched-once=true &&
+    flux module remove sched.backfill
+'
+
+test_expect_success 'module-load: sched loads the backfill plugin with arguments' '
+    flux module load sched.backfill easy-backfill=true &&
     flux module list sched
 '
 

--- a/t/t1004-module-load.t
+++ b/t/t1004-module-load.t
@@ -67,7 +67,7 @@ test_expect_success 'module-load: sched loads the backfill plugin with an argume
 '
 
 test_expect_success 'module-load: sched loads the backfill plugin with arguments' '
-    flux module load sched.backfill easy-backfill=true &&
+    flux module load sched.backfill reserve-depth=-1 &&
     flux module list sched
 '
 

--- a/t/t2002-easy.t
+++ b/t/t2002-easy.t
@@ -31,7 +31,7 @@ test_expect_success 'loading exec works' '
 	flux module load sim_exec
 '
 test_expect_success 'loading sched works' '
-	flux module load sched rdl-conf=${rdlconf} in-sim=true plugin=sched.backfill
+	flux module load sched rdl-conf=${rdlconf} in-sim=true plugin=sched.backfill plugin-opts=reserve-depth=1
 '
 
 while flux kvs get lwj.12.complete_time 2>&1 | grep -q "No such file"; do sleep 0.5; done


### PR DESCRIPTION
Addresses issue #159 

To pass options through to the plugin when launching sched, use plugin-opts.  This list is comma separated. (e.g. `flux module load sched plugin=sched.backfill plugin-opts=reserve-depth=1,foo=bar`)

To pass options through to the plugin when loading just the plugin, specify them as a space separated list. (e.g. `flux module load sched.backfill reserve-depth=1 foo=bar`)

Examples of launching with various backfilling algorithms:
- Conservative
  - `flux module load sched.backfill reserve-depth=-1`
- EASY
  - `flux module load sched.backfill reserve-depth=1`
- Hybrid
  - `flux module load sched.backfill reserve-depth=4`
- Pure
  - `flux module load sched.backfill reserve-depth=0`