### PR TITLE
build: strip leading "v" from tag name

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 
 AC_PREREQ([2.63])
 AC_INIT([flux-sched],
-        m4_esyscmd([git describe --always | awk '/.*/ {printf "%s",$1; exit}']))
+        m4_esyscmd([git describe --always | awk '/.*/ {sub(/^v/, ""); printf "%s",$1; exit}']))
 AC_CONFIG_SRCDIR([NEWS])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_AUX_DIR([config])


### PR DESCRIPTION
This is a copy of @garlick's fix to allow `v` prefix tags from flux-core. 

We'll need this to tag `v0.2.0` of flux-sched.

When generating PACKAGE_ variables from git describe, drop a
leading "v" character if present.  This allows release tags
to be prefixed with a "v" as is the common convention,
without that being reflected in the dist tarball, etc..