### PR TITLE
    sched:  Add priority plugin

### DIFF
--- a/sched/Makefile.am
+++ b/sched/Makefile.am
@@ -15,7 +15,7 @@ LUA_CPATH = $(abs_top_builddir)/rdl/?.so;$${LUA_CPATH};;
 fluxmod_LTLIBRARIES = sched.la
 
 schedplugin_LTLIBRARIES = sched_fcfs.la \
-                  sched_backfill.la
+                  sched_backfill.la sched_priority.la
 
 noinst_HEADERS = scheduler.h rs2rank.h rsreader.h plugin.h
 
@@ -37,6 +37,12 @@ sched_backfill_la_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/resrc
 sched_backfill_la_LIBADD = $(top_builddir)/resrc/libflux-resrc.la \
     $(FLUX_CORE_LIBS) $(JANSSON_LIBS) $(CZMQ_LIBS)
 sched_backfill_la_LDFLAGS = $(AM_LDFLAGS) $(schedplugin_ldflags)
+
+sched_priority_la_SOURCES = sched_priority.c
+sched_priority_la_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/resrc
+sched_priority_la_LIBADD = $(top_builddir)/resrc/libflux-resrc.la \
+    $(FLUX_CORE_LIBS) $(JANSSON_LIBS) $(CZMQ_LIBS)
+sched_priority_la_LDFLAGS = $(AM_LDFLAGS) $(schedplugin_ldflags)
 
 fluxcmd_PROGRAMS = flux-waitjob
 flux_waitjob_SOURCES = flux-waitjob.c

--- a/sched/plugin.c
+++ b/sched/plugin.c
@@ -35,10 +35,11 @@
 
 struct sched_plugin_loader {
     flux_t *h;
-    struct sched_plugin *plugin;
+    struct behavior_plugin *behavior_plugin;
+    struct priority_plugin *priority_plugin;
 };
 
-static void plugin_destroy (struct sched_plugin *plugin)
+static void behavior_plugin_destroy (struct behavior_plugin *plugin)
 {
     if (plugin) {
         if (plugin->dso)
@@ -51,11 +52,24 @@ static void plugin_destroy (struct sched_plugin *plugin)
     }
 }
 
