### PR TITLE
sched: Fix possible missed reservation

### DIFF
--- a/sched/sched.c
+++ b/sched/sched.c
@@ -1489,9 +1489,21 @@ int schedule_job (ssrvctx_t *ctx, flux_lwj_t *job, int64_t starttime)
                 if (rc) {
                     resrc_tree_destroy (selected_tree, false);
                     job->resrc_tree = NULL;
-                } else
+                } else {
                     job->resrc_tree = selected_tree;
+                }
             }
+        }
+    } else {
+        rc = plugin->reserve_resources (h, &selected_tree, job->lwj_id,
+                                        starttime, job->req->walltime,
+                                        ctx->rctx.root_resrc,
+                                        resrc_reqst);
+        if (rc) {
+            resrc_tree_destroy (selected_tree, false);
+            job->resrc_tree = NULL;
+        } else {
+            job->resrc_tree = selected_tree;
         }
     }
     rc = 0;


### PR DESCRIPTION
If find_resources returned 0, then the scheduler would not call
reserve_resources, as it should.

Fixes #197