### PR TITLE
optimizations: add queue-depth and better job search support

### DIFF
--- a/sched/Makefile.am
+++ b/sched/Makefile.am
@@ -19,20 +19,20 @@ schedplugin_LTLIBRARIES = sched_fcfs.la \
 
 noinst_HEADERS = scheduler.h rs2rank.h rsreader.h
 
-sched_la_SOURCES = sched.c rs2rank.c rsreader.c plugin.c plugin.h
+sched_la_SOURCES = sched.c scheduler.h rs2rank.c rsreader.c plugin.c plugin.h
 sched_la_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/resrc
 sched_la_LIBADD = $(top_builddir)/resrc/libflux-resrc.la \
     $(FLUX_CORE_LIBS) $(JSON_LIBS) $(CZMQ_LIBS) \
     $(top_builddir)/simulator/libflux-sim.la
 sched_la_LDFLAGS = $(AM_LDFLAGS) $(fluxmod_ldflags) -module
 
-sched_fcfs_la_SOURCES = sched_fcfs.c
+sched_fcfs_la_SOURCES = sched_fcfs.c scheduler.h
 sched_fcfs_la_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/resrc
 sched_fcfs_la_LIBADD = $(top_builddir)/resrc/libflux-resrc.la \
     $(FLUX_CORE_LIBS) $(JSON_LIBS) $(CZMQ_LIBS)
 sched_fcfs_la_LDFLAGS = $(AM_LDFLAGS) $(schedplugin_ldflags)
 
-sched_backfill_la_SOURCES = sched_backfill.c
+sched_backfill_la_SOURCES = sched_backfill.c scheduler.h
 sched_backfill_la_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/resrc
 sched_backfill_la_LIBADD = $(top_builddir)/resrc/libflux-resrc.la \
     $(FLUX_CORE_LIBS) $(JSON_LIBS) $(CZMQ_LIBS)

--- a/sched/plugin.c
+++ b/sched/plugin.c
@@ -30,9 +30,7 @@
 #include <czmq.h>
 
 #include "src/common/libutil/shortjson.h"
