### PR TITLE
track bulk message handler registration API change

### DIFF
--- a/rdl/test/Makefile.am
+++ b/rdl/test/Makefile.am
@@ -5,7 +5,7 @@ AM_CPPFLAGS = -I$(top_srcdir) $(JANSSON_CFLAGS) $(LUA_INCLUDE)
 
 TESTS_ENVIRONMENT = \
     LUA_PATH="$(abs_top_srcdir)/rdl/?.lua;$(FLUX_PREFIX)/share/lua/5.1/?.lua;$(FLUX_PREFIX)/share/lua/5.1/fluxometer/?.lua;$(LUA_PATH);;" \
-    LUA_CPATH="$(abs_top_builddir)/rdl/?.so;$(abs_top_builddir)/rdl/test/.libs/?.so;$(FLUX_PREFIX)/lib64/lua/5.1/?.so;$(LUA_CPATH);;" \
+    LUA_CPATH="$(abs_top_builddir)/rdl/?.so;$(abs_top_builddir)/rdl/test/.libs/?.so;$(FLUX_PREFIX)/lib64/lua/5.1/?.so;$(FLUX_PREFIX)/lib/lua/5.1/?.so;$(LUA_CPATH);;" \
     TESTRDL_INPUT_FILE="$(abs_top_srcdir)/conf/hype.lua"
 
 TESTS = trdl test-jansson.lua

--- a/resource/planner/test/Makefile.am
+++ b/resource/planner/test/Makefile.am
@@ -9,7 +9,7 @@ AM_CPPFLAGS = -I$(top_srcdir) $(CZMQ_CFLAGS) $(FLUX_CORE_CFLAGS)
 TESTS_ENVIRONMENT = \
     TESTRESRC_INPUT_FILE="$(abs_top_srcdir)/conf/hype.lua" \
     LUA_PATH="$(abs_top_srcdir)/rdl/?.lua;$(FLUX_PREFIX)/share/lua/5.1/?.lua;$(LUA_PATH);;" \
-    LUA_CPATH="$(abs_top_builddir)/rdl/?.so;$(FLUX_PREFIX)/lib64/lua/5.1/?.so;$(LUA_CPATH);;"
+    LUA_CPATH="$(abs_top_builddir)/rdl/?.so;$(abs_top_builddir)/rdl/test/.libs/?.so;$(FLUX_PREFIX)/lib64/lua/5.1/?.so;$(FLUX_PREFIX)/lib/lua/5.1/?.so;$(LUA_CPATH);;"
 
 TESTS = planner_test01
 

--- a/resrc/test/Makefile.am
+++ b/resrc/test/Makefile.am
@@ -6,7 +6,7 @@ AM_CPPFLAGS = -I$(top_srcdir) $(JANSSON_CFLAGS) $(CZMQ_CFLAGS) $(FLUX_CORE_CFLAG
 TESTS_ENVIRONMENT = \
     TESTRESRC_INPUT_FILE="$(abs_top_srcdir)/conf/hype.lua" \
     LUA_PATH="$(abs_top_srcdir)/rdl/?.lua;$(FLUX_PREFIX)/share/lua/5.1/?.lua;$(LUA_PATH);;" \
-    LUA_CPATH="$(abs_top_builddir)/rdl/?.so;$(FLUX_PREFIX)/lib64/lua/5.1/?.so;$(LUA_CPATH);;"
+    LUA_CPATH="$(abs_top_builddir)/rdl/?.so;$(abs_top_builddir)/rdl/test/.libs/?.so;$(FLUX_PREFIX)/lib64/lua/5.1/?.so;$(FLUX_PREFIX)/lib/lua/5.1/?.so;$(LUA_CPATH);;"
 
 TESTS = tresrc
 

--- a/simulator/simsrv.c
+++ b/simulator/simsrv.c
@@ -434,7 +434,6 @@ static const struct flux_msg_handler_spec htab[] = {
     {FLUX_MSGTYPE_EVENT, "rdl.update", rdl_update_cb, 0},
     FLUX_MSGHANDLER_TABLE_END,
 };
-const int htablen = sizeof (htab) / sizeof (htab[0]);
 
 int mod_main (flux_t *h, int argc, char **argv)
 {

--- a/t/t1004-module-load.t
+++ b/t/t1004-module-load.t
@@ -85,7 +85,7 @@ test_expect_success 'module-load: sched loads the backfill plugin with arguments
 test_expect_success 'module-load: no jobs are lost' '
     for i in `seq $sched_start_jobid $sched_end_jobid`
     do
-        state=$(flux kvs get $(job_kvs_path $i).state)
+        state=$(flux kvs get -j $(job_kvs_path $i).state)
         if test $state != "submitted"; then
             return 48
         fi


### PR DESCRIPTION
This PR will allow sched to compile after flux-framework/flux-core#1277 is merged.

I was able to compile test this but for some reason could not get `make check` to pass on my desktop.  I reverted back to master on both flux-core and flux-sched and couldn't get that to work either so I assume it's environmental and unrelated to this PR, so submitted it anyway.

After the above gets merged, travis will need to be manually restarted here.