### PR TITLE
require jansson >= 2.6 and eliminate conditional code for older versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ addons:
       - lua5.1
       - liblua5.1-0-dev
       - luarocks
-      - libjansson-dev
       - uuid-dev
       - aspell
       - libopenmpi-dev

--- a/configure.ac
+++ b/configure.ac
@@ -32,7 +32,7 @@ PKG_PROG_PKG_CONFIG
 PKG_CHECK_MODULES([CZMQ], [libczmq >= 3.0.0])
 AC_CHECK_LIB([dl], [dlerror])
 AC_CHECK_LIB([hwloc], [hwloc_topology_init])
-PKG_CHECK_MODULES([JANSSON], [jansson], [], [])
+PKG_CHECK_MODULES([JANSSON], [jansson >= 2.6], [], [])
 PKG_CHECK_MODULES([XML2], [libxml-2.0])
 AX_PROG_LUA([5.1],[5.3])
 AX_LUA_HEADERS

--- a/rdl/jansson-lua.c
+++ b/rdl/jansson-lua.c
@@ -30,14 +30,6 @@
 #include <lauxlib.h>
 #include <jansson.h>
 
-#if JANSSON_VERSION_HEX <= 0x020300
-#define json_object_foreach(x, k, v) \
-    for(void *__json_iterator__ = json_object_iter(x); \
-        __json_iterator__ && \
-        (k = json_object_iter_key(__json_iterator__), v = json_object_iter_value(__json_iterator__), 1); \
-        __json_iterator__ = json_object_iter_next(x, __json_iterator__))
-#endif
-
 static void * json_nullptr;
 
 static int json_object_to_lua_table (lua_State *L, json_t *o);

--- a/src/common/libutil/shortjansson.h
+++ b/src/common/libutil/shortjansson.h
@@ -5,14 +5,6 @@
 #include <stdbool.h>
 #include "oom.h"
 
-#if JANSSON_VERSION_HEX <= 0x020300
-#define json_object_foreach(x, k, v) \
-    for(void *__json_iterator__ = json_object_iter(x); \
-        __json_iterator__ && \
-        (k = json_object_iter_key(__json_iterator__), v = json_object_iter_value(__json_iterator__), 1); \
-        __json_iterator__ = json_object_iter_next(x, __json_iterator__))
-#endif
-
 /* Creates JSON object with refcount of 1.
  */
 static __inline__ json_t *
@@ -259,28 +251,7 @@ static __inline__ json_t *
 Jfromstr (const char *s)
 {
     json_error_t err;
-#if JANSSON_VERSION_HEX >= 0x020300
     json_t *o = json_loads (s, JSON_DECODE_ANY, &err);
-#else /* Jansson < 2.3, no JSON_DECODE_ANY */
-    json_t *o = json_loads (s, 0, &err);
-    if (o == NULL) {
-        /* Jansson < 2.3 will only decode full JSON object or array,
-         *  try wrapping s in {}, then extract inner object.
-         */
-        char *p;
-        if (asprintf (&p, "{\"foo\": %s}", s) >= 0) {
-            json_t *x = json_loads (p, 0, &err);
-            if (x != NULL) {
-                o = json_incref (json_object_get (x, "foo"));
-                json_decref (x);
-            }
-            else
-                fprintf (stderr, "json_loads: %s:%d: %s\n",
-                    err.source, err.position, err.text);
-            free (p);
-        }
-    }
-#endif
     /* XXX: what to do with error object? */
     return (o);
 }


### PR DESCRIPTION
flux-core will shortly require jansson >= 2.6, which tightens up the API allowed in the new functions based on json_pack/json_unpack.

flux-sched should require the same minimum version and by doing so can drop some conditional code for older jansson releases.

This PR should be merged after flux-framework/flux-core#884 is merged.