-#include "resrc.h"
-#include "resrc_tree.h"
-#include "resrc_reqst.h"
+#include "scheduler.h"
 #include "plugin.h"
 
 struct sched_plugin_loader {
@@ -212,6 +210,7 @@ static void insmod_cb (flux_t h, flux_msg_handler_t *w,
 {
     struct sched_plugin_loader *sploader = arg;
     struct sched_plugin *plugin = sched_plugin_get (sploader);
+    const sched_params_t *sp = sched_params_get (h);
     const char *json_str;
     char *path = NULL;
     char *argz = NULL;
@@ -229,7 +228,7 @@ static void insmod_cb (flux_t h, flux_msg_handler_t *w,
     if (sched_plugin_load (sploader, path) < 0)
         goto done;
 
-    if (sploader->plugin->process_args (sploader->h, argz, argz_len) < 0) {
+    if (sploader->plugin->process_args (sploader->h, argz, argz_len, sp) < 0) {
         goto done;
     }
     rc = 0;

--- a/sched/plugin.h
+++ b/sched/plugin.h
@@ -1,9 +1,7 @@
 #ifndef _FLUX_SCHED_PLUGIN_H
 #define _FLUX_SCHED_PLUGIN_H
 
-#include "resrc.h"
-#include "resrc_tree.h"
-#include "resrc_reqst.h"
+#include "scheduler.h"
 
 struct sched_plugin {
     void         *dso;                /* Scheduler plug-in DSO handle */
@@ -38,7 +36,8 @@ struct sched_plugin {
 
     int                  (*process_args)(flux_t h,
                                          char *argz,
-                                         size_t argz_len);
+                                         size_t argz_len,
+                                         const sched_params_t *params);
 };
 
 /* Create/destroy the plugin loader apparatus.

--- a/sched/sched_fcfs.c
+++ b/sched/sched_fcfs.c
@@ -50,7 +50,7 @@ resrc_tree_t *select_resources (flux_t h, resrc_tree_t *found_tree,
                                 resrc_reqst_t *resrc_reqst,
                                 resrc_tree_t *selected_parent);
 
-int sched_loop_setup (void)
+int sched_loop_setup (flux_t h)
 {
     return 0;
 }

--- a/sched/scheduler.h
+++ b/sched/scheduler.h
@@ -23,11 +23,8 @@
  \*****************************************************************************/
 
 /*
- * scheduler.h - common data structure for scheduler framework and plugins
- *
- * Update Log:
- *       Apr 08 2015 DHA: Code refactoring w/ JSC API
- * 	     May 24 2014 DHA: File created.
+ * scheduler.h - common data structure and macroes
+ *    for scheduler framework and plugins
  */
 
 #ifndef SCHEDULER_H
@@ -62,6 +59,27 @@ typedef struct {
     resrc_tree_t *resrc_tree; /*!< resources allocated to this LWJ */
     int64_t starttime;
 } flux_lwj_t;
+
+
+/**
+ *  Defines parameters that control scheduling optimization
+ */
+typedef struct {
+    long queue_depth;        /* max njobs to consider per sched event */
+} sched_params_t;
+
+
+/*
+ * The following defines the default values for all of the scheduling
+ * parameters and should be used by both scheduler framework service
+ * comms module and the scheduling plug-ins. If the default values
+ * are overriden via other mechanisms (e.g., sched load options), the
+ * new values also need to be passed down to the scheduling
+ * plug-ins.
+ */
+#define SCHED_PARAM_Q_DEPTH_DEFAULT 1024
+
+const sched_params_t *sched_params_get (flux_t h);
 
 #endif /* SCHEDULER_H */
 

--- a/t/t1004-module-load.t
+++ b/t/t1004-module-load.t
@@ -12,6 +12,7 @@ basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # each of the 4 brokers manages an exclusive set of cores (4) of the cab node
 excl_1N4B=$basepath/001N/exclusive/04-brokers
 excl_1N4B_nc=4
+qd=512
 
 #
 # test_under_flux is under sharness.d/
@@ -30,7 +31,7 @@ test_debug '
 test_expect_success 'module-load: sched loads the fcfs plugin' '
     adjust_session_info 4 &&
     flux hwloc reload ${excl_1N4B} &&
-    flux module load sched sched-once=true &&
+    flux module load sched sched-once=true sched-params=queue-depth=${qd} &&
     flux module list sched &&
     timed_wait_job 5
 '
@@ -61,8 +62,18 @@ test_expect_success 'module-load: sched unloads the backfill plugin' '
     flux module list sched
 '
 
-test_expect_success 'module-load: sched loads the backfill plugin with an argument meant for sched' '
+test_expect_success 'module-load: loads backfill with an argument meant for sched' '
     test_must_fail flux module load sched.backfill sched-once=true &&
+    flux module remove sched.backfill
+'
+
+test_expect_success 'module-load: loads backfill with too deep reservation' '
+    test_must_fail flux module load sched.backfill reserve-depth=$((qd+1000)) &&
+    flux module remove sched.backfill
+'
+
+test_expect_success 'module-load: loads with slightly invalid reservation depth' '
+    test_must_fail flux module load sched.backfill reserve-depth=$((qd+2)) &&
     flux module remove sched.backfill
 '
 


### PR DESCRIPTION
This PR adds two enhancements to address some of the performance issues discovered from the phase I of our CTS scheduler scalability milestone work [flux-distribution#14](https://github.com/flux-framework/distribution/issues/14).

 - Queue-depth support that allows sched to only consider a limited, configurable number of jobs for scheduling on each scheduling event;
 - Faster job search using an job index instead of a linear search over all of the job queues.

More details can be found in the individual commit messages. Fix Issue #182 and #183.