### PR TITLE
sched: Add queue-depth=1 FCFS perf/scalability optimization

### DIFF
--- a/sched/plugin.c
+++ b/sched/plugin.c
@@ -79,6 +79,12 @@ static struct behavior_plugin *behavior_plugin_create (flux_t *h, void *dso)
     memset (plugin, 0, sizeof (*plugin));
     dlerror (); // Clear old dlerrors
 
+    plugin->get_sched_properties = dlsym (dso, "get_sched_properties");
+    strerr = dlerror();
+    if (strerr || !plugin->get_sched_properties || !*plugin->get_sched_properties) {
+        flux_log (h, LOG_ERR, "can't load get_sched_properties: %s", strerr);
+        goto error;
+    }
     plugin->sched_loop_setup = dlsym (dso, "sched_loop_setup");
     strerr = dlerror();
     if (strerr || !plugin->sched_loop_setup || !*plugin->sched_loop_setup) {

--- a/sched/plugin.h
+++ b/sched/plugin.h
@@ -8,6 +8,9 @@ struct behavior_plugin {
     char         *name;               /* Name of plugin */
     char         *path;               /* Path to plugin dso */
 
+    int                  (*get_sched_properties)(flux_t *h,
+                                                 struct sched_prop *prop);
+
     int                  (*sched_loop_setup)(flux_t *h);
 
     int64_t              (*find_resources)(flux_t *h,

--- a/sched/plugin_version.map
+++ b/sched/plugin_version.map
@@ -1,4 +1,5 @@
 { global:
+    get_sched_properties;
     allocate_resources;
     find_resources;
     reserve_resources;

--- a/sched/sched_backfill.c
+++ b/sched/sched_backfill.c
@@ -74,6 +74,15 @@ resrc_tree_t *select_resources (flux_t *h, resrc_api_ctx_t *rsapi,
                                 resrc_reqst_t *resrc_reqst,
                                 resrc_tree_t *selected_parent);
 
+int get_sched_properties (flux_t *h, struct sched_prop *prop)
+{
+    if (!prop)
+        return -1;
+
+    prop->out_of_order_capable = true;
+    return 0;
+}
+
 int sched_loop_setup (flux_t *h)
 {
     curr_reservation_depth = 0;

--- a/sched/sched_fcfs.c
+++ b/sched/sched_fcfs.c
@@ -41,6 +41,7 @@
 #include "resrc_reqst.h"
 #include "scheduler.h"
 
+static int queue_depth = SCHED_PARAM_Q_DEPTH_DEFAULT;
 
 static bool select_children (flux_t *h, resrc_api_ctx_t *rsapi,
                              resrc_tree_list_t *children,
@@ -51,6 +52,15 @@ resrc_tree_t *select_resources (flux_t *h, resrc_api_ctx_t *rsapi,
                                 resrc_tree_t *found_tree,
                                 resrc_reqst_t *resrc_reqst,
                                 resrc_tree_t *selected_parent);
+
+int get_sched_properties (flux_t *h, struct sched_prop *prop)
+{
+    if (!prop)
+        return -1;
+
+    prop->out_of_order_capable = (queue_depth > 1)? true : false;
+    return 0;
+}
 
 int sched_loop_setup (flux_t *h)
 {
@@ -252,14 +262,16 @@ int reserve_resources (flux_t *h, resrc_api_ctx_t *rsapi,
 {
     int rc = -1;
 
-    if (*selected_tree)
+    /* If queue_depth is 1, this scheduler isn't out-of-order capable */
+    if (queue_depth > 1 && *selected_tree)
         rc = resrc_tree_reserve (*selected_tree, job_id, 0, 0);
     return rc;
 }
 
 
-int process_args (flux_t *h, char *argz, size_t argz_len)
+int process_args (flux_t *h, char *argz, size_t argz_len, const sched_params_t *sp)
 {
+    queue_depth = sp->queue_depth;
     return 0;
 }
 

--- a/sched/scheduler.h
+++ b/sched/scheduler.h
@@ -67,6 +67,12 @@ typedef struct {
     double priority;     /*!< scheduling priority */
 } flux_lwj_t;
 
+/**
+ *  Defines the properties of the scheduler plugin
+ */
+struct sched_prop {
+    bool out_of_order_capable; ;   /*!< true if out of order scheduling*/
+};
 
 /**
  *  Defines parameters that control scheduling optimization

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -52,6 +52,7 @@ TESTS = \
     t2000-fcfs.t \
     t2001-fcfs-aware.t \
     t2002-easy.t \
+    t2003-fcfs-inorder.t \
     t3001-resource-basic.t \
     t3002-resource-prefix.t \
     t3003-resource-global.t \

--- a/t/t2003-fcfs-inorder.t
+++ b/t/t2003-fcfs-inorder.t
@@ -1,0 +1,50 @@
+#!/bin/bash
+#set -x
+
+test_description='Test fcfs scheduler with queue-depth=1 in simulator
+'
+
+# source sharness from the directore where this test
+# file resides
+#
+. $(dirname $0)/sharness.sh
+FLUX_MODULE_PATH="${SHARNESS_BUILD_DIRECTORY}/simulator/.libs:${FLUX_MODULE_PATH}"
+
+rdlconf=$(readlink -e "${SHARNESS_TEST_SRCDIR}/../conf/hype-io.lua")
+jobdata=$(readlink -e "${SHARNESS_TEST_SRCDIR}/data/job-traces/hype-test.csv")
+expected_order=$(readlink -e "${SHARNESS_TEST_SRCDIR}/data/emulator-data/fcfs_expected")
+
+#
+# print only with --debug
+#
+test_debug '
+	echo rdlconf=${rdlconf} &&
+    echo jobdata=${jobdata} &&
+    echo expected_order=${expected_order}
+'
+
+#
+# test_under_flux is under sharness.d/
+#
+test_under_flux 1
+
+test_expect_success 'sim: started successfully with queue-depth=1' '
+    adjust_session_info 12 &&
+    timed_wait_job 5 &&
+    flux module load sim exit-on-complete=false &&
+    flux module load submit job-csv=${jobdata} &&
+    flux module load sim_exec &&
+	flux module load sched rdl-conf=${rdlconf} in-sim=true plugin=sched.fcfs sched-params=queue-depth=1
+'
+
+test_expect_success 'sim: scheduled and ran all jobs with queue-depth=1' '
+    timed_sync_wait_job 60
+'
+
+for x in $(seq 1 12); do echo "$x $(flux kvs get $(job_kvs_path $x).starting_time)"; done | sort -k 2n -k 1n | cut -d ' ' -f 1 > actual
+
+test_expect_success 'jobs scheduled in correct order with queue-depth=1' '
+    diff -u ${expected_order} ./actual
+'
+
+test_done


### PR DESCRIPTION
Avoid traversing the entire resource tree to release reservations at every schedule loop invocation when a very simple, high performance, in-order (queue-depth=1) FCFS policy is used.

See the discussion in https://github.com/flux-framework/flux-core/issues/1358#issuecomment-375429011