### PR TITLE
Add node exclusion support

### DIFF
--- a/resrc/resrc.c
+++ b/resrc/resrc.c
@@ -87,6 +87,7 @@ struct resrc {
     zhash_t *properties;
     zhash_t *tags;
     zhash_t *allocs;
+    zlist_t *alloc_keys;
     zhash_t *reservtns;
     zhashx_t *twindow;
 };
@@ -414,7 +415,7 @@ ret:
     return min_available;
 }
 
-char* resrc_state (resrc_t *resrc)
+char* resrc_state_string (resrc_t *resrc)
 {
     char* str = NULL;
 
@@ -428,6 +429,8 @@ char* resrc_state (resrc_t *resrc)
             str = "allocated";  break;
         case RESOURCE_RESERVED:
             str = "reserved";   break;
+        case RESOURCE_EXCLUDED:
+            str = "excluded";   break;
         case RESOURCE_DOWN:
             str = "down";       break;
         case RESOURCE_UNKNOWN:
@@ -438,6 +441,23 @@ char* resrc_state (resrc_t *resrc)
         }
     }
     return str;
+}
+
+int resrc_state (resrc_t *resrc)
+{
+    if (!resrc)
+        return -1;
+    return (int) resrc->state;
+}
+
+int resrc_set_state (resrc_t *resrc, int state)
+{
+    int oldstate = -1;
+    if (!resrc)
+        return oldstate;
+    oldstate = resrc->state;
+    resrc->state = state;
+    return oldstate;
 }
 
 resrc_tree_t *resrc_phys_tree (resrc_t *resrc)
@@ -452,6 +472,27 @@ size_t resrc_size_allocs (resrc_t *resrc)
     if (resrc)
         return zhash_size (resrc->allocs);
     return 0;
+}
+
+int64_t resrc_alloc_job_first (resrc_t *resrc)
+{
+    char *jobid_str = NULL;
+    if (resrc->alloc_keys) {
+        zlist_destroy (&(resrc->alloc_keys));
+        resrc->alloc_keys = NULL;
+    }
+    resrc->alloc_keys = zhash_keys (resrc->allocs);
+    jobid_str = (char *)zlist_first (resrc->alloc_keys);
+    return (jobid_str)? (int64_t) strtol (jobid_str, NULL, 10) : -1;
+}
+
+int64_t resrc_alloc_job_next (resrc_t *resrc)
+{
+    char *jobid_str = NULL;
+    if (!resrc->alloc_keys)
+        return -1;
+    jobid_str = (char *)zlist_next (resrc->alloc_keys);
+    return (jobid_str)? (int64_t) strtol (jobid_str, NULL, 10) : -1;
 }
 
 size_t resrc_size_reservtns (resrc_t *resrc)
@@ -475,11 +516,32 @@ int resrc_graph_insert (resrc_t *resrc, const char *name, resrc_flow_t *flow)
     return rc;
 }
 
