### PR TITLE
Fix simulator and re-enable sim integration tests

### DIFF
--- a/sched/sched.c
+++ b/sched/sched.c
@@ -1112,8 +1112,7 @@ static inline int bridge_send_runrequest (ssrvctx_t *ctx, flux_lwj_t *job)
         if (asprintf (&topic, "sim_exec.run.%"PRId64"", job->lwj_id) < 0) {
             flux_log (h, LOG_ERR, "%s: topic create failed: %s",
                       __FUNCTION__, strerror (errno));
-        } else if (!(msg = flux_msg_create (FLUX_MSGTYPE_REQUEST))
-                   || flux_msg_set_topic (msg, topic) < 0
+        } else if (!(msg = flux_request_encode (topic, NULL))
                    || flux_send (h, msg, 0) < 0) {
             flux_log (h, LOG_ERR, "%s: request create failed: %s",
                       __FUNCTION__, strerror (errno));

--- a/simulator/simsrv.c
+++ b/simulator/simsrv.c
@@ -81,10 +81,8 @@ static int send_trigger (flux_t *h, char *mod_name, sim_state_t *sim_state)
 
     o = sim_state_to_json (sim_state);
 
-    msg = flux_msg_create (FLUX_MSGTYPE_REQUEST);
     topic = xasprintf ("%s.trigger", mod_name);
-    flux_msg_set_topic (msg, topic);
-    flux_msg_set_json (msg, Jtostr (o));
+    msg = flux_request_encode (topic, Jtostr (o));
     if (flux_send (h, msg, 0) < 0) {
         flux_log (h, LOG_ERR, "failed to send trigger to %s", mod_name);
         rc = -1;

--- a/simulator/simsrv.c
+++ b/simulator/simsrv.c
@@ -290,37 +290,37 @@ static int check_for_new_timers (const char *key, double *reply_event_time,
         (double *)zhash_lookup (curr_sim_state->timers, key);
 
     if (*curr_event_time < 0 && *reply_event_time < 0) {
-        // flux_log (ctx->h, LOG_DEBUG, "no timers found for %s, doing nothing",
-        // key);
+        // flux_log (ctx->h, LOG_DEBUG, "%s - no timers found for %s, doing nothing", __FUNCTION__,
+        //           key);
         return 0;
     } else if (*curr_event_time < 0) {
         if (*reply_event_time >= sim_time) {
             *curr_event_time = *reply_event_time;
-            // flux_log (ctx->h, LOG_DEBUG, "change in timer accepted for %s",
-            // key);
+            // flux_log (ctx->h, LOG_DEBUG, "%s - change in timer accepted for %s", __FUNCTION__,
+            //           key);
             return 0;
         } else {
-            flux_log (ctx->h, LOG_ERR, "bad reply timer for %s", key);
+            flux_log (ctx->h, LOG_ERR, "%s - bad reply timer for %s", __FUNCTION__, key);
             return -1;
         }
     } else if (*reply_event_time < 0) {
-        flux_log (ctx->h, LOG_ERR, "event timer deleted from %s", key);
+        flux_log (ctx->h, LOG_ERR, "%s - event timer deleted from %s", __FUNCTION__, key);
         return -1;
     } else if (*reply_event_time < sim_time
                && *curr_event_time != *reply_event_time) {
         flux_log (ctx->h,
                   LOG_ERR,
-                  "incoming modified time is before sim time for %s",
+                  "%s - incoming modified time is before sim time for %s", __FUNCTION__,
                   key);
         return -1;
     } else if (*reply_event_time >= sim_time
                && *reply_event_time < *curr_event_time) {
         *curr_event_time = *reply_event_time;
-        // flux_log (ctx->h, LOG_DEBUG, "change in timer accepted for %s", key);
+        // flux_log (ctx->h, LOG_DEBUG, "%s - change in timer accepted for %s", __FUNCTION__, key);
         return 0;
     } else {
-        // flux_log (ctx->h, LOG_DEBUG, "no changes made to %s timer, curr_time:
-        // %f\t reply_time: %f", key, *curr_event_time, *reply_event_time);
+        // flux_log (ctx->h, LOG_DEBUG, "%s - no changes made to %s timer, curr_time:"
+        //           "%f\t reply_time: %f", __FUNCTION__, key, *curr_event_time, *reply_event_time);
         return 0;
     }
 }

--- a/simulator/simsrv.c
+++ b/simulator/simsrv.c
@@ -328,10 +328,13 @@ static void copy_new_state_data (ctx_t *ctx,
         curr_sim_state->sim_time = reply_sim_state->sim_time;
     }
 
-    void *item = zhash_first (reply_sim_state->timers);
-    while (item) {
-        check_for_new_timers (zhash_cursor (item), item, ctx);
-        item = zhash_next (reply_sim_state->timers);
+    void *item = NULL;
+    const char *key = NULL;
+    for (item = zhash_first (reply_sim_state->timers);
+         item;
+         item = zhash_next (reply_sim_state->timers)) {
+        key = zhash_cursor (reply_sim_state->timers);
+        check_for_new_timers (key, item, ctx);
     }
 }
 

--- a/simulator/simulator.c
+++ b/simulator/simulator.c
@@ -242,7 +242,7 @@ job_t *pull_job_from_kvs (int id, kvsdir_t *kvsdir)
 int send_alive_request (flux_t *h, const char *module_name)
 {
     int rc = 0;
-    flux_msg_t *msg = NULL;
+    flux_future_t *future = NULL;
     json_t *o = Jnew ();
     uint32_t rank;
 
@@ -252,12 +252,14 @@ int send_alive_request (flux_t *h, const char *module_name)
     Jadd_str (o, "mod_name", module_name);
     Jadd_int (o, "rank", rank);
 
-    msg = flux_request_encode ("sim.alive", Jtostr (o));
-    if (flux_send (h, msg, 0) < 0) {
+    future = flux_rpc (h, "sim.alive", Jtostr (o), FLUX_NODEID_ANY, FLUX_RPC_NORESPONSE);
+    if (!future) {
         rc = -1;
     }
 
     Jput (o);
+    flux_future_destroy (future);
+
     return rc;
 }
 
@@ -267,19 +269,20 @@ int send_reply_request (flux_t *h,
                         sim_state_t *sim_state)
 {
     int rc = 0;
-    flux_msg_t *msg = NULL;
+    flux_future_t *future = NULL;
     json_t *o = NULL;
 
     o = sim_state_to_json (sim_state);
     Jadd_str (o, "mod_name", module_name);
 
-    msg = flux_request_encode ("sim.reply", Jtostr (o));
-    if (flux_send (h, msg, 0) < 0) {
+    future = flux_rpc (h, "sim.reply", Jtostr (o), FLUX_NODEID_ANY, FLUX_RPC_NORESPONSE);
+    if (!future) {
         rc = -1;
     }
 
     flux_log (h, LOG_DEBUG, "sent a reply request: %s", Jtostr (o));
     Jput (o);
+    flux_future_destroy(future);
     return rc;
 }
 
@@ -287,7 +290,7 @@ int send_reply_request (flux_t *h,
 int send_join_request (flux_t *h, const char *module_name, double next_event)
 {
     int rc = 0;
-    flux_msg_t *msg = NULL;
+    flux_future_t *future = NULL;
     json_t *o = Jnew ();
     uint32_t rank;
 
@@ -298,13 +301,13 @@ int send_join_request (flux_t *h, const char *module_name, double next_event)
     Jadd_int (o, "rank", rank);
     Jadd_double (o, "next_event", next_event);
 
-    msg = flux_request_encode("sim.join", Jtostr(o));
-
-    if (flux_send (h, msg, 0) < 0) {
+    future = flux_rpc (h, "sim.join", Jtostr (o), FLUX_NODEID_ANY, FLUX_RPC_NORESPONSE);
+    if (!future) {
         rc = -1;
     }
 
     Jput (o);
+    flux_future_destroy (future);
     return rc;
 }
 

--- a/simulator/simulator.c
+++ b/simulator/simulator.c
@@ -71,10 +71,13 @@ json_t *sim_state_to_json (sim_state_t *sim_state)
     json_t *o = Jnew ();
     json_t *event_timers = Jnew ();
 
-    void *item = zhash_first (sim_state->timers);
-    while (item) {
-        add_timers_to_json (zhash_cursor (item), item, event_timers);
-        item = zhash_next (sim_state->timers);
+    void *item = NULL;
+    const char *key = NULL;
+    for (item = zhash_first (sim_state->timers);
+         item;
+         item = zhash_next (sim_state->timers)) {
+        key = zhash_cursor (sim_state->timers);
+        add_timers_to_json (key, item, event_timers);
     }
 
     // build the main json obg

--- a/simulator/simulator.c
+++ b/simulator/simulator.c
@@ -249,9 +249,7 @@ int send_alive_request (flux_t *h, const char *module_name)
     Jadd_str (o, "mod_name", module_name);
     Jadd_int (o, "rank", rank);
 
-    msg = flux_msg_create (FLUX_MSGTYPE_REQUEST);
-    flux_msg_set_topic (msg, "sim.alive");
-    flux_msg_set_json (msg, Jtostr (o));
+    msg = flux_request_encode ("sim.alive", Jtostr (o));
     if (flux_send (h, msg, 0) < 0) {
         rc = -1;
     }
@@ -272,9 +270,7 @@ int send_reply_request (flux_t *h,
     o = sim_state_to_json (sim_state);
     Jadd_str (o, "mod_name", module_name);
 
-    msg = flux_msg_create (FLUX_MSGTYPE_REQUEST);
-    flux_msg_set_topic (msg, "sim.reply");
-    flux_msg_set_json (msg, Jtostr (o));
+    msg = flux_request_encode ("sim.reply", Jtostr (o));
     if (flux_send (h, msg, 0) < 0) {
         rc = -1;
     }
@@ -299,9 +295,8 @@ int send_join_request (flux_t *h, const char *module_name, double next_event)
     Jadd_int (o, "rank", rank);
     Jadd_double (o, "next_event", next_event);
 
-    msg = flux_msg_create (FLUX_MSGTYPE_REQUEST);
-    flux_msg_set_topic (msg, "sim.join");
-    flux_msg_set_json (msg, Jtostr (o));
+    msg = flux_request_encode("sim.join", Jtostr(o));
+
     if (flux_send (h, msg, 0) < 0) {
         rc = -1;
     }

--- a/simulator/submitsrv.c
+++ b/simulator/submitsrv.c
@@ -214,6 +214,8 @@ int schedule_next_job (flux_t *h, sim_state_t *sim_state)
     job = zlist_pop (jobs);
     if (job == NULL) {
         flux_log (h, LOG_DEBUG, "no more jobs to submit");
+        new_submit_mod_time = (double *)zhash_lookup (timers, module_name);
+        *new_submit_mod_time = -1;
         return -1;
     }
 

--- a/t/t2000-fcfs.t
+++ b/t/t2000-fcfs.t
@@ -14,10 +14,6 @@ rdlconf=$(readlink -e "${SHARNESS_TEST_SRCDIR}/../conf/hype-io.lua")
 jobdata=$(readlink -e "${SHARNESS_TEST_SRCDIR}/data/job-traces/hype-test.csv")
 expected_order=$(readlink -e "${SHARNESS_TEST_SRCDIR}/data/emulator-data/fcfs_expected")
 
-skip_all="disabled pending resolution of issue 249"
-test_done
-
-
 #
 # print only with --debug
 #

--- a/t/t2001-fcfs-aware.t
+++ b/t/t2001-fcfs-aware.t
@@ -14,9 +14,6 @@ rdlconf=$(readlink -e "${SHARNESS_TEST_SRCDIR}/../conf/hype-io.lua")
 jobdata=$(readlink -e "${SHARNESS_TEST_SRCDIR}/data/job-traces/hype-io-test.csv")
 expected_order=$(readlink -e "${SHARNESS_TEST_SRCDIR}/data/emulator-data/fcfs_expected")
 
-skip_all="disabled pending resolution of issue 249"
-test_done
-
 #
 # print only with --debug
 #

--- a/t/t2002-easy.t
+++ b/t/t2002-easy.t
@@ -15,10 +15,6 @@ expected_order=$(readlink -e "${SHARNESS_TEST_SRCDIR}/data/emulator-data/easy_ex
 
 FLUX_MODULE_PATH_PREPEND="$FLUX_MODULE_PATH_PREPEND:$(sched_build_path simulator/.libs)"
 
-skip_all="disabled pending resolution of issue 249"
-test_done
-
-
 #
 # print only with --debug
 #


### PR DESCRIPTION
Problems with the simulator were unearthed in https://github.com/flux-framework/flux-sched/pull/246 since this was the first PR to sched in several months.  We temporarily disabled the simulator integration tests until the problems were resolved.   This PR fixes those problems and re-enables the simulator integration tests.

I also refactored a few functions in the simulator to simplify their main loops and logging (I can put these changes into a separate PR, if desired)

To avoid this situation in the future, we have setup a nightly cron job on Travis CI for flux-sched.

Fixes https://github.com/flux-framework/flux-sched/issues/249