### PR TITLE
track KVS API changes in flux-core

### DIFF
--- a/sched/sched.c
+++ b/sched/sched.c
@@ -572,7 +572,7 @@ static json_t *get_string_blocking (flux_t *h, const char *key)
     json_t *o = NULL;
     int saved_errno;
 
-    if (kvs_watch_once (h, key, &json_str) < 0) {
+    if (flux_kvs_watch_once (h, key, &json_str) < 0) {
         saved_errno = errno;
         goto error;
     }

--- a/simulator/simulator.h
+++ b/simulator/simulator.h
@@ -47,7 +47,7 @@ typedef struct {
     int nnodes;
     int ncpus;
     int64_t io_rate;
-    kvsdir_t *kvs_dir;
+    flux_kvsdir_t *kvs_dir;
 } job_t;
 
 sim_state_t *new_simstate ();
@@ -55,9 +55,9 @@ void free_simstate (sim_state_t *sim_state);
 json_t *sim_state_to_json (sim_state_t *state);
 sim_state_t *json_to_sim_state (json_t *o);
 
-kvsdir_t *job_kvsdir (flux_t *h, int jobid);
+flux_kvsdir_t *job_kvsdir (flux_t *h, int jobid);
 int put_job_in_kvs (job_t *job);
-job_t *pull_job_from_kvs (int id, kvsdir_t *kvs_dir);
+job_t *pull_job_from_kvs (int id, flux_kvsdir_t *kvs_dir);
 void free_job (job_t *job);
 job_t *blank_job ();
 int send_alive_request (flux_t *h, const char *module_name);

--- a/simulator/submitsrv.c
+++ b/simulator/submitsrv.c
@@ -222,7 +222,7 @@ int schedule_next_job (flux_t *h, sim_state_t *sim_state)
 {
     flux_future_t *f = NULL;
     flux_msg_t *msg = NULL;
-    kvsdir_t *dir = NULL;
+    flux_kvsdir_t *dir = NULL;
     job_t *job = NULL;
     int64_t new_jobid = -1;
     double *new_sched_mod_time = NULL, *new_submit_mod_time = NULL;
@@ -258,7 +258,7 @@ int schedule_next_job (flux_t *h, sim_state_t *sim_state)
     // Update lwj.%jobid%'s state in the kvs to "submitted"
     if (!(dir = job_kvsdir (h, new_jobid)))
         log_err_exit ("kvs_get_dir (id=%lu)", new_jobid);
-    kvsdir_put_string (dir, "state", "submitted");
+    flux_kvsdir_pack (dir, "state", "s", "submitted");
     job->kvs_dir = dir;
     if (put_job_in_kvs (job) < 0)
         log_err_exit ("put_job_in_kvs");


### PR DESCRIPTION
This PR tracks flux-core API changes proposed in flux-framework/flux-core#1233.  It should not be merged until after that one (and sched travis-ci can be shown to run successfully)

The first commit simply renames functions and types to get sched to comple.

The rest of the commits migrate sched off of functions that now cause "deprecated" warnings from the compiler.  In the process, I did some minor refactoring and error handling cleanup in the simulator code surrounding KVS access to job data.  I hope it's not a pain to review @SteVwonder!