### PR TITLE
optimization: delayed scheduling support 

### DIFF
--- a/sched/Makefile.am
+++ b/sched/Makefile.am
@@ -17,22 +17,22 @@ fluxmod_LTLIBRARIES = sched.la
 schedplugin_LTLIBRARIES = sched_fcfs.la \
                   sched_backfill.la
 
-noinst_HEADERS = scheduler.h rs2rank.h rsreader.h
+noinst_HEADERS = scheduler.h rs2rank.h rsreader.h plugin.h
 
-sched_la_SOURCES = sched.c scheduler.h rs2rank.c rsreader.c plugin.c plugin.h
+sched_la_SOURCES = sched.c rs2rank.c rsreader.c plugin.c
 sched_la_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/resrc
 sched_la_LIBADD = $(top_builddir)/resrc/libflux-resrc.la \
     $(FLUX_CORE_LIBS) $(JSON_LIBS) $(CZMQ_LIBS) \
     $(top_builddir)/simulator/libflux-sim.la
 sched_la_LDFLAGS = $(AM_LDFLAGS) $(fluxmod_ldflags) -module
 
-sched_fcfs_la_SOURCES = sched_fcfs.c scheduler.h
+sched_fcfs_la_SOURCES = sched_fcfs.c
 sched_fcfs_la_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/resrc
 sched_fcfs_la_LIBADD = $(top_builddir)/resrc/libflux-resrc.la \
     $(FLUX_CORE_LIBS) $(JSON_LIBS) $(CZMQ_LIBS)
 sched_fcfs_la_LDFLAGS = $(AM_LDFLAGS) $(schedplugin_ldflags)
 
-sched_backfill_la_SOURCES = sched_backfill.c scheduler.h
+sched_backfill_la_SOURCES = sched_backfill.c
 sched_backfill_la_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/resrc
 sched_backfill_la_LIBADD = $(top_builddir)/resrc/libflux-resrc.la \
     $(FLUX_CORE_LIBS) $(JSON_LIBS) $(CZMQ_LIBS)

--- a/sched/scheduler.h
+++ b/sched/scheduler.h
@@ -58,6 +58,7 @@ typedef struct {
     flux_res_t *req;     /*!< resources requested by this LWJ */
     resrc_tree_t *resrc_tree; /*!< resources allocated to this LWJ */
     int64_t starttime;
+    int64_t enqueue_pos; /*!< the initial enqueue position */
 } flux_lwj_t;
 
 
