### PR TITLE
Add functions to iterate over all hierarchies in an RDL conf

### DIFF
--- a/rdl/RDL/memstore.lua
+++ b/rdl/RDL/memstore.lua
@@ -1108,6 +1108,11 @@ function MemStore:serialize ()
     return serialize (self)
 end
 
+function MemStore:hierarchy_next (last)
+    local x,y,z = next (self.__hierarchy, last)
+    return x
+end
+
 local function bless_memstore (t)
     if not t.__resources or not t.__hierarchy or not t.__types then
         return nil, "Doesn't appear to be a memstore table"

--- a/rdl/flux-rdltool.c
+++ b/rdl/flux-rdltool.c
@@ -152,6 +152,14 @@ void aggregate (struct prog_ctx *ctx, struct rdl *rdl, const char *uri)
     return;
 }
 
+void list_hierarchies (struct prog_ctx *ctx, struct rdl *rdl)
+{
+    const char *h = NULL;
+    while ((h = rdl_next_hierarchy (rdl, h)))
+        fprintf (stdout, "%s\n", h);
+    return;
+}
+
 int main (int ac, char **av)
 {
     struct prog_ctx *ctx = prog_ctx_create (ac, av);
@@ -169,6 +177,9 @@ int main (int ac, char **av)
     }
     else if (strcmp (ctx->cmd, "aggregate") == 0) {
         aggregate (ctx, rdl, ctx->args[0]);
+    }
+    else if (strcmp (ctx->cmd, "list-hierarchies") == 0) {
+        list_hierarchies (ctx, rdl);
     }
     else
         fatal (1, "Unknown command: %s\n", ctx->cmd);

--- a/rdl/flux-rdltool.c
+++ b/rdl/flux-rdltool.c
@@ -57,7 +57,8 @@ static int parse_cmdline (struct prog_ctx *ctx, int ac, char **av)
         "Supported CMDs include:\n"
         " resource URI\t Print resource at URI\n"
         " tree URI\t print hierarchy tree at URI\n"
