### PR TITLE
simulator: Update for recent kvs API changes

### DIFF
--- a/simulator/sim_execsrv.c
+++ b/simulator/sim_execsrv.c
@@ -121,7 +121,7 @@ static int update_job_state (ctx_t *ctx,
     jsc_update_jcb(ctx->h, jobid, JSC_STATE_PAIR, Jtostr (jcb));
 
     kvsdir_put_double (kvs_dir, timer_key, update_time);
-    kvs_commit (ctx->h);
+    kvs_commit (ctx->h, 0);
 
     Jput (jcb);
     Jput (o);
@@ -203,7 +203,7 @@ static int complete_job (ctx_t *ctx, job_t *job, double completion_time)
     kvsdir_put_double (job->kvs_dir, "complete_time", completion_time);
     kvsdir_put_double (job->kvs_dir, "io_time", job->io_time);
 
-    kvs_commit (h);
+    kvs_commit (h, 0);
     free_job (job);
 
     return 0;

--- a/simulator/simulator.c
+++ b/simulator/simulator.c
@@ -173,7 +173,7 @@ int put_job_in_kvs (job_t *job)
     } else if (kvsdir_put_int64 (job->kvs_dir, "io_rate", job->io_rate) < 0) {
         flux_log (h, LOG_ERR, "%s: failed to put 'io_rate'", __FUNCTION__);
         goto ret;
-    } else if (kvs_commit (h) < 0) {
+    } else if (kvs_commit (h, 0) < 0) {
         flux_log (h, LOG_ERR, "%s: failed to commit information for job %d", __FUNCTION__, job->id);
         goto ret;
     }


### PR DESCRIPTION
Add flags argument to kvs_commit() calls to work with new KVS API.

To be merged after flux-core PR #982 is merged.