### PR TITLE
travis-ci: install libjansson-dev package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,7 @@ script:
  - git clone https://github.com/flux-framework/flux-core.git $HOME/flux-core
  - (cd $HOME/flux-core && ./autogen.sh && ./configure --prefix=$HOME/local2 && make -j 2 && make install)
  - (rm -fr $HOME/flux-core)
+ - (find $HOME/local2/lib -name \*.la | xargs rm -f)
  - ($HOME/local2/bin/flux keygen)
 
  # Enable coverage for $CC+coverage build

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ addons:
       - lua5.1
       - liblua5.1-0-dev
       - luarocks
+      - libjansson-dev
       - uuid-dev
       - aspell
       - libopenmpi-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ addons:
       - aspell
       - libopenmpi-dev
       - ccache
+      - apport # for coredumps
+      - gdb
       - libhwloc-dev
       - libmunge-dev
       - munge
@@ -61,6 +63,7 @@ before_install:
   - if test "$COVERAGE" = "t"; then gem install coveralls-lcov; fi
 
 script:
+ - ulimit -c unlimited
  - export CC="ccache $CC"
  - export MAKECMDS="make distcheck"
  - export FLUX_TESTS_LOGFILE=t
@@ -93,6 +96,7 @@ after_success:
 after_failure:
  - find . -name t[0-9]*.output -print0 | xargs -0 -I'{}' sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'
  - find . -name *.broker.log -print0 | xargs -0 -I'{}' sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'
+ - src/test/backtrace-all.sh
 
 before_deploy:
   # Get anchor (formatted properly) and base URI for latest tag in NEWS file

--- a/rdl/test/Makefile.am
+++ b/rdl/test/Makefile.am
@@ -16,6 +16,6 @@ trdl_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/rdl
 trdl_LDADD = $(top_builddir)/rdl/libflux-rdl.la \
     $(top_builddir)/src/common/liblsd/liblsd.la \
     $(top_builddir)/src/common/libutil/libutil.la \
-    $(LUA_LIB) $(JSON_LIBS) $(CZMQ_LIBS)
+    $(FLUX_CORE_LIBS) $(LUA_LIB) $(JSON_LIBS) $(CZMQ_LIBS)
 
 EXTRA_DIST= test-rdl.lua

--- a/src/test/backtrace-all.sh
+++ b/src/test/backtrace-all.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+#  Find all possible core files under current directory. Attempt
+#  to determine exe using file(1) and dump stack trace with gdb.
+#
+say () { printf "\033[91m%s\033[39m\n" "$@" >&2; }
+die () { say "$@"; exit 1; }
+
+find . -name *.core -o -name core | while read -r line; do
+    d=$(dirname $line)
+    f=$(basename $line)
+    exe=$(file $line | sed "s/.*from '\([^ \t]*\).*'.*/\1/")
+    ( cd $d &&
+      test -x $exe || die "Failed to find executable at $exe" &&
+      say "Found corefile for $exe" &&
+      gdb --batch --quiet -ex "thread apply all bt full" $exe $f
+    )
+done


### PR DESCRIPTION
Since we build flux-core in travis, and flux-core
recently added a dependency on libjansson, ensure
that it is present in the travis build environment.

Fixes #209