### PR TITLE
Ats fixes, performance and memory leaks

### DIFF
--- a/resrc/resrc.c
+++ b/resrc/resrc.c
@@ -244,13 +244,6 @@ static int compare_windows_endtime (const void *item1, const void *item2)
     return 1;
 }
 
-static __inline__ void
-myJput (void* o)
-{
-    if (o)
-        Jput ((json_t *)o);
-}
-
 size_t resrc_available_during_range (resrc_t *resrc, int64_t range_starttime,
                                      int64_t range_endtime, bool exclusive)
 {
@@ -639,9 +632,13 @@ resrc_t *resrc_new_from_json (json_t *o, resrc_t *parent, bool physical)
     if (Jget_int64 (o, "size", &ssize))
         size = (size_t) ssize;
     if (!Jget_str (o, "path", &path)) {
-        if ((jhierarchyo = Jobj_get (o, "hierarchy")))
+        if ((jhierarchyo = Jobj_get (o, "hierarchy"))) {
             Jget_str (jhierarchyo, "default", &path);
+        }
     }
+    // Duplicate unowned json string
+    if (path)
+        path = xstrdup (path);
     if (!path) {
         if (parent)
             path = xasprintf ("%s/%s", parent->path, name);
@@ -707,6 +704,7 @@ resrc_t *resrc_new_from_json (json_t *o, resrc_t *parent, bool physical)
         }
     }
 ret:
+    free ((void*)path);
     return resrc;
 }
 

--- a/resrc/resrc.h
+++ b/resrc/resrc.h
@@ -124,7 +124,7 @@ size_t resrc_size_reservtns (resrc_t *resrc);
  *  If key is already present returns -1 and leaves existing item
  *  unchanged.  Returns 0 on success.
  */
-int resrc_twindow_insert (resrc_t *resrc, const char *key, void *item);
+int resrc_twindow_insert (resrc_t *resrc, const char *key, int64_t starttime, int64_t endtime);
 
 /*
  *  Insert a resource flow pointer into the graph table using the

--- a/resrc/resrc_flow.c
+++ b/resrc/resrc_flow.c
@@ -240,6 +240,7 @@ resrc_flow_t *resrc_flow_new_from_json (json_t *o, resrc_flow_t *parent)
     if (resrc)
         resrc_graph_insert (resrc, hierarchy, resrc_flow);
 ret:
+    free ((void*)path);
     return resrc_flow;
 }
 

--- a/resrc/resrc_flow.c
+++ b/resrc/resrc_flow.c
@@ -223,12 +223,8 @@ resrc_flow_t *resrc_flow_new_from_json (json_t *o, resrc_flow_t *parent)
         /* add time window if we are given a start time */
         int64_t starttime;
         if (Jget_int64 (o, "starttime", &starttime)) {
-            json_t *   w = Jnew ();
-            char    *json_str;
             int64_t endtime;
             int64_t wall_time;
-
-            Jadd_int64 (w, "starttime", starttime);
 
             if (!Jget_int64 (o, "endtime", &endtime)) {
                 if (Jget_int64 (o, "walltime", &wall_time))
@@ -236,12 +232,9 @@ resrc_flow_t *resrc_flow_new_from_json (json_t *o, resrc_flow_t *parent)
                 else
                     endtime = TIME_MAX;
             }
-            Jadd_int64 (w, "endtime", endtime);
 
-            json_str = xstrdup (Jtostr (w));
             resrc_twindow_insert (resrc_flow->flow_resrc, "0",
-                                  (void *) json_str);
-            Jput (w);
+                                  starttime, endtime);
         }
     }
     if (resrc)

--- a/sched/sched.c
+++ b/sched/sched.c
@@ -1259,7 +1259,9 @@ static int build_contain_req (ssrvctx_t *ctx, flux_lwj_t *job, resrc_tree_t *rt,
             else {
                 int cores = job->req->corespernode ? job->req->corespernode :
                     n_resources_of_type(rt, "core");
-                build_contain_1node_req (cores, rank, arr);
+                if (cores) {
+                    build_contain_1node_req (cores, rank, arr);
+                }
             }
         }
     }


### PR DESCRIPTION
A test of performance with the ATS backend found that more than 55% of the overall samples taken in the broker were in json_loads, in sched_backfill, almost all of that time inside the encoding and decoding of twindow entries.  There may be a couple more tweaks here, and the zhashx is not terribly fast and it still sorts and so-forth, but this should cut out almost all of that overhead.