@@ -66,6 +67,7 @@ typedef struct {
  */
 typedef struct {
     long queue_depth;        /* max njobs to consider per sched event */
+    bool delay_sched;        /* delay scheduling on individual job event */
 } sched_params_t;
 
 
@@ -78,6 +80,7 @@ typedef struct {
  * plug-ins.
  */
 #define SCHED_PARAM_Q_DEPTH_DEFAULT 1024
+#define SCHED_PARAM_DELAY_DEFAULT true
 
 const sched_params_t *sched_params_get (flux_t h);
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -45,6 +45,7 @@ TESTS = \
     t1002-rs2rank-64ranks.t \
     t1003-stress.t \
     t1004-module-load.t \
+    t1005-sched-params.t \
     t2000-fcfs.t \
     t2001-fcfs-aware.t \
     t2002-easy.t

--- a/t/t1005-sched-params.t
+++ b/t/t1005-sched-params.t
@@ -1,0 +1,109 @@
+#!/bin/sh
+#set -x
+
+test_description='Test the basics of scheduling optimization parameters
+
+Ensure jobs are correctly scheduled under different values of
+scheduling optimization parameters and their combinations
+'
+
+. `dirname $0`/sharness.sh
+
+basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+# each of the 4 brokers manages a full cab node exclusively
+excl_4N4B=$basepath/004N/exclusive/04-brokers
+excl_4N4B_nc=16
+
+#
+# test_under_flux is under sharness.d/
+#
+test_under_flux 4
+
+#
+# print only with --debug
+#
+test_debug '
+    echo ${basepath} &&
+    echo ${excl_4N4B} &&
+    echo ${excl_4N4B_nc}
+'
+
+test_expect_success 'sched-params: works with a short queue depth (4)' '
+    adjust_session_info 4 &&
+    flux hwloc reload ${excl_4N4B} &&
+    flux module load sched sched-once=true sched-params=queue-depth=4 &&
+    timed_wait_job 5 &&
+    submit_1N_nproc_sleep_jobs ${excl_4N4B_nc} 0 &&
+    timed_sync_wait_job 10 &&
+    verify_1N_nproc_sleep_jobs ${excl_4N4B_nc} 
+'
+
+test_expect_success 'sched-params: works with queue-depth=16' '
+    adjust_session_info 4 &&
+    flux module remove sched &&
+    flux hwloc reload ${excl_4N4B} &&
+    flux module load sched sched-once=true sched-params=queue-depth=16 &&
+    timed_wait_job 5 &&
+    submit_1N_nproc_sleep_jobs ${excl_4N4B_nc} 0 &&
+    timed_sync_wait_job 10 &&
+    verify_1N_nproc_sleep_jobs ${excl_4N4B_nc} 
+'
+
+test_expect_success 'sched-params: works with a long queue depth (2048)' '
+    adjust_session_info 4 &&
+    flux module remove sched &&
+    flux hwloc reload ${excl_4N4B} &&
+    flux module load sched sched-once=true sched-params=queue-depth=2048 &&
+    timed_wait_job 5 &&
+    submit_1N_nproc_sleep_jobs ${excl_4N4B_nc} 0 &&
+    timed_sync_wait_job 10 &&
+    verify_1N_nproc_sleep_jobs ${excl_4N4B_nc} 
+'
+
+test_expect_success 'sched-params: works with delay-sched=true' '
+    adjust_session_info 4 &&
+    flux module remove sched &&
+    flux hwloc reload ${excl_4N4B} &&
+    flux module load sched sched-once=true sched-params=delay-sched=true &&
+    timed_wait_job 5 &&
+    submit_1N_nproc_sleep_jobs ${excl_4N4B_nc} 0 &&
+    timed_sync_wait_job 10 &&
+    verify_1N_nproc_sleep_jobs ${excl_4N4B_nc} 
+'
+
+test_expect_success 'sched-params: works with delay-sched=false' '
+    adjust_session_info 4 &&
+    flux module remove sched &&
+    flux hwloc reload ${excl_4N4B} &&
+    flux module load sched sched-once=true sched-params=delay-sched=false &&
+    timed_wait_job 5 &&
+    submit_1N_nproc_sleep_jobs ${excl_4N4B_nc} 0 &&
+    timed_sync_wait_job 10 &&
+    verify_1N_nproc_sleep_jobs ${excl_4N4B_nc} 
+'
+
+test_expect_success 'sched-params: delay can be combined with a short depth' '
+    adjust_session_info 4 &&
+    flux module remove sched &&
+    flux hwloc reload ${excl_4N4B} &&
+    flux module load sched sched-once=true \
+sched-params=delay-sched=true,queue-depth=16 &&
+    timed_wait_job 5 &&
+    submit_1N_nproc_sleep_jobs ${excl_4N4B_nc} 0 &&
+    timed_sync_wait_job 10 &&
+    verify_1N_nproc_sleep_jobs ${excl_4N4B_nc} 
+'
+
+test_expect_success 'sched-params: no-delay combines with a long depth' '
+    adjust_session_info 4 &&
+    flux module remove sched &&
+    flux hwloc reload ${excl_4N4B} &&
+    flux module load sched sched-once=true \
+sched-params=queue-depth=2048,delay-sched=false &&
+    timed_wait_job 5 &&
+    submit_1N_nproc_sleep_jobs ${excl_4N4B_nc} 0 &&
+    timed_sync_wait_job 10 &&
+    verify_1N_nproc_sleep_jobs ${excl_4N4B_nc} 
+'
+
+test_done


### PR DESCRIPTION
This is an experimental PR. My apology that this PR contains other optimization items as they are pending for @lipari's review. Commit [22236](https://github.com/flux-framework/flux-sched/commit/22236289334b1c64c2ea6ec64dce5d390b415d2b) is the main commit that I can use your review.  It implements the techniques we discussed at Issue #185. 

Two things:
- This currently breaks a test case: `t2002-easy.t.` I don't understand why changing the timing of invoking schedule_jobs changes the order of a schedule under EASY backfill... There could be some integration I need to do further to make our emulator happy. Since I am not super familiar enough with the emulator code, I thought I could use @SteVwonder's review for this. 

- It is not yet clear whether this actually improves the performance of scheduling with high throughput workloads. I am running some tests with my sched scalability testing rig.   