-static struct sched_plugin *plugin_create (flux_t *h, void *dso)
+static void priority_plugin_destroy (struct priority_plugin *plugin)
+{
+    if (plugin) {
+        if (plugin->dso)
+            dlclose (plugin->dso);
+        if (plugin->name)
+            free (plugin->name);
+        if (plugin->path)
+            free (plugin->path);
+        free (plugin);
+    }
+}
+
+static struct behavior_plugin *behavior_plugin_create (flux_t *h, void *dso)
 {
     int saved_errno;
     char *strerr = NULL;
-    struct sched_plugin *plugin = malloc (sizeof (*plugin));
+    struct behavior_plugin *plugin = malloc (sizeof (*plugin));
 
     if (!plugin) {
         errno = ENOMEM;
@@ -110,11 +124,60 @@ error:
     return NULL;
 }
 
-void sched_plugin_unload (struct sched_plugin_loader *sploader)
+static struct priority_plugin *priority_plugin_create (flux_t *h, void *dso)
 {
-    if (sploader->plugin) {
-        plugin_destroy (sploader->plugin);
-        sploader->plugin = NULL;
+    int saved_errno;
+    char *strerr = NULL;
+    struct priority_plugin *plugin = malloc (sizeof (*plugin));
+
+    if (!plugin) {
+        errno = ENOMEM;
+        goto error;
+    }
+    memset (plugin, 0, sizeof (*plugin));
+    dlerror (); // Clear old dlerrors
+
+    plugin->priority_setup = dlsym (dso, "priority_setup");
+    strerr = dlerror();
+    if (strerr || !plugin->priority_setup || !*plugin->priority_setup) {
+        flux_log (h, LOG_ERR, "can't load priority_setup: %s", strerr);
+        goto error;
+    }
+    plugin->prioritize_jobs = dlsym (dso, "prioritize_jobs");
+    strerr = dlerror();
+    if (strerr || !plugin->prioritize_jobs || !*plugin->prioritize_jobs) {
+        flux_log (h, LOG_ERR, "can't load prioritize_jobs: %s", strerr);
+        goto error;
+    }
+    plugin->record_job_usage = dlsym (dso, "record_job_usage");
+    strerr = dlerror();
+    if (strerr || !plugin->record_job_usage || !*plugin->record_job_usage) {
+        flux_log (h, LOG_ERR, "can't load record_job_usage: %s", strerr);
+        goto error;
+    }
+    plugin->dso = dso;
+    return plugin;
+error:
+    saved_errno = errno;
+    if (plugin)
+        free (plugin);
+    errno = saved_errno;
+    return NULL;
+}
+
+void behavior_plugin_unload (struct sched_plugin_loader *sploader)
+{
+    if (sploader->behavior_plugin) {
+        behavior_plugin_destroy (sploader->behavior_plugin);
+        sploader->behavior_plugin = NULL;
+    }
+}
+
+void priority_plugin_unload (struct sched_plugin_loader *sploader)
+{
+    if (sploader->priority_plugin) {
+        priority_plugin_destroy (sploader->priority_plugin);
+        sploader->priority_plugin = NULL;
     }
 }
 
@@ -125,10 +188,6 @@ int sched_plugin_load (struct sched_plugin_loader *sploader, const char *s)
     char *searchpath = getenv ("FLUX_MODULE_PATH");
     void *dso = NULL;
 
-    if (sploader->plugin) {
-        errno = EEXIST;
-        goto error;
-    }
     if (!searchpath) {
         flux_log (sploader->h, LOG_ERR, "FLUX_MODULE_PATH not set");
         goto error;
@@ -158,12 +217,35 @@ int sched_plugin_load (struct sched_plugin_loader *sploader, const char *s)
         goto error;
     }
     flux_log (sploader->h, LOG_DEBUG, "loaded: %s", name);
-    if (!(sploader->plugin = plugin_create (sploader->h, dso))) {
-        dlclose (dso);
-        goto error;
+
+    dlerror (); // Clear old dlerrors
+    dlsym (dso, "sched_loop_setup");
+    if (dlerror()) {
+        // It is not a behavior plugin so assume it is the priority plugin
+        dlerror (); // Clear old dlerrors
+        if (sploader->priority_plugin) {
+            errno = EEXIST;
+            goto error;
+        }
+        if (!(sploader->priority_plugin = priority_plugin_create (sploader->h,
+                                                              dso))) {
+            dlclose (dso);
+            goto error;
+        }
+        sploader->priority_plugin->name = name;
+        sploader->priority_plugin->path = path;
+    } else {
+        if (sploader->behavior_plugin) {
+            errno = EEXIST;
+            goto error;
+        }
+        if (!(sploader->behavior_plugin = behavior_plugin_create (sploader->h, dso))) {
+            dlclose (dso);
+            goto error;
+        }
+        sploader->behavior_plugin->name = name;
+        sploader->behavior_plugin->path = path;
     }
-    sploader->plugin->name = name;
-    sploader->plugin->path = path;
     return 0;
 error:
     if (path)
@@ -173,16 +255,23 @@ error:
     return -1;
 }
 
-struct sched_plugin *sched_plugin_get (struct sched_plugin_loader *sploader)
+struct behavior_plugin *behavior_plugin_get (struct sched_plugin_loader *sploader)
 {
-    return sploader->plugin;
+    return sploader->behavior_plugin;
+}
+
+struct priority_plugin *priority_plugin_get (struct sched_plugin_loader
+                                             *sploader)
+{
+    return sploader->priority_plugin;
 }
 
 static void rmmod_cb (flux_t *h, flux_msg_handler_t *w,
                       const flux_msg_t *msg, void *arg)
 {
     struct sched_plugin_loader *sploader = arg;
-    struct sched_plugin *plugin = sched_plugin_get (sploader);
+    struct behavior_plugin *behavior_plugin = behavior_plugin_get (sploader);
+    struct priority_plugin *priority_plugin = priority_plugin_get (sploader);
     const char *json_str;
     char *name = NULL;
     int rc = -1;
@@ -195,13 +284,19 @@ static void rmmod_cb (flux_t *h, flux_msg_handler_t *w,
     }
     if (flux_rmmod_json_decode (json_str, &name) < 0)
         goto done;
-    if (!plugin || strcmp (name, plugin->name) != 0) {
-        errno = ENOENT;
-        goto done;
+
+    if ((behavior_plugin) && (strcmp (name, behavior_plugin->name) == 0)) {
+        behavior_plugin_unload (sploader);
+        flux_log (h, LOG_INFO, "%s unloaded", name);
+        rc = 0;
     }
-    sched_plugin_unload (sploader);
-    flux_log (h, LOG_INFO, "%s unloaded", name);
-    rc = 0;
+    if ((priority_plugin) && (strcmp (name, priority_plugin->name) == 0)) {
+        priority_plugin_unload (sploader);
+        flux_log (h, LOG_INFO, "%s unloaded", name);
+        rc = 0;
+    }
+    if (rc)
+        errno = ENOENT;
 done:
     if (flux_respond (h, msg, rc < 0 ? errno : 0, NULL) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
@@ -213,7 +308,6 @@ static void insmod_cb (flux_t *h, flux_msg_handler_t *w,
                        const flux_msg_t *msg, void *arg)
 {
     struct sched_plugin_loader *sploader = arg;
-    struct sched_plugin *plugin = sched_plugin_get (sploader);
     const sched_params_t *sp = sched_params_get (h);
     const char *json_str;
     char *path = NULL;
@@ -229,14 +323,10 @@ static void insmod_cb (flux_t *h, flux_msg_handler_t *w,
     }
     if (flux_insmod_json_decode (json_str, &path, &argz, &argz_len) < 0)
         goto done;
-    if (plugin) {
-        errno = EEXIST;
-        goto done;
-    }
     if (sched_plugin_load (sploader, path) < 0)
         goto done;
-
-    if (sploader->plugin->process_args (sploader->h, argz, argz_len, sp) < 0) {
+    if (argz && sploader->behavior_plugin->process_args (sploader->h, argz,
+                                                      argz_len, sp) < 0) {
         goto done;
     }
     rc = 0;
@@ -254,7 +344,8 @@ static void lsmod_cb (flux_t *h, flux_msg_handler_t *w,
                       const flux_msg_t *msg, void *arg)
 {
     struct sched_plugin_loader *sploader = arg;
-    struct sched_plugin *plugin = sched_plugin_get (sploader);
+    struct behavior_plugin *behavior_plugin = behavior_plugin_get (sploader);
+    struct priority_plugin *priority_plugin = priority_plugin_get (sploader);
     flux_modlist_t *mods = NULL;
     zfile_t *zf = NULL;
     char *json_str = NULL;
@@ -265,12 +356,22 @@ static void lsmod_cb (flux_t *h, flux_msg_handler_t *w,
         goto done;
     if (!(mods = flux_modlist_create ()))
         goto done;
-    if (plugin) {
-        if (stat (plugin->path, &sb) < 0)
+    if (behavior_plugin) {
+        if (stat (behavior_plugin->path, &sb) < 0)
             goto done;
-        if (!(zf = zfile_new (NULL, plugin->path)))
+        if (!(zf = zfile_new (NULL, behavior_plugin->path)))
             goto done;
-        if (flux_modlist_append (mods, plugin->name, sb.st_size,
+        if (flux_modlist_append (mods, behavior_plugin->name, sb.st_size,
+                                 zfile_digest (zf),
+                                 0, FLUX_MODSTATE_RUNNING) < 0)
+            goto done;
+    }
+    if (priority_plugin) {
+        if (stat (priority_plugin->path, &sb) < 0)
+            goto done;
+        if (!(zf = zfile_new (NULL, priority_plugin->path)))
+            goto done;
+        if (flux_modlist_append (mods, priority_plugin->name, sb.st_size,
                                  zfile_digest (zf),
                                  0, FLUX_MODSTATE_RUNNING) < 0)
             goto done;
@@ -317,7 +418,8 @@ struct sched_plugin_loader *sched_plugin_loader_create (flux_t *h)
 void sched_plugin_loader_destroy (struct sched_plugin_loader *sploader)
 {
     if (sploader) {
-        sched_plugin_unload (sploader);
+        behavior_plugin_unload (sploader);
+        priority_plugin_unload (sploader);
         flux_msg_handler_delvec (plugin_htab);
         free (sploader);
     }

--- a/sched/plugin.h
+++ b/sched/plugin.h
@@ -3,7 +3,7 @@
 
 #include "scheduler.h"
 
-struct sched_plugin {
+struct behavior_plugin {
     void         *dso;                /* Scheduler plug-in DSO handle */
     char         *name;               /* Name of plugin */
     char         *path;               /* Path to plugin dso */
@@ -44,6 +44,16 @@ struct sched_plugin {
                                          const sched_params_t *params);
 };
 
+struct priority_plugin {
+    void         *dso;                /* Scheduler plug-in DSO handle */
+    char         *name;               /* Name of plugin */
+    char         *path;               /* Path to plugin dso */
+
+    int         (*priority_setup)(flux_t *h);
+    void        (*prioritize_jobs)(flux_t *h, zlist_t *jobs);
+    int         (*record_job_usage)(flux_t *h, flux_lwj_t *job);
+};
+
 /* Create/destroy the plugin loader apparatus.
  */
 struct sched_plugin_loader;
@@ -63,7 +73,10 @@ void sched_plugin_unload (struct sched_plugin_loader *sploader);
 /* Retrieve the currently loaded plugin.
  * Return NULL if plugin is not loaded.
  */
-struct sched_plugin *sched_plugin_get (struct sched_plugin_loader *sploader);
+struct behavior_plugin *behavior_plugin_get (struct sched_plugin_loader
+                                             *sploader);
+struct priority_plugin *priority_plugin_get (struct sched_plugin_loader
+                                             *sploader);
 
 #endif /* !_FLUX_SCHED_PLUGIN_H */
 

--- a/sched/plugin_version.map
+++ b/sched/plugin_version.map
@@ -6,5 +6,8 @@
     select_resources;
     mod_name;
     process_args;
+    priority_setup;
+    prioritize_jobs;
+    record_job_usage;
   local: *;
 };

--- a/sched/sched.c
+++ b/sched/sched.c
@@ -101,6 +101,7 @@ typedef struct {
     char         *uri;
     char         *userplugin;
     char         *userplugin_opts;
+    char         *prio_plugin;
     bool          sim;
     bool          schedonce;          /* Use resources only once */
     bool          fail_on_error;      /* Fail immediately on error */
@@ -189,6 +190,7 @@ static inline void ssrvarg_init (ssrvarg_t *arg)
     arg->uri = NULL;
     arg->userplugin = NULL;
     arg->userplugin_opts = NULL;
+    arg->prio_plugin = NULL;
     arg->sim = false;
     arg->schedonce = false;
     arg->fail_on_error = false;
@@ -206,6 +208,8 @@ static inline void ssrvarg_free (ssrvarg_t *arg)
         free (arg->userplugin);
     if (arg->userplugin_opts)
         free (arg->userplugin_opts);
+    if (arg->prio_plugin)
+        free (arg->prio_plugin);
 }
 
 static inline int ssrvarg_process_args (int argc, char **argv, ssrvarg_t *a)
@@ -234,6 +238,9 @@ static inline int ssrvarg_process_args (int argc, char **argv, ssrvarg_t *a)
             a->userplugin = xstrdup (strstr (argv[i], "=") + 1);
         } else if (!strncmp ("plugin-opts=", argv[i], sizeof ("plugin-opts"))) {
             a->userplugin_opts = xstrdup (strstr (argv[i], "=") + 1);
+        } else if (!strncmp ("priority-plugin=", argv[i],
+                             sizeof ("priority-plugin"))) {
+            a->prio_plugin = xstrdup (strstr (argv[i], "=") + 1);
         } else if (!strncmp ("sched-params=", argv[i], sizeof ("sched-params"))) {
             sprms = xstrdup (strstr (argv[i], "=") + 1);
         } else {
@@ -399,6 +406,9 @@ static inline int fill_resource_req (flux_t *h, flux_lwj_t *j)
         flux_log (h, LOG_ERR, "fill_resource_req: error parsing JSON string");
         goto done;
     }
+    /* TODO:  add user name and charge account to info the JSC provides */
+    j->user = NULL;
+    j->account = NULL;
     if (!Jget_obj (jcb, JSC_RDESC, &o)) goto done;
     if (!Jget_int64 (o, JSC_RDESC_NNODES, &nn)) goto done;
     if (!Jget_int64 (o, JSC_RDESC_NTASKS, &nc)) goto done;
@@ -445,7 +455,7 @@ static int plugin_process_args (ssrvctx_t *ctx, char *userplugin_opts)
     int rc = -1;
     char *argz = NULL;
     size_t argz_len = 0;
-    struct sched_plugin *plugin = sched_plugin_get (ctx->loader);
+    struct behavior_plugin *plugin = behavior_plugin_get (ctx->loader);
     const sched_params_t *sp = &(ctx->arg.s_params);
 
     if (userplugin_opts)
@@ -482,6 +492,7 @@ static int q_enqueue_into_pqueue (ssrvctx_t *ctx, json_t *jcb)
 
     job->lwj_id = jid;
     job->state = J_NULL;
+    job->submittime = time (NULL);
     if (zlist_append (ctx->p_queue, job) != 0) {
         flux_log (ctx->h, LOG_ERR, "failed to append to pending job queue.");
         goto done;
@@ -1451,6 +1462,20 @@ done:
     return resrc_reqst;
 }
 
+/* Sort jobs by decreasing priority */
+static int compare_priority (void *item1, void *item2)
+{
+    int ret = 0;
+    flux_lwj_t *job1 = (flux_lwj_t*)item1;
+    flux_lwj_t *job2 = (flux_lwj_t*)item2;
+
+    if (job1->priority < job2->priority)
+        ret = 1;
+    else if (job1->priority > job2->priority)
+        ret = -1;
+    return ret;
+}
+
 /*
  * schedule_job() searches through all of the idle resources to
  * satisfy a job's requirements.  If enough resources are found, it
@@ -1468,7 +1493,7 @@ int schedule_job (ssrvctx_t *ctx, flux_lwj_t *job, int64_t starttime)
     resrc_reqst_t *resrc_reqst = NULL;
     resrc_tree_t *found_tree = NULL;
     resrc_tree_t *selected_tree = NULL;
-    struct sched_plugin *plugin = sched_plugin_get (ctx->loader);
+    struct behavior_plugin *plugin = behavior_plugin_get (ctx->loader);
 
     if (!plugin)
         return rc;
@@ -1539,10 +1564,9 @@ static int schedule_jobs (ssrvctx_t *ctx)
     int rc = 0;
     int qdepth = 0;
     flux_lwj_t *job = NULL;
-    struct sched_plugin *plugin = sched_plugin_get (ctx->loader);
-    /* Prioritizing the job queue is left to an external agent.  In
-     * this way, the scheduler's activities are pared down to just
-     * scheduling activies.
+    struct behavior_plugin *behavior_plugin = behavior_plugin_get (ctx->loader);
+    struct priority_plugin *priority_plugin = priority_plugin_get (ctx->loader);
+    /*
      * TODO: when dynamic scheduling is supported, the loop should
      * traverse through running job queue as well.
      */
@@ -1550,11 +1574,16 @@ static int schedule_jobs (ssrvctx_t *ctx)
     int64_t starttime = (ctx->sctx.in_sim) ?
         (int64_t) ctx->sctx.sim_state->sim_time : epochtime();
 
+    if (priority_plugin)
+        priority_plugin->prioritize_jobs (ctx->h, jobs);
+
+    /* Sort by decreasing priority */
+    zlist_sort (jobs, compare_priority);
     resrc_tree_release_all_reservations (resrc_tree_root (ctx->rsapi));
 
-    if (!plugin)
+    if (!behavior_plugin)
         return -1;
-    rc = plugin->sched_loop_setup (ctx->h);
+    rc = behavior_plugin->sched_loop_setup (ctx->h);
     job = zlist_first (jobs);
     while (!rc && job && (qdepth < ctx->arg.s_params.queue_depth)) {
         if (job->state == J_SCHEDREQ) {
@@ -1593,6 +1622,7 @@ static int action (ssrvctx_t *ctx, flux_lwj_t *job, job_state_t newstate)
 {
     flux_t *h = ctx->h;
     job_state_t oldstate = job->state;
+    struct priority_plugin *priority_plugin = priority_plugin_get (ctx->loader);
 
     flux_log (h, LOG_DEBUG, "attempting job %"PRId64" state change from "
               "%s to %s", job->lwj_id, jsc_job_num2state (oldstate),
@@ -1669,6 +1699,8 @@ static int action (ssrvctx_t *ctx, flux_lwj_t *job, job_state_t newstate)
         break;
     case J_COMPLETE:
         VERIFY (trans (J_REAPED, newstate, &(job->state)));
+        if (priority_plugin)
+            priority_plugin->record_job_usage (ctx->h, job);
         zlist_remove (ctx->c_queue, job);
         if (job->req)
             free (job->req);
@@ -1816,10 +1848,28 @@ int mod_main (flux_t *h, int argc, char **argv)
             goto done;
         }
         if (plugin_process_args (ctx, ctx->arg.userplugin_opts) < 0) {
-            flux_log_error (h, "failed to process args for %s", ctx->arg.userplugin);
+            flux_log_error (h, "failed to process args for %s",
+                            ctx->arg.userplugin);
             goto done;
         }
         flux_log (h, LOG_INFO, "%s plugin loaded", ctx->arg.userplugin);
+    }
+    if (ctx->arg.prio_plugin) {
+        if (sched_plugin_load (ctx->loader, ctx->arg.prio_plugin) < 0) {
+            flux_log_error (h, "failed to load %s", ctx->arg.prio_plugin);
+            goto done;
+        }
+        flux_log (h, LOG_INFO, "%s plugin loaded", ctx->arg.prio_plugin);
+        struct priority_plugin *priority_plugin = priority_plugin_get
+            (ctx->loader);
+        if (priority_plugin) {
+            if (priority_plugin->priority_setup (h))
+                flux_log (h, LOG_ERR, "failed to setup priority plugin");
+            else
+                flux_log (h, LOG_INFO, "successfully setup priority plugin");
+        } else {
+            flux_log (h, LOG_ERR, "failed to get priority plugin");
+        }
     }
     if (load_resources (ctx) != 0) {
         flux_log (h, LOG_ERR, "failed to load resources");

--- a/sched/sched_priority.c
+++ b/sched/sched_priority.c
@@ -1,0 +1,478 @@
+#if HAVE_CONFIG_H
+# include <config.h>
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <argz.h>
+#include <libgen.h>
+#include <errno.h>
+#include <libgen.h>
+#include <czmq.h>
+
+#include <flux/core.h>
+
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/shortjansson.h"
+#include "src/common/libutil/xzmalloc.h"
+#include "scheduler.h"
+
+typedef struct {
+    char   *name;
+    double weight;
+    double (*fn)(flux_lwj_t *job);
+} job_priority_factor_t;
+
+static zlist_t *prio_factors;          /* Job priority factors */
+static zhash_t *associations;          /* charge account / user associations */
+
+/*
+ * An association contains the shares of computing resources assigned
+ * to a charge account and optionally the user permitted to charge
+ * that account.  There can be a hierarchy of associations with the
+ * "root" account at the top.  Each level in the hierarchy contains
+ * associations of associations with the leaves being associations of
+ * users.
+ *
+ * For example, if a user is permitted to charge the "physics"
+ * account, there will be an association of that user and account
+ * "physics".  A different association will exist for every other user
+ * permitted to charge the physics account.
+ *
+ * If the physics account is a child of the "science" account, then
+ * both the physics and science associations will have their user
+ * member set to NULL.
+ *
+ * In addition to shares, an association records the usage of
+ * computing resource, which is nominally in units of core * seconds.
+ *
+ * The fair-share factor for the association represents the difference
+ * between the assigned shares and accrued usage.  The fair-share
+ * factor ranges from 0.0 to 1.0 where:
+ *   0.0 represents an over-serviced association
+ *   0.5 usage is commensurate with assigned shares
+ *   1.0 association has no accrued usage
+ */
+typedef struct association association_t;
+struct association {
+    char   *account;
+    char   *user;
+    double shares;
+    double sibling_shares;      /* sum of all children's shares */
+    double usage;               /* historical cpu-second sum */
+    double sibling_usage;       /* sum of all children's usage */
+    double low_factor;          /* fair-share factor of next lowest sibling */
+    double fs_factor;           /* normalized fair-share factor */
+    association_t *parent;
+    zlist_t *children;
+};
+
+
+static association_t *create_association (char* account, char *user, double shares,
+                                          association_t *parent)
+{
+    association_t *assoc = xzmalloc (sizeof (association_t));
+
+    assoc->account = account;
+    assoc->user = user;
+    assoc->shares = shares;
+    assoc->usage = 0.0;
+    assoc->low_factor = 0.0;
+    assoc->fs_factor = 1.0;
+    assoc->parent = parent;
+
+    return assoc;
+}
+
+/*
+ * Create the associations file that this plugin requires by invoking:
+ * sacctmgr -n -p show assoc cluster=$LCSCHEDCLUSTER
+ *   format=account,share,parentn,user > associations
+ */
+static int read_association_file (flux_t *h)
+{
+    FILE        *fp;
+    association_t *assoc;
+    association_t *parent_assoc;
+    char        line[1028];
+    char        *account = NULL;
+    char        *field = NULL;
+    char        *filename = "associations";
+    char        *key;
+    char        *parent_name = NULL;
+    char        *ptr;
+    char        *user = NULL;
+    double      shares = 1.0;
+    int         n_assoc = 0;
+    int         rc = 0;
+
+    if ((fp = fopen (filename, "r"))) {
+        while (fgets (line, sizeof(line), fp) != NULL) {
+            if ((ptr = strchr (line, '|'))) {
+                *ptr = '\0';
+                account = line;
+                field = ptr + 1;
+            }
+            if ((ptr = strchr (field, '|'))) {
+                *ptr = '\0';
+                shares = atof (field);
+                field = ptr + 1;
+            }
+            if ((ptr = strchr (field, '|'))) {
+                *ptr = '\0';
+                parent_name = field;
+                field = ptr + 1;
+            }
+            if ((ptr = strchr (field, '|'))) {
+                *ptr = '\0';
+                user = field;
+            }
+            /*
+             * In the ordering accounts in the sacctmgr output, parent
+             * accounts appear before child accounts.  Hence
+             * parent_assoc should always found and be non-NULL.  The
+             * only exception is the root account - it has no parent.
+             */
+            parent_assoc = zhash_lookup (associations, parent_name);
+
+            if ((assoc = create_association (account, user, shares, parent_assoc))) {
+                if (user)
+                    /* the key will be a fusing of the account and user name */
+                    key = xasprintf ("%s-%s", account, user);
+                else
+                    /* this is an account, so the key is just the account */
+                    key = xasprintf ("%s", account);
+                zhash_insert (associations, key, assoc);
+                zhash_freefn (associations, key, free);
+                n_assoc++;
+            } else {
+                flux_log (h, LOG_ERR, "%s: failed to create association %s-%s", __FUNCTION__,
+                          account, user);
+                rc = -1;
+            }
+        }
+        fclose(fp);
+        flux_log (h, LOG_INFO, "priority plugin loaded %d associations", n_assoc);
+    } else {
+        flux_log (h, LOG_ERR, "%s: failed to open %s", __FUNCTION__, filename);
+        rc = -1;
+    }
+
+    return rc;
+}
+
+/* Computes the sum of raw shares and used resources across all
+ * siblings */
+static void sum_sibling_shares_usage (association_t *a)
+{
+    association_t *sib;
+    zlist_t *sibs = a->children;
+
+    a->sibling_shares = 0.0;
+    a->sibling_usage = 0.0;
+    sib = zlist_first (sibs);
+    while (sib) {
+        a->sibling_shares += sib->shares;
+        a->sibling_usage += sib->usage;
+        sib = zlist_next (sibs);
+    }
+}
+
+/*
+ * The formula for the fair-share factor is:
+ *   fs = 2**(-U/S)
+ * where:
+ * U = my_usage / clusters_usage
+ * S = ((my_shares / all_siblings_shares) *
+ *      (my_parents_shares / all_parents_siblings_shares) *
+ *      (grandparents_shares / all_grandparents_siblings_shares) *
+ *      ...
+ * The fair-share factor ranges from 0.0 to 1.0:
+ *  0.0 - represents an over-serviced association
+ *  0.5 - usage is commensurate with assigned shares
+ *  1.0 - association has no accrued usage
+ *
+ * Plotted, it looks like this:
+ * http://www.wolframalpha.com/input/?i=Plot%5B2**(-u%2Fs)%5D,+%7Bu,+0.,+1.%7D,+%7Bs,+0.,+1.%7D
+ *
+ * While this gives us our fs factor relative to our siblings, we need
+ * to "inherit" the fair-share of our parent's account.  Our parent's
+ * fair-share factor.  Pictorially, it looks like this:
+ *
+ * 0.0                                                   1.0
+ *  |-----------------------------------------------------|
+ *  |----------|--------------------|-------------------|-|
+ *             A                    B                   C
+ *             |----|--------|------|
+ *                  U1       U2     U3
+ *
+ * where A, B, and C are three accounts plotted at their fair-share
+ * value.  U3 is a user in account B who has no accrued usage.  Hence,
+ * U3's fair-share on its own is 1.0.  However, it inherits its parent
+ * (B)'s fair-share value.  U1 and U2 have their own fair-share values
+ * of 0.3 and 0.7.  However, these also inherit parent B's fairshare.
+ * This is done by multiplying (one minus their local values) by the
+ * the difference between their parent (B)'s fair-share value and the
+ * fair-share value of the next lower sibling of their parent: A in
+ * this case; and then subtracting this product from their parent B's
+ * fair-share value.
+ *
+ * You'll see this formula in calc_fs_factor()
+ */
+
+static void calc_fs_factor (association_t *a)
+{
+    association_t *p = a->parent;
+    double my_factor;
+    double norm_shares;
+    double norm_usage;
+    double parent_factor_range;
+
+    norm_shares = a->shares / a->sibling_shares;
+    norm_usage = a->usage / a->sibling_usage;
+    if (norm_shares > 0.0)
+        my_factor = pow (2.0, -(norm_usage/norm_shares));
+    else
+        my_factor = 0.0;
+    parent_factor_range = p->fs_factor - p->low_factor;
+
+    a->fs_factor = p->fs_factor - (1.0 - my_factor) * parent_factor_range;
+}
+
+/*
+ * Sort the associations by their fair-share factor: low to high
+ */
+static int compare_factors (void *item1, void *item2)
+{
+    int ret = 0;
+    association_t *sib1 = (association_t*)item1;
+    association_t *sib2 = (association_t*)item2;
+
+    if (sib1->fs_factor < sib2->fs_factor)
+        ret = 1;
+    else if (sib1->fs_factor > sib2->fs_factor)
+        ret = -1;
+    return ret;
+}
+
+static void calc_sibling_fs_factors (association_t *a)
+{
+    association_t *p = a->parent;
+    association_t *sib;
+    double last_low_factor;
+    double sav_low_factor;
+
+    sum_sibling_shares_usage (a);
+
+    sib = zlist_first (a->children);
+    while (sib) {
+        calc_fs_factor (sib);
+        sib = zlist_next (a->children);
+    }
+
+    /* Sort sibling fair-share factors - low to high */
+    zlist_sort (a->children, compare_factors);
+
+    last_low_factor = p->low_factor;
+    sav_low_factor = last_low_factor;
+    sib = zlist_first (a->children);
+    while (sib) {
+        /*
+         * We need to support successive siblings with the same
+         * fs_factor.  All siblings with the same fs_factor should be
+         * assigned the same low_factor
+         */
+        if (sib->fs_factor == last_low_factor)
+            sib->low_factor = sav_low_factor;
+        else {
+            sib->low_factor = last_low_factor;
+            sav_low_factor = last_low_factor;
+            last_low_factor = sib->fs_factor;
+        }
+        sib = zlist_next (a->children);
+    }
+}
+
+/*
+ * A recursive function that is first called for the root association.
+ * All siblings' fair-share factors are computed before children are
+ * considered.
+ */
+static void calc_fs_factors (association_t *a)
+{
+    association_t *child;
+
+    calc_sibling_fs_factors (a);
+    child = zlist_first (a->children);
+    while (child) {
+        calc_fs_factors (child);
+        child = zlist_next (a->children);
+    }
+}
+
+/* Return the number of seconds that have elapsed since the job was
+ * submitted.  The longer the job has been waiting in the queue, the
+ * greater its wait_time priority component.
+ */
+static double wait_time (flux_lwj_t *job)
+{
+    if (job->submittime)
+        return ((double)time (NULL) - job->submittime);
+    return 0.0;
+}
+
+/*
+ * Retrieve the latest fair-share factor associated with this user and
+ * account.  If that association can't be found, return a zero
+ * fair-share factor.
+ */
+static double fair_share (flux_lwj_t *job)
+{
+    association_t *assoc;
+    char *key;
+    double fs_factor = 0.0;
+
+    key = xasprintf ("%s-%s", job->account, job->user);
+    assoc = zhash_lookup (associations, key);
+    if (assoc)
+        fs_factor = assoc->fs_factor;
+    free (key);
+
+    return fs_factor;
+}
+
+static double qos (flux_lwj_t *job)
+{
+    /*
+     * TODO: Return the value associated with a Quality of Service
+     */
+    return 0.0;
+}
+
+static double queue (flux_lwj_t *job)
+{
+    /*
+     * TODO: Return the value associated with Flux's equivalent of a
+     * node partition (job queue)
+     */
+    return 0.0;
+}
+
+static double job_size (flux_lwj_t *job)
+{
+    /*
+     * TODO: If smaller jobs should receive the higher priority, then
+     * the total number of cores in the cluster will need to be passed
+     * in.  The return value would then change to:
+     *   ncores_in_cluster - job->req->nnodes * job->req->ncores
+     */
+    return job->req->nnodes * job->req->ncores;
+}
+
+static double user (flux_lwj_t *job)
+{
+    /* User allowed to decrease their job's priority only */
+    if (job->user_prio < 0.0)
+        return (job->user_prio);
+    return 0.0;
+}
+
+job_priority_factor_t jpfs[] = {
+    { "WaitTime", 100.0, wait_time},
+    { "FairShare", 200.0, fair_share},
+    { "QoS", 300.0, qos},
+    { "Queue", 400.0, queue},
+    { "JobSize", 500.0, job_size},
+    { "User", 600.0, user},
+    { NULL, 0.0, NULL}
+};
+
+int priority_setup (flux_t *h)
+{
+    int rc = -1;
+    job_priority_factor_t* jpf = NULL;
+
+    if (!(prio_factors = zlist_new ()))
+        oom ();
+
+    if (!(associations = zhash_new ()))
+        oom ();
+
+    jpf = &jpfs[0];
+    while (jpf->name) {
+        zlist_append (prio_factors, jpf);
+        jpf++;
+    }
+
+    rc = read_association_file (h);
+    return rc;
+}
+
+/*
+ * Record usage for this association and all parent associations up to
+ * and including the root association.
+ */
+void record_association_usage (association_t *assoc, double usage)
+{
+    if (assoc) {
+        assoc->usage += usage;
+        if (assoc->parent)
+            record_association_usage (assoc->parent, usage);
+    }
+}
+
+/*
+ * Usage is currently implemented as core*seconds.  This could
+ * eventually expand to include memory, GPUs, power, etc.  The scalar
+ * "usage" value is intended to represent a weighted composite of all
+ * of the charge-able, compute-related resources.  record_job_usage()
+ * will meter that data at the completion of every job.
+ */
+int record_job_usage (flux_t *h, flux_lwj_t *job)
+{
+    association_t *assoc;
+    char *key;
+    double usage;
+    int rc = -1;
+
+    key = xasprintf ("%s-%s", job->account, job->user);
+    assoc = zhash_lookup (associations, key);
+    if (assoc) {
+        usage = (job->endtime - job->starttime) * job->req->nnodes * job->req->ncores;
+        record_association_usage (assoc, usage);
+        rc = 0;
+    }
+    free (key);
+
+    return rc;
+}
+
+void prioritize_jobs (flux_t *h, zlist_t *jobs)
+{
+    flux_lwj_t *job = NULL;
+    job_priority_factor_t *factor = NULL;
+    association_t *root = zhash_lookup (associations, "root");
+
+    if (root) {
+        calc_fs_factors (root);
+
+        job = zlist_first (jobs);
+        while (job) {
+            job->priority = 0;
+            factor = zlist_first (prio_factors);
+            while (factor) {
+                job->priority += factor->weight * factor->fn(job);
+                factor = zlist_next (prio_factors);
+            }
+            job = zlist_next (jobs);
+        }
+    }
+}
+
+MOD_NAME ("sched.priority");
+
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/sched/scheduler.h
+++ b/sched/scheduler.h
@@ -55,10 +55,16 @@ typedef struct flux_resources {
 typedef struct {
     int64_t     lwj_id;  /*!< LWJ id */
     job_state_t state;   /*!< current job state */
+    char    *user;       /*!< user name of person who submitted job */
+    char    *account;    /*!< account to charge for resource usage */
     flux_res_t *req;     /*!< resources requested by this LWJ */
     resrc_tree_t *resrc_tree; /*!< resources allocated to this LWJ */
+    int64_t submittime;
     int64_t starttime;
+    int64_t endtime;
     int64_t enqueue_pos; /*!< the initial enqueue position */
+    double user_prio;    /*!< user-requested priority */
+    double priority;     /*!< scheduling priority */
 } flux_lwj_t;
 
 


### PR DESCRIPTION
    The new priority plugin can be loaded in addition to the existing fcfs
    or backfill plugins.

    With the introduction of the priority plugin, the existing "sched_plugin"
    had to be renamed to the "behavior_plugin".  "sched_plugin" now refers to
    any plugin loaded by the sched module.  The two categories of sched
    plugins, with different API's, are the behavior and priority plugins.