### PR TITLE
sim: testing and kvs operation cleanup

### DIFF
--- a/simulator/simulator.c
+++ b/simulator/simulator.c
@@ -178,6 +178,14 @@ int put_job_in_kvs (job_t *job)
         goto ret;
     }
 
+    kvsdir_t *tmp = job->kvs_dir;
+    if (kvs_get_dir (h, &job->kvs_dir, "%s", kvsdir_key (tmp)) < 0) {
+        flux_log_error (h, "%s: kvs_get_dir", __FUNCTION__);
+        job->kvs_dir = tmp; // restore last known good kvs_dir
+        goto ret;
+    }
+    kvsdir_destroy (tmp);
+
     rc = 0;
  ret:
     return (rc);

--- a/t/t2000-fcfs.t
+++ b/t/t2000-fcfs.t
@@ -19,12 +19,9 @@ expected_order=$(readlink -e "${SHARNESS_TEST_SRCDIR}/data/emulator-data/fcfs_ex
 # print only with --debug
 #
 test_debug '
-	echo ${rdlconf} &&
-    echo ${submit} &&
-    echo ${jobdata} &&
-    echo ${sim_exec} &&
-    echo ${sim} &&
-    echo ${expected_order}
+	echo rdlconf=${rdlconf} &&
+    echo jobdata=${jobdata} &&
+    echo expected_order=${expected_order}
 '
 
 #
@@ -32,21 +29,19 @@ test_debug '
 #
 test_under_flux 1
 
-test_expect_success 'loading sim works' '
-	flux module load sim exit-on-complete=false
-'
-test_expect_success 'loading submit works' '
-	flux module load submit job-csv=${jobdata}
-'
-test_expect_success 'loading exec works' '
-	flux module load sim_exec
-'
-test_expect_success 'loading sched works' '
+test_expect_success 'sim: started successfully' '
+    adjust_session_info 12 &&
+    timed_wait_job 5 &&
+    flux module load sim exit-on-complete=false &&
+    flux module load submit job-csv=${jobdata} &&
+    flux module load sim_exec &&
 	flux module load sched rdl-conf=${rdlconf} in-sim=true plugin=sched.fcfs
 '
 
-while flux kvs get $(job_kvs_path 12).complete_time 2>&1 | grep -q "No such file"; do sleep 0.5; done
-sleep 0.5
+test_expect_success 'sim: scheduled and ran all jobs' '
+    timed_sync_wait_job 60
+'
+
 for x in $(seq 1 12); do echo "$x $(flux kvs get $(job_kvs_path $x).starting_time)"; done | sort -k 2n -k 1n | cut -d ' ' -f 1 > actual
 
 test_expect_success 'jobs scheduled in correct order' '

--- a/t/t2001-fcfs-aware.t
+++ b/t/t2001-fcfs-aware.t
@@ -16,25 +16,32 @@ expected_order=$(readlink -e "${SHARNESS_TEST_SRCDIR}/data/emulator-data/fcfs_ex
 
 
 #
+# print only with --debug
+#
+test_debug '
+	echo rdlconf=${rdlconf} &&
+    echo jobdata=${jobdata} &&
+    echo expected_order=${expected_order}
+'
+
+#
 # test_under_flux is under sharness.d/
 #
 test_under_flux 1
 
-test_expect_success 'loading sim works' '
-	flux module load sim exit-on-complete=false
-'
-test_expect_success 'loading submit works' '
-	flux module load submit job-csv=${jobdata}
-'
-test_expect_success 'loading exec works' '
-	flux module load sim_exec
-'
-test_expect_success 'loading sched works' '
+test_expect_success 'sim: started successfully' '
+    adjust_session_info 12 &&
+    timed_wait_job 5 &&
+    flux module load sim exit-on-complete=false &&
+    flux module load submit job-csv=${jobdata} &&
+    flux module load sim_exec &&
 	flux module load sched rdl-conf=${rdlconf} in-sim=true plugin=sched.fcfs
 '
 
-while flux kvs get $(job_kvs_path 12).complete_time 2>&1 | grep -q "No such file"; do sleep 0.5; done
-sleep 0.5
+test_expect_success 'sim: scheduled and ran all jobs' '
+    timed_sync_wait_job 60
+'
+
 for x in $(seq 1 12); do echo "$x $(flux kvs get $(job_kvs_path $x).starting_time)"; done | sort -k 2n -k 1n | cut -d ' ' -f 1 > actual
 
 test_expect_success 'jobs scheduled in correct order' '

--- a/t/t2002-easy.t
+++ b/t/t2002-easy.t
@@ -17,26 +17,32 @@ FLUX_MODULE_PATH_PREPEND="$FLUX_MODULE_PATH_PREPEND:$(sched_build_path simulator
 
 
 #
+# print only with --debug
+#
+test_debug '
+	echo rdlconf=${rdlconf} &&
+    echo jobdata=${jobdata} &&
+    echo expected_order=${expected_order}
+'
+
+#
 # test_under_flux is under sharness.d/
 #
 test_under_flux 1
 
-test_expect_success 'loading sim works' '
-	flux module load sim exit-on-complete=false
-'
-test_expect_success 'loading submit works' '
-	flux module load submit job-csv=${jobdata}
-'
-test_expect_success 'loading exec works' '
-	flux module load sim_exec
-'
-test_expect_success 'loading sched works' '
-	flux module load sched rdl-conf=${rdlconf} in-sim=true plugin=sched.backfill plugin-opts=reserve-depth=1
+test_expect_success 'sim: started successfully' '
+    adjust_session_info 12 &&
+    timed_wait_job 5 &&
+    flux module load sim exit-on-complete=false &&
+    flux module load submit job-csv=${jobdata} &&
+    flux module load sim_exec &&
+    flux module load sched rdl-conf=${rdlconf} in-sim=true plugin=sched.backfill plugin-opts=reserve-depth=1
 '
 
-while flux kvs get $(job_kvs_path 12).complete_time 2>&1 | grep -q "No such file"; do sleep 0.5; done
-sleep 0.5
-for x in $(seq 1 12); do echo "$x $(flux kvs get $(job_kvs_path $x).submit_time)"; done | sort -k 2n -k 1n
+test_expect_success 'sim: scheduled and ran all jobs' '
+    timed_sync_wait_job 60
+'
+
 for x in $(seq 1 12); do echo "$x $(flux kvs get $(job_kvs_path $x).starting_time)"; done | sort -k 2n -k 1n | cut -d ' ' -f 1 > actual
 
 test_expect_success 'jobs scheduled in correct order' '


### PR DESCRIPTION
Restores the `kvs_get_dir` that was removed in #281
Cleans up the sim testing scripts so that they are consistent, use flux-waitjob, and have debug printing.