### PR TITLE
Graph work

### DIFF
--- a/conf/hype.lua
+++ b/conf/hype.lua
@@ -12,3 +12,53 @@ Hierarchy "default" {
                }
     }
 }
+
+Hierarchy "power" {
+    Resource{ "powerpanel", name="ppnl", size = 1000, children = {
+      Resource{ "pdu", name = "pdu1", id = "1", size = 500,
+        children = { ListOf{ Node,
+                       ids = "201-299",
+                       args = { basename = "hype",
+                                sockets = { "0" },
+                                size = 10 }
+                     }
+                   }
+        },
+      Resource{ "pdu", name = "pdu2", id = "2", size = 500,
+        children = { ListOf{ Node,
+                      ids = "300-354",
+                      args = { basename = "hype",
+                            sockets = { "0" },
+                            size = 20  }
+                     }
+                   }
+        }
+      }}
+}
+
+Hierarchy "bandwidth" {
+    Resource{ "filesystem", name="pfs", size = 90000, children = {
+      Resource{ "gateway", name = "gateway_node_pool", size = 90000, children = {
+        Resource{ "core_switch", name = "core_switch_pool", size = 144000, children = {
+          Resource{ "switch", name = "edge_switch1",  id = "1",size= 72000,
+            children = { ListOf{ Node,
+                         ids = "201-299",
+                         args = { basename = "hype",
+                                  sockets = { "0" },
+                                  size = 4000 }
+                           }
+                       }
+            },
+          Resource{ "switch", name = "edge_switch2",  id = "2", size= 72000,
+            children = { ListOf{ Node,
+                         ids = "300-354",
+                         args = { basename = "hype",
+                                  sockets = { "0" },
+                                  size = 4000  }
+                           }
+                       }
+            }
+        }}
+      }}
+    }}
+}

--- a/rdl/RDL/types/Node.lua
+++ b/rdl/RDL/types/Node.lua
@@ -41,6 +41,7 @@ function Node:initialize (arg)
           basename = basename,
           id = id,
           name = name,
+          size = arg.size,
           properties = arg.properties or {},
           tags = arg.tags or {}
         }

--- a/resrc/Makefile.am
+++ b/resrc/Makefile.am
@@ -8,9 +8,9 @@ SUBDIRS = . test
 
 noinst_LTLIBRARIES = libflux-resrc.la
 
-noinst_HEADERS = resrc.h resrc_tree.h resrc_reqst.h
+noinst_HEADERS = resrc.h resrc_tree.h resrc_flow.h resrc_reqst.h
 
-libflux_resrc_la_SOURCES = resrc.c resrc_tree.c resrc_reqst.c
+libflux_resrc_la_SOURCES = resrc.c resrc_tree.c resrc_flow.c resrc_reqst.c
 libflux_resrc_la_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/rdl
 libflux_resrc_la_LIBADD = $(top_builddir)/rdl/libflux-rdl.la \
     $(top_builddir)/src/common/libutil/libutil.la \

