### PR TITLE
Do not assume kvs path to jobs is lwj.ID

### DIFF
--- a/simulator/sim_execsrv.c
+++ b/simulator/sim_execsrv.c
@@ -515,8 +515,8 @@ static int handle_queued_events (ctx_t *ctx)
 
     while (zlist_size (queued_events) > 0) {
         jobid = zlist_pop (queued_events);
-        if (kvs_get_dir (h, &kvs_dir, "lwj.%d", *jobid) < 0)
-            log_err_exit ("kvs_get_dir (id=%d)", *jobid);
+        if (!(kvs_dir = job_kvsdir (ctx->h, *jobid)))
+            log_err_exit ("job_kvsdir (id=%d)", *jobid);
         job = pull_job_from_kvs (*jobid, kvs_dir);
         if (update_job_state (ctx, *jobid, kvs_dir, J_STARTING, sim_time) < 0) {
             flux_log (h,

--- a/simulator/sim_execsrv.c
+++ b/simulator/sim_execsrv.c
@@ -517,7 +517,7 @@ static int handle_queued_events (ctx_t *ctx)
         jobid = zlist_pop (queued_events);
         if (kvs_get_dir (h, &kvs_dir, "lwj.%d", *jobid) < 0)
             log_err_exit ("kvs_get_dir (id=%d)", *jobid);
-        job = pull_job_from_kvs (kvs_dir);
+        job = pull_job_from_kvs (*jobid, kvs_dir);
         if (update_job_state (ctx, *jobid, kvs_dir, J_STARTING, sim_time) < 0) {
             flux_log (h,
                       LOG_ERR,

--- a/simulator/simulator.c
+++ b/simulator/simulator.c
@@ -174,7 +174,7 @@ int put_job_in_kvs (job_t *job)
     return (rc);
 }
 
-job_t *pull_job_from_kvs (kvsdir_t *kvsdir)
+job_t *pull_job_from_kvs (int id, kvsdir_t *kvsdir)
 {
     if (kvsdir == NULL)
         return NULL;
@@ -182,8 +182,8 @@ job_t *pull_job_from_kvs (kvsdir_t *kvsdir)
     job_t *job = blank_job ();
 
     job->kvs_dir = kvsdir;
+    job->id = id;
 
-    sscanf (kvsdir_key (job->kvs_dir), "lwj.%d", &job->id);
     kvsdir_get_string (job->kvs_dir, "user", &job->user);
     kvsdir_get_string (job->kvs_dir, "jobname", &job->jobname);
     kvsdir_get_string (job->kvs_dir, "account", &job->account);

--- a/simulator/simulator.h
+++ b/simulator/simulator.h
@@ -55,6 +55,7 @@ void free_simstate (sim_state_t *sim_state);
 json_t *sim_state_to_json (sim_state_t *state);
 sim_state_t *json_to_sim_state (json_t *o);
 
+kvsdir_t *job_kvsdir (flux_t *h, int jobid);
 int put_job_in_kvs (job_t *job);
 job_t *pull_job_from_kvs (int id, kvsdir_t *kvs_dir);
 void free_job (job_t *job);

--- a/simulator/simulator.h
+++ b/simulator/simulator.h
@@ -56,7 +56,7 @@ json_t *sim_state_to_json (sim_state_t *state);
 sim_state_t *json_to_sim_state (json_t *o);
 
 int put_job_in_kvs (job_t *job);
-job_t *pull_job_from_kvs (kvsdir_t *kvs_dir);
+job_t *pull_job_from_kvs (int id, kvsdir_t *kvs_dir);
 void free_job (job_t *job);
 job_t *blank_job ();
 int send_alive_request (flux_t *h, const char *module_name);

--- a/simulator/submitsrv.c
+++ b/simulator/submitsrv.c
@@ -248,7 +248,7 @@ int schedule_next_job (flux_t *h, sim_state_t *sim_state)
     Jput (resp_json);
 
     // Update lwj.%jobid%'s state in the kvs to "submitted"
-    if (kvs_get_dir (h, &dir, "lwj.%lu", new_jobid) < 0)
+    if (!(dir = job_kvsdir (h, new_jobid)))
         log_err_exit ("kvs_get_dir (id=%lu)", new_jobid);
     kvsdir_put_string (dir, "state", "submitted");
     job->kvs_dir = dir;

--- a/t/sharness.d/sched-sharness.sh
+++ b/t/sharness.d/sched-sharness.sh
@@ -33,6 +33,14 @@ sched_src_path () {
     readlink -e "${SHARNESS_TEST_SRCDIR}/../${1}"
 }
 
+job_kvs_path () {
+    if flux wreck help 2>&1 | grep -q kvs-path; then
+        flux wreck kvs-path "$1"
+    else
+        echo "lwj.$1"
+    fi
+}
+
 export FLUX_EXEC_PATH_PREPEND
 export FLUX_SCHED_RC_NOOP
 export FLUX_SCHED_RC_PATH
@@ -116,7 +124,7 @@ verify_1N_sleep_jobs () {
     local rank=0
     for i in `seq $sched_start_jobid $sched_end_jobid`
     do
-        flux kvs get lwj.$i.rank.$rank.cores \
+        flux kvs get $(job_kvs_path $i).rank.$rank.cores \
             > $sched_test_session.$i.out
         grep $cores $sched_test_session.$i.out
         if [ $? -ne 0 ]

--- a/t/t1004-module-load.t
+++ b/t/t1004-module-load.t
@@ -85,7 +85,7 @@ test_expect_success 'module-load: sched loads the backfill plugin with arguments
 test_expect_success 'module-load: no jobs are lost' '
     for i in `seq $sched_start_jobid $sched_end_jobid`
     do
-        state=$(flux kvs get lwj.$i.state)
+        state=$(flux kvs get $(job_kvs_path $i).state)
         if test $state != "submitted"; then
             return 48
         fi

--- a/t/t2000-fcfs.t
+++ b/t/t2000-fcfs.t
@@ -45,9 +45,9 @@ test_expect_success 'loading sched works' '
 	flux module load sched rdl-conf=${rdlconf} in-sim=true plugin=sched.fcfs
 '
 
-while flux kvs get lwj.12.complete_time 2>&1 | grep -q "No such file"; do sleep 0.5; done
+while flux kvs get $(job_kvs_path 12).complete_time 2>&1 | grep -q "No such file"; do sleep 0.5; done
 sleep 0.5
-for x in $(seq 1 12); do echo "$x $(flux kvs get lwj.$x.starting_time)"; done | sort -k 2n -k 1n | cut -d ' ' -f 1 > actual
+for x in $(seq 1 12); do echo "$x $(flux kvs get $(job_kvs_path $x).starting_time)"; done | sort -k 2n -k 1n | cut -d ' ' -f 1 > actual
 
 test_expect_success 'jobs scheduled in correct order' '
     diff -u ${expected_order} ./actual

--- a/t/t2001-fcfs-aware.t
+++ b/t/t2001-fcfs-aware.t
@@ -33,9 +33,9 @@ test_expect_success 'loading sched works' '
 	flux module load sched rdl-conf=${rdlconf} in-sim=true plugin=sched.fcfs
 '
 
-while flux kvs get lwj.12.complete_time 2>&1 | grep -q "No such file"; do sleep 0.5; done
+while flux kvs get $(job_kvs_path 12).complete_time 2>&1 | grep -q "No such file"; do sleep 0.5; done
 sleep 0.5
-for x in $(seq 1 12); do echo "$x $(flux kvs get lwj.$x.starting_time)"; done | sort -k 2n -k 1n | cut -d ' ' -f 1 > actual
+for x in $(seq 1 12); do echo "$x $(flux kvs get $(job_kvs_path $x).starting_time)"; done | sort -k 2n -k 1n | cut -d ' ' -f 1 > actual
 
 test_expect_success 'jobs scheduled in correct order' '
     test_cmp ${expected_order} ./actual

--- a/t/t2002-easy.t
+++ b/t/t2002-easy.t
@@ -34,9 +34,9 @@ test_expect_success 'loading sched works' '
 	flux module load sched rdl-conf=${rdlconf} in-sim=true plugin=sched.backfill plugin-opts=reserve-depth=1
 '
 
-while flux kvs get lwj.12.complete_time 2>&1 | grep -q "No such file"; do sleep 0.5; done
+while flux kvs get $(job_kvs_path 12).complete_time 2>&1 | grep -q "No such file"; do sleep 0.5; done
 sleep 0.5
-for x in $(seq 1 12); do echo "$x $(flux kvs get lwj.$x.starting_time)"; done | sort -k 2n -k 1n | cut -d ' ' -f 1 > actual
+for x in $(seq 1 12); do echo "$x $(flux kvs get $(job_kvs_path $x).starting_time)"; done | sort -k 2n -k 1n | cut -d ' ' -f 1 > actual
 
 # XXX disabled temporarily - see #212
 #test_expect_success 'jobs scheduled in correct order' '


### PR DESCRIPTION
Remove assumptions where necessary that path to kvs for job `$id` is `lwj.$id`.

Where available, use the `job.kvspath` service to translate jobid to kvs path, if `job.kvspath` is not available, fall back to `lwj.$id`.

@dongahn, the flux-sched branch here, in combination with flux-framework/flux-core#811 should allow PerfExplore testing, once PerfExplore is similarly updated as here. For examples, see `job_kvs_path()` function in `t/sharness.d/sched-sharness.sh` for shell function, or `job_kvspath()` function in `simulator/simulator.c` for C example.

Currently this PR is built on top of #215, if that is merged I can rebase and retest.