-        " aggregate URI\t aggregate hierarchy tree at URI\n";
+        " aggregate URI\t aggregate hierarchy tree at URI\n"
+        " list-hierarchies\t list all hierarchies in config\n";
     const char *options = "+f:";
     const struct option longopts[] = {
         { "config-file", required_argument, 0, 'f' },

--- a/rdl/flux-rdltool.c
+++ b/rdl/flux-rdltool.c
@@ -164,9 +164,11 @@ int main (int ac, char **av)
 {
     struct prog_ctx *ctx = prog_ctx_create (ac, av);
     struct rdllib *l = rdllib_open ();
+    struct rdl *rdl;
 
-    struct rdl *rdl = rdl_loadfile (l, ctx->filename);
-    if (!rdl)
+    if (!l)
+        fatal (1, "Failed to load rdllib\n");
+    if (!(rdl = rdl_loadfile (l, ctx->filename)))
         fatal (1, "Failed to load config file: %s\n", ctx->filename);
 
     if (strcmp (ctx->cmd, "resource") == 0) {

--- a/rdl/flux-rdltool.c
+++ b/rdl/flux-rdltool.c
@@ -58,7 +58,7 @@ static int parse_cmdline (struct prog_ctx *ctx, int ac, char **av)
         " resource URI\t Print resource at URI\n"
         " tree URI\t print hierarchy tree at URI\n"
         " aggregate URI\t aggregate hierarchy tree at URI\n";
-    const char *options = "+f";
+    const char *options = "+f:";
     const struct option longopts[] = {
         { "config-file", required_argument, 0, 'f' },
         { 0, 0, 0, 0 },

--- a/rdl/rdl.c
+++ b/rdl/rdl.c
@@ -537,6 +537,28 @@ static int lua_rdl_method_push (struct rdl *rdl, const char *name)
     return (0);
 }
 
+const char *rdl_next_hierarchy (struct rdl *rdl, const char *last)
+{
+    lua_rdl_method_push (rdl, "hierarchy_next");
+
+    if (last)
+        lua_pushstring (rdl->L, last);
+    else
+        lua_pushnil (rdl->L);
+
+    /* stack: [ Method, object, last ] */
+    if (lua_pcall (rdl->L, 2, LUA_MULTRET, 0)) {
+        VERR (rdl->rl, "next_hierarchy: %s\n", lua_tostring (rdl->L, -1));
+        return (NULL);
+    }
+    if (lua_isnil (rdl->L, -1)) {
+        /* End of child list is indicated by nil return */
+        return (NULL);
+    }
+    return (lua_tostring (rdl->L, -1));
+}
+
+
 struct rdl * rdl_find (struct rdl *rdl, json_object *args)
 {
     lua_rdl_method_push (rdl, "find");

--- a/rdl/rdl.h
+++ b/rdl/rdl.h
@@ -109,6 +109,14 @@ char *rdl_serialize (struct rdl *rdl);
 
 
 /*
+ *  Get next hierarchy name from internal list of hierarchies in rdl.
+ *   Start iteration with [last] == NULL, and pass previous result
+ *   to get next value. Returns NULL after last hierarchy name is returned.
+ */
+const char *rdl_next_hierarchy (struct rdl *rdl, const char *last);
+
+
+/*
  *   RDL Resource methods:
  */
 

--- a/rdl/test/trdl.c
+++ b/rdl/test/trdl.c
@@ -67,6 +67,7 @@ int main (int argc, char *argv[])
     struct rdl_accumulator *a;
     struct resource *r, *c;
     int64_t val;
+    const char *h = NULL;
 
     const char *filename = argv[1];
 
@@ -81,6 +82,9 @@ int main (int argc, char *argv[])
 
     if (!(rdl1 = rdl_loadfile (l, filename)))
         log_err_exit ("loadfile: %s", filename);
+
+    while ((h = rdl_next_hierarchy (rdl1, h)))
+        fprintf (stderr, "%s\n", h);
 
     if (!(rdl2 = rdl_copy (rdl1)))
         log_err_exit ("copy");

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -41,6 +41,7 @@ TESTS = \
     lua/t0005-multi-hierarchy.t \
     t0002-waitjob.t \
     t0003-basic-install.t \
+    t0004-rdltool.t \
     t1000-jsc.t \
     t1001-rs2rank-basic.t \
     t1002-rs2rank-64ranks.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -38,6 +38,7 @@ TESTS = \
     lua/t0002-multilevel.t \
     lua/t0003-default-tags.t \
     lua/t0004-derived-type.t \
+    lua/t0005-multi-hierarchy.t \
     t0002-waitjob.t \
     t0003-basic-install.t \
     t1000-jsc.t \

--- a/t/data/rdl/hype.lua
+++ b/t/data/rdl/hype.lua
@@ -1,0 +1,64 @@
+
+uses "Node"
+
+Hierarchy "default" {
+    Resource{ "cluster", name = "hype",
+    children = { ListOf{ Node,
+                  ids = "201-354",
+                  args = { basename = "hype",
+                           sockets = {"0-7", "8-15"},
+                           memory_per_socket = 15000 }
+                 },
+               }
+    }
+}
+
+Hierarchy "power" {
+    Resource{ "powerpanel", name="ppnl", size = 1000, children = {
+      Resource{ "pdu", name = "pdu1", id = "1", size = 500,
+        children = { ListOf{ Node,
+                       ids = "201-299",
+                       args = { basename = "hype",
+                                sockets = { "0" },
+                                size = 10 }
+                     }
+                   }
+        },
+      Resource{ "pdu", name = "pdu2", id = "2", size = 500,
+        children = { ListOf{ Node,
+                      ids = "300-354",
+                      args = { basename = "hype",
+                            sockets = { "0" },
+                            size = 20  }
+                     }
+                   }
+        }
+      }}
+}
+
+Hierarchy "bandwidth" {
+    Resource{ "filesystem", name="pfs", size = 90000, children = {
+      Resource{ "gateway", name = "gateway_node_pool", size = 90000, children = {
+        Resource{ "core_switch", name = "core_switch_pool", size = 144000, children = {
+          Resource{ "switch", name = "edge_switch1",  id = "1",size= 72000,
+            children = { ListOf{ Node,
+                         ids = "201-299",
+                         args = { basename = "hype",
+                                  sockets = { "0" },
+                                  size = 4000 }
+                           }
+                       }
+            },
+          Resource{ "switch", name = "edge_switch2",  id = "2", size= 72000,
+            children = { ListOf{ Node,
+                         ids = "300-354",
+                         args = { basename = "hype",
+                                  sockets = { "0" },
+                                  size = 4000  }
+                           }
+                       }
+            }
+        }}
+      }}
+    }}
+}

--- a/t/lua/t0005-multi-hierarchy.t
+++ b/t/lua/t0005-multi-hierarchy.t
@@ -1,0 +1,48 @@
+#!/usr/bin/env lua
+--
+--  Basic rdl testing. Multi-hierarchy
+--
+local t = require 'fluxometer'.init (...)
+local RDL = require_ok ('RDL')
+
+local rdl, err = RDL.eval ([[
+uses "Node"
+
+ Hierarchy "default" {
+   Resource{ "cluster", name = "foo",
+             children = {
+               ListOf{ Node, ids="1-4",
+                 args = { basename = "bar", sockets = { "0-1", "2-3" } }
+               }
+	     }
+   }
+ }
+ Hierarchy "power" {
+   Resource{ "powerpanel", name="ppn1", size = 1000 }
+ }
+]])
+
+type_ok (rdl, 'table', "load RDL")
+is (err, nil, "error is nil")
+
+local r, err = rdl:resource ("default")
+type_ok (r, 'table', "get handle to top of default hierarchy")
+is (r.name, "foo", "Got a handle to resource default:/foo")
+
+local r, err = rdl:resource ("power")
+type_ok (r, 'table', "get handle to top of power hierarchy")
+is (r.name, "ppn1", "Got a handle to resource power:/ppn1")
+
+local h = rdl:hierarchy_next ()
+local r = {}
+while h do
+    r [h] = true
+    h = rdl:hierarchy_next (h)
+end
+
+ok (r.default, "hierarchy_next got default hierarchy")
+ok (r.power, "hierarchy_next got power hierarchy")
+
+done_testing ()
+
+-- vi: ts=4 sw=4 expandtab

--- a/t/t0004-rdltool.t
+++ b/t/t0004-rdltool.t
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+test_description='Test flux-rdltool 
+
+Test rdl C interface using flux-rdltool frontend utility
+'
+. `dirname $0`/sharness.sh
+
+rdltool=$SHARNESS_BUILD_DIRECTORY/rdl/flux-rdltool
+conf=$SHARNESS_TEST_SRCDIR/data/rdl/hype.lua
+
+test_expect_success  'flux-rdltool exists' '
+	test -x $rdltool
+'
+test_expect_success  'flux-rdltool resource works' '
+	$rdltool -f $conf resource default://
+'
+test_expect_success  'flux-rdltool tree works' '
+	$rdltool -f $conf tree default://hype/hype201 >output.tree &&
+	cat <<-EOF >expected.tree &&
+/hype201
+ /socket0
+  /core0
+  /memory
+  /core1
+  /core2
+  /core3
+  /core4
+  /core5
+  /core6
+  /core7
+ /socket1
+  /memory
+  /core8
+  /core9
+  /core10
+  /core11
+  /core12
+  /core13
+  /core14
+  /core15
+EOF
+	test_cmp expected.tree output.tree
+'
+test_expect_success  'flux-rdltool aggregate works' '
+	$rdltool -f $conf aggregate default:// >output.aggregate &&
+	cat >expected.aggregate <<-EOF &&
+	default://:
+	{ "core": 2464, "socket": 308, "cluster": 1, "node": 154, "memory": 4620000 }
+	EOF
+	test_cmp expected.aggregate output.aggregate
+'
+test_expect_success  'flux-rdltool list-hierarchies works' '
+	$rdltool -f $conf list-hierarchies | sort > output.hierarchies &&
+	cat >expected.hierarchies <<-EOF &&
+	bandwidth
+	default
+	power
+	EOF
+	test_cmp expected.hierarchies output.hierarchies
+'
+
+test_done


### PR DESCRIPTION
As requested by @dongahn, this PR introduces `rdl:hierarchy_next()` method for Lua rdl to iterate over all hierarchies registered in a give rdl config.

Additionally a C interface `rdl_next_hierarchy (const char *prev)` is introduced to iterate over the hierarchies from C.