--- a/resrc/resrc.c
+++ b/resrc/resrc.c
@@ -1044,36 +1044,36 @@ bool resrc_match_resource (resrc_t *resrc, resrc_reqst_t *request,
                            bool available)
 {
     bool rc = false;
-    char *rproperty = NULL;     /* request property */
-    char *rtag = NULL;          /* request tag */
+    char *rproperty = NULL;                             /* request property */
+    char *rtag = NULL;                                  /* request tag */
+    resrc_t *reqst_resrc = resrc_reqst_resrc (request); /* request's resrc */
 
-    if (!strcmp (resrc->type, resrc_reqst_resrc (request)->type)) {
-        if (zhash_size (resrc_reqst_resrc (request)->properties)) {
+    if (reqst_resrc && !strcmp (resrc->type, reqst_resrc->type)) {
+        if (zhash_size (reqst_resrc->properties)) {
             if (!zhash_size (resrc->properties)) {
                 goto ret;
             }
             /* be sure the resource has all the requested properties */
             /* TODO: validate the value of each property */
-            zhash_first (resrc_reqst_resrc (request)->properties);
+            zhash_first (reqst_resrc->properties);
             do {
-                rproperty = (char *)zhash_cursor (
-                    resrc_reqst_resrc (request)->properties);
+                rproperty = (char *)zhash_cursor (reqst_resrc->properties);
                 if (!zhash_lookup (resrc->properties, rproperty))
                     goto ret;
-            } while (zhash_next (resrc_reqst_resrc (request)->properties));
+            } while (zhash_next (reqst_resrc->properties));
         }
 
-        if (zhash_size (resrc_reqst_resrc (request)->tags)) {
+        if (zhash_size (reqst_resrc->tags)) {
             if (!zhash_size (resrc->tags)) {
                 goto ret;
             }
             /* be sure the resource has all the requested tags */
-            zhash_first (resrc_reqst_resrc (request)->tags);
+            zhash_first (reqst_resrc->tags);
             do {
-                rtag = (char *)zhash_cursor (resrc_reqst_resrc (request)->tags);
+                rtag = (char *)zhash_cursor (reqst_resrc->tags);
                 if (!zhash_lookup (resrc->tags, rtag))
                     goto ret;
-            } while (zhash_next (resrc_reqst_resrc (request)->tags));
+            } while (zhash_next (reqst_resrc->tags));
         }
 
         if (available) {

--- a/resrc/resrc.c
+++ b/resrc/resrc.c
@@ -1159,10 +1159,28 @@ ret:
     return rc;
 }
 
-void resrc_stage_resrc (resrc_t *resrc, size_t size)
+int resrc_stage_resrc (resrc_t *resrc, size_t size)
 {
-    if (resrc)
-        resrc->staged = size;
+    int rc = -1;
+
+    if (resrc) {
+        resrc->staged += size;
+        rc = 0;
+    }
+ret:
+    return rc;
+}
+
+int resrc_unstage_resrc (resrc_t *resrc)
+{
+    int rc = -1;
+
+    if (resrc) {
+        resrc->staged = 0;
+        rc = 0;
+    }
+ret:
+    return rc;
 }
 
 /*

--- a/resrc/resrc.c
+++ b/resrc/resrc.c
@@ -125,6 +125,13 @@ size_t resrc_size (resrc_t *resrc)
     return 0;
 }
 
+size_t resrc_available (resrc_t *resrc)
+{
+    if (resrc)
+        return resrc->available;
+    return 0;
+}
+
 size_t resrc_available_at_time (resrc_t *resrc, int64_t time)
 {
     int64_t starttime = 0;
@@ -443,6 +450,20 @@ resrc_tree_t *resrc_phys_tree (resrc_t *resrc)
     if (resrc)
         return resrc->phys_tree;
     return NULL;
+}
+
+size_t resrc_size_allocs (resrc_t *resrc)
+{
+    if (resrc)
+        return zhash_size (resrc->allocs);
+    return 0;
+}
+
+size_t resrc_size_reservtns (resrc_t *resrc)
+{
+    if (resrc)
+        return zhash_size (resrc->reservtns);
+    return 0;
 }
 
 resrc_t *resrc_new_resource (const char *type, const char *path,

--- a/resrc/resrc.c
+++ b/resrc/resrc.c
@@ -1068,7 +1068,8 @@ resrc_t *resrc_create_cluster (char *cluster)
  * Finds if a resource request matches the specified resource over a period
  * defined by the start and end times.
  */
-static bool resrc_walltime_match (resrc_t *resrc, resrc_reqst_t *request)
+bool resrc_walltime_match (resrc_t *resrc, resrc_reqst_t *request,
+                           size_t reqrd_size)
 {
     bool rc = false;
     char *json_str_window = NULL;
@@ -1094,7 +1095,7 @@ static bool resrc_walltime_match (resrc_t *resrc, resrc_reqst_t *request)
     available = resrc_available_during_range (resrc, starttime, endtime,
                                               resrc_reqst_exclusive (request));
 
-    rc = (available >= resrc_reqst_reqrd_size (request));
+    rc = (available >= reqrd_size);
 
     return rc;
 }
@@ -1143,7 +1144,8 @@ bool resrc_match_resource (resrc_t *resrc, resrc_reqst_t *request,
              * expensive.
              */
             if (resrc_reqst_starttime (request))
-                rc = resrc_walltime_match (resrc, request);
+                rc = resrc_walltime_match (resrc, request,
+                                           resrc_reqst_reqrd_size (request));
             else {
                 rc = (resrc_reqst_reqrd_size (request) <= resrc->available);
                 if (rc && resrc_reqst_exclusive (request)) {

--- a/resrc/resrc.c
+++ b/resrc/resrc.c
@@ -53,7 +53,7 @@ struct resrc {
     size_t staged;
     resource_state_t state;
     resrc_tree_t *phys_tree;
-    zlist_t *graphs;
+    zhash_t *graphs;
     zhash_t *properties;
     zhash_t *tags;
     zhash_t *allocs;
@@ -480,7 +480,7 @@ resrc_t *resrc_new_resource (const char *type, const char *path,
         resrc->staged = 0;
         resrc->state = RESOURCE_INVALID;
         resrc->phys_tree = NULL;
-        resrc->graphs = NULL;
+        resrc->graphs = zhash_new ();
         resrc->allocs = zhash_new ();
         resrc->reservtns = zhash_new ();
         resrc->properties = zhash_new ();
@@ -506,7 +506,7 @@ resrc_t *resrc_copy_resource (resrc_t *resrc)
         uuid_copy (new_resrc->uuid, resrc->uuid);
         new_resrc->state = resrc->state;
         new_resrc->phys_tree = resrc_tree_copy (resrc->phys_tree);
-        new_resrc->graphs = zlist_dup (resrc->graphs);
+        new_resrc->graphs = zhash_dup (resrc->graphs);
         new_resrc->allocs = zhash_dup (resrc->allocs);
         new_resrc->reservtns = zhash_dup (resrc->reservtns);
         new_resrc->properties = zhash_dup (resrc->properties);
@@ -537,8 +537,7 @@ void resrc_resource_destroy (void *object)
             free (resrc->digest);
         /* Use resrc_tree_destroy() to destroy this resource along
          * with its physical tree */
-        if (resrc->graphs)
-            zlist_destroy (&resrc->graphs);
+        zhash_destroy (&resrc->graphs);
         zhash_destroy (&resrc->allocs);
         zhash_destroy (&resrc->reservtns);
         zhash_destroy (&resrc->properties);

--- a/resrc/resrc.c
+++ b/resrc/resrc.c
@@ -479,6 +479,13 @@ size_t resrc_size_reservtns (resrc_t *resrc)
     return 0;
 }
 
+int resrc_twindow_insert (resrc_t *resrc, const char *key, void *item)
+{
+    int rc = zhash_insert (resrc->twindow, key, item);
+    zhash_freefn (resrc->twindow, key, free);
+    return rc;
+}
+
 resrc_t *resrc_lookup (const char *path)
 {
     if (resrc_hash && path)
@@ -669,8 +676,7 @@ resrc_t *resrc_new_from_json (JSON o, resrc_t *parent, bool physical)
                 Jadd_int64 (w, "endtime", endtime);
 
                 json_str = xstrdup (Jtostr (w));
-                zhash_insert (resrc->twindow, "0", (void *) json_str);
-                zhash_freefn (resrc->twindow, "0", free);
+                resrc_twindow_insert (resrc, "0", (void *) json_str);
                 Jput (w);
             }
         }
@@ -846,8 +852,7 @@ static resrc_t *resrc_new_from_hwloc_obj (hwloc_obj_t obj, resrc_t *parent,
             Jadd_int64 (w, "starttime", epochtime ());
             Jadd_int64 (w, "endtime", TIME_MAX);
             char *json_str = xstrdup (Jtostr (w));
-            zhash_insert (resrc->twindow, "0", (void *) json_str);
-            zhash_freefn (resrc->twindow, "0", free);
+            resrc_twindow_insert (resrc, "0", (void *) json_str);
             Jput (w);
         }
     }
@@ -1225,8 +1230,7 @@ static int resrc_allocate_resource_in_time (resrc_t *resrc, int64_t job_id,
         Jadd_int64 (j, "starttime", starttime);
         Jadd_int64 (j, "endtime", endtime);
         json_str = xstrdup (Jtostr (j));
-        zhash_insert (resrc->twindow, id_ptr, (void *) json_str);
-        zhash_freefn (resrc->twindow, id_ptr, free);
+        resrc_twindow_insert (resrc, id_ptr, (void *) json_str);
         Jput (j);
 
         rc = 0;
@@ -1314,8 +1318,7 @@ static int resrc_reserve_resource_in_time (resrc_t *resrc, int64_t job_id,
         Jadd_int64 (j, "starttime", starttime);
         Jadd_int64 (j, "endtime", endtime);
         json_str = xstrdup (Jtostr (j));
-        zhash_insert (resrc->twindow, id_ptr, (void *) json_str);
-        zhash_freefn (resrc->twindow, id_ptr, free);
+        resrc_twindow_insert (resrc, id_ptr, (void *) json_str);
         Jput (j);
 
         rc = 0;

--- a/resrc/resrc.h
+++ b/resrc/resrc.h
@@ -26,6 +26,16 @@ typedef enum {
 
 
 /*
+ * Initialize necessary components of the resource library
+ */
+void resrc_init (void);
+
+/*
+ * Destroy all internal components of the resource library
+ */
+void resrc_fini (void);
+
+/*
  * Return the type of the resouce
  */
 char *resrc_type (resrc_t *resrc);
@@ -103,6 +113,11 @@ size_t resrc_size_allocs (resrc_t *resrc);
  * Return the number of jobs reserved for this resource
  */
 size_t resrc_size_reservtns (resrc_t *resrc);
+
+/*
+ * Return the pointer to the resource with the given path
+ */
+resrc_t *resrc_lookup (const char *path);
 
 /*
  * Create a new resource object

--- a/resrc/resrc.h
+++ b/resrc/resrc.h
@@ -115,6 +115,13 @@ size_t resrc_size_allocs (resrc_t *resrc);
 size_t resrc_size_reservtns (resrc_t *resrc);
 
 /*
+ *  Insert item into twindow hash table with specified key and item.
+ *  If key is already present returns -1 and leaves existing item
+ *  unchanged.  Returns 0 on success.
+ */
+int resrc_twindow_insert (resrc_t *resrc, const char *key, void *item);
+
+/*
  * Return the pointer to the resource with the given path
  */
 resrc_t *resrc_lookup (const char *path);

--- a/resrc/resrc.h
+++ b/resrc/resrc.h
@@ -198,7 +198,12 @@ bool resrc_match_resource (resrc_t *resrc, resrc_reqst_t *request,
 /*
  * Stage size elements of a resource
  */
-void resrc_stage_resrc(resrc_t *resrc, size_t size);
+int resrc_stage_resrc(resrc_t *resrc, size_t size);
+
+/*
+ * Zero-out all the staged elements of a resource
+ */
+int resrc_unstage_resrc (resrc_t *resrc);
 
 /*
  * Allocate a resource to a job

--- a/resrc/resrc.h
+++ b/resrc/resrc.h
@@ -13,6 +13,7 @@ typedef struct hwloc_topology * TOPOLOGY;
 typedef struct resrc resrc_t;
 typedef struct resrc_reqst resrc_reqst_t;
 typedef struct resrc_tree resrc_tree_t;
+typedef struct resrc_flow resrc_flow_t;
 
 typedef enum {
     RESOURCE_INVALID,
@@ -24,6 +25,10 @@ typedef enum {
     RESOURCE_END
 } resource_state_t;
 
+typedef struct resrc_graph_req {
+    char   *name;
+    size_t size;
+} resrc_graph_req_t;
 
 /*
  * Initialize necessary components of the resource library
@@ -122,6 +127,13 @@ size_t resrc_size_reservtns (resrc_t *resrc);
 int resrc_twindow_insert (resrc_t *resrc, const char *key, void *item);
 
 /*
+ *  Insert a resource flow pointer into the graph table using the
+ *  specified name.  If key is already present returns -1 and leaves
+ *  existing item unchanged.  Returns 0 on success.
+ */
+int resrc_graph_insert (resrc_t *resrc, const char *name, resrc_flow_t *flow);
+
+/*
  * Return the pointer to the resource with the given path
  */
 resrc_t *resrc_lookup (const char *path);
@@ -203,9 +215,11 @@ bool resrc_match_resource (resrc_t *resrc, resrc_reqst_t *request,
                            bool available);
 
 /*
- * Stage size elements of a resource
+ * Stage size elements of a resource along with any associated graph
+ * resources
  */
-int resrc_stage_resrc(resrc_t *resrc, size_t size);
+int resrc_stage_resrc (resrc_t *resrc, size_t size,
+                       resrc_graph_req_t *graph_req);
 
 /*
  * Zero-out all the staged elements of a resource

--- a/resrc/resrc.h
+++ b/resrc/resrc.h
@@ -185,6 +185,13 @@ void resrc_print_resource (resrc_t *resrc);
 resrc_t *resrc_create_cluster (char *cluster);
 
 /*
+ * Finds if a resource request matches the specified resource over a period
+ * defined by the start and end times.
+ */
+bool resrc_walltime_match (resrc_t *resrc, resrc_reqst_t *request,
+                           size_t reqrd_size);
+
+/*
  * Determine whether a specific resource has the required characteristics
  * Inputs:  resrc     - the specific resource under evaluation
  *          request   - resource request with the required characteristics

--- a/resrc/resrc.h
+++ b/resrc/resrc.h
@@ -68,6 +68,11 @@ int64_t resrc_id (resrc_t *resrc);
 size_t resrc_size (resrc_t *resrc);
 
 /*
+ * Return the quantity of available units
+ */
+size_t resrc_available (resrc_t *resrc);
+
+/*
  * Return the amount of the resource available at the given time
  */
 size_t resrc_available_at_time (resrc_t *resrc, int64_t time);
@@ -88,6 +93,16 @@ char* resrc_state (resrc_t *resrc);
  * Return the physical tree for the resouce
  */
 resrc_tree_t *resrc_phys_tree (resrc_t *resrc);
+
+/*
+ * Return the number of jobs allocated to this resource
+ */
+size_t resrc_size_allocs (resrc_t *resrc);
+
+/*
+ * Return the number of jobs reserved for this resource
+ */
+size_t resrc_size_reservtns (resrc_t *resrc);
 
 /*
  * Create a new resource object

--- a/resrc/resrc_flow.c
+++ b/resrc/resrc_flow.c
@@ -1,0 +1,640 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+# include <config.h>
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <assert.h>
+#include <czmq.h>
+
+#include "src/common/libutil/shortjson.h"
+#include "rdl.h"
+#include "resrc_flow.h"
+#include "resrc_reqst.h"
+#include "src/common/libutil/xzmalloc.h"
+
+struct resrc_flow_list {
+    zlist_t *list;
+};
+
+/*
+ * A resrc_flow structure requires the following members to represent
+ * flow that reaches a resource and is independent from the attributes
+ * of the physical resource (resrc_t members).  For example, a compute
+ * node resource could receive power from an enclosure which is
+ * powered by a pdu.  Hence the node's "flow resource" models
+ * electrical current and is a member of the power flow hierarchy
+ * while the associated compute node resource is part of the physical
+ * hierarchy with separate parentage.
+ *
+ *  char *path;
+ *  char *basename;
+ *  char *name;
+ *  size_t size;
+ *  size_t available;
+ *  size_t staged;
+ *  zhash_t *allocs;
+ *  zhash_t *reservtns;
+ *  zhash_t *twindow;
+ *
+ * The resrc_flow structure therefore includes a flow_resrc resource,
+ * independent from the associated resource, to hold all these values
+ * and allow us to leverage the resrc's time window search code.
+ */
+
+struct resrc_flow {
+    resrc_flow_t *parent;
+    resrc_t *resrc;
+    resrc_t *flow_resrc;
+    resrc_flow_list_t *children;
+};
+
+/***********************************************************************
+ * Resource flow
+ ***********************************************************************/
+
+resrc_t *resrc_flow_resrc (resrc_flow_t *resrc_flow)
+{
+    if (resrc_flow)
+        return resrc_flow->resrc;
+    return NULL;
+}
+
+resrc_t *resrc_flow_flow_resrc (resrc_flow_t *resrc_flow)
+{
+    if (resrc_flow)
+        return resrc_flow->flow_resrc;
+    return NULL;
+}
+
+size_t resrc_flow_num_children (resrc_flow_t *resrc_flow)
+{
+    if (resrc_flow)
+        return resrc_flow_list_size (resrc_flow->children);
+    return 0;
+}
+
+resrc_flow_list_t *resrc_flow_children (resrc_flow_t *resrc_flow)
+{
+    if (resrc_flow)
+        return resrc_flow->children;
+    return NULL;
+}
+
+int resrc_flow_add_child (resrc_flow_t *parent, resrc_flow_t *child)
+{
+    int rc = -1;
+    if (parent) {
+        child->parent = parent;
+        rc = resrc_flow_list_append (parent->children, child);
+    }
+
+    return rc;
+}
+
+resrc_flow_t *resrc_flow_new (resrc_flow_t *parent, resrc_t *flow_resrc,
+                              resrc_t *resrc)
+{
+    resrc_flow_t *resrc_flow = xzmalloc (sizeof (resrc_flow_t));
+
+    if (resrc_flow) {
+        resrc_flow->parent = parent;
+        resrc_flow->resrc = resrc;
+        resrc_flow->flow_resrc = flow_resrc;
+        resrc_flow->children = resrc_flow_list_new ();
+        if (parent)
+            (void) resrc_flow_add_child (parent, resrc_flow);
+    }
+
+    return resrc_flow;
+}
+
+resrc_flow_t *resrc_flow_copy (resrc_flow_t *resrc_flow)
+{
+    resrc_flow_t *new_resrc_flow = xzmalloc (sizeof (resrc_flow_t));
+
+    if (new_resrc_flow) {
+        new_resrc_flow->parent = resrc_flow->parent;
+        new_resrc_flow->resrc = resrc_flow->resrc;
+        new_resrc_flow->flow_resrc = resrc_flow->flow_resrc;
+        new_resrc_flow->children = resrc_flow_list_new ();
+        new_resrc_flow->children->list = zlist_dup (resrc_flow->children->list);
+    }
+
+    return new_resrc_flow;
+}
+
+void resrc_flow_destroy (resrc_flow_t *resrc_flow)
+{
+    if (resrc_flow) {
+        if (resrc_flow->parent)
+            resrc_flow_list_remove (resrc_flow->parent->children, resrc_flow);
+        if (resrc_flow->children) {
+            resrc_flow_list_destroy (resrc_flow->children);
+            resrc_flow->children = NULL;
+        }
+        resrc_resource_destroy (resrc_flow->flow_resrc);
+        free (resrc_flow);
+    }
+}
+
+resrc_flow_t *resrc_flow_new_from_json (JSON o, resrc_flow_t *parent)
+{
+    JSON jhierarchyo = NULL; /* json hierarchy object */
+    const char *basename = NULL;
+    const char *name = NULL;
+    const char *hierarchy = NULL;
+    const char *path = NULL;
+    const char *hierarchy_path = NULL;
+    const char *tmp = NULL;
+    const char *type = NULL;
+    int64_t id;
+    int64_t ssize;
+    resrc_flow_t *resrc_flow = NULL;
+    resrc_t *flow_resrc;
+    resrc_t *resrc = NULL;
+    size_t size = 1;
+    uuid_t uuid;
+
+    if (!Jget_str (o, "type", &type))
+        goto ret;
+    Jget_str (o, "basename", &basename);
+    Jget_str (o, "name", &name);
+    if (!(Jget_int64 (o, "id", &id)))
+        id = -1;
+    if (Jget_str (o, "uuid", &tmp))
+        uuid_parse (tmp, uuid);
+    else
+        uuid_clear(uuid);
+    if (Jget_int64 (o, "size", &ssize))
+        size = (size_t) ssize;
+    if ((jhierarchyo = Jobj_get (o, "hierarchy"))) {
+        struct json_object *val = NULL;
+        struct lh_entry *entry = json_object_get_object (jhierarchyo)->head;
+
+        if (entry) {
+            hierarchy = (char*)entry->k;
+            val = (struct json_object*)entry->v;
+            hierarchy_path = json_object_get_string (val);
+        }
+    }
+    if (!Jget_str (o, "path", &path)) {
+        if (hierarchy_path)
+            path = xstrdup (hierarchy_path);
+    }
+    if (!path) {
+        if (parent)
+            path = xasprintf ("%s/%s", resrc_path (parent->flow_resrc), name);
+        else
+            path = xasprintf ("/%s", name);
+    }
+
+    if (!(flow_resrc = resrc_new_resource (type, path, basename, name, NULL, id,
+                                           uuid, size)))
+        goto ret;
+
+    if (!strncmp (type, "node", 5)) {
+        resrc = resrc_lookup (name);
+    }
+    if ((resrc_flow = resrc_flow_new (parent, flow_resrc, resrc))) {
+        /* add time window if we are given a start time */
+        int64_t starttime;
+        if (Jget_int64 (o, "starttime", &starttime)) {
+            JSON    w = Jnew ();
+            char    *json_str;
+            int64_t endtime;
+            int64_t wall_time;
+
+            Jadd_int64 (w, "starttime", starttime);
+
+            if (!Jget_int64 (o, "endtime", &endtime)) {
+                if (Jget_int64 (o, "walltime", &wall_time))
+                    endtime = starttime + wall_time;
+                else
+                    endtime = TIME_MAX;
+            }
+            Jadd_int64 (w, "endtime", endtime);
+
+            json_str = xstrdup (Jtostr (w));
+            resrc_twindow_insert (resrc_flow->flow_resrc, "0",
+                                  (void *) json_str);
+            Jput (w);
+        }
+    }
+    if (resrc)
+        resrc_graph_insert (resrc, hierarchy, resrc_flow);
+ret:
+    return resrc_flow;
+}
+
+
+static resrc_flow_t *resrc_flow_add_rdl (resrc_flow_t *parent,
+                                         struct resource *r)
+{
+    JSON o = NULL;
+    resrc_flow_t *resrc_flow = NULL;
+    struct resource *c;
+
+    o = rdl_resource_json (r);
+    resrc_flow = resrc_flow_new_from_json (o, parent);
+
+    while ((c = rdl_resource_next_child (r))) {
+        (void) resrc_flow_add_rdl (resrc_flow, c);
+        rdl_resource_destroy (c);
+    }
+
+    Jput (o);
+    return resrc_flow;
+}
+
+resrc_flow_t *resrc_flow_generate_rdl (const char *path, char *uri)
+{
+    resrc_flow_t *flow = NULL;
+    struct rdl *rdl = NULL;
+    struct rdllib *l = NULL;
+    struct resource *r = NULL;
+
+    if (!(l = rdllib_open ()) || !(rdl = rdl_loadfile (l, path)))
+        goto ret;
+
+    if ((r = rdl_resource_get (rdl, uri)))
+        flow = resrc_flow_add_rdl (NULL, r);
+
+    rdl_destroy (rdl);
+    rdllib_close (l);
+ret:
+    return flow;
+}
+
+void resrc_flow_print (resrc_flow_t *resrc_flow)
+{
+    if (resrc_flow) {
+        resrc_print_resource (resrc_flow->flow_resrc);
+        if (resrc_flow_num_children (resrc_flow)) {
+            resrc_flow_t *child = resrc_flow_list_first (resrc_flow->children);
+            while (child) {
+                resrc_flow_print (child);
+                child = resrc_flow_list_next (resrc_flow->children);
+            }
+        }
+    }
+}
+
+int resrc_flow_serialize (JSON o, resrc_flow_t *resrc_flow)
+{
+    int rc = -1;
+
+    if (o && resrc_flow) {
+        rc = resrc_to_json (o, resrc_flow->flow_resrc);
+        if (!rc && resrc_flow_num_children (resrc_flow)) {
+            JSON ja = Jnew_ar ();
+
+            if (!(rc = resrc_flow_list_serialize (ja, resrc_flow->children)))
+                json_object_object_add (o, "children", ja);
+        }
+    }
+    return rc;
+}
+
+resrc_flow_t *resrc_flow_deserialize (JSON o, resrc_flow_t *parent)
+{
+    JSON ca = NULL;     /* array of child json objects */
+    JSON co = NULL;     /* child json object */
+    resrc_t *resrc = NULL;
+    resrc_flow_t *resrc_flow = NULL;
+
+    resrc = resrc_new_from_json (o, NULL, false);
+    if (resrc) {
+        resrc_flow = resrc_flow_new (parent, resrc, NULL);
+
+        if ((ca = Jobj_get (o, "children"))) {
+            int i, nchildren = 0;
+
+            if (Jget_ar_len (ca, &nchildren)) {
+                for (i=0; i < nchildren; i++) {
+                    Jget_ar_obj (ca, i, &co);
+                    (void) resrc_flow_deserialize (co, resrc_flow);
+                }
+            }
+        }
+    }
+
+    return resrc_flow;
+}
+
+int resrc_flow_allocate (resrc_flow_t *resrc_flow, int64_t job_id,
+                         int64_t starttime, int64_t endtime)
+{
+    int rc = -1;
+    if (resrc_flow) {
+        rc = resrc_allocate_resource (resrc_flow->flow_resrc, job_id,
+                                      starttime, endtime);
+        if (resrc_flow->parent)
+            rc = resrc_flow_allocate (resrc_flow->parent, job_id,
+                                      starttime, endtime);
+    }
+    return rc;
+}
+
+int resrc_flow_reserve (resrc_flow_t *resrc_flow, int64_t job_id,
+                        int64_t starttime, int64_t endtime)
+{
+    int rc = -1;
+    if (resrc_flow) {
+        rc = resrc_reserve_resource (resrc_flow->flow_resrc, job_id,
+                                     starttime, endtime);
+        if (resrc_flow->parent)
+            rc = resrc_flow_reserve (resrc_flow->parent, job_id,
+                                     starttime, endtime);
+    }
+    return rc;
+}
+
+int resrc_flow_release (resrc_flow_t *resrc_flow, int64_t job_id)
+{
+    int rc = -1;
+    if (resrc_flow) {
+        rc = resrc_release_allocation (resrc_flow->flow_resrc, job_id);
+        if (resrc_flow->parent)
+            rc = resrc_flow_release (resrc_flow->parent, job_id);
+    }
+    return rc;
+}
+
+int resrc_flow_release_all_reservations (resrc_flow_t *resrc_flow)
+{
+    int rc = -1;
+    if (resrc_flow) {
+        rc = resrc_release_all_reservations (resrc_flow->flow_resrc);
+        if (resrc_flow->parent)
+            rc = resrc_flow_release_all_reservations (resrc_flow->parent);
+    }
+    return rc;
+}
+
+int resrc_flow_stage_resources (resrc_flow_t *resrc_flow, size_t size)
+{
+    int rc =-1;
+
+    if (resrc_flow) {
+        rc = resrc_stage_resrc (resrc_flow->flow_resrc, size, NULL);
+        if (!rc && resrc_flow->parent)
+            rc = resrc_flow_stage_resources (resrc_flow->parent, size);
+    }
+    return rc;
+}
+
+int resrc_flow_unstage_resources (resrc_flow_t *resrc_flow)
+{
+    int rc =-1;
+
+    if (resrc_flow) {
+        rc = resrc_unstage_resrc (resrc_flow->flow_resrc);
+        if (!rc && resrc_flow->parent)
+            rc = resrc_flow_unstage_resources (resrc_flow->parent);
+    }
+    return rc;
+}
+
+/*
+ * We rely on the available value of this node in the flow graph being
+ * current.  This eliminates the need to check every parent up the
+ * tree for available flow.
+ */
+bool resrc_flow_available (resrc_flow_t *resrc_flow, size_t flow,
+                           resrc_reqst_t *request)
+{
+    bool rc = false;
+
+    if (resrc_flow && resrc_flow->flow_resrc) {
+        resrc_t *flow_resrc = resrc_flow->flow_resrc;
+
+        if (resrc_reqst_starttime (request))
+            rc = resrc_walltime_match (flow_resrc, request, flow);
+        else {
+            rc = flow <= resrc_available (flow_resrc);
+            if (rc && resrc_reqst_exclusive (request)) {
+                rc = !resrc_size_allocs (flow_resrc) &&
+                    !resrc_size_reservtns (flow_resrc);
+            }
+        }
+    }
+
+    return rc;
+}
+
+/***********************************************************************
+ * Resource flow list
+ ***********************************************************************/
+
+resrc_flow_list_t *resrc_flow_list_new ()
+{
+    resrc_flow_list_t *new_list = xzmalloc (sizeof (resrc_flow_list_t));
+    new_list->list = zlist_new ();
+    return new_list;
+}
+
+int resrc_flow_list_append (resrc_flow_list_t *rfl, resrc_flow_t *rf)
+{
+    if (rfl && rfl->list && rf)
+        return zlist_append (rfl->list, (void *) rf);
+    return -1;
+}
+
+resrc_flow_t *resrc_flow_list_first (resrc_flow_list_t *rfl)
+{
+    if (rfl && rfl->list)
+        return zlist_first (rfl->list);
+    return NULL;
+}
+
+resrc_flow_t *resrc_flow_list_next (resrc_flow_list_t *rfl)
+{
+    if (rfl && rfl->list)
+        return zlist_next (rfl->list);
+    return NULL;
+}
+
+size_t resrc_flow_list_size (resrc_flow_list_t *rfl)
+{
+    if (rfl && rfl->list)
+        return zlist_size (rfl->list);
+    return 0;
+}
+
+void resrc_flow_list_remove (resrc_flow_list_t *rfl, resrc_flow_t *rf)
+{
+    zlist_remove (rfl->list, rf);
+}
+
+void resrc_flow_list_destroy (resrc_flow_list_t *resrc_flow_list)
+{
+    if (resrc_flow_list) {
+        if (resrc_flow_list_size (resrc_flow_list)) {
+            resrc_flow_t *child = resrc_flow_list_first (resrc_flow_list);
+            while (child) {
+                resrc_flow_destroy (child);
+                child = resrc_flow_list_next (resrc_flow_list);
+            }
+        }
+        if (resrc_flow_list->list) {
+            zlist_destroy (&(resrc_flow_list->list));
+        }
+        free (resrc_flow_list);
+    }
+}
+
+int resrc_flow_list_serialize (JSON o, resrc_flow_list_t *rfl)
+{
+    resrc_flow_t *rf;
+    int rc = -1;
+
+    if (o && rfl && rfl->list) {
+        rc = 0;
+        rf = resrc_flow_list_first (rfl);
+        while (rf) {
+            JSON co = Jnew ();
+
+            if ((rc = resrc_flow_serialize (co, rf)))
+                break;
+            json_object_array_add (o, co);
+            rf = resrc_flow_list_next (rfl);
+        }
+    }
+
+    return rc;
+}
+
+resrc_flow_list_t *resrc_flow_list_deserialize (JSON o)
+{
+    JSON ca = NULL;     /* array of child json objects */
+    int i, nchildren = 0;
+    resrc_flow_t *rf = NULL;
+    resrc_flow_list_t *rfl = resrc_flow_list_new ();
+
+    if (o && rfl) {
+        if (Jget_ar_len (o, &nchildren)) {
+            for (i=0; i < nchildren; i++) {
+                Jget_ar_obj (o, i, &ca);
+                rf = resrc_flow_deserialize (ca, NULL);
+                if (!rf || resrc_flow_list_append (rfl, rf))
+                    break;
+            }
+        }
+    }
+
+    return rfl;
+}
+
+int resrc_flow_list_allocate (resrc_flow_list_t *rtl, int64_t job_id,
+                              int64_t starttime, int64_t endtime)
+{
+    resrc_flow_t *rt;
+    int rc = -1;
+
+    if (rtl) {
+        rc = 0;
+        rt = resrc_flow_list_first (rtl);
+        while (!rc && rt) {
+            rc = resrc_flow_allocate (rt, job_id, starttime, endtime);
+            rt = resrc_flow_list_next (rtl);
+        }
+    }
+
+    return rc;
+}
+
+int resrc_flow_list_reserve (resrc_flow_list_t *rtl, int64_t job_id,
+                             int64_t starttime, int64_t endtime)
+{
+    resrc_flow_t *rt;
+    int rc = -1;
+
+    if (rtl) {
+        rc = 0;
+        rt = resrc_flow_list_first (rtl);
+        while (!rc && rt) {
+            rc = resrc_flow_reserve (rt, job_id, starttime, endtime);
+            rt = resrc_flow_list_next (rtl);
+        }
+    }
+
+    return rc;
+}
+
+int resrc_flow_list_release (resrc_flow_list_t *rtl, int64_t job_id)
+{
+    resrc_flow_t *rt;
+    int rc = -1;
+
+    if (rtl) {
+        rc = 0;
+        rt = resrc_flow_list_first (rtl);
+        while (!rc && rt) {
+            rc = resrc_flow_release (rt, job_id);
+            rt = resrc_flow_list_next (rtl);
+        }
+    }
+
+    return rc;
+}
+
+int resrc_flow_list_release_all_reservations (resrc_flow_list_t *rtl)
+{
+    resrc_flow_t *rt;
+    int rc = -1;
+
+    if (rtl) {
+        rc = 0;
+        rt = resrc_flow_list_first (rtl);
+        while (!rc && rt) {
+            rc = resrc_flow_release_all_reservations (rt);
+            rt = resrc_flow_list_next (rtl);
+        }
+    }
+
+    return rc;
+}
+
+void resrc_flow_list_unstage_resources (resrc_flow_list_t *rtl)
+{
+    resrc_flow_t *rt;
+
+    if (rtl) {
+        rt = resrc_flow_list_first (rtl);
+        while (rt) {
+            resrc_flow_unstage_resources (rt);
+            rt = resrc_flow_list_next (rtl);
+        }
+    }
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */
+

--- a/resrc/resrc_flow.h
+++ b/resrc/resrc_flow.h
@@ -1,0 +1,198 @@
+#ifndef FLUX_RESRC_FLOW_H
+#define FLUX_RESRC_FLOW_H
+
+/*
+ *  C API interface to Flux Resource Flow Graph
+ */
+
+#include "resrc.h"
+
+typedef struct resrc_flow_list resrc_flow_list_t;
+
+/***********************************************************************
+ * Resource flow API
+ ***********************************************************************/
+/*
+ * Return the resrc_t associated with this flow
+ */
+resrc_t *resrc_flow_resrc (resrc_flow_t *resrc_flow);
+
+/*
+ * Return the resrc_t containing the flow information
+ */
+resrc_t *resrc_flow_flow_resrc (resrc_flow_t *resrc_flow);
+
+/*
+ * Return the number of children in the resource flow
+ */
+size_t resrc_flow_num_children (resrc_flow_t *resrc_flow);
+
+/*
+ * Return the list of child resource flows for the resouce flow input
+ */
+resrc_flow_list_t *resrc_flow_children (resrc_flow_t *resrc_flow);
+
+/*
+ * Add a child resource flow to the input resource flow
+ */
+int resrc_flow_add_child (resrc_flow_t *parent, resrc_flow_t *child);
+
+/*
+ * Create a new resrc_flow_t object
+ */
+resrc_flow_t *resrc_flow_new (resrc_flow_t *parent, resrc_t *flow_resrc,
+                              resrc_t *resrc);
+
+/*
+ * Return a copy of the input resource flow
+ */
+resrc_flow_t *resrc_flow_copy (resrc_flow_t *resrc_flow);
+
+/*
+ * Destroy an entire flow of resrc_flow_t objects
+ */
+void resrc_flow_destroy (resrc_flow_t *resrc_flow);
+
+/*
+ * Create a resrc_flow_t object from a json object
+ */
+resrc_flow_t *resrc_flow_new_from_json (JSON o, resrc_flow_t *parent);
+
+/*
+ * Return the head of a resource flow tree of all resources described
+ * by an rdl-formatted configuration file
+ */
+resrc_flow_t *resrc_flow_generate_rdl (const char *path, char *uri);
+
+/*
+ * Print the resources in a resrc_flow_t object
+ */
+void resrc_flow_print (resrc_flow_t *resrc_flow);
+
+/*
+ * Add the input resource flow to the json object
+ */
+int resrc_flow_serialize (json_object *o, resrc_flow_t *resrc_flow);
+
+/*
+ * Allocate all the resources in a resource flow
+ */
+int resrc_flow_allocate (resrc_flow_t *resrc_flow, int64_t job_id,
+                         int64_t starttime, int64_t endtime);
+
+/*
+ * Reserve all the resources in a resource flow
+ */
+int resrc_flow_reserve (resrc_flow_t *resrc_flow, int64_t job_id,
+                        int64_t starttime, int64_t endtime);
+
+/*
+ * Release an allocation from a resource flow
+ */
+int resrc_flow_release (resrc_flow_t *resrc_flow, int64_t job_id);
+
+/*
+ * Remove all reservations from a resource flow
+ */
+int resrc_flow_release_all_reservations (resrc_flow_t *resrc_flow);
+
+/*
+ * Stage the required quantity of the resource flow
+ */
+int resrc_flow_stage_resources (resrc_flow_t *resrc_flow, size_t size);
+
+/*
+ * Unstage all resources in a resource flow
+ */
+int resrc_flow_unstage_resources (resrc_flow_t *resrc_flow);
+
+/*
+ * Create a resource flow from a json object
+ */
+resrc_flow_t *resrc_flow_deserialize (json_object *o, resrc_flow_t *parent);
+
+/*
+ * We rely on the available value of this node in the flow graph being
+ * current.  This eliminates the need to check every parent up the
+ * tree for available flow.
+ */
+bool resrc_flow_available (resrc_flow_t *resrc_flow, size_t flow,
+                           resrc_reqst_t *request);
+
+/***********************************************************************
+ * Resource flow list
+ ***********************************************************************/
+/*
+ * Create a new list of resrc_flow_t objects
+ */
+resrc_flow_list_t *resrc_flow_list_new ();
+
+/*
+ * Append a resource flow to the resource flow list
+ */
+int resrc_flow_list_append (resrc_flow_list_t *rfl, resrc_flow_t *rf);
+
+/*
+ * Get the first element in the resource flow list
+ */
+resrc_flow_t *resrc_flow_list_first (resrc_flow_list_t *rfl);
+
+/*
+ * Get the next element in the resource flow list
+ */
+resrc_flow_t *resrc_flow_list_next (resrc_flow_list_t *rfl);
+
+/*
+ * Get the number of elements in the resource flow list
+ */
+size_t resrc_flow_list_size (resrc_flow_list_t *rfl);
+
+/*
+ * Remove an item from the resource flow list
+ */
+void resrc_flow_list_remove (resrc_flow_list_t *rfl, resrc_flow_t *rf);
+
+/*
+ * Destroy a resrc_flow_list_t object including all children
+ */
+void resrc_flow_list_destroy (resrc_flow_list_t *rfl);
+
+/*
+ * Add the input list of resource flows to the json array object
+ */
+int resrc_flow_list_serialize (json_object *o, resrc_flow_list_t *rfl);
+
+/*
+ * Create a resource flow list from a json object
+ */
+resrc_flow_list_t *resrc_flow_list_deserialize (json_object *o);
+
+/*
+ * Allocate all the resources in a list of resource flows
+ */
+int resrc_flow_list_allocate (resrc_flow_list_t *rtl, int64_t job_id,
+                              int64_t starttime, int64_t endtime);
+
+/*
+ * Reserve all the resources in a list of resource flows
+ */
+int resrc_flow_list_reserve (resrc_flow_list_t *rtl, int64_t job_id,
+                             int64_t starttime, int64_t endtime);
+
+/*
+ * Release an allocation from a list of resource flows
+ */
+int resrc_flow_list_release (resrc_flow_list_t *rtl, int64_t job_id);
+
+/*
+ * Release all the reservations from a list of resource flows
+ */
+int resrc_flow_list_release_all_reservations (resrc_flow_list_t *rtl);
+
+/*
+ * Unstage all resources in a list of resource flows
+ */
+void resrc_flow_list_unstage_resources (resrc_flow_list_t *rtl);
+
+
+#endif /* !FLUX_RESRC_FLOW_H */

--- a/resrc/resrc_reqst.h
+++ b/resrc/resrc_reqst.h
@@ -21,6 +21,12 @@ typedef struct resrc_reqst_list resrc_reqst_list_t;
 resrc_t *resrc_reqst_resrc (resrc_reqst_t *resrc_reqst);
 
 /*
+ * Return the array of graph names:sizes associated with this resource
+ * request
+ */
+resrc_graph_req_t *resrc_reqst_graph_reqs (resrc_reqst_t *resrc_reqst);
+
+/*
  * Return the start time of this request
  */
 int64_t resrc_reqst_starttime (resrc_reqst_t *resrc_reqst);

--- a/resrc/resrc_tree.c
+++ b/resrc/resrc_tree.c
@@ -237,7 +237,7 @@ int resrc_tree_release_all_reservations (resrc_tree_t *resrc_tree)
 void resrc_tree_unstage_resources (resrc_tree_t *resrc_tree)
 {
     if (resrc_tree) {
-        resrc_stage_resrc (resrc_tree->resrc, 0);
+        resrc_unstage_resrc (resrc_tree->resrc);
         if (resrc_tree_num_children (resrc_tree))
             resrc_tree_list_unstage_resources (resrc_tree->children);
     }

--- a/resrc/test/tresrc.c
+++ b/resrc/test/tresrc.c
@@ -41,6 +41,7 @@
 
 
 static struct timeval start_time;
+int verbose = 0;
 
 void init_time() {
     gettimeofday(&start_time, NULL);
@@ -232,7 +233,6 @@ static int test_a_resrc (resrc_t *resrc, bool rdl)
 {
     int found = 0;
     int rc = 0;
-    int verbose = 0;
     int64_t nowtime = epochtime ();
     JSON o = NULL;
     JSON req_res = NULL;

--- a/resrc/test/tresrc.c
+++ b/resrc/test/tresrc.c
@@ -432,16 +432,19 @@ int main (int argc, char *argv[])
         ok ((access (filename, R_OK) == 0), "resource file readable");
 
         init_time();
+        resrc_init ();
         resrc = resrc_generate_rdl_resources (filename, "default");
         ok ((resrc != NULL), "resource generation from config file took: %lf",
             ((double)get_time())/1000000);
         if (resrc) {
             rc1 = test_a_resrc (resrc, true);
             resrc_tree_destroy (resrc_phys_tree (resrc), true);
+            resrc_fini ();
         }
     }
 
     init_time();
+    resrc_init ();
     ok ((hwloc_topology_init (&topology) == 0),
         "hwloc topology init succeeded");
     ok ((hwloc_topology_load (topology) == 0),
@@ -455,6 +458,7 @@ int main (int argc, char *argv[])
     if (resrc) {
         rc2 = test_a_resrc (resrc, false);
         resrc_tree_destroy (resrc_phys_tree (resrc), true);
+        resrc_fini ();
     }
 
     done_testing ();

--- a/resrc/test/tresrc.c
+++ b/resrc/test/tresrc.c
@@ -356,6 +356,7 @@ static int test_a_resrc (resrc_t *resrc, bool rdl)
         rc = resrc_tree_allocate (selected_tree, 1, 0, 0);
     ok (!rc, "successfully allocated resources for job 1");
     resrc_tree_destroy (selected_tree, false);
+    resrc_tree_unstage_resources (found_tree);
 
     selected_tree = test_select_resources (found_tree, NULL, 2);
     if (rdl)
@@ -364,6 +365,7 @@ static int test_a_resrc (resrc_t *resrc, bool rdl)
         rc = resrc_tree_allocate (selected_tree, 2, 0, 0);
     ok (!rc, "successfully allocated resources for job 2");
     resrc_tree_destroy (selected_tree, false);
+    resrc_tree_unstage_resources (found_tree);
 
     selected_tree = test_select_resources (found_tree, NULL, 3);
     if (rdl)
@@ -372,6 +374,7 @@ static int test_a_resrc (resrc_t *resrc, bool rdl)
         rc = resrc_tree_allocate (selected_tree, 3, 0, 0);
     ok (!rc, "successfully allocated resources for job 3");
     resrc_tree_destroy (selected_tree, false);
+    resrc_tree_unstage_resources (found_tree);
 
     selected_tree = test_select_resources (found_tree, NULL, 4);
     if (rdl)
@@ -380,6 +383,7 @@ static int test_a_resrc (resrc_t *resrc, bool rdl)
         rc = resrc_tree_reserve (selected_tree, 4, 0, 0);
     ok (!rc, "successfully reserved resources for job 4");
     resrc_tree_destroy (selected_tree, false);
+    resrc_tree_unstage_resources (found_tree);
 
     printf ("        allocate and reserve took: %lf\n",
             ((double)get_time ())/1000000);

--- a/sched/sched.c
+++ b/sched/sched.c
@@ -266,6 +266,7 @@ static void freectx (void *arg)
     rs2rank_tab_destroy (ctx->machs);
     ssrvarg_free (&(ctx->arg));
     resrc_tree_destroy (resrc_phys_tree (ctx->rctx.root_resrc), true);
+    resrc_fini ();
     free (ctx->rctx.root_uri);
     free_simstate (ctx->sctx.sim_state);
     if (ctx->sctx.res_queue)
@@ -296,6 +297,7 @@ static ssrvctx_t *getctx (flux_t h)
         if (!(ctx->machs = rs2rank_tab_new ()))
             oom ();
         ssrvarg_init (&(ctx->arg));
+        resrc_init ();
         ctx->rctx.root_resrc = NULL;
         ctx->rctx.root_uri = NULL;
         ctx->sctx.in_sim = false;

--- a/sched/sched_backfill.c
+++ b/sched/sched_backfill.c
@@ -201,7 +201,8 @@ resrc_tree_t *select_resources (flux_t h, resrc_tree_t *found_tree,
                                      resrc_reqst_children (resrc_reqst),
                                      selected_tree)) {
                     resrc_stage_resrc (resrc,
-                                       resrc_reqst_reqrd_size (resrc_reqst));
+                                       resrc_reqst_reqrd_size (resrc_reqst),
+                                       resrc_reqst_graph_reqs (resrc_reqst));
                     resrc_reqst_add_found (resrc_reqst, 1);
                     flux_log (h, LOG_DEBUG, "selected %s", resrc_name (resrc));
                 } else {
@@ -210,7 +211,8 @@ resrc_tree_t *select_resources (flux_t h, resrc_tree_t *found_tree,
             }
         } else {
             selected_tree = resrc_tree_new (selected_parent, resrc);
-            resrc_stage_resrc (resrc, resrc_reqst_reqrd_size (resrc_reqst));
+            resrc_stage_resrc (resrc, resrc_reqst_reqrd_size (resrc_reqst),
+                                       resrc_reqst_graph_reqs (resrc_reqst));
             resrc_reqst_add_found (resrc_reqst, 1);
             flux_log (h, LOG_DEBUG, "selected %s", resrc_name (resrc));
         }

--- a/sched/sched_fcfs.c
+++ b/sched/sched_fcfs.c
@@ -185,7 +185,8 @@ resrc_tree_t *select_resources (flux_t h, resrc_tree_t *found_tree,
                                      resrc_reqst_children (resrc_reqst),
                                      selected_tree)) {
                     resrc_stage_resrc (resrc,
-                                       resrc_reqst_reqrd_size (resrc_reqst));
+                                       resrc_reqst_reqrd_size (resrc_reqst),
+                                       resrc_reqst_graph_reqs (resrc_reqst));
                     resrc_reqst_add_found (resrc_reqst, 1);
                     flux_log (h, LOG_DEBUG, "selected %s", resrc_name (resrc));
                 } else {
@@ -194,7 +195,8 @@ resrc_tree_t *select_resources (flux_t h, resrc_tree_t *found_tree,
             }
         } else {
             selected_tree = resrc_tree_new (selected_parent, resrc);
-            resrc_stage_resrc (resrc, resrc_reqst_reqrd_size (resrc_reqst));
+            resrc_stage_resrc (resrc, resrc_reqst_reqrd_size (resrc_reqst),
+                               resrc_reqst_graph_reqs (resrc_reqst));
             resrc_reqst_add_found (resrc_reqst, 1);
             flux_log (h, LOG_DEBUG, "selected %s", resrc_name (resrc));
         }


### PR DESCRIPTION
Introduce flow graph support to the resrc
    
Expanded the resrc module to support associations to hierarchies beyond just the physical, composite hierarchy.  Multiple hierarchies are now represented by the new flow_graph module.

Yet to do is expand the sched module to exercise scheduling of the flow graphs.  However, I wanted to provide an early preview of the changes.