### PR TITLE
sim: fix emulator after introduction of new submit RPC

### DIFF
--- a/t/t2000-fcfs.t
+++ b/t/t2000-fcfs.t
@@ -9,11 +9,6 @@ test_description='Test fcfs scheduler in simulator
 #
 . $(dirname $0)/sharness.sh
 
-if test -z "$FLUX_SCHED_ENABLE_SIM_TESTS"; then
-  skip_all='skipping simulator driven tests temporarily'
-  test_done
-fi
-
 FLUX_MODULE_PATH="${SHARNESS_BUILD_DIRECTORY}/simulator/.libs:${FLUX_MODULE_PATH}"
 
 rdlconf=$(readlink -e "${SHARNESS_TEST_SRCDIR}/../conf/hype-io.lua")

--- a/t/t2001-fcfs-aware.t
+++ b/t/t2001-fcfs-aware.t
@@ -9,11 +9,6 @@ test_description='Test fcfs io-aware scheduler in simulator
 #
 . $(dirname $0)/sharness.sh
 
-if test -z "$FLUX_SCHED_ENABLE_SIM_TESTS"; then
-  skip_all='skipping simulator driven tests temporarily'
-  test_done
-fi
-
 FLUX_MODULE_PATH_PREPEND="$FLUX_MODULE_PATH_PREPEND:$(sched_build_path simulator/.libs)"
 
 rdlconf=$(readlink -e "${SHARNESS_TEST_SRCDIR}/../conf/hype-io.lua")

--- a/t/t2002-easy.t
+++ b/t/t2002-easy.t
@@ -8,11 +8,6 @@ test_description='Test easy scheduler in simulator
 #
 . $(dirname $0)/sharness.sh
 
-if test -z "$FLUX_SCHED_ENABLE_SIM_TESTS"; then
-  skip_all='skipping simulator driven tests temporarily'
-  test_done
-fi
-
 rdlconf=$(sched_src_path "conf/hype-io.lua")
 jobdata=$(readlink -e "${SHARNESS_TEST_SRCDIR}/data/job-traces/hype-test.csv")
 expected_order=$(readlink -e "${SHARNESS_TEST_SRCDIR}/data/emulator-data/easy_expected")

--- a/t/t2003-fcfs-inorder.t
+++ b/t/t2003-fcfs-inorder.t
@@ -9,11 +9,6 @@ test_description='Test fcfs scheduler with queue-depth=1 in simulator
 #
 . $(dirname $0)/sharness.sh
 
-if test -z "$FLUX_SCHED_ENABLE_SIM_TESTS"; then
-  skip_all='skipping simulator driven tests temporarily'
-  test_done
-fi
-
 FLUX_MODULE_PATH="${SHARNESS_BUILD_DIRECTORY}/simulator/.libs:${FLUX_MODULE_PATH}"
 
 rdlconf=$(readlink -e "${SHARNESS_TEST_SRCDIR}/../conf/hype-io.lua")


### PR DESCRIPTION
The main problem was a pre-mature destruction of the flux_future.  The unpacked values were later accessed in the packing of the wreck event.  While making changes in the simulator, went ahead and added some additional error checking/messaging and refactored to take advantage of the new `job.submit-nocreate` RPC.

Fixes: #303 
