### PR TITLE
Added ISO time parsing to job traces

### DIFF
--- a/simulator/submitsrv.c
+++ b/simulator/submitsrv.c
@@ -90,7 +90,7 @@ double convert_time_to_sec (char *time)
 }
 
 // Populate a field in the job_t based off a value extracted from the csv
-int insert_into_job (job_t *job, char *column_name, char *value)
+int insert_into_job (flux_t *h, job_t *job, char *column_name, char *value)
 {
     if (!strcmp (column_name, "JobID")) {
         job->id = atoi (value);
@@ -110,16 +110,20 @@ int insert_into_job (job_t *job, char *column_name, char *value)
         char *endptr;
         struct tm tm_spec; 
         double stime = strtod(value, &endptr);
-        // If this fails then try to parse the string
-        if (endptr != NULL && endptr != value) {
+        // Check if you parsed only a bit of the string (e.g. the year)
+        // Trailing whitespace is allowed too.
+        if (*endptr != '\0' && *endptr != ' ' && *endptr != '\t') {
             endptr = strptime(value, "%Y-%m-%dT%H:%M:%S", &tm_spec);
             if (endptr == NULL) {
-                // flux_log (h, LOG_WARNING, "Incorrect Submit fmt, expects %s",
-                //         "%Y-%m-%dT%H:%M:%S or seconds since epoch");
-                stime = atof(value);
+                endptr = value;
             } else {
                 stime = (double) mktime(&tm_spec);
             }
+        }
+        if (endptr == value) {
+            flux_log (h, LOG_WARNING, "Incorrect Submit fmt, expects %s"
+                        " or seconds since epoch; replacing '%s' with %f",
+                        "%Y-%m-%dT%H:%M:%S", value, stime);
         }
         job->submit_time = stime;
     } else if (!strcmp (column_name, "Elapsed")) {
@@ -185,7 +189,7 @@ int parse_job_csv (flux_t *h, char *filename, zlist_t *jobs)
                 flux_log (h, LOG_ERR, "column name is NULL");
                 return -1;
             }
-            insert_into_job (curr_job, curr_column, token);
+            insert_into_job (h, curr_job, curr_column, token);
             token = strtok (NULL, ",");
             curr_column = zlist_next (header);
         }

--- a/simulator/submitsrv.c
+++ b/simulator/submitsrv.c
@@ -110,8 +110,8 @@ int insert_into_job (flux_t *h, job_t *job, char *column_name, char *value)
         char *endptr;
         struct tm tm_spec; 
         double stime = strtod(value, &endptr);
-        // Check if you parsed only a bit of the string (e.g. the year)
-        // Trailing whitespace is allowed too.
+        // Check if you parsed only a bit of the string (e.g. just the year)
+        // Trailing whitespace is not an error.
         if (*endptr != '\0' && *endptr != ' ' && *endptr != '\t') {
             endptr = strptime(value, "%Y-%m-%dT%H:%M:%S", &tm_spec);
             if (endptr == NULL) {
@@ -120,10 +120,12 @@ int insert_into_job (flux_t *h, job_t *job, char *column_name, char *value)
                 stime = (double) mktime(&tm_spec);
             }
         }
+        // endptr gets set by strtod or by strptime
         if (endptr == value) {
-            flux_log (h, LOG_WARNING, "Incorrect Submit fmt, expects %s"
+            flux_log (h, LOG_WARNING, "Incorrect Submit format, expects %s"
                         " or seconds since epoch; replacing '%s' with %f",
-                        "%Y-%m-%dT%H:%M:%S", value, stime);
+                        "%Y-%m-%dT%H:%M:%S (yyyy-mm-ddThh:mm:ss)",
+                        value, stime);
         }
         job->submit_time = stime;
     } else if (!strcmp (column_name, "Elapsed")) {

--- a/simulator/submitsrv.c
+++ b/simulator/submitsrv.c
@@ -107,7 +107,21 @@ int insert_into_job (job_t *job, char *column_name, char *value)
     } else if (!strcmp (column_name, "Timelimit")) {
         job->time_limit = convert_time_to_sec (value);
     } else if (!strcmp (column_name, "Submit")) {
-        job->submit_time = atof (value);
+        char *endptr;
+        struct tm tm_spec; 
+        double stime = strtod(value, &endptr);
+        // If this fails then try to parse the string
+        if (endptr != NULL && endptr != value) {
+            endptr = strptime(value, "%Y-%m-%dT%H:%M:%S", &tm_spec);
+            if (endptr == NULL) {
+                // flux_log (h, LOG_WARNING, "Incorrect Submit fmt, expects %s",
+                //         "%Y-%m-%dT%H:%M:%S or seconds since epoch");
+                stime = atof(value);
+            } else {
+                stime = (double) mktime(&tm_spec);
+            }
+        }
+        job->submit_time = stime;
     } else if (!strcmp (column_name, "Elapsed")) {
         job->execution_time = convert_time_to_sec (value);
     } else if (!strncmp (column_name,


### PR DESCRIPTION
It would be nice if we could take the output of `sacct` with no (or very little) modification and use it in a simulator run. This is the first step towards this.

You'll notice a bit of weirdness around line 119. This was required to get make check to pass, and I believe it has to do with the semantics when the Submit column is missing or ill-formed. Normally this should be an error but `atof` never returns an error. I tried to just set `stime = 0.0` or something, but that didn't work either. I'm not quite sure what is going on, but this passes `make check` so I am tempted to just leave it.