### PR TITLE
Adjust to flux_t no longer containing pointer

### DIFF
--- a/sched/flux-waitjob.c
+++ b/sched/flux-waitjob.c
@@ -36,13 +36,13 @@
 #include "src/common/libutil/xzmalloc.h"
 
 typedef struct {
-    flux_t h;
+    flux_t *h;
     int64_t jobid;
     char *start;
     char *complete;
 } wjctx_t;
 
-static flux_t sig_flux_h;
+static flux_t *sig_flux_h;
 
 #define OPTIONS "+hc:s:"
 static const struct option longopts[] = {
@@ -76,7 +76,7 @@ static void freectx (void *arg)
     ctx = NULL;
 }
 
-static wjctx_t *getctx (flux_t h)
+static wjctx_t *getctx (flux_t *h)
 {
     wjctx_t *ctx = (wjctx_t *)flux_aux_get (h, "waitjob");
     if (!ctx) {
@@ -151,7 +151,7 @@ static int waitjob_cb (const char *jcbstr, void *arg, int errnum)
 {
     json_object *jcb = NULL;
     int64_t os = 0, ns = 0, j = 0;
-    flux_t h = (flux_t)arg;
+    flux_t *h = (flux_t *)arg;
     wjctx_t *ctx = getctx (h);
 
     if (errnum > 0) {
@@ -176,7 +176,7 @@ static int waitjob_cb (const char *jcbstr, void *arg, int errnum)
     return 0;
 }
 
-static int wait_job_complete (flux_t h)
+static int wait_job_complete (flux_t *h)
 {
     int rc = -1;
     sig_flux_h = h;
@@ -217,7 +217,7 @@ done:
 
 int main (int argc, char *argv[])
 {
-    flux_t h;
+    flux_t *h;
     int ch = 0;
     int64_t jobid = -1;
     char *sfn = NULL;

--- a/sched/plugin.c
+++ b/sched/plugin.c
@@ -34,7 +34,7 @@
 #include "plugin.h"
 
 struct sched_plugin_loader {
-    flux_t h;
+    flux_t *h;
     struct sched_plugin *plugin;
 };
 
@@ -51,7 +51,7 @@ static void plugin_destroy (struct sched_plugin *plugin)
     }
 }
 
-static struct sched_plugin *plugin_create (flux_t h, void *dso)
+static struct sched_plugin *plugin_create (flux_t *h, void *dso)
 {
     int saved_errno;
     char *strerr = NULL;
@@ -178,7 +178,7 @@ struct sched_plugin *sched_plugin_get (struct sched_plugin_loader *sploader)
     return sploader->plugin;
 }
 
-static void rmmod_cb (flux_t h, flux_msg_handler_t *w,
+static void rmmod_cb (flux_t *h, flux_msg_handler_t *w,
                       const flux_msg_t *msg, void *arg)
 {
     struct sched_plugin_loader *sploader = arg;
@@ -205,7 +205,7 @@ done:
         free (name);
 }
 
-static void insmod_cb (flux_t h, flux_msg_handler_t *w,
+static void insmod_cb (flux_t *h, flux_msg_handler_t *w,
                        const flux_msg_t *msg, void *arg)
 {
     struct sched_plugin_loader *sploader = arg;
@@ -242,7 +242,7 @@ done:
         free (argz);
 }
 
-static void lsmod_cb (flux_t h, flux_msg_handler_t *w,
+static void lsmod_cb (flux_t *h, flux_msg_handler_t *w,
                       const flux_msg_t *msg, void *arg)
 {
     struct sched_plugin_loader *sploader = arg;
@@ -289,7 +289,7 @@ static struct flux_msg_handler_spec plugin_htab[] = {
     FLUX_MSGHANDLER_TABLE_END,
 };
 
-struct sched_plugin_loader *sched_plugin_loader_create (flux_t h)
+struct sched_plugin_loader *sched_plugin_loader_create (flux_t *h)
 {
     struct sched_plugin_loader *sploader = malloc (sizeof (*sploader));
     if (!sploader) {

--- a/sched/plugin.h
+++ b/sched/plugin.h
@@ -8,25 +8,25 @@ struct sched_plugin {
     char         *name;               /* Name of plugin */
     char         *path;               /* Path to plugin dso */
 
-    int                  (*sched_loop_setup)(flux_t h);
+    int                  (*sched_loop_setup)(flux_t *h);
 
-    int64_t              (*find_resources)(flux_t h,
+    int64_t              (*find_resources)(flux_t *h,
                                            resrc_t *resrc,
                                            resrc_reqst_t *resrc_reqst,
                                            resrc_tree_t **found_tree);
 
-    resrc_tree_t *       (*select_resources)(flux_t h,
+    resrc_tree_t *       (*select_resources)(flux_t *h,
                                              resrc_tree_t *found_tree,
                                              resrc_reqst_t *resrc_reqst,
                                              resrc_tree_t *selected_parent);
 
-    int                  (*allocate_resources)(flux_t h,
+    int                  (*allocate_resources)(flux_t *h,
                                                resrc_tree_t *rt,
                                                int64_t job_id,
                                                int64_t starttime,
                                                int64_t endtime);
 
-    int                  (*reserve_resources)(flux_t h,
+    int                  (*reserve_resources)(flux_t *h,
                                               resrc_tree_t **selected_tree,
                                               int64_t job_id,
                                               int64_t starttime,
@@ -34,7 +34,7 @@ struct sched_plugin {
                                               resrc_t *resrc,
                                               resrc_reqst_t *resrc_reqst);
 
-    int                  (*process_args)(flux_t h,
+    int                  (*process_args)(flux_t *h,
                                          char *argz,
                                          size_t argz_len,
                                          const sched_params_t *params);
@@ -43,7 +43,7 @@ struct sched_plugin {
 /* Create/destroy the plugin loader apparatus.
  */
 struct sched_plugin_loader;
-struct sched_plugin_loader *sched_plugin_loader_create (flux_t h);
+struct sched_plugin_loader *sched_plugin_loader_create (flux_t *h);
 void sched_plugin_loader_destroy (struct sched_plugin_loader *sploader);
 
 /* Load plugin by name.

--- a/sched/sched_backfill.c
+++ b/sched/sched_backfill.c
@@ -70,15 +70,15 @@ static int compare_int64_ascending (void *item1, void *item2)
 }
 #endif
 
-static bool select_children (flux_t h, resrc_tree_list_t *children,
+static bool select_children (flux_t *h, resrc_tree_list_t *children,
                              resrc_reqst_list_t *reqst_children,
                              resrc_tree_t *selected_parent);
 
-resrc_tree_t *select_resources (flux_t h, resrc_tree_t *found_tree,
+resrc_tree_t *select_resources (flux_t *h, resrc_tree_t *found_tree,
                                 resrc_reqst_t *resrc_reqst,
                                 resrc_tree_t *selected_parent);
 
-int sched_loop_setup (flux_t h)
+int sched_loop_setup (flux_t *h)
 {
     curr_reservation_depth = 0;
     if (!completion_times)
@@ -98,7 +98,7 @@ int sched_loop_setup (flux_t h)
  *          found_tree  - a resource tree containing resources that satisfy the
  *                        job's request or NULL if none are found
  */
-int64_t find_resources (flux_t h, resrc_t *resrc, resrc_reqst_t *resrc_reqst,
+int64_t find_resources (flux_t *h, resrc_t *resrc, resrc_reqst_t *resrc_reqst,
                         resrc_tree_t **found_tree)
 {
     int64_t nfound = 0;
@@ -123,7 +123,7 @@ ret:
  * cycles through all of the resource children and returns true when
  * the requested quantity of resources have been selected.
  */
-static bool select_child (flux_t h, resrc_tree_list_t *children,
+static bool select_child (flux_t *h, resrc_tree_list_t *children,
                           resrc_reqst_t *child_reqst,
                           resrc_tree_t *selected_parent)
 {
@@ -148,7 +148,7 @@ static bool select_child (flux_t h, resrc_tree_list_t *children,
  * cycles through all of the resource requests and returns true if all
  * of the requested children were selected
  */
-static bool select_children (flux_t h, resrc_tree_list_t *children,
+static bool select_children (flux_t *h, resrc_tree_list_t *children,
                              resrc_reqst_list_t *reqst_children,
                              resrc_tree_t *selected_parent)
 {
@@ -178,7 +178,7 @@ static bool select_children (flux_t h, resrc_tree_list_t *children,
  *          selected_parent - parent of the selected resource tree
  * Returns: a resource tree of however many resources were selected
  */
-resrc_tree_t *select_resources (flux_t h, resrc_tree_t *found_tree,
+resrc_tree_t *select_resources (flux_t *h, resrc_tree_t *found_tree,
                                 resrc_reqst_t *resrc_reqst,
                                 resrc_tree_t *selected_parent)
 {
@@ -242,7 +242,7 @@ resrc_tree_t *select_resources (flux_t h, resrc_tree_t *found_tree,
     return selected_tree;
 }
 
-int allocate_resources (flux_t h, resrc_tree_t *selected_tree, int64_t job_id,
+int allocate_resources (flux_t *h, resrc_tree_t *selected_tree, int64_t job_id,
                         int64_t starttime, int64_t endtime)
 {
     int rc = -1;
@@ -271,7 +271,7 @@ int allocate_resources (flux_t h, resrc_tree_t *selected_tree, int64_t job_id,
  * available, reserve those, and return the pointer to the selected
  * tree.
  */
-int reserve_resources (flux_t h, resrc_tree_t **selected_tree, int64_t job_id,
+int reserve_resources (flux_t *h, resrc_tree_t **selected_tree, int64_t job_id,
                        int64_t starttime, int64_t walltime, resrc_t *resrc,
                        resrc_reqst_t *resrc_reqst)
 {
@@ -341,7 +341,7 @@ ret:
     return rc;
 }
 
-int process_args (flux_t h, char *argz, size_t argz_len, const sched_params_t *sp)
+int process_args (flux_t *h, char *argz, size_t argz_len, const sched_params_t *sp)
 {
     int rc = 0;
     char *reserve_depth_str = NULL;

--- a/sched/sched_fcfs.c
+++ b/sched/sched_fcfs.c
@@ -42,15 +42,15 @@
 #include "scheduler.h"
 
 
-static bool select_children (flux_t h, resrc_tree_list_t *children,
+static bool select_children (flux_t *h, resrc_tree_list_t *children,
                              resrc_reqst_list_t *reqst_children,
                              resrc_tree_t *selected_parent);
 
-resrc_tree_t *select_resources (flux_t h, resrc_tree_t *found_tree,
+resrc_tree_t *select_resources (flux_t *h, resrc_tree_t *found_tree,
                                 resrc_reqst_t *resrc_reqst,
                                 resrc_tree_t *selected_parent);
 
-int sched_loop_setup (flux_t h)
+int sched_loop_setup (flux_t *h)
 {
     return 0;
 }
@@ -67,7 +67,7 @@ int sched_loop_setup (flux_t h)
  *          found_tree  - a resource tree containing resources that satisfy the
  *                        job's request or NULL if none are found
  */
-int64_t find_resources (flux_t h, resrc_t *resrc, resrc_reqst_t *resrc_reqst,
+int64_t find_resources (flux_t *h, resrc_t *resrc, resrc_reqst_t *resrc_reqst,
                         resrc_tree_t **found_tree)
 {
     int64_t nfound = 0;
@@ -99,7 +99,7 @@ ret:
  * cycles through all of the resource children and returns true when
  * the requested quantity of resources have been selected.
  */
-static bool select_child (flux_t h, resrc_tree_list_t *children,
+static bool select_child (flux_t *h, resrc_tree_list_t *children,
                           resrc_reqst_t *child_reqst,
                           resrc_tree_t *selected_parent)
 {
@@ -124,7 +124,7 @@ static bool select_child (flux_t h, resrc_tree_list_t *children,
  * cycles through all of the resource requests and returns true if all
  * of the requested children were selected
  */
-static bool select_children (flux_t h, resrc_tree_list_t *children,
+static bool select_children (flux_t *h, resrc_tree_list_t *children,
                              resrc_reqst_list_t *reqst_children,
                              resrc_tree_t *selected_parent)
 {
@@ -154,7 +154,7 @@ static bool select_children (flux_t h, resrc_tree_list_t *children,
  *          selected_parent - parent of the selected resource tree
  * Returns: a resource tree of however many resources were selected
  */
-resrc_tree_t *select_resources (flux_t h, resrc_tree_t *found_tree,
+resrc_tree_t *select_resources (flux_t *h, resrc_tree_t *found_tree,
                                 resrc_reqst_t *resrc_reqst,
                                 resrc_tree_t *selected_parent)
 {
@@ -226,7 +226,7 @@ resrc_tree_t *select_resources (flux_t h, resrc_tree_t *found_tree,
     return selected_tree;
 }
 
-int allocate_resources (flux_t h, resrc_tree_t *selected_tree, int64_t job_id,
+int allocate_resources (flux_t *h, resrc_tree_t *selected_tree, int64_t job_id,
                         int64_t starttime, int64_t endtime)
 {
     int rc = -1;
@@ -236,7 +236,7 @@ int allocate_resources (flux_t h, resrc_tree_t *selected_tree, int64_t job_id,
     return rc;
 }
 
-int reserve_resources (flux_t h, resrc_tree_t **selected_tree, int64_t job_id,
+int reserve_resources (flux_t *h, resrc_tree_t **selected_tree, int64_t job_id,
                        int64_t starttime, int64_t walltime, resrc_t *resrc,
                        resrc_reqst_t *resrc_reqst)
 {
@@ -248,7 +248,7 @@ int reserve_resources (flux_t h, resrc_tree_t **selected_tree, int64_t job_id,
 }
 
 
-int process_args (flux_t h, char *argz, size_t argz_len)
+int process_args (flux_t *h, char *argz, size_t argz_len)
 {
     return 0;
 }

--- a/sched/scheduler.h
+++ b/sched/scheduler.h
@@ -82,7 +82,7 @@ typedef struct {
 #define SCHED_PARAM_Q_DEPTH_DEFAULT 1024
 #define SCHED_PARAM_DELAY_DEFAULT true
 
-const sched_params_t *sched_params_get (flux_t h);
+const sched_params_t *sched_params_get (flux_t *h);
 
 #endif /* SCHEDULER_H */
 

--- a/simulator/sim_execsrv.c
+++ b/simulator/sim_execsrv.c
@@ -44,7 +44,7 @@ typedef struct {
     sim_state_t *sim_state;
     zlist_t *queued_events;  // holds int *
     zlist_t *running_jobs;  // holds job_t *
-    flux_t h;
+    flux_t *h;
     double prev_sim_time;
     struct rdllib *rdllib;
     struct rdl *rdl;
@@ -73,7 +73,7 @@ static void freectx (void *arg)
     free (ctx);
 }
 
-static ctx_t *getctx (flux_t h)
+static ctx_t *getctx (flux_t *h)
 {
     ctx_t *ctx = (ctx_t *)flux_aux_get (h, "sim_exec");
 
@@ -194,7 +194,7 @@ static int set_event_timer (ctx_t *ctx, char *mod_name, double timer_value)
 // Also change the state of the job in the KVS
 static int complete_job (ctx_t *ctx, job_t *job, double completion_time)
 {
-    flux_t h = ctx->h;
+    flux_t *h = ctx->h;
 
     flux_log (h, LOG_INFO, "Job %d completed", job->id);
 
@@ -508,7 +508,7 @@ static int handle_queued_events (ctx_t *ctx)
     job_t *job = NULL;
     int *jobid = NULL;
     kvsdir_t *kvs_dir;
-    flux_t h = ctx->h;
+    flux_t *h = ctx->h;
     zlist_t *queued_events = ctx->queued_events;
     zlist_t *running_jobs = ctx->running_jobs;
     double sim_time = ctx->sim_state->sim_time;
@@ -544,7 +544,7 @@ static int handle_queued_events (ctx_t *ctx)
 }
 
 // Received an event that a simulation is starting
-static void start_cb (flux_t h,
+static void start_cb (flux_t *h,
                       flux_msg_handler_t *w,
                       const flux_msg_t *msg,
                       void *arg)
@@ -564,7 +564,7 @@ static void start_cb (flux_t h,
 }
 
 // Handle trigger requests from the sim module ("sim_exec.trigger")
-static void trigger_cb (flux_t h,
+static void trigger_cb (flux_t *h,
                         flux_msg_handler_t *w,
                         const flux_msg_t *msg,
                         void *arg)
@@ -606,7 +606,7 @@ static void trigger_cb (flux_t h,
     zhash_destroy (&job_hash);
 }
 
-static void run_cb (flux_t h,
+static void run_cb (flux_t *h,
                     flux_msg_handler_t *w,
                     const flux_msg_t *msg,
                     void *arg)
@@ -637,7 +637,7 @@ static struct flux_msg_handler_spec htab[] = {
     FLUX_MSGHANDLER_TABLE_END,
 };
 
-int mod_main (flux_t h, int argc, char **argv)
+int mod_main (flux_t *h, int argc, char **argv)
 {
     ctx_t *ctx = getctx (h);
     uint32_t rank;

--- a/simulator/simsrv.c
+++ b/simulator/simsrv.c
@@ -39,7 +39,7 @@
 
 typedef struct {
     sim_state_t *sim_state;
-    flux_t h;
+    flux_t *h;
     bool rdl_changed;
     char *rdl_string;
     bool exit_on_complete;
@@ -53,7 +53,7 @@ static void freectx (void *arg)
     free (ctx);
 }
 
-static ctx_t *getctx (flux_t h, bool exit_on_complete)
+static ctx_t *getctx (flux_t *h, bool exit_on_complete)
 {
     ctx_t *ctx = (ctx_t *)flux_aux_get (h, "simsrv");
 
@@ -72,7 +72,7 @@ static ctx_t *getctx (flux_t h, bool exit_on_complete)
 
 // builds the trigger request and sends it to "mod_name"
 // converts sim_state to JSON, formats request tag based on "mod_name"
-static int send_trigger (flux_t h, char *mod_name, sim_state_t *sim_state)
+static int send_trigger (flux_t *h, char *mod_name, sim_state_t *sim_state)
 {
     int rc = 0;
     flux_msg_t *msg = NULL;
@@ -97,7 +97,7 @@ static int send_trigger (flux_t h, char *mod_name, sim_state_t *sim_state)
 
 // Send out a call to all modules that the simulation is starting
 // and that they should join
-int send_start_event (flux_t h)
+int send_start_event (flux_t *h)
 {
     int rc = 0;
     flux_msg_t *msg = NULL;
@@ -122,7 +122,7 @@ int send_start_event (flux_t h)
 }
 
 // Send an event to all modules that the simulation has completed
-int send_complete_event (flux_t h)
+int send_complete_event (flux_t *h)
 {
     int rc = 0;
     flux_msg_t *msg = NULL;
@@ -206,7 +206,7 @@ static int handle_next_event (ctx_t *ctx)
 }
 
 // Recevied a request to join the simulation ("sim.join")
-static void join_cb (flux_t h,
+static void join_cb (flux_t *h,
                      flux_msg_handler_t *w,
                      const flux_msg_t *msg,
                      void *arg)
@@ -337,7 +337,7 @@ static void copy_new_state_data (ctx_t *ctx,
     zhash_foreach (reply_sim_state->timers, check_for_new_timers, ctx);
 }
 
-static void rdl_update_cb (flux_t h,
+static void rdl_update_cb (flux_t *h,
                            flux_msg_handler_t *w,
                            const flux_msg_t *msg,
                            void *arg)
@@ -364,7 +364,7 @@ static void rdl_update_cb (flux_t h,
 }
 
 // Recevied a reply to a trigger ("sim.reply")
-static void reply_cb (flux_t h,
+static void reply_cb (flux_t *h,
                       flux_msg_handler_t *w,
                       const flux_msg_t *msg,
                       void *arg)
@@ -399,7 +399,7 @@ static void reply_cb (flux_t h,
     Jput (request);
 }
 
-static void alive_cb (flux_t h,
+static void alive_cb (flux_t *h,
                       flux_msg_handler_t *w,
                       const flux_msg_t *msg,
                       void *arg)
@@ -429,7 +429,7 @@ static struct flux_msg_handler_spec htab[] = {
 };
 const int htablen = sizeof (htab) / sizeof (htab[0]);
 
-int mod_main (flux_t h, int argc, char **argv)
+int mod_main (flux_t *h, int argc, char **argv)
 {
     zhash_t *args = zhash_fromargv (argc, argv);
     ctx_t *ctx;

--- a/simulator/simulator.c
+++ b/simulator/simulator.c
@@ -167,7 +167,7 @@ int put_job_in_kvs (job_t *job)
     if (!kvsdir_exists (job->kvs_dir, "io_rate"))
         kvsdir_put_int64 (job->kvs_dir, "io_rate", job->io_rate);
 
-    flux_t h = kvsdir_handle (job->kvs_dir);
+    flux_t *h = kvsdir_handle (job->kvs_dir);
     kvs_commit (h);
 
     // TODO: Check to see if this is necessary, i assume the kvsdir becomes
@@ -205,7 +205,7 @@ job_t *pull_job_from_kvs (kvsdir_t *kvsdir)
     return job;
 }
 
-int send_alive_request (flux_t h, const char *module_name)
+int send_alive_request (flux_t *h, const char *module_name)
 {
     int rc = 0;
     flux_msg_t *msg = NULL;
@@ -230,7 +230,7 @@ int send_alive_request (flux_t h, const char *module_name)
 }
 
 // Reply back to the sim module with the updated sim state (in JSON form)
-int send_reply_request (flux_t h,
+int send_reply_request (flux_t *h,
                         const char *module_name,
                         sim_state_t *sim_state)
 {
@@ -254,7 +254,7 @@ int send_reply_request (flux_t h,
 }
 
 // Request to join the simulation
-int send_join_request (flux_t h, const char *module_name, double next_event)
+int send_join_request (flux_t *h, const char *module_name, double next_event)
 {
     int rc = 0;
     flux_msg_t *msg = NULL;

--- a/simulator/simulator.h
+++ b/simulator/simulator.h
@@ -59,16 +59,16 @@ int put_job_in_kvs (job_t *job);
 job_t *pull_job_from_kvs (kvsdir_t *kvs_dir);
 void free_job (job_t *job);
 job_t *blank_job ();
-int send_alive_request (flux_t h, const char *module_name);
-int send_reply_request (flux_t h,
+int send_alive_request (flux_t *h, const char *module_name);
+int send_reply_request (flux_t *h,
                         const char *module_name,
                         sim_state_t *sim_state);
-int send_join_request (flux_t h, const char *module_name, double next_event);
+int send_join_request (flux_t *h, const char *module_name, double next_event);
 
 zhash_t *zhash_fromargv (int argc, char **argv);
 
 /*
-struct rdl *get_rdl (flux_t h, char *path);
+struct rdl *get_rdl (flux_t *h, char *path);
 void close_rdl ();
 */
 #endif /* SIMULATOR_H */

--- a/simulator/submitsrv.c
+++ b/simulator/submitsrv.c
@@ -134,7 +134,7 @@ int populate_header (char *header_line, zlist_t *header_list)
 
 // Populate a list of jobs using the data contained in the csv
 // TODO: breakup this function into several smaller functions
-int parse_job_csv (flux_t h, char *filename, zlist_t *jobs)
+int parse_job_csv (flux_t *h, char *filename, zlist_t *jobs)
 {
     const int MAX_LINE_LEN = 500;  // sort of arbitrary, works for my data
     char curr_line[MAX_LINE_LEN];  // current line of the input file
@@ -198,7 +198,7 @@ int parse_job_csv (flux_t h, char *filename, zlist_t *jobs)
 // Based on the sim_time, schedule any jobs that need to be scheduled
 // Next, add an event timer for the scheduler to the sim_state
 // Finally, updated the submit event timer with the next submit time
-int schedule_next_job (flux_t h, sim_state_t *sim_state)
+int schedule_next_job (flux_t *h, sim_state_t *sim_state)
 {
     const char *resp_json_str = NULL;
     json_object *req_json = NULL;
@@ -290,7 +290,7 @@ int schedule_next_job (flux_t h, sim_state_t *sim_state)
 }
 
 // Received an event that a simulation is starting
-static void start_cb (flux_t h,
+static void start_cb (flux_t *h,
                       flux_msg_handler_t *w,
                       const flux_msg_t *msg,
                       void *arg)
@@ -312,7 +312,7 @@ static void start_cb (flux_t h,
 }
 
 // Handle trigger requests from the sim module ("submit.trigger")
-static void trigger_cb (flux_t h,
+static void trigger_cb (flux_t *h,
                         flux_msg_handler_t *w,
                         const flux_msg_t *msg,
                         void *arg)
@@ -350,7 +350,7 @@ static struct flux_msg_handler_spec htab[] = {
     FLUX_MSGHANDLER_TABLE_END,
 };
 
-int mod_main (flux_t h, int argc, char **argv)
+int mod_main (flux_t *h, int argc, char **argv)
 {
     zhash_t *args = zhash_fromargv (argc, argv);
     if (!args)


### PR DESCRIPTION
The flux_t typedef in flux-core no longer hides a pointer.
Change flux-sched's use of flux_t to match the new pointer-less
definition of flux_t.