### PR TITLE
build: enable -Werror=missing-field-initializers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@ AC_PROG_MAKE_SET
 AM_PROG_CC_C_O
 AX_CODE_COVERAGE
 
-GCCWARN="-Wall -Werror -Wno-error=deprecated-declarations"
+GCCWARN="-Wall -Werror -Werror=missing-field-initializers -Wno-error=deprecated-declarations"
 AC_SUBST([GCCWARN])
 
 # Checks for libraries.

--- a/sched/plugin.c
+++ b/sched/plugin.c
@@ -291,9 +291,9 @@ done:
 
 
 static struct flux_msg_handler_spec plugin_htab[] = {
-    { FLUX_MSGTYPE_REQUEST, "sched.insmod",         insmod_cb },
-    { FLUX_MSGTYPE_REQUEST, "sched.rmmod",          rmmod_cb },
-    { FLUX_MSGTYPE_REQUEST, "sched.lsmod",          lsmod_cb },
+    { FLUX_MSGTYPE_REQUEST, "sched.insmod",         insmod_cb, 0, NULL },
+    { FLUX_MSGTYPE_REQUEST, "sched.rmmod",          rmmod_cb, 0, NULL },
+    { FLUX_MSGTYPE_REQUEST, "sched.lsmod",          lsmod_cb, 0, NULL },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/sched/sched.c
+++ b/sched/sched.c
@@ -947,9 +947,9 @@ static void trigger_cb (flux_t *h,
  * Simulator Initialization Functions
  */
 static struct flux_msg_handler_spec sim_htab[] = {
-    {FLUX_MSGTYPE_EVENT, "sim.start", start_cb},
-    {FLUX_MSGTYPE_REQUEST, "sched.trigger", trigger_cb},
-    {FLUX_MSGTYPE_EVENT, "sched.res.*", sim_res_event_cb},
+    {FLUX_MSGTYPE_EVENT, "sim.start", start_cb, 0, NULL},
+    {FLUX_MSGTYPE_REQUEST, "sched.trigger", trigger_cb, 0, NULL},
+    {FLUX_MSGTYPE_EVENT, "sched.res.*", sim_res_event_cb, 0, NULL},
     FLUX_MSGHANDLER_TABLE_END,
 };
 
@@ -1008,7 +1008,7 @@ static int setup_sim (ssrvctx_t *ctx, bool sim)
  ******************************************************************************/
 
 static struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_EVENT,     "sched.res.*", res_event_cb},
+    { FLUX_MSGTYPE_EVENT,     "sched.res.*", res_event_cb, 0, NULL},
     FLUX_MSGHANDLER_TABLE_END
 };
 

--- a/simulator/sim_execsrv.c
+++ b/simulator/sim_execsrv.c
@@ -632,9 +632,9 @@ static void run_cb (flux_t *h,
 }
 
 static struct flux_msg_handler_spec htab[] = {
-    {FLUX_MSGTYPE_EVENT, "sim.start", start_cb},
-    {FLUX_MSGTYPE_REQUEST, "sim_exec.trigger", trigger_cb},
-    {FLUX_MSGTYPE_REQUEST, "sim_exec.run.*", run_cb},
+    {FLUX_MSGTYPE_EVENT, "sim.start", start_cb, 0, NULL},
+    {FLUX_MSGTYPE_REQUEST, "sim_exec.trigger", trigger_cb, 0, NULL},
+    {FLUX_MSGTYPE_REQUEST, "sim_exec.run.*", run_cb, 0, NULL},
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/simulator/simsrv.c
+++ b/simulator/simsrv.c
@@ -418,10 +418,10 @@ static void alive_cb (flux_t *h,
 }
 
 static struct flux_msg_handler_spec htab[] = {
-    {FLUX_MSGTYPE_REQUEST, "sim.join", join_cb},
-    {FLUX_MSGTYPE_REQUEST, "sim.reply", reply_cb},
-    {FLUX_MSGTYPE_REQUEST, "sim.alive", alive_cb},
-    {FLUX_MSGTYPE_EVENT, "rdl.update", rdl_update_cb},
+    {FLUX_MSGTYPE_REQUEST, "sim.join", join_cb, 0, NULL},
+    {FLUX_MSGTYPE_REQUEST, "sim.reply", reply_cb, 0, NULL},
+    {FLUX_MSGTYPE_REQUEST, "sim.alive", alive_cb, 0, NULL},
+    {FLUX_MSGTYPE_EVENT, "rdl.update", rdl_update_cb, 0, NULL},
     FLUX_MSGHANDLER_TABLE_END,
 };
 const int htablen = sizeof (htab) / sizeof (htab[0]);

--- a/simulator/submitsrv.c
+++ b/simulator/submitsrv.c
@@ -327,8 +327,8 @@ static void trigger_cb (flux_t *h,
 }
 
 static struct flux_msg_handler_spec htab[] = {
-    {FLUX_MSGTYPE_EVENT, "sim.start", start_cb},
-    {FLUX_MSGTYPE_REQUEST, "submit.trigger", trigger_cb},
+    {FLUX_MSGTYPE_EVENT, "sim.start", start_cb, 0, NULL},
+    {FLUX_MSGTYPE_REQUEST, "submit.trigger", trigger_cb, 0, NULL},
     FLUX_MSGHANDLER_TABLE_END,
 };
 


### PR DESCRIPTION
This PR should be merged after flux-framework/flux-core#1032 is merged.

It adds `-Werror=missing-field-initializers` to CFLAGS and adds missing initializers to the various statically defined `struct flux_msg_handler_spec` arrays.  In flux-core, a "rolemask" field has been added to this struct, and due to ambiguities about how these arrays might be declared and implicitly initialized, it is probably best to make sure rolemask isn't ever registered without explicit initialization.

