### PR TITLE
fix build error in simulator against latest flux-core master

### DIFF
--- a/simulator/simulator.c
+++ b/simulator/simulator.c
@@ -172,13 +172,12 @@ int put_job_in_kvs (job_t *job)
 
     // TODO: Check to see if this is necessary, i assume the kvsdir becomes
     // stale after a commit
-    char *dir_key;
-    dir_key = xasprintf ("%s", kvsdir_key (job->kvs_dir));
-    kvsdir_destroy (job->kvs_dir);
-    kvs_get_dir (h, &job->kvs_dir, dir_key);
-    free (dir_key);
-
-    return 0;
+    kvsdir_t *tmp = job->kvs_dir;
+    int rc = kvs_get_dir (h, &job->kvs_dir, "%s", kvsdir_key (tmp));
+    kvsdir_destroy (tmp);
+    if (rc < 0)
+        flux_log_error (h, "put_job_in_kvs: kvs_get_dir");
+    return (rc);
 }
 
 job_t *pull_job_from_kvs (kvsdir_t *kvsdir)

--- a/simulator/submitsrv.c
+++ b/simulator/submitsrv.c
@@ -250,7 +250,8 @@ int schedule_next_job (flux_t h, sim_state_t *sim_state)
         log_err_exit ("kvs_get_dir (id=%lu)", new_jobid);
     kvsdir_put_string (dir, "state", "submitted");
     job->kvs_dir = dir;
-    put_job_in_kvs (job);
+    if (put_job_in_kvs (job) < 0)
+        log_err_exit ("put_job_in_kvs");
     kvs_commit (h);
 
     // Send "submitted" event

--- a/simulator/submitsrv.c
+++ b/simulator/submitsrv.c
@@ -252,7 +252,6 @@ int schedule_next_job (flux_t h, sim_state_t *sim_state)
     job->kvs_dir = dir;
     if (put_job_in_kvs (job) < 0)
         log_err_exit ("put_job_in_kvs");
-    kvs_commit (h);
 
     // Send "submitted" event
     event_json = Jnew();


### PR DESCRIPTION
flux-framework/flux-core#823 added format attributes to applicable kvs functions, and this caused one place in simluator to exit with a secure-format error where a non-literal format was used.

This PR fixes that build error, and additionally adds some error checking (and removes an extraneous `kvs_commit()`), while I was in there.
