### PR TITLE
travis updates, and NEWS for 0.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,3 +82,24 @@ after_failure:
  - find . -name t[0-9]*.output -print0 | xargs -0 -I'{}' sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'
  - find . -name *.broker.log -print0 | xargs -0 -I'{}' sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'
 
+before_deploy:
+  # Get anchor (formatted properly) and base URI for latest tag in NEWS file
+  - export ANCHOR=$(sed -n '/^flux-sched version/{s/\.//g; s/\s/-/gp;Q}' NEWS.md)
+  - export TAG_URI="https://github.com/${TRAVIS_REPO_SLUG}/blob/${TRAVIS_TAG}"
+  - export TARBALL=$(echo flux-sched*.tar.gz)
+  - ls -l $TARBALL
+  - echo "Deploying tag ${TRAVIS_TAG} as $TARBALL"
+
+deploy:
+  provider: releases
+  skip_cleanup: true
+  file: $TARBALL
+  prerelease: true
+  body: "View [Release Notes](${TAG_URI}/NEWS.md#${ANCHOR}) for flux-sched ${TRAVIS_TAG}."
+  api_key:
+    secure: h+xiQ6lg0SNrHor+cwSKFCUBDk51maSQILAhLYZXWB8LvAib7TQ17ZCUiwYZ8Pwt6aacrqshWuYapbm7PzTv2kfQqtuVgPh0ILphXGXyokhv1PpIlz3bePKfa/cNwPr1GAHtAxqsZndqvRMKeAmkfH00iezGzK72xwhslnbqVfE=
+  on:
+    # Only deploy from first job in build matrix
+    condition: $TRAVIS_JOB_NUMBER = $TRAVIS_BUILD_NUMBER.1
+    tags: true
+    repo: flux-framework/flux-sched

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,13 @@ sudo: false
 compiler:
   - gcc
   - clang
-  - gcc+coverage
-  - gcc+install
+
+matrix:
+  include:
+    - compiler: gcc
+      env: COVERAGE=t
+    - compiler: gcc
+      env: TEST_INSTALL=t
 
 cache:
   directories:
@@ -18,7 +23,15 @@ cache:
 addons:
   apt:
     sources:
+      - ubuntu-toolchain-r-test
+      - llvm-toolchain-precise-3.8
+      - george-edison55-precise-backports # CMake 3.0
     packages:
+      - cmake
+      - cmake-data
+      - clang-3.8
+      - gcc-4.9
+      - g++-4.9
       - lua5.1
       - liblua5.1-0-dev
       - luarocks
@@ -32,12 +45,6 @@ addons:
       - lcov
 
 before_install:
