### PR TITLE
avoid deprecated KVS functions, minor simulator cleanup

### DIFF
--- a/simulator/simulator.c
+++ b/simulator/simulator.c
@@ -161,7 +161,7 @@ static int txn_dir_pack (flux_kvs_txn_t *txn, flux_kvsdir_t *dir,
     return rc;
 }
 
-int put_job_in_kvs (job_t *job)
+int put_job_in_kvs (job_t *job, const char *initial_state)
 {
     if (job->kvs_dir == NULL)
         return (-1);
@@ -192,6 +192,8 @@ int put_job_in_kvs (job_t *job)
     if (txn_dir_pack (txn, job->kvs_dir, "ncpus", "i", job->ncpus) < 0)
         goto error;
     if (txn_dir_pack (txn, job->kvs_dir, "io_rate", "I", job->io_rate) < 0)
+        goto error;
+    if (txn_dir_pack (txn, job->kvs_dir, "state", "s", initial_state) < 0)
         goto error;
     if (!(f = flux_kvs_commit (h, 0, txn)) || flux_future_get (f, NULL) < 0)
         goto error;

--- a/simulator/simulator.c
+++ b/simulator/simulator.c
@@ -153,31 +153,40 @@ int put_job_in_kvs (job_t *job)
     if (flux_kvsdir_pack (job->kvs_dir, "user", "s", job->user) < 0) {
         flux_log (h, LOG_ERR, "%s: failed to put 'user'", __FUNCTION__);
         goto ret;
-    } else if (flux_kvsdir_pack (job->kvs_dir, "jobname", "s", job->jobname) < 0) {
+    }
+    if (flux_kvsdir_pack (job->kvs_dir, "jobname", "s", job->jobname) < 0) {
         flux_log (h, LOG_ERR, "%s: failed to put 'jobname'", __FUNCTION__);
         goto ret;
-    } else if (flux_kvsdir_pack (job->kvs_dir, "account", "s", job->account) < 0) {
+    }
+    if (flux_kvsdir_pack (job->kvs_dir, "account", "s", job->account) < 0) {
         flux_log (h, LOG_ERR, "%s: failed to put 'account'", __FUNCTION__);
         goto ret;
-    } else if (flux_kvsdir_pack (job->kvs_dir, "submit_time", "f", job->submit_time) < 0) {
+    }
+    if (flux_kvsdir_pack (job->kvs_dir, "submit_time", "f", job->submit_time) < 0) {
         flux_log (h, LOG_ERR, "%s: failed to put 'submit_time'", __FUNCTION__);
         goto ret;
-    } else if (flux_kvsdir_pack (job->kvs_dir, "execution_time", "f", job->execution_time) < 0) {
+    }
+    if (flux_kvsdir_pack (job->kvs_dir, "execution_time", "f", job->execution_time) < 0) {
         flux_log (h, LOG_ERR, "%s: failed to put 'execution_time'", __FUNCTION__);
         goto ret;
-    } else if (flux_kvsdir_pack (job->kvs_dir, "time_limit", "f", job->time_limit) < 0) {
+    }
+    if (flux_kvsdir_pack (job->kvs_dir, "time_limit", "f", job->time_limit) < 0) {
         flux_log (h, LOG_ERR, "%s: failed to put 'time_limit'", __FUNCTION__);
         goto ret;
-    } else if (flux_kvsdir_pack (job->kvs_dir, "nnodes", "i", job->nnodes) < 0) {
+    }
+    if (flux_kvsdir_pack (job->kvs_dir, "nnodes", "i", job->nnodes) < 0) {
         flux_log (h, LOG_ERR, "%s: failed to put 'nnodes'", __FUNCTION__);
         goto ret;
-    } else if (flux_kvsdir_pack (job->kvs_dir, "ncpus", "i", job->ncpus) < 0) {
+    }
+    if (flux_kvsdir_pack (job->kvs_dir, "ncpus", "i", job->ncpus) < 0) {
         flux_log (h, LOG_ERR, "%s: failed to put 'ncpus'", __FUNCTION__);
         goto ret;
-    } else if (flux_kvsdir_pack (job->kvs_dir, "io_rate", "I", job->io_rate) < 0) {
+    }
+    if (flux_kvsdir_pack (job->kvs_dir, "io_rate", "I", job->io_rate) < 0) {
         flux_log (h, LOG_ERR, "%s: failed to put 'io_rate'", __FUNCTION__);
         goto ret;
-    } else if (flux_kvs_commit_anon (h, 0) < 0) {
+    }
+    if (flux_kvs_commit_anon (h, 0) < 0) {
         flux_log (h, LOG_ERR, "%s: failed to commit information for job %d", __FUNCTION__, job->id);
         goto ret;
     }

--- a/simulator/simulator.c
+++ b/simulator/simulator.c
@@ -191,14 +191,6 @@ int put_job_in_kvs (job_t *job)
         goto ret;
     }
 