-resrc_t *resrc_lookup (resrc_api_ctx_t *ctx, const char *path)
+resrc_t *resrc_lookup_first (resrc_api_ctx_t *ctx, const char *path)
 {
+    zlist_t *l = NULL;
+    resrc_t *r = NULL;
     if (!ctx || !(ctx->resrc_hash) || !path)
         return NULL;
-    return (resrc_t *)zhash_lookup (ctx->resrc_hash, path);
+    if ((l = zhash_lookup (ctx->resrc_hash, path)))
+        r = zlist_first (l);
+    return r;
+}
+
+resrc_t *resrc_lookup_next (resrc_api_ctx_t *ctx, const char *path)
+{
+    zlist_t *l = NULL;
+    resrc_t *r = NULL;
+    if (!ctx || !(ctx->resrc_hash) || !path)
+        return NULL;
+    if ((l = zhash_lookup (ctx->resrc_hash, path)))
+        r = zlist_next (l);
+    return r;
+}
+
+static void list_free_wrap (void *data)
+{
+    zlist_t *l = (zlist_t *)data;
+    zlist_destroy (&l);
 }
 
 resrc_t *resrc_new_resource (resrc_api_ctx_t *ctx, const char *type, const char *path,
@@ -507,8 +569,13 @@ resrc_t *resrc_new_resource (resrc_api_ctx_t *ctx, const char *type, const char 
         }
         if (!strncmp (type, "node", 5)) {
             /* Add this new resource to the resource hash table.
-             * Do not supply a zhash_freefn() */
-            zhash_insert (ctx->resrc_hash, resrc->name, (void *)resrc);
+             * Do not supply a zlist_freefn() */
+            zlist_t *l = NULL;
+            if (!(l = zhash_lookup (ctx->resrc_hash, resrc->name)))
+                l = zlist_new ();
+            zlist_append (l, (void *)resrc);
+            zhash_insert (ctx->resrc_hash, resrc->name, (void *)l);
+            zhash_freefn (ctx->resrc_hash, resrc->name, list_free_wrap);
         }
         resrc->digest = NULL;
         if (sig)
@@ -524,6 +591,7 @@ resrc_t *resrc_new_resource (resrc_api_ctx_t *ctx, const char *type, const char 
         resrc->phys_tree = NULL;
         resrc->graphs = zhash_new ();
         resrc->allocs = zhash_new ();
+        resrc->alloc_keys = NULL;
         resrc->reservtns = zhash_new ();
         resrc->properties = zhash_new ();
         resrc->tags = zhash_new ();
@@ -593,6 +661,10 @@ void resrc_resource_destroy (resrc_api_ctx_t *ctx, void *object)
          * with its physical tree */
         zhash_destroy (&resrc->graphs);
         zhash_destroy (&resrc->allocs);
+        if (resrc->alloc_keys) {
+            zlist_destroy (&(resrc->alloc_keys));
+            resrc->alloc_keys = NULL;
+        }
         zhash_destroy (&resrc->reservtns);
         zhash_destroy (&resrc->properties);
         zhash_destroy (&resrc->tags);
@@ -1048,7 +1120,7 @@ char *resrc_to_string (resrc_t *resrc)
              "id: %"PRId64", state: %s, "
              "uuid: %s, size: %zd, avail: %zd",
              resrc->type, resrc->path, resrc->basename, resrc->name,
-             resrc->digest, resrc->id, resrc_state (resrc),
+             resrc->digest, resrc->id, resrc_state_string (resrc),
              uuid, resrc->size, resrc->available);
     if (zhash_size (resrc->properties)) {
         fprintf (ss, ", properties:");
@@ -1147,6 +1219,11 @@ bool resrc_match_resource (resrc_t *resrc, resrc_reqst_t *request,
     *reason = REASON_NONE;
 
     if (reqst_resrc && !strcmp (resrc->type, reqst_resrc->type)) {
+        if (resrc_state (resrc) == RESOURCE_EXCLUDED) {
+            *reason = DUE_TO_EXCLUSION;
+            goto ret;
+        }
+
         if (zhash_size (reqst_resrc->properties)) {
             if (!zhash_size (resrc->properties)) {
                 *reason = DUE_TO_FEATURE;
@@ -1528,7 +1605,9 @@ int resrc_release_allocation (resrc_t *resrc, int64_t rel_job)
             zhashx_delete (resrc->twindow, id_ptr);
 
         zhash_delete (resrc->allocs, id_ptr);
-        if ((resrc->state != RESOURCE_INVALID) && !zhash_size (resrc->allocs)) {
+        if (((resrc->state != RESOURCE_INVALID)
+              && (resrc->state != RESOURCE_EXCLUDED))
+            && !zhash_size (resrc->allocs)) {
             if (zhash_size (resrc->reservtns))
                 resrc->state = RESOURCE_RESERVED;
             else
@@ -1575,7 +1654,8 @@ int resrc_release_all_reservations (resrc_t *resrc)
         resrc->reservtns = zhash_new ();
     }
 
-    if (resrc->state != RESOURCE_INVALID) {
+    if (resrc->state != RESOURCE_INVALID
+        && resrc->state != RESOURCE_EXCLUDED) {
         if (zhash_size (resrc->allocs))
             resrc->state = RESOURCE_ALLOCATED;
         else

--- a/resrc/resrc.h
+++ b/resrc/resrc.h
@@ -27,6 +27,16 @@ typedef enum {
     RESOURCE_END
 } resource_state_t;
 
+typedef enum {
+    DUE_TO_EXCLUSION = 1,
+    DUE_TO_EXCLUSIVITY,
+    DUE_TO_SIZE,
+    DUE_TO_TYPE,
+    DUE_TO_FEATURE,
+    DUE_TO_TIME,
+    REASON_NONE
+} unmatch_reason_t;
+
 typedef struct resrc_graph_req {
     char   *name;
     size_t size;
@@ -196,7 +206,7 @@ void resrc_print_resource (resrc_t *resrc);
  * defined by the start and end times.
  */
 bool resrc_walltime_match (resrc_t *resrc, resrc_reqst_t *request,
-                           size_t reqrd_size);
+                           size_t reqrd_size, int *reason);
 
 /*
  * Determine whether a specific resource has the required characteristics
@@ -204,10 +214,11 @@ bool resrc_walltime_match (resrc_t *resrc, resrc_reqst_t *request,
  *          request   - resource request with the required characteristics
  *          available - when true, consider only idle resources
  *                      otherwise find all possible resources matching type
+ *          reason    - unmatch reason
  * Returns: true if the input resource has the required characteristics
  */
 bool resrc_match_resource (resrc_t *resrc, resrc_reqst_t *request,
-                           bool available);
+                           bool available, int *reason);
 
 /*
  * Stage size elements of a resource along with any associated graph

--- a/resrc/resrc.h
+++ b/resrc/resrc.h
@@ -18,10 +18,11 @@ typedef struct resrc_tree resrc_tree_t;
 typedef struct resrc_flow resrc_flow_t;
 
 typedef enum {
-    RESOURCE_INVALID,
+    RESOURCE_INVALID = 1,
     RESOURCE_IDLE,
     RESOURCE_ALLOCATED,
     RESOURCE_RESERVED,
+    RESOURCE_EXCLUDED,
     RESOURCE_DOWN,
     RESOURCE_UNKNOWN,
     RESOURCE_END
@@ -104,7 +105,17 @@ size_t resrc_available_during_range (resrc_t *resrc, int64_t range_starttime,
 /*
  * Return the resource state as a string
  */
-char *resrc_state (resrc_t *resrc);
+char *resrc_state_string (resrc_t *resrc);
+
+/*
+ * Return the resource state
+ */
+int resrc_state (resrc_t *resrc);
+
+/*
+ * Set the state field of resrc. This will return the old state.
+ */
+int resrc_set_state (resrc_t *resrc, int state);
 
 /*
  * Return the physical tree for the resouce
@@ -115,6 +126,16 @@ resrc_tree_t *resrc_phys_tree (resrc_t *resrc);
  * Return the number of jobs allocated to this resource
  */
 size_t resrc_size_allocs (resrc_t *resrc);
+
+/*
+ * Return the jobid of an allocated job
+ */
+int64_t resrc_alloc_job_first (resrc_t *resrc);
+
+/*
+ * Return the jobid of the next allocated job
+ */
+int64_t resrc_alloc_job_next (resrc_t *resrc);
 
 /*
  * Return the number of jobs reserved for this resource
@@ -137,9 +158,14 @@ int resrc_twindow_insert (resrc_t *resrc, const char *key,
 int resrc_graph_insert (resrc_t *resrc, const char *name, resrc_flow_t *flow);
 
 /*
- * Return the pointer to the resource with the given path
+ * Return the first resrc object with the given path
  */
-resrc_t *resrc_lookup (resrc_api_ctx_t *ctx, const char *path);
+resrc_t *resrc_lookup_first (resrc_api_ctx_t *ctx, const char *path);
+
+/*
+ * Return the next resrc object with the given path
+ */
+resrc_t *resrc_lookup_next (resrc_api_ctx_t *ctx, const char *path);
 
 /*
  * Create a new resource object

--- a/resrc/resrc_flow.c
+++ b/resrc/resrc_flow.c
@@ -463,12 +463,13 @@ bool resrc_flow_available (resrc_flow_t *resrc_flow, size_t flow,
                            resrc_reqst_t *request)
 {
     bool rc = false;
+    int reason = REASON_NONE;
 
     if (resrc_flow && resrc_flow->flow_resrc) {
         resrc_t *flow_resrc = resrc_flow->flow_resrc;
 
         if (resrc_reqst_starttime (request))
-            rc = resrc_walltime_match (flow_resrc, request, flow);
+            rc = resrc_walltime_match (flow_resrc, request, flow, &reason);
         else {
             rc = flow <= resrc_available (flow_resrc);
             if (rc && resrc_reqst_exclusive (request)) {

--- a/resrc/resrc_flow.c
+++ b/resrc/resrc_flow.c
@@ -255,7 +255,7 @@ resrc_flow_t *resrc_flow_new_from_json (resrc_api_ctx_t *ctx,
         goto ret;
 
     if (!strncmp (type, "node", 5)) {
-        resrc = resrc_lookup (ctx, name);
+        resrc = resrc_lookup_first (ctx, name);
     }
     if ((resrc_flow = resrc_flow_new (ctx, parent, flow_resrc, resrc))) {
         /* add time window if we are given a start time */

--- a/resrc/resrc_reqst.c
+++ b/resrc/resrc_reqst.c
@@ -553,7 +553,7 @@ int64_t resrc_tree_search (resrc_api_ctx_t *ctx,
             resrc_reqst->nfound++;
         }
     } else if (resrc_tree_num_children (resrc_phys_tree (resrc_in))
-               && reason != DUE_TO_EXCLUSIVITY) {
+               && reason != DUE_TO_EXCLUSIVITY && reason != DUE_TO_EXCLUSION) {
 
         /*
          * This clause visits the children of the current resource

--- a/resrc/resrc_reqst.c
+++ b/resrc/resrc_reqst.c
@@ -525,6 +525,7 @@ int64_t resrc_tree_search (resrc_api_ctx_t *ctx,
                            resrc_tree_t **found_tree, bool available)
 {
     int64_t nfound = 0;
+    int reason = REASON_NONE;
     resrc_tree_list_t *children = NULL;
     resrc_tree_t *child_tree;
     resrc_tree_t *new_tree = NULL;
@@ -533,7 +534,7 @@ int64_t resrc_tree_search (resrc_api_ctx_t *ctx,
         goto ret;
     }
 
-    if (resrc_match_resource (resrc_in, resrc_reqst, available)) {
+    if (resrc_match_resource (resrc_in, resrc_reqst, available, &reason)) {
         if (resrc_reqst_num_children (resrc_reqst)) {
             if (resrc_tree_num_children (resrc_phys_tree (resrc_in))) {
                 new_tree = resrc_tree_new (*found_tree, resrc_in);
@@ -551,7 +552,9 @@ int64_t resrc_tree_search (resrc_api_ctx_t *ctx,
             nfound = 1;
             resrc_reqst->nfound++;
         }
-    } else if (resrc_tree_num_children (resrc_phys_tree (resrc_in))) {
+    } else if (resrc_tree_num_children (resrc_phys_tree (resrc_in))
+               && reason != DUE_TO_EXCLUSIVITY) {
+
         /*
          * This clause visits the children of the current resource
          * searching for a match to the resource request.  The found
@@ -562,6 +565,7 @@ int64_t resrc_tree_search (resrc_api_ctx_t *ctx,
          * defined.  E.g., it might only stipulate a node with 4 cores
          * and omit the intervening socket.
          */
+
         if (*found_tree)
             new_tree = resrc_tree_new (*found_tree, resrc_in);
         else {

--- a/sched/sched.c
+++ b/sched/sched.c
@@ -70,6 +70,10 @@ static void res_event_cb (flux_t *h, flux_msg_handler_t *w,
                           const flux_msg_t *msg, void *arg);
 static void cancel_request_cb (flux_t *h, flux_msg_handler_t *w,
                                const flux_msg_t *msg, void *arg);
+static void exclude_request_cb (flux_t *h, flux_msg_handler_t *w,
+                              const flux_msg_t *msg, void *arg);
+static void include_request_cb (flux_t *h, flux_msg_handler_t *w,
+                              const flux_msg_t *msg, void *arg);
 static int job_status_cb (const char *jcbstr, void *arg, int errnum);
 
 
@@ -1074,7 +1078,9 @@ static int setup_sim (ssrvctx_t *ctx, bool sim)
 
 static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST,   "sched.cancel", cancel_request_cb, 0},
-    { FLUX_MSGTYPE_EVENT,     "sched.res.*", res_event_cb, 0},
+    { FLUX_MSGTYPE_REQUEST,   "sched.exclude",  exclude_request_cb, 0},
+    { FLUX_MSGTYPE_REQUEST,   "sched.include",  include_request_cb, 0},
+    { FLUX_MSGTYPE_EVENT,     "sched.res.*",  res_event_cb, 0},
     FLUX_MSGHANDLER_TABLE_END
 };
 
@@ -1857,6 +1863,144 @@ static void cancel_request_cb (flux_t *h, flux_msg_handler_t *w,
     if (flux_respond_pack (h, msg, "{s:I}", "jobid", jobid) < 0)
         flux_log_error (h, "%s", __FUNCTION__);
     return;
+error:
+    if (flux_respond (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+}
+
+static int kill_jobs_on_node (flux_t *h, resrc_t *node)
+{
+   int64_t jobid = -1;
+   char *topic = NULL;
+   flux_msg_t *msg = NULL;
+
+   for (jobid = resrc_alloc_job_first (node); jobid > 0;
+        jobid = resrc_alloc_job_next (node)) {
+       if (asprintf (&topic, "wreck.%"PRId64".kill", jobid) < 0) {
+           flux_log (h, LOG_DEBUG, "%s: topic creation failed", __FUNCTION__);
+           goto error;
+       } else if (!(msg = flux_event_encode (topic, NULL))
+                  || flux_send (h, msg, 0) < 0) {
+           flux_log (h, LOG_DEBUG, "%s: event failed", __FUNCTION__);
+           goto error;
+       }
+       free (topic);
+       topic = NULL;
+       flux_msg_destroy (msg);
+       msg = NULL;
+   }
+   return 0;
+
+error:
+    if (topic)
+        free (topic);
+    if (msg)
+        flux_msg_destroy (msg);
+    return -1;
+}
+
+static void exclude_request_cb (flux_t *h, flux_msg_handler_t *w,
+                                const flux_msg_t *msg, void *arg)
+{
+    ssrvctx_t *ctx = getctx ((flux_t *)arg);
+    const char *hostname = NULL;
+    bool kill = false;
+    uint32_t userid = 0;
+    char *topic = NULL;
+    resrc_t *node = NULL;
+    flux_msg_t *msg2 = NULL;
+
+    if (flux_msg_get_userid (msg, &userid) < 0)
+        goto error;
+
+    flux_log (h, LOG_INFO, "node exclusion requested by user (%u).", userid);
+    if (flux_request_unpack (msg, NULL, "{s:s s:b}",
+                            "node", &hostname, "kill", &kill) < 0)
+        goto error;
+
+    node = resrc_lookup_first (ctx->rsapi, hostname);
+    do {
+        if (!node) {
+            errno = ENOENT;
+            flux_log (h, LOG_DEBUG,
+                      "attempt to exclude nonexistent node (%s).", hostname);
+            goto error;
+        }
+        resrc_set_state (node, RESOURCE_EXCLUDED);
+        if (kill) {
+            if (kill_jobs_on_node (h, node) != 0) {
+                goto error;
+            }
+        }
+    } while ((node = resrc_lookup_next (ctx->rsapi, hostname)));
+
+    flux_log (ctx->h, LOG_INFO, "%s excluded from scheduling.", hostname);
+    msg2 = flux_event_encode ("sched.res.excluded", NULL);
+    if (!msg2 || flux_send (h, msg2, 0) < 0) {
+        flux_log (h, LOG_DEBUG, "%s: error sending event", __FUNCTION__);
+        goto error;
+    }
+    flux_msg_destroy (msg2);
+
+    if (flux_respond_pack (h, msg, "{}") < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+    return;
+
+error:
+    if (topic)
+        free (topic);
+    if (msg2)
+        flux_msg_destroy (msg2);
+    if (flux_respond (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+}
+
+static void include_request_cb (flux_t *h, flux_msg_handler_t *w,
+                                const flux_msg_t *msg, void *arg)
+{
+    ssrvctx_t *ctx = getctx ((flux_t *)arg);
+    const char *hostname = NULL;
+    flux_msg_t *msg2 = NULL;
+    uint32_t userid = 0;
+    resrc_t *node = NULL;
+
+    if (flux_msg_get_userid (msg, &userid) < 0)
+        goto error;
+
+    flux_log (h, LOG_INFO, "node inclusion requested by user (%u).", userid);
+    if (flux_request_unpack (msg, NULL, "{s:s}", "node", &hostname) < 0)
+        goto error;
+
+    node = resrc_lookup_first (ctx->rsapi, hostname);
+    do {
+        if (!node) {
+            errno = ENOENT;
+            flux_log (h, LOG_DEBUG,
+                      "attempt to include nonexistent node (%s).", hostname);
+            goto error;
+        } else if (resrc_state (node) != RESOURCE_EXCLUDED
+                   && resrc_state (node) != RESOURCE_IDLE
+                   && resrc_state (node) != RESOURCE_INVALID) {
+            errno = EINVAL;
+            flux_log (h, LOG_DEBUG,
+                      "cannot include node (%s) due to state (%s).",
+                      hostname, resrc_state_string (node));
+            continue;
+        }
+        resrc_set_state (node, RESOURCE_IDLE);
+    } while ((node = resrc_lookup_next (ctx->rsapi, hostname)));
+
+    flux_log (h, LOG_DEBUG, "include node resource (%s), ", hostname);
+    msg2 = flux_event_encode ("sched.res.included", NULL);
+    if (!msg2 || flux_send (h, msg2, 0) < 0) {
+        flux_log (h, LOG_ERR, "%s: error sending event: %s",
+                  __FUNCTION__, strerror (errno));
+    }
+    flux_msg_destroy (msg2);
+    if (flux_respond_pack (h, msg, "{}") < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+    return;
+
 error:
     if (flux_respond (h, msg, errno, NULL) < 0)
         flux_log_error (h, "%s", __FUNCTION__);

--- a/sched/sched.c
+++ b/sched/sched.c
@@ -431,7 +431,7 @@ static inline int fill_resource_req (flux_t *h, flux_lwj_t *j, json_t *jcb)
         goto done;
     if (!Jget_int64 (o, JSC_RDESC_NNODES, &nn))
         goto done;
-    if (!Jget_int64 (o, JSC_RDESC_NTASKS, &nc))
+    if (!Jget_int64 (o, JSC_RDESC_NCORES, &nc))
         goto done;
 
     j->req->nnodes = (uint64_t) nn;

--- a/sched/sched_backfill.c
+++ b/sched/sched_backfill.c
@@ -192,6 +192,7 @@ resrc_tree_t *select_resources (flux_t *h, resrc_api_ctx_t *rsapi,
                                 resrc_reqst_t *resrc_reqst,
                                 resrc_tree_t *selected_parent)
 {
+    int reason = REASON_NONE;
     resrc_t *resrc;
     resrc_tree_list_t *children = NULL;
     resrc_tree_t *child_tree;
@@ -203,7 +204,7 @@ resrc_tree_t *select_resources (flux_t *h, resrc_api_ctx_t *rsapi,
     }
 
     resrc = resrc_tree_resrc (found_tree);
-    if (resrc_match_resource (resrc, resrc_reqst, true)) {
+    if (resrc_match_resource (resrc, resrc_reqst, true, &reason)) {
         if (resrc_reqst_num_children (resrc_reqst)) {
             if (resrc_tree_num_children (found_tree)) {
                 selected_tree = resrc_tree_new (selected_parent, resrc);

--- a/sched/sched_fcfs.c
+++ b/sched/sched_fcfs.c
@@ -175,6 +175,7 @@ resrc_tree_t *select_resources (flux_t *h, resrc_api_ctx_t *rsapi,
                                 resrc_reqst_t *resrc_reqst,
                                 resrc_tree_t *selected_parent)
 {
+    int reason = REASON_NONE;
     resrc_t *resrc;
     resrc_tree_list_t *children = NULL;
     resrc_tree_t *child_tree;
@@ -194,7 +195,7 @@ resrc_tree_t *select_resources (flux_t *h, resrc_api_ctx_t *rsapi,
         return NULL;
 
     resrc = resrc_tree_resrc (found_tree);
-    if (resrc_match_resource (resrc, resrc_reqst, true)) {
+    if (resrc_match_resource (resrc, resrc_reqst, true, &reason)) {
         if (resrc_reqst_num_children (resrc_reqst)) {
             if (resrc_tree_num_children (found_tree)) {
                 selected_tree = resrc_tree_new (selected_parent, resrc);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -49,6 +49,7 @@ TESTS = \
     t1004-module-load.t \
     t1005-sched-params.t \
     t1006-cancel.t \
+    t1007-exclude.t \
     t2000-fcfs.t \
     t2001-fcfs-aware.t \
     t2002-easy.t \

--- a/t/t1007-exclude.t
+++ b/t/t1007-exclude.t
@@ -1,0 +1,100 @@
+#!/bin/sh
+#set -x
+
+test_description='Test node exclude/include command
+
+Ensure flux-wreck-exclude can exclude a node from being scheduled.
+Ensure flux-wreck-include can include a node back to be scheduled.
+'
+. `dirname $0`/sharness.sh
+
+basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+# each of the 4 brokers manages a full cab node exclusively
+excl_4N4B=$basepath/004N/exclusive/04-brokers
+excl_4N4B_nc=16
+
+#
+# test_under_flux is under sharness.d/
+#
+test_under_flux 4
+
+test_debug '
+    echo ${basepath} &&
+    echo ${excl_4N4B} &&
+    echo ${excl_4N4B_nc}
+'
+
+test_expect_success 'excluding a node with no job allocated or reserved works' '
+    adjust_session_info 4 &&
+    flux hwloc reload ${excl_4N4B} &&
+    flux module load sched sched-once=true node-excl=true &&
+    flux wreck exclude cab1234 &&
+    timed_wait_job 5 submitted &&
+    flux submit -N 1 sleep 0 &&
+    flux submit -N 1 sleep 0 &&
+    flux submit -N 1 sleep 0 &&
+    flux submit -N 1 sleep 0 &&
+    timed_sync_wait_job 10 &&
+    state=$(flux kvs get -j $(job_kvs_path 4).state) &&
+    test ${state} = "submitted"
+'
+
+test_expect_success 'including an excluded node works' '
+    timed_wait_job 5 &&
+    flux wreck include cab1234 &&
+    timed_sync_wait_job 10 &&
+    state=$(flux kvs get -j $(job_kvs_path 4).state) &&
+    test ${state} = "complete"
+'
+
+test_expect_success 'excluding a node does not kill the jobs' '
+    adjust_session_info 1 &&
+    flux module remove sched &&
+    flux module load sched sched-once=true node-excl=true &&
+    timed_wait_job 5 running &&
+    flux submit -N 1 sleep 120 &&
+    timed_sync_wait_job 10 &&
+    flux wreck exclude cab1234 &&
+    state=$(flux kvs get -j $(job_kvs_path 5).state) &&
+    test ${state} = "running" &&
+    flux wreck cancel -f 5 &&
+    state=$(flux kvs get -j $(job_kvs_path 5).state) &&
+    test ${state} = "complete" &&
+    flux wreck include cab1234
+'
+
+test_expect_success '-k option kills the jobs using the node' '
+    adjust_session_info 1 &&
+    timed_wait_job 5 running &&
+    flux submit -N 1 sleep 120 &&
+    timed_sync_wait_job 10 &&
+    flux wreck exclude --kill cab1235 &&
+    state=$(flux kvs get -j $(job_kvs_path 6).state) &&
+    test ${state} = "complete" &&
+    flux wreck include cab1235
+'
+
+test_expect_success 'excluding a node with reservations works' '
+    adjust_session_info 4 &&
+    flux module remove sched &&
+    flux module load sched sched-once=true node-excl=true plugin=sched.backfill &&
+    timed_wait_job 5 submitted &&
+    flux submit -N 4 sleep 0 &&
+    flux submit -N 4 sleep 0 &&
+    flux submit -N 4 sleep 0 &&
+    flux submit -N 4 sleep 0 &&
+    timed_sync_wait_job 10 &&
+    flux wreck exclude -k cab1235 &&
+    state=$(flux kvs get -j $(job_kvs_path 7).state) &&
+    test ${state} = "complete"
+'
+
+test_expect_success 'attempting to exclude or include an invalid node must fail' '
+    flux module remove sched &&
+    flux module load sched node-excl=true &&
+    test_must_fail flux wreck exclude foo &&
+    test_must_fail flux wreck exclude -k bar &&
+    test_must_fail flux wreck include foo
+'
+
+test_done


### PR DESCRIPTION
This is an experimental PR. Please don't merge yet.

As requested in https://github.com/flux-framework/flux-core/issues/1415#issuecomment-378117471, I added rudimentary support for excluding or including a node resource by the node's name.

To facilitate testing, this PR also adds support for node-exclusion support. 

This PR has not been fully validated for backfill scheduling. Also, only manually tested with no addition test cases yet.

An node-exclusion command is valid only when the target node has nothing allocated or reserved.

This requires another experimental PR I will post to flux-core that includes `flux wreck exclude` and `flux wreck include`