### PR TITLE
sim: track changes in flux-core to jansson functions

### DIFF
--- a/simulator/simsrv.c
+++ b/simulator/simsrv.c
@@ -109,7 +109,7 @@ int send_start_event (flux_t *h)
     if (flux_get_rank (h, &rank) < 0)
         return -1;
 
-    if (!(msg = flux_event_encodef ("sim.start", "{ s:s s:i s:i }",
+    if (!(msg = flux_event_pack ("sim.start", "{ s:s s:i s:i }",
                                     "mod_name", "sim",
                                     "rank", rank,
                                     "sim_time", 0))

--- a/simulator/simulator.c
+++ b/simulator/simulator.c
@@ -206,7 +206,7 @@ int kvsdir_get_double (kvsdir_t *dir, const char *name, double *valp)
         goto done;
     if (!(f = flux_kvs_lookup (h, 0, key)))
         goto done;
-    if (flux_kvs_lookup_getf (f, "F", valp) < 0)
+    if (flux_kvs_lookup_get_unpack (f, "F", valp) < 0)
         goto done;
     rc = 0;
 done:
@@ -229,7 +229,7 @@ int kvsdir_get_int (kvsdir_t *dir, const char *name, int *valp)
         goto done;
     if (!(f = flux_kvs_lookup (h, 0, key)))
         goto done;
-    if (flux_kvs_lookup_getf (f, "i", valp) < 0)
+    if (flux_kvs_lookup_get_unpack (f, "i", valp) < 0)
         goto done;
     rc = 0;
 done:
@@ -252,7 +252,7 @@ int kvsdir_get_int64 (kvsdir_t *dir, const char *name, int64_t *valp)
         goto done;
     if (!(f = flux_kvs_lookup (h, 0, key)))
         goto done;
-    if (flux_kvs_lookup_getf (f, "I", valp) < 0)
+    if (flux_kvs_lookup_get_unpack (f, "I", valp) < 0)
         goto done;
     rc = 0;
 done:
@@ -276,7 +276,7 @@ int kvsdir_get_string (kvsdir_t *dir, const char *name, char **valp)
         goto done;
     if (!(f = flux_kvs_lookup (h, 0, key)))
         goto done;
-    if (flux_kvs_lookup_getf (f, "s", &s) < 0)
+    if (flux_kvs_lookup_get_unpack (f, "s", &s) < 0)
         goto done;
     if (!(*valp = strdup (s))) {
         errno = ENOMEM;
@@ -417,13 +417,13 @@ kvsdir_t *job_kvsdir (flux_t *h, int jobid)
     const char *kvs_path;
     kvsdir_t *d = NULL;
 
-    f = flux_rpcf (h, "job.kvspath", FLUX_NODEID_ANY, 0,
+    f = flux_rpc_pack (h, "job.kvspath", FLUX_NODEID_ANY, 0,
                     "{s:[i]}", "ids", jobid);
     if (!f) {
-        flux_log_error (h, "flux_rpcf");
+        flux_log_error (h, "flux_rpc_pack");
         return (NULL);
     }
-    if (flux_rpc_getf (f, "{s:[s]}", "paths", &kvs_path) < 0) {
+    if (flux_rpc_get_unpack (f, "{s:[s]}", "paths", &kvs_path) < 0) {
         flux_log (h, LOG_DEBUG, "%s: failed to resolve job directory, falling back to lwj.%d", __FUNCTION__, jobid);
         // Fall back to lwj.%d:
         if (kvs_get_dir (h, &d, "lwj.%d", jobid))

--- a/simulator/submitsrv.c
+++ b/simulator/submitsrv.c
@@ -219,7 +219,7 @@ int schedule_next_job (flux_t *h, sim_state_t *sim_state)
         return -1;
     }
 
-    f = flux_rpcf (h, "job.create", FLUX_NODEID_ANY, 0,
+    f = flux_rpc_pack (h, "job.create", FLUX_NODEID_ANY, 0,
                      "{ s:i s:i s:I }",
                      "nnodes", job->nnodes,
                      "ntasks", job->ncpus,
@@ -228,7 +228,7 @@ int schedule_next_job (flux_t *h, sim_state_t *sim_state)
         flux_log (h, LOG_ERR, "%s: %s", __FUNCTION__, strerror (errno));
         return -1;
     }
-    if (flux_rpc_getf (f, "{ s:I }", "jobid", &new_jobid) < 0) {
+    if (flux_rpc_get_unpack (f, "{ s:I }", "jobid", &new_jobid) < 0) {
         flux_log (h, LOG_ERR, "%s: %s", __FUNCTION__, strerror (errno));
 	flux_future_destroy (f);
         return -1;
@@ -244,7 +244,7 @@ int schedule_next_job (flux_t *h, sim_state_t *sim_state)
         log_err_exit ("put_job_in_kvs");
 
     // Send "submitted" event
-    if (!(msg = flux_event_encodef ("wreck.state.submitted",
+    if (!(msg = flux_event_pack ("wreck.state.submitted",
                                     "{ s:I }", "lwj", new_jobid))
         || flux_send (h, msg, 0) < 0) {
         return -1;


### PR DESCRIPTION
Tracks changes in https://github.com/flux-framework/flux-core/pull/1104

Old | New
-- | --
flux_kvs_lookup_getf() | flux_kvs_lookup_get_unpack()
flux_msg_set_jsonf() | flux_msg_pack()
flux_msg_vset_jsonf() | flux_msg_vpack()
flux_msg_get_jsonf() | flux_msg_unpack()
flux_msg_vget_jsonf() | flux_msg_vunpack()
flux_rpcf() | flux_rpc_pack()
flux_rpc_getf() | flux_rpc_get_unpack()
flux_event_decodef() | flux_event_unpack()
flux_event_encodef() | flux_event_pack()
flux_request_decodef() | flux_request_unpack()
flux_respondf() | flux_respond_pack()


Fixes #254