### PR TITLE
sched: Add pending job cancellation support

### DIFF
--- a/resource/dfu_traverse_impl.hpp
+++ b/resource/dfu_traverse_impl.hpp
@@ -313,7 +313,7 @@ int dfu_impl_t::count (planner_t *plan, const lookup_t &lookup,
     int rc = 0;
     size_t len = planner_resources_len (plan);
     const char **resource_types = planner_resource_types (plan);
-    for (int i = 0; i < len; ++i) {
+    for (unsigned int i = 0; i < len; ++i) {
         if (lookup.find (resource_types[i]) != lookup.end ()) {
             uint64_t n = (uint64_t)lookup.at (resource_types[i]);
             resource_counts.push_back (n);

--- a/resource/scoring_api.hpp
+++ b/resource/scoring_api.hpp
@@ -162,12 +162,12 @@ public:
             return -1;
         }
 
-        int i = 0;
+        unsigned int i = 0;
         int old = (int)m_best_k;
         int to_be_selected = k;
         std::sort (m_eval_egroups.begin (), m_eval_egroups.end (), comp);
         while (to_be_selected > 0) {
-            if (to_be_selected <= m_eval_egroups[i].count)
+            if (to_be_selected <= (int)m_eval_egroups[i].count)
                 m_eval_egroups[i].needs = to_be_selected;
             else
                 m_eval_egroups[i].needs = m_eval_egroups[i].count;
@@ -188,7 +188,7 @@ public:
             return -1;
         }
         int64_t score_accum = init;
-        for (int i = 0; i < m_best_i; i++)
+        for (unsigned int i = 0; i < m_best_i; i++)
             score_accum = accum (score_accum, m_eval_egroups[i]);
         return score_accum;
     }

--- a/sched/sched.c
+++ b/sched/sched.c
@@ -705,12 +705,16 @@ static int load_resources (ssrvctx_t *ctx)
     case RSREADER_RESRC_EMUL:
         if (rsreader_resrc_bulkload (ctx->rsapi, path, uri) != 0) {
             flux_log (ctx->h, LOG_ERR, "failed to load resrc");
+            errno = EINVAL;
             goto done;
         } else if (build_hwloc_rs2rank (ctx, r_mode) != 0) {
             flux_log (ctx->h, LOG_ERR, "failed to build rs2rank");
+            if (errno != 0)
+                errno = EINVAL;
             goto done;
         } else if (rsreader_force_link2rank (ctx->rsapi, ctx->machs) != 0) {
             flux_log (ctx->h, LOG_ERR, "failed to force a link to a rank");
+            errno = EINVAL;
             goto done;
         }
         flux_log (ctx->h, LOG_INFO, "loaded resrc");
@@ -720,9 +724,11 @@ static int load_resources (ssrvctx_t *ctx)
     case RSREADER_RESRC:
         if (rsreader_resrc_bulkload (ctx->rsapi, path, uri) != 0) {
             flux_log (ctx->h, LOG_ERR, "failed to load resrc");
+            errno = EINVAL;
             goto done;
         } else if (build_hwloc_rs2rank (ctx, r_mode) != 0) {
             flux_log (ctx->h, LOG_ERR, "failed to build rs2rank");
+            errno = EINVAL;
             goto done;
         }
         flux_log (ctx->h, LOG_INFO, "resrc constructed using RDL ");
@@ -737,7 +743,8 @@ static int load_resources (ssrvctx_t *ctx)
                 free (e_str);
             }
             if (ctx->arg.fail_on_error)
-                goto done;
+                goto done; /* don't set errno: only needed for testing */
+
             flux_log (ctx->h, LOG_INFO, "rebuild resrc using hwloc");
             resrc_tree_t *mismatch_root = resrc_tree_root (ctx->rsapi);
             if (mismatch_root)
@@ -753,6 +760,7 @@ static int load_resources (ssrvctx_t *ctx)
     case RSREADER_HWLOC:
         if (build_hwloc_rs2rank (ctx, r_mode) != 0) {
             flux_log (ctx->h, LOG_ERR, "failed to load resrc using hwloc");
+            errno = EINVAL;
             goto done;
         }
         flux_log (ctx->h, LOG_INFO, "resrc constructed using hwloc");

--- a/sched/sched.c
+++ b/sched/sched.c
@@ -699,6 +699,8 @@ static int load_resources (ssrvctx_t *ctx)
 
     setup_rdl_lua (ctx->h);
 
+    flux_log (ctx->h, LOG_INFO, "start to read resources");
+
     switch (r_mode) {
     case RSREADER_RESRC_EMUL:
         if (rsreader_resrc_bulkload (ctx->rsapi, path, uri) != 0) {
@@ -723,6 +725,7 @@ static int load_resources (ssrvctx_t *ctx)
             flux_log (ctx->h, LOG_ERR, "failed to build rs2rank");
             goto done;
         }
+        flux_log (ctx->h, LOG_INFO, "resrc constructed using RDL ");
         if (ctx->arg.verbosity > 0) {
             flux_log (ctx->h, LOG_INFO, "resrc state after resrc read");
             dump_resrc_state (ctx->h, resrc_tree_root (ctx->rsapi));
@@ -752,11 +755,13 @@ static int load_resources (ssrvctx_t *ctx)
             flux_log (ctx->h, LOG_ERR, "failed to load resrc using hwloc");
             goto done;
         }
+        flux_log (ctx->h, LOG_INFO, "resrc constructed using hwloc");
         /* linking has already been done by build_hwloc_rs2rank above */
         if (ctx->arg.verbosity > 0) {
             flux_log (ctx->h, LOG_INFO, "resrc state after hwloc read");
             dump_resrc_state (ctx->h, resrc_tree_root (ctx->rsapi));
         }
+        flux_log (ctx->h, LOG_INFO, "loaded resrc");
         rc = 0;
         break;
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -48,6 +48,7 @@ TESTS = \
     t1003-stress.t \
     t1004-module-load.t \
     t1005-sched-params.t \
+    t1006-cancel.t \
     t2000-fcfs.t \
     t2001-fcfs-aware.t \
     t2002-easy.t \

--- a/t/sharness.d/sched-sharness.sh
+++ b/t/sharness.d/sched-sharness.sh
@@ -224,10 +224,15 @@ timed_run_flux_jstat () {
 #
 timed_wait_job () {
     local tout=$1
+    local state=$2
     local sfile=wo.st.$sched_test_session
     local cfile=wo.end.$sched_test_session
     rm -f ${sfile} ${cfile}
-    flux waitjob -s ${sfile} -c ${cfile} $sched_end_jobid &
+    if [ "x${state}" = "x" ]; then
+        flux waitjob -s ${sfile} -c ${cfile} ${sched_end_jobid} &
+    else
+        flux waitjob -s ${sfile} -c ${cfile} -j ${state} ${sched_end_jobid} &
+    fi
     $SHARNESS_TEST_SRCDIR/scripts/waitfile.lua --timeout ${tout} ${sfile} >&2
 }
 

--- a/t/t1006-cancel.t
+++ b/t/t1006-cancel.t
@@ -1,0 +1,58 @@
+#!/bin/sh
+#set -x
+
+test_description='Test cancel
+
+Ensure flux-wreck-cancel can cancel pending jobs.
+'
+. `dirname $0`/sharness.sh
+
+basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+# each of the 4 brokers manages an exclusive set of cores (4) of the cab node
+excl_1N4B=$basepath/001N/exclusive/04-brokers
+excl_1N4B_nc=4
+
+#
+# test_under_flux is under sharness.d/
+#
+test_under_flux 4
+
+test_debug '
+    echo ${basepath} &&
+    echo ${excl_1N4B} &&
+    echo ${excl_1N4B_nc}
+'
+
+test_expect_success 'cancel: cancelling a pending job works' '
+    adjust_session_info 4 &&
+    flux hwloc reload ${excl_1N4B} &&
+    flux module load sched sched-once=true &&
+    timed_wait_job 5 &&
+    submit_1N_nproc_sleep_jobs ${excl_1N4B_nc} 0 &&
+    timed_sync_wait_job 10 &&
+    verify_1N_nproc_sleep_jobs ${excl_1N4B_nc} &&
+    adjust_session_info 4 &&
+    timed_wait_job 8 submitted &&
+    submit_1N_nproc_sleep_jobs ${excl_1N4B_nc} 0 &&
+    timed_sync_wait_job 10 &&
+    flux wreck cancel 7 &&
+    state=$(flux kvs get -j $(job_kvs_path 7).state) &&
+    test ${state} = "cancelled"
+'
+
+test_expect_success 'cancel: attempt to cancel nonexistent jobs must fail' '
+    test_must_fail flux wreck cancel 10 &&
+    test_must_fail flux wreck cancel 100
+'
+
+test_expect_success 'cancel: attempt to cancel completed jobs must fail' '
+    test_must_fail flux wreck cancel 1 &&
+    state=$(flux kvs get -j $(job_kvs_path 1).state) &&
+    test ${state} = "complete" &&
+    state=$(flux kvs get -j $(job_kvs_path 2).state) &&
+    test_must_fail flux wreck cancel 2 &&
+    test ${state} = "complete" &&
+    flux module remove sched
+'
+
+test_done


### PR DESCRIPTION
This adds support for cancelling pending jobs in response to the `flux wreck cancel` command. (Please see [flux-core Issue #1359](https://github.com/flux-framework/flux-core/issues/1359)).

Note that this PR requires [flux-core PR #1374](https://github.com/flux-framework/flux-core/pull/1374) to be merged into flux-core first. 

Two more items:

- add `errno` support when resource loading fails. [flux-core Issue #1361](https://github.com/flux-framework/flux-core/issues/1361).

- add some log print statements which can be used to help identify the performance/scalability bottleneck of resource loading. [flux-core Issue #1363](https://github.com/flux-framework/flux-core/issues/1363).

Maybe, @SteVwonder and/or @grondo can review this?
