### PR TITLE
avoid flux-core bug 1027

### DIFF
--- a/sched/flux-waitjob.c
+++ b/sched/flux-waitjob.c
@@ -173,6 +173,7 @@ static int wait_job_complete (flux_t *h)
 
     if (jsc_notify_status (h, waitjob_cb, (void *)h) != 0) {
         flux_log (h, LOG_ERR, "failed to register a waitjob CB");
+        goto done;
     }
     /* once jsc_notify_status is returned, all of JSC events
      * will be queued and delivered. It is safe to signal
@@ -185,6 +186,7 @@ static int wait_job_complete (flux_t *h)
         if (ctx->complete)
             touch_outfile (ctx->complete);
         flux_log (ctx->h, LOG_INFO, "wait_job_complete: completion detected");
+        goto done;
     }
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
         flux_log (h, LOG_ERR, "error in flux_reactor_run");

--- a/sched/flux-waitjob.c
+++ b/sched/flux-waitjob.c
@@ -126,10 +126,10 @@ static bool complete_job (wjctx_t *ctx)
         Jget_int64 (o, JSC_STATE_PAIR_NSTATE, &state);
         Jput (jcb);
         free (json_str);
-        flux_log (ctx->h, LOG_INFO, "%"PRId64" already started (%s)",
-                     ctx->jobid, jsc_job_num2state (state));
+        log_msg ("%"PRId64" already started (%s)",
+                 ctx->jobid, jsc_job_num2state (state));
         if (state == J_COMPLETE) {
-            flux_log (ctx->h, LOG_INFO, "%"PRId64" already completed", ctx->jobid);
+            log_msg ("%"PRId64" already completed", ctx->jobid);
             rc = true;
         }
     }
@@ -144,12 +144,12 @@ static int waitjob_cb (const char *jcbstr, void *arg, int errnum)
     wjctx_t *ctx = getctx (h);
 
     if (errnum > 0) {
-        flux_log (ctx->h, LOG_ERR, "waitjob_cb: errnum passed in");
+        log_errn (errnum, "waitjob_cb: jsc error");
         return -1;
     }
 
     if (!(jcb = Jfromstr (jcbstr))) {
-        flux_log (ctx->h, LOG_ERR, "waitjob_cb: error parsing JSON string");
+        log_msg ("waitjob_cb: error parsing JSON string");
         return -1;
     }
     get_jobid (jcb, &j);
@@ -158,7 +158,7 @@ static int waitjob_cb (const char *jcbstr, void *arg, int errnum)
     if ((j == ctx->jobid) && (ns == J_COMPLETE)) {
         if (ctx->complete)
             touch_outfile (ctx->complete);
-        flux_log (ctx->h, LOG_INFO, "waitjob_cb: completion notified");
+        log_msg ("waitjob_cb: completion notified");
         flux_reactor_stop (flux_get_reactor (ctx->h));
     }
 
@@ -172,7 +172,7 @@ static int wait_job_complete (flux_t *h)
     wjctx_t *ctx = getctx (h);
 
     if (jsc_notify_status (h, waitjob_cb, (void *)h) != 0) {
-        flux_log (h, LOG_ERR, "failed to register a waitjob CB");
+        log_err ("failed to register a waitjob CB");
         goto done;
     }
     /* once jsc_notify_status is returned, all of JSC events
@@ -185,11 +185,11 @@ static int wait_job_complete (flux_t *h)
     if (complete_job (ctx)) {
         if (ctx->complete)
             touch_outfile (ctx->complete);
-        flux_log (ctx->h, LOG_INFO, "wait_job_complete: completion detected");
+        log_msg ("wait_job_complete: completion detected");
         goto done;
     }
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
-        flux_log (h, LOG_ERR, "error in flux_reactor_run");
+        log_err ("error in flux_reactor_run");
         goto done;
     }
     rc = 0;
@@ -245,7 +245,6 @@ int main (int argc, char *argv[])
         ctx->complete = cfn;
     ctx->jobid = jobid;
 
-    flux_log_set_appname (h, "waitjob");
     wait_job_complete (h);
 
     flux_close (h);

--- a/t/sharness.d/sched-sharness.sh
+++ b/t/sharness.d/sched-sharness.sh
@@ -224,11 +224,11 @@ timed_run_flux_jstat () {
 #
 timed_wait_job () {
     local tout=$1
-    flux waitjob -s wo.st.$sched_test_session \
-         -c wo.end.$sched_test_session $sched_end_jobid &
-    $SHARNESS_TEST_SRCDIR/scripts/waitfile.lua --timeout ${tout} \
-        wo.st.$sched_test_session >&2
-    return $?
+    local sfile=wo.st.$sched_test_session
+    local cfile=wo.end.$sched_test_session
+    rm -f ${sfile} ${cfile}
+    flux waitjob -s ${sfile} -c ${cfile} $sched_end_jobid &
+    $SHARNESS_TEST_SRCDIR/scripts/waitfile.lua --timeout ${tout} ${sfile} >&2
 }
 
 # PUBLIC:
@@ -237,9 +237,8 @@ timed_wait_job () {
 #
 timed_sync_wait_job () {
     local tout=$1
-    $SHARNESS_TEST_SRCDIR/scripts/waitfile.lua --timeout ${tout} \
-        wo.end.$sched_test_session >&2
-    return $?
+    local cfile=wo.end.$sched_test_session
+    $SHARNESS_TEST_SRCDIR/scripts/waitfile.lua --timeout ${tout} ${cfile} >&2
 }
 
 # PUBLIC: 

--- a/t/t0002-waitjob.t
+++ b/t/t0002-waitjob.t
@@ -12,9 +12,12 @@ Ensure flux-waitjob works as expected.
 #
 test_under_flux 4
 
+test_expect_success  'waitjob: load sched module' '
+    flux module load sched
+'
+
 test_expect_success  'waitjob: works when the job has not started' '
     adjust_session_info 1 &&
-    flux module load sched &&
     timed_wait_job 5 &&
     flux submit -N 4 -n 4 hostname &&
     timed_sync_wait_job 5
@@ -30,6 +33,10 @@ test_expect_success 'waitjob: works when the job started but has not completed' 
     flux submit -N 4 -n 4 sleep 2 &&
     timed_wait_job 3 &&
     timed_sync_wait_job 3
+'
+
+test_expect_success  'waitjob: remove sched module' '
+    flux module remove sched
 '
 
 test_done


### PR DESCRIPTION
The main point of this PR is to add a workaround for flux-framework/flux-core#1027 so we don't have to push out another tag immediately, but the workaround turned out to be a bug fix in `flux-waitjob`, which was not exiting when a job had already run.

The "remove old sentinel files" fix was not based on any observed failure.  Happy to rebase without that one if it's not correct, but it seems right based on my read of hte code.