### PR TITLE
sched/simulator:  Add missing sim_state = NULL assignments

### DIFF
--- a/sched/sched.c
+++ b/sched/sched.c
@@ -932,6 +932,7 @@ static void trigger_cb (flux_t *h,
     send_reply_request (h, "sched", ctx->sctx.sim_state);
 
     free_simstate (ctx->sctx.sim_state);
+    ctx->sctx.sim_state = NULL;
     Jput (o);
 }
 

--- a/simulator/sim_execsrv.c
+++ b/simulator/sim_execsrv.c
@@ -602,6 +602,7 @@ static void trigger_cb (flux_t *h,
 
     // Cleanup
     free_simstate (ctx->sim_state);
+    ctx->sim_state = NULL;
     Jput (o);
     zhash_destroy (&job_hash);
 }


### PR DESCRIPTION
Corrects a problem that was revealed with
https://github.com/flux-framework/flux-sched/pull/238