-    flux_kvsdir_t *tmp = job->kvs_dir;
-    if (flux_kvs_get_dir (h, &job->kvs_dir, "%s", flux_kvsdir_key (tmp)) < 0) {
-        flux_log_error (h, "%s: kvs_get_dir", __FUNCTION__);
-        job->kvs_dir = tmp; // restore last known good kvs_dir
-        goto ret;
-    }
-    flux_kvsdir_destroy (tmp);
-
     rc = 0;
  ret:
     return (rc);

--- a/simulator/simulator.c
+++ b/simulator/simulator.c
@@ -143,57 +143,38 @@ job_t *blank_job ()
 
 int put_job_in_kvs (job_t *job)
 {
-    int rc = -1;
-
     if (job->kvs_dir == NULL)
-        goto ret;
+        return (-1);
 
     flux_t *h = flux_kvsdir_handle (job->kvs_dir);
 
-    if (flux_kvsdir_pack (job->kvs_dir, "user", "s", job->user) < 0) {
-        flux_log (h, LOG_ERR, "%s: failed to put 'user'", __FUNCTION__);
-        goto ret;
-    }
-    if (flux_kvsdir_pack (job->kvs_dir, "jobname", "s", job->jobname) < 0) {
-        flux_log (h, LOG_ERR, "%s: failed to put 'jobname'", __FUNCTION__);
-        goto ret;
-    }
-    if (flux_kvsdir_pack (job->kvs_dir, "account", "s", job->account) < 0) {
-        flux_log (h, LOG_ERR, "%s: failed to put 'account'", __FUNCTION__);
-        goto ret;
-    }
-    if (flux_kvsdir_pack (job->kvs_dir, "submit_time", "f", job->submit_time) < 0) {
-        flux_log (h, LOG_ERR, "%s: failed to put 'submit_time'", __FUNCTION__);
-        goto ret;
-    }
-    if (flux_kvsdir_pack (job->kvs_dir, "execution_time", "f", job->execution_time) < 0) {
-        flux_log (h, LOG_ERR, "%s: failed to put 'execution_time'", __FUNCTION__);
-        goto ret;
-    }
-    if (flux_kvsdir_pack (job->kvs_dir, "time_limit", "f", job->time_limit) < 0) {
-        flux_log (h, LOG_ERR, "%s: failed to put 'time_limit'", __FUNCTION__);
-        goto ret;
-    }
-    if (flux_kvsdir_pack (job->kvs_dir, "nnodes", "i", job->nnodes) < 0) {
-        flux_log (h, LOG_ERR, "%s: failed to put 'nnodes'", __FUNCTION__);
-        goto ret;
-    }
-    if (flux_kvsdir_pack (job->kvs_dir, "ncpus", "i", job->ncpus) < 0) {
-        flux_log (h, LOG_ERR, "%s: failed to put 'ncpus'", __FUNCTION__);
-        goto ret;
-    }
-    if (flux_kvsdir_pack (job->kvs_dir, "io_rate", "I", job->io_rate) < 0) {
-        flux_log (h, LOG_ERR, "%s: failed to put 'io_rate'", __FUNCTION__);
-        goto ret;
-    }
-    if (flux_kvs_commit_anon (h, 0) < 0) {
-        flux_log (h, LOG_ERR, "%s: failed to commit information for job %d", __FUNCTION__, job->id);
-        goto ret;
-    }
+    if (flux_kvsdir_pack (job->kvs_dir, "user", "s", job->user) < 0)
+        goto error;
+    if (flux_kvsdir_pack (job->kvs_dir, "jobname", "s", job->jobname) < 0)
+        goto error;
+    if (flux_kvsdir_pack (job->kvs_dir, "account", "s", job->account) < 0)
+        goto error;
+    if (flux_kvsdir_pack (job->kvs_dir, "submit_time", "f",
+                          job->submit_time) < 0)
+        goto error;
+    if (flux_kvsdir_pack (job->kvs_dir, "execution_time", "f",
+                          job->execution_time) < 0)
+        goto error;
+    if (flux_kvsdir_pack (job->kvs_dir, "time_limit", "f", job->time_limit) < 0)
+        goto error;
+    if (flux_kvsdir_pack (job->kvs_dir, "nnodes", "i", job->nnodes) < 0)
+        goto error;
+    if (flux_kvsdir_pack (job->kvs_dir, "ncpus", "i", job->ncpus) < 0)
+        goto error;
+    if (flux_kvsdir_pack (job->kvs_dir, "io_rate", "I", job->io_rate) < 0)
+        goto error;
+    if (flux_kvs_commit_anon (h, 0) < 0)
+        goto error;
 
-    rc = 0;
- ret:
-    return (rc);
+    return (0);
+error:
+    flux_log_error (h, "%s", __FUNCTION__);
+    return (-1);
 }
 
 int kvsdir_get_double (flux_kvsdir_t *dir, const char *name, double *valp)