-  # If CC has "+coverage" appended then turn on code coverage for this build
-  - case "$CC" in *+coverage) CC=${CC//+*}; export COVERAGE=t;; esac
-
-  # If CC has "+install" appended then test "make install"
-  - case "$CC" in *+install)  CC=${CC//+*}; export TEST_INSTALL=t;; esac
-
   - wget https://raw.githubusercontent.com/flux-framework/flux-core/master/src/test/travis-dep-builder.sh
   - eval $(bash ./travis-dep-builder.sh --printenv)
   - export PKG_CONFIG_PATH=$HOME/local2/lib/pkgconfig:${PKG_CONFIG_PATH}

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ matrix:
       env: TEST_INSTALL=t
     - compiler: clang
       env: CC=clang-3.8 CXX=clang++-3.8
-
+    - compiler: clang
+      env: CPPCHECK=t
 cache:
   directories:
     - $HOME/local
@@ -72,6 +73,15 @@ script:
  
  # Use "make install" and set FLUX_SCHED_TEST_INSTALLED in environment for installed testing:
  - if test "$TEST_INSTALL" = "t"; then ARGS=--prefix=$HOME/local2; MAKECMDS="make && make install && FLUX_SCHED_TEST_INSTALLED=t make check"; fi
+
+ # cppcheck instead of make
+ - >
+   if test "$CPPCHECK" = "t"; then
+     MAKECMDS="cppcheck --force --inline-suppr -j 2 --std=c99 --quiet
+             --error-exitcode=1
+             -i src/common/libtap
+              .";
+   fi
 
  - autoreconf -i && ./configure ${ARGS} && eval ${MAKECMDS}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
       env: COVERAGE=t
     - compiler: gcc
       env: TEST_INSTALL=t
+    - compiler: clang
+      env: CC=clang-3.8 CXX=clang++-3.8
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,8 @@ before_install:
   - export PKG_CONFIG_PATH=$HOME/local2/lib/pkgconfig:${PKG_CONFIG_PATH}
   - test "$TRAVIS_PULL_REQUEST" == "false" || export CCACHE_READONLY=1
   - if test "$CC" = "clang"; then export CCACHE_CPP2=1; fi
-  - bash ./travis-dep-builder.sh --cachedir=$HOME/local/.cache
+  - depbuilder=$(pwd)/travis-dep-builder.sh
+  - (mkdir -p ../depbuild && cd ../depbuild && bash ${depbuilder} --cachedir=$HOME/local/.cache)
 
   # coveralls-lcov required only for coveralls.io upload:
   - if test "$COVERAGE" = "t"; then gem install coveralls-lcov; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ script:
 
 after_success:
  - ccache -s
- - if test "$COVERAGE" = "t"; then coveralls-lcov flux*-coverage.info; fi
+ - if test "$COVERAGE" = "t"; then coveralls-lcov flux*-coverage.info;  bash <(curl -s https://codecov.io/bash); fi
 after_failure:
  - find . -name t[0-9]*.output -print0 | xargs -0 -I'{}' sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'
  - find . -name *.broker.log -print0 | xargs -0 -I'{}' sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ script:
               .";
    fi
 
- - autoreconf -i && ./configure ${ARGS} && eval ${MAKECMDS}
+ - autoreconf -i && ./configure ${ARGS} && echo $MAKECMDS && eval ${MAKECMDS}
 
 after_success:
  - ccache -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ script:
  - autoreconf -i && ./configure ${ARGS} && eval ${MAKECMDS}
 
 after_success:
- - ccacche -s
+ - ccache -s
  - if test "$COVERAGE" = "t"; then coveralls-lcov flux*-coverage.info; fi
 after_failure:
  - find . -name t[0-9]*.output -print0 | xargs -0 -I'{}' sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'

--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,1 @@
+See NEWS.md for recent Release Notes for flux-sched.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,5 @@
+
+flux-sched version 0.1.0 - 2016-05-16
+-------------------------------------
+
+ * Initial release for build testing only

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,33 @@
 
+flux-sched version 0.2.0 - 2016-08-13
+-------------------------------------
+
+#### New Features
+
+ * Versatile scheduling: replace resource tree list searches
+   with tree searches.
+
+ * Runtime selection of backfill algorithm (#159).
+   Examples of selecting various algorithms are:
+
+  - *Conservative* : `flux module load sched.backfill reserve-depth=-1`
+  - *EASY*         : `flux module load sched.backfill reserve-depth=1`
+  - *Hybrid*       : `flux module load sched.backfill reserve-depth=4`
+  - *Pure*         : `flux module load sched.backfill reserve-depth=0`
+
+#### Fixes
+
+ * Update to latest flux-core logging apis
+
+ * Fix segfaults in simulator during shutdown
+
+ * Small leak fixes in simulator
+
+#### Deprecations
+
+ * Remove `sim_sched` code that ran under simulator. The simulator
+   now interfaces directly with sched module.
+
 flux-sched version 0.1.0 - 2016-05-16
 -------------------------------------
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+ precision: 1
+ round: down
+ range: "50...100"
+ ignore:
+ - ".*/test/*.c"
+ - ".*/tests/*.c"
+ - ".*/libtap/*"
+ - ".*/libjsonc/*"
+ - ".*/libev/*"
+ patch:
+  default:
+   target: 50%
+ comment:
+  layout: "header, diff, changes, tree"

--- a/simulator/sim_execsrv.c
+++ b/simulator/sim_execsrv.c
@@ -617,6 +617,7 @@ static void run_cb (flux_t h,
 
     if (flux_msg_get_topic (msg, &topic) < 0) {
         flux_log (h, LOG_ERR, "%s: bad message", __FUNCTION__);
+        free (jobid);
         return;
     }
 


### PR DESCRIPTION
This PR updates flux-sched travis-ci with new dependencies from flux-core, adds gcc-4.9 and clang-3.8, as well as a new `cppcheck` target for testing (along with a couple fixes required for cppcheck to pass, these should be vetted by @SteVwonder).

Additionally, a `deploy:` section is added to auto-upload travis releases on tags.

Finally, a `NEWS.md` file is created with content for the upcoming `0.2.0` release. (Actually I could split that out into a separate PR if people want) 