--- a/simulator/simulator.h
+++ b/simulator/simulator.h
@@ -56,7 +56,7 @@ json_t *sim_state_to_json (sim_state_t *state);
 sim_state_t *json_to_sim_state (json_t *o);
 
 flux_kvsdir_t *job_kvsdir (flux_t *h, int jobid);
-int put_job_in_kvs (job_t *job);
+int put_job_in_kvs (job_t *job, const char *initial_state);
 job_t *pull_job_from_kvs (int id, flux_kvsdir_t *kvs_dir);
 void free_job (job_t *job);
 job_t *blank_job ();

--- a/simulator/simulator.h
+++ b/simulator/simulator.h
@@ -58,6 +58,11 @@ sim_state_t *json_to_sim_state (json_t *o);
 flux_kvsdir_t *job_kvsdir (flux_t *h, int jobid);
 int put_job_in_kvs (job_t *job, const char *initial_state);
 job_t *pull_job_from_kvs (int id, flux_kvsdir_t *kvs_dir);
+
+#define SIM_TIME_NONE (-1.) // skip setting this timestamp
+int set_job_timestamps (flux_kvsdir_t *dir, double t_starting,
+		        double t_running, double t_complete, double t_io);
+
 void free_job (job_t *job);
 job_t *blank_job ();
 int send_alive_request (flux_t *h, const char *module_name);

--- a/simulator/submitsrv.c
+++ b/simulator/submitsrv.c
@@ -258,9 +258,8 @@ int schedule_next_job (flux_t *h, sim_state_t *sim_state)
     // Update lwj.%jobid%'s state in the kvs to "submitted"
     if (!(dir = job_kvsdir (h, new_jobid)))
         log_err_exit ("kvs_get_dir (id=%lu)", new_jobid);
-    flux_kvsdir_pack (dir, "state", "s", "submitted");
     job->kvs_dir = dir;
-    if (put_job_in_kvs (job) < 0)
+    if (put_job_in_kvs (job, "submitted") < 0)
         log_err_exit ("put_job_in_kvs");
 
     // Send "submitted" event


### PR DESCRIPTION
This PR was peeled off of #271.  It migrates sched off of functions that now cause "deprecated" warnings from the compiler.  In the process, I did some minor refactoring and error handling cleanup in the simulator code surrounding KVS access to job data.