### PR TITLE
Fix for reading hwloc xml files generated from Sierra compute nodes

### DIFF
--- a/resrc/resrc.c
+++ b/resrc/resrc.c
@@ -796,6 +796,9 @@ static resrc_t *resrc_new_from_hwloc_obj (resrc_api_ctx_t *ctx, hwloc_obj_t obj,
         if (!hwloc_name)
             goto ret;
         name = xstrdup (hwloc_name);
+    } else if (!hwloc_compare_types (obj->type, HWLOC_OBJ_GROUP)) {
+        type = xstrdup ("group");
+        name = xasprintf ("%s%"PRId64"", type, id);
 #if HWLOC_API_VERSION < 0x00010b00
     } else if (!hwloc_compare_types (obj->type, HWLOC_OBJ_NODE)) {
 #else

--- a/t/data/hwloc-data/004N/exclusive/04-brokers-sierra/0.xml
+++ b/t/data/hwloc-data/004N/exclusive/04-brokers-sierra/0.xml
@@ -1,0 +1,655 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff" online_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0xf0000000,,,,,,,0x00000101" complete_nodeset="0xf0000000,,,,,,,0x00000101" allowed_nodeset="0xf0000000,,,,,,,0x00000101">
+    <page_type size="65536" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <page_type size="1073741824" count="0"/>
+    <info name="PlatformName" value="PowerNV"/>
+    <info name="PlatformModel" value="PowerNV 8335-GTC"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="4.11.0-44.2.1.el7a.ppc64le"/>
+    <info name="OSVersion" value="#1 SMP Thu Nov 9 02:48:01 EST 2017"/>
+    <info name="HostName" value="sierra4367"/>
+    <info name="Architecture" value="ppc64le"/>
+    <info name="hwlocVersion" value="1.11.7"/>
+    <info name="ProcessName" value="lstopo"/>
+    <distances nbobjs="6" relative_depth="2" latency_base="10.000000">
+      <latency value="1.000000"/>
+      <latency value="4.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="4.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+    </distances>
+    <object type="Group" cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff" online_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0x00000101" complete_nodeset="0x00000101" allowed_nodeset="0x00000101" depth="0">
+      <object type="NUMANode" os_index="0" cpuset="0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff" online_cpuset="0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="270271709184">
+        <page_type size="65536" count="4124019"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Package" os_index="0" cpuset="0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff" online_cpuset="0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <info name="CPUModel" value="POWER9 (raw), altivec supported"/>
+          <info name="CPURevision" value="2.1 (pvr 004e 1201)"/>
+          <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="32" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="36" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="40" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="44" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000" complete_cpuset="0x00ff0000" online_cpuset="0x00ff0000" allowed_cpuset="0x00ff0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000" complete_cpuset="0x00ff0000" online_cpuset="0x00ff0000" allowed_cpuset="0x00ff0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="48" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="52" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000" complete_cpuset="0xff000000" online_cpuset="0xff000000" allowed_cpuset="0xff000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000" complete_cpuset="0xff000000" online_cpuset="0xff000000" allowed_cpuset="0xff000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="56" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="60" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,0x0" complete_cpuset="0x000000ff,0x0" online_cpuset="0x000000ff,0x0" allowed_cpuset="0x000000ff,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,0x0" complete_cpuset="0x000000ff,0x0" online_cpuset="0x000000ff,0x0" allowed_cpuset="0x000000ff,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="64" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="68" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,0x0" complete_cpuset="0x0000ff00,0x0" online_cpuset="0x0000ff00,0x0" allowed_cpuset="0x0000ff00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,0x0" complete_cpuset="0x0000ff00,0x0" online_cpuset="0x0000ff00,0x0" allowed_cpuset="0x0000ff00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="72" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="76" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,0x0" complete_cpuset="0x00ff0000,0x0" online_cpuset="0x00ff0000,0x0" allowed_cpuset="0x00ff0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,0x0" complete_cpuset="0x00ff0000,0x0" online_cpuset="0x00ff0000,0x0" allowed_cpuset="0x00ff0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="80" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="84" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000,0x0" complete_cpuset="0xff000000,0x0" online_cpuset="0xff000000,0x0" allowed_cpuset="0xff000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,0x0" complete_cpuset="0xff000000,0x0" online_cpuset="0xff000000,0x0" allowed_cpuset="0xff000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="88" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="92" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-01]">
+          <object type="Bridge" os_index="0" bridge_type="1-1" depth="1" bridge_pci="0000:[01-01]" pci_busid="0000:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="PCIDev" os_index="4096" pci_busid="0000:01:00.0" pci_type="0108 [144d:a822] [1014:0621] 01" pci_link_speed="0.000000"/>
+          </object>
+        </object>
+        <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0002:[00-02]">
+          <object type="Bridge" os_index="2097152" bridge_type="1-1" depth="1" bridge_pci="0002:[01-02]" pci_busid="0002:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="Bridge" os_index="2101248" bridge_type="1-1" depth="2" bridge_pci="0002:[02-02]" pci_busid="0002:01:00.0" pci_type="0604 [1a03:1150] [1a03:1150] 04" pci_link_speed="0.000000">
+              <object type="PCIDev" os_index="2105344" pci_busid="0002:02:00.0" pci_type="0300 [1a03:2000] [1a03:2000] 41" pci_link_speed="0.000000">
+                <object type="OSDev" name="card0" osdev_type="1"/>
+                <object type="OSDev" name="controlD64" osdev_type="1"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0003:[00-01]">
+          <object type="Bridge" os_index="3145728" bridge_type="1-1" depth="1" bridge_pci="0003:[01-01]" pci_busid="0003:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="PCIDev" os_index="3149824" pci_busid="0003:01:00.0" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+              <object type="OSDev" name="hsi0" osdev_type="2">
+                <info name="Address" value="00:00:00:86:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:83:51:46"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" name="mlx5_0" osdev_type="3">
+                <info name="NodeGUID" value="ec0d:9a03:0083:5146"/>
+                <info name="SysImageGUID" value="ec0d:9a03:0083:5146"/>
+                <info name="Port1State" value="4"/>
+                <info name="Port1LID" value="0x136d"/>
+                <info name="Port1LMC" value="0"/>
+                <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:0083:5146"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="3149825" pci_busid="0003:01:00.1" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+              <object type="OSDev" name="hsi1" osdev_type="2">
+                <info name="Address" value="00:00:08:86:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:83:51:47"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" name="mlx5_1" osdev_type="3">
+                <info name="NodeGUID" value="ec0d:9a03:0083:5147"/>
+                <info name="SysImageGUID" value="ec0d:9a03:0083:5146"/>
+                <info name="Port1State" value="4"/>
+                <info name="Port1LID" value="0x136e"/>
+                <info name="Port1LMC" value="0"/>
+                <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:0083:5147"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="4" bridge_type="0-1" depth="0" bridge_pci="0004:[00-0a]">
+          <object type="Bridge" os_index="4194304" bridge_type="1-1" depth="1" bridge_pci="0004:[01-0a]" pci_busid="0004:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="Bridge" os_index="4198400" bridge_type="1-1" depth="2" bridge_pci="0004:[02-0a]" pci_busid="0004:01:00.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+              <object type="Bridge" os_index="4202528" bridge_type="1-1" depth="3" bridge_pci="0004:[03-03]" pci_busid="0004:02:02.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+                <object type="PCIDev" os_index="4206592" pci_busid="0004:03:00.0" pci_type="0106 [1b4b:9235] [1014:0612] 11" pci_link_speed="0.000000">
+                  <object type="OSDev" name="sda" osdev_type="0">
+                    <info name="LinuxDeviceID" value="8:0"/>
+                    <info name="Vendor" value="Seagate"/>
+                    <info name="Model" value="ST2000NX0253_00LY418_00LY417IBM"/>
+                    <info name="Revision" value="BE35"/>
+                    <info name="SerialNumber" value="W460Q5F6"/>
+                    <info name="Type" value="Disk"/>
+                  </object>
+                  <object type="OSDev" name="sdb" osdev_type="0">
+                    <info name="LinuxDeviceID" value="8:16"/>
+                    <info name="Vendor" value="Seagate"/>
+                    <info name="Model" value="ST2000NX0253_00LY418_00LY417IBM"/>
+                    <info name="Revision" value="BE35"/>
+                    <info name="SerialNumber" value="W460KLXH"/>
+                    <info name="Type" value="Disk"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Bridge" os_index="4202656" bridge_type="1-1" depth="3" bridge_pci="0004:[04-04]" pci_busid="0004:02:0a.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+                <object type="PCIDev" os_index="4210688" pci_busid="0004:04:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+                  <object type="OSDev" name="card1" osdev_type="1"/>
+                  <object type="OSDev" name="renderD128" osdev_type="1"/>
+                </object>
+              </object>
+              <object type="Bridge" os_index="4202672" bridge_type="1-1" depth="3" bridge_pci="0004:[05-05]" pci_busid="0004:02:0b.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+                <object type="PCIDev" os_index="4214784" pci_busid="0004:05:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+                  <object type="OSDev" name="card2" osdev_type="1"/>
+                  <object type="OSDev" name="renderD129" osdev_type="1"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="5" bridge_type="0-1" depth="0" bridge_pci="0005:[00-01]">
+          <object type="Bridge" os_index="5242880" bridge_type="1-1" depth="1" bridge_pci="0005:[01-01]" pci_busid="0005:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="PCIDev" os_index="5246976" pci_busid="0005:01:00.0" pci_type="0200 [14e4:1657] [14e4:1981] 01" pci_link_speed="0.000000">
+              <object type="OSDev" name="enP5p1s0f0" osdev_type="2">
+                <info name="Address" value="70:e2:84:14:3f:18"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="5246977" pci_busid="0005:01:00.1" pci_type="0200 [14e4:1657] [14e4:1657] 01" pci_link_speed="0.000000">
+              <object type="OSDev" name="prov" osdev_type="2">
+                <info name="Address" value="70:e2:84:14:3f:19"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="8" cpuset="0xffffffff,0xffffffff,,0x0" complete_cpuset="0xffffffff,0xffffffff,,0x0" online_cpuset="0xffffffff,0xffffffff,,0x0" allowed_cpuset="0xffffffff,0xffffffff,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" local_memory="274469093376">
+        <page_type size="65536" count="4188066"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Package" os_index="8" cpuset="0xffffffff,0xffffffff,,0x0" complete_cpuset="0xffffffff,0xffffffff,,0x0" online_cpuset="0xffffffff,0xffffffff,,0x0" allowed_cpuset="0xffffffff,0xffffffff,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+          <info name="CPUModel" value="POWER9 (raw), altivec supported"/>
+          <info name="CPURevision" value="2.1 (pvr 004e 1201)"/>
+          <object type="Cache" cpuset="0x000000ff,,0x0" complete_cpuset="0x000000ff,,0x0" online_cpuset="0x000000ff,,0x0" allowed_cpuset="0x000000ff,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,0x0" complete_cpuset="0x000000ff,,0x0" online_cpuset="0x000000ff,,0x0" allowed_cpuset="0x000000ff,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2080" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2084" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,,0x0" complete_cpuset="0x0000ff00,,0x0" online_cpuset="0x0000ff00,,0x0" allowed_cpuset="0x0000ff00,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,,0x0" complete_cpuset="0x0000ff00,,0x0" online_cpuset="0x0000ff00,,0x0" allowed_cpuset="0x0000ff00,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2088" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2092" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,0x0" online_cpuset="0x00ff0000,,0x0" allowed_cpuset="0x00ff0000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,0x0" online_cpuset="0x00ff0000,,0x0" allowed_cpuset="0x00ff0000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2096" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2100" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000,,0x0" complete_cpuset="0xff000000,,0x0" online_cpuset="0xff000000,,0x0" allowed_cpuset="0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,,0x0" complete_cpuset="0xff000000,,0x0" online_cpuset="0xff000000,,0x0" allowed_cpuset="0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2104" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2108" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,,0x0" complete_cpuset="0x000000ff,,,0x0" online_cpuset="0x000000ff,,,0x0" allowed_cpuset="0x000000ff,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,,0x0" complete_cpuset="0x000000ff,,,0x0" online_cpuset="0x000000ff,,,0x0" allowed_cpuset="0x000000ff,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2112" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="96" cpuset="0x00000001,,,0x0" complete_cpuset="0x00000001,,,0x0" online_cpuset="0x00000001,,,0x0" allowed_cpuset="0x00000001,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="97" cpuset="0x00000002,,,0x0" complete_cpuset="0x00000002,,,0x0" online_cpuset="0x00000002,,,0x0" allowed_cpuset="0x00000002,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="98" cpuset="0x00000004,,,0x0" complete_cpuset="0x00000004,,,0x0" online_cpuset="0x00000004,,,0x0" allowed_cpuset="0x00000004,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="99" cpuset="0x00000008,,,0x0" complete_cpuset="0x00000008,,,0x0" online_cpuset="0x00000008,,,0x0" allowed_cpuset="0x00000008,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2116" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="100" cpuset="0x00000010,,,0x0" complete_cpuset="0x00000010,,,0x0" online_cpuset="0x00000010,,,0x0" allowed_cpuset="0x00000010,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="101" cpuset="0x00000020,,,0x0" complete_cpuset="0x00000020,,,0x0" online_cpuset="0x00000020,,,0x0" allowed_cpuset="0x00000020,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="102" cpuset="0x00000040,,,0x0" complete_cpuset="0x00000040,,,0x0" online_cpuset="0x00000040,,,0x0" allowed_cpuset="0x00000040,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="103" cpuset="0x00000080,,,0x0" complete_cpuset="0x00000080,,,0x0" online_cpuset="0x00000080,,,0x0" allowed_cpuset="0x00000080,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,,,0x0" complete_cpuset="0x0000ff00,,,0x0" online_cpuset="0x0000ff00,,,0x0" allowed_cpuset="0x0000ff00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,,,0x0" complete_cpuset="0x0000ff00,,,0x0" online_cpuset="0x0000ff00,,,0x0" allowed_cpuset="0x0000ff00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2120" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="104" cpuset="0x00000100,,,0x0" complete_cpuset="0x00000100,,,0x0" online_cpuset="0x00000100,,,0x0" allowed_cpuset="0x00000100,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="105" cpuset="0x00000200,,,0x0" complete_cpuset="0x00000200,,,0x0" online_cpuset="0x00000200,,,0x0" allowed_cpuset="0x00000200,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="106" cpuset="0x00000400,,,0x0" complete_cpuset="0x00000400,,,0x0" online_cpuset="0x00000400,,,0x0" allowed_cpuset="0x00000400,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="107" cpuset="0x00000800,,,0x0" complete_cpuset="0x00000800,,,0x0" online_cpuset="0x00000800,,,0x0" allowed_cpuset="0x00000800,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2124" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="108" cpuset="0x00001000,,,0x0" complete_cpuset="0x00001000,,,0x0" online_cpuset="0x00001000,,,0x0" allowed_cpuset="0x00001000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="109" cpuset="0x00002000,,,0x0" complete_cpuset="0x00002000,,,0x0" online_cpuset="0x00002000,,,0x0" allowed_cpuset="0x00002000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="110" cpuset="0x00004000,,,0x0" complete_cpuset="0x00004000,,,0x0" online_cpuset="0x00004000,,,0x0" allowed_cpuset="0x00004000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="111" cpuset="0x00008000,,,0x0" complete_cpuset="0x00008000,,,0x0" online_cpuset="0x00008000,,,0x0" allowed_cpuset="0x00008000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,,,0x0" complete_cpuset="0x00ff0000,,,0x0" online_cpuset="0x00ff0000,,,0x0" allowed_cpuset="0x00ff0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,,,0x0" complete_cpuset="0x00ff0000,,,0x0" online_cpuset="0x00ff0000,,,0x0" allowed_cpuset="0x00ff0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2128" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="112" cpuset="0x00010000,,,0x0" complete_cpuset="0x00010000,,,0x0" online_cpuset="0x00010000,,,0x0" allowed_cpuset="0x00010000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="113" cpuset="0x00020000,,,0x0" complete_cpuset="0x00020000,,,0x0" online_cpuset="0x00020000,,,0x0" allowed_cpuset="0x00020000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="114" cpuset="0x00040000,,,0x0" complete_cpuset="0x00040000,,,0x0" online_cpuset="0x00040000,,,0x0" allowed_cpuset="0x00040000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="115" cpuset="0x00080000,,,0x0" complete_cpuset="0x00080000,,,0x0" online_cpuset="0x00080000,,,0x0" allowed_cpuset="0x00080000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2132" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="116" cpuset="0x00100000,,,0x0" complete_cpuset="0x00100000,,,0x0" online_cpuset="0x00100000,,,0x0" allowed_cpuset="0x00100000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="117" cpuset="0x00200000,,,0x0" complete_cpuset="0x00200000,,,0x0" online_cpuset="0x00200000,,,0x0" allowed_cpuset="0x00200000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="118" cpuset="0x00400000,,,0x0" complete_cpuset="0x00400000,,,0x0" online_cpuset="0x00400000,,,0x0" allowed_cpuset="0x00400000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="119" cpuset="0x00800000,,,0x0" complete_cpuset="0x00800000,,,0x0" online_cpuset="0x00800000,,,0x0" allowed_cpuset="0x00800000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000,,,0x0" complete_cpuset="0xff000000,,,0x0" online_cpuset="0xff000000,,,0x0" allowed_cpuset="0xff000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,,,0x0" complete_cpuset="0xff000000,,,0x0" online_cpuset="0xff000000,,,0x0" allowed_cpuset="0xff000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2136" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="120" cpuset="0x01000000,,,0x0" complete_cpuset="0x01000000,,,0x0" online_cpuset="0x01000000,,,0x0" allowed_cpuset="0x01000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="121" cpuset="0x02000000,,,0x0" complete_cpuset="0x02000000,,,0x0" online_cpuset="0x02000000,,,0x0" allowed_cpuset="0x02000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="122" cpuset="0x04000000,,,0x0" complete_cpuset="0x04000000,,,0x0" online_cpuset="0x04000000,,,0x0" allowed_cpuset="0x04000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="123" cpuset="0x08000000,,,0x0" complete_cpuset="0x08000000,,,0x0" online_cpuset="0x08000000,,,0x0" allowed_cpuset="0x08000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2140" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="124" cpuset="0x10000000,,,0x0" complete_cpuset="0x10000000,,,0x0" online_cpuset="0x10000000,,,0x0" allowed_cpuset="0x10000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="125" cpuset="0x20000000,,,0x0" complete_cpuset="0x20000000,,,0x0" online_cpuset="0x20000000,,,0x0" allowed_cpuset="0x20000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="126" cpuset="0x40000000,,,0x0" complete_cpuset="0x40000000,,,0x0" online_cpuset="0x40000000,,,0x0" allowed_cpuset="0x40000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="127" cpuset="0x80000000,,,0x0" complete_cpuset="0x80000000,,,0x0" online_cpuset="0x80000000,,,0x0" allowed_cpuset="0x80000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="8" bridge_type="0-1" depth="0" bridge_pci="0030:[00-01]">
+          <object type="Bridge" os_index="50331648" bridge_type="1-1" depth="1" bridge_pci="0030:[01-01]" pci_busid="0030:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="PCIDev" os_index="50335744" pci_busid="0030:01:00.0" pci_type="0200 [14e4:168a] [1014:0493] 10" pci_link_speed="0.000000">
+              <object type="OSDev" name="nfs" osdev_type="2">
+                <info name="Address" value="98:be:94:73:cc:84"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="50335745" pci_busid="0030:01:00.1" pci_type="0200 [14e4:168a] [1014:0493] 10" pci_link_speed="0.000000">
+              <object type="OSDev" name="pub" osdev_type="2">
+                <info name="Address" value="98:be:94:73:cc:85"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="50335746" pci_busid="0030:01:00.2" pci_type="0200 [14e4:168a] [1014:0494] 10" pci_link_speed="0.000000">
+              <object type="OSDev" name="enP48p1s0f2" osdev_type="2">
+                <info name="Address" value="98:be:94:73:cc:86"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="50335747" pci_busid="0030:01:00.3" pci_type="0200 [14e4:168a] [1014:0494] 10" pci_link_speed="0.000000">
+              <object type="OSDev" name="enP48p1s0f3" osdev_type="2">
+                <info name="Address" value="98:be:94:73:cc:87"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="9" bridge_type="0-1" depth="0" bridge_pci="0033:[00-01]">
+          <object type="Bridge" os_index="53477376" bridge_type="1-1" depth="1" bridge_pci="0033:[01-01]" pci_busid="0033:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="PCIDev" os_index="53481472" pci_busid="0033:01:00.0" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+              <object type="OSDev" name="hsi2" osdev_type="2">
+                <info name="Address" value="00:00:04:86:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:83:51:48"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" name="mlx5_2" osdev_type="3">
+                <info name="NodeGUID" value="ec0d:9a03:0083:5148"/>
+                <info name="SysImageGUID" value="ec0d:9a03:0083:5146"/>
+                <info name="Port1State" value="4"/>
+                <info name="Port1LID" value="0x1371"/>
+                <info name="Port1LMC" value="0"/>
+                <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:0083:5148"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="53481473" pci_busid="0033:01:00.1" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+              <object type="OSDev" name="hsi3" osdev_type="2">
+                <info name="Address" value="00:00:0c:86:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:83:51:49"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" name="mlx5_3" osdev_type="3">
+                <info name="NodeGUID" value="ec0d:9a03:0083:5149"/>
+                <info name="SysImageGUID" value="ec0d:9a03:0083:5146"/>
+                <info name="Port1State" value="4"/>
+                <info name="Port1LID" value="0x1372"/>
+                <info name="Port1LMC" value="0"/>
+                <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:0083:5149"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="11" bridge_type="0-1" depth="0" bridge_pci="0035:[00-09]">
+          <object type="Bridge" os_index="55574528" bridge_type="1-1" depth="1" bridge_pci="0035:[01-09]" pci_busid="0035:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="Bridge" os_index="55578624" bridge_type="1-1" depth="2" bridge_pci="0035:[02-09]" pci_busid="0035:01:00.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+              <object type="Bridge" os_index="55582784" bridge_type="1-1" depth="3" bridge_pci="0035:[03-03]" pci_busid="0035:02:04.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+                <object type="PCIDev" os_index="55586816" pci_busid="0035:03:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+                  <object type="OSDev" name="card3" osdev_type="1"/>
+                  <object type="OSDev" name="renderD130" osdev_type="1"/>
+                </object>
+              </object>
+              <object type="Bridge" os_index="55582800" bridge_type="1-1" depth="3" bridge_pci="0035:[04-04]" pci_busid="0035:02:05.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+                <object type="PCIDev" os_index="55590912" pci_busid="0035:04:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+                  <object type="OSDev" name="renderD131" osdev_type="1"/>
+                  <object type="OSDev" name="card4" osdev_type="1"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="NUMANode" os_index="252" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x10000000,,,,,,,0x0" complete_nodeset="0x10000000,,,,,,,0x0" allowed_nodeset="0x10000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="253" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x20000000,,,,,,,0x0" complete_nodeset="0x20000000,,,,,,,0x0" allowed_nodeset="0x20000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="254" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x40000000,,,,,,,0x0" complete_nodeset="0x40000000,,,,,,,0x0" allowed_nodeset="0x40000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="255" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x80000000,,,,,,,0x0" complete_nodeset="0x80000000,,,,,,,0x0" allowed_nodeset="0x80000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+  </object>
+</topology>

--- a/t/data/hwloc-data/004N/exclusive/04-brokers-sierra/1.xml
+++ b/t/data/hwloc-data/004N/exclusive/04-brokers-sierra/1.xml
@@ -1,0 +1,655 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff" online_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0xf0000000,,,,,,,0x00000101" complete_nodeset="0xf0000000,,,,,,,0x00000101" allowed_nodeset="0xf0000000,,,,,,,0x00000101">
+    <page_type size="65536" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <page_type size="1073741824" count="0"/>
+    <info name="PlatformName" value="PowerNV"/>
+    <info name="PlatformModel" value="PowerNV 8335-GTC"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="4.11.0-44.2.1.el7a.ppc64le"/>
+    <info name="OSVersion" value="#1 SMP Thu Nov 9 02:48:01 EST 2017"/>
+    <info name="HostName" value="sierra4369"/>
+    <info name="Architecture" value="ppc64le"/>
+    <info name="hwlocVersion" value="1.11.7"/>
+    <info name="ProcessName" value="lstopo"/>
+    <distances nbobjs="6" relative_depth="2" latency_base="10.000000">
+      <latency value="1.000000"/>
+      <latency value="4.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="4.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+    </distances>
+    <object type="Group" cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff" online_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0x00000101" complete_nodeset="0x00000101" allowed_nodeset="0x00000101" depth="0">
+      <object type="NUMANode" os_index="0" cpuset="0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff" online_cpuset="0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="270271709184">
+        <page_type size="65536" count="4124019"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Package" os_index="0" cpuset="0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff" online_cpuset="0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <info name="CPUModel" value="POWER9 (raw), altivec supported"/>
+          <info name="CPURevision" value="2.1 (pvr 004e 1201)"/>
+          <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="16" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="20" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="32" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="36" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000" complete_cpuset="0x00ff0000" online_cpuset="0x00ff0000" allowed_cpuset="0x00ff0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000" complete_cpuset="0x00ff0000" online_cpuset="0x00ff0000" allowed_cpuset="0x00ff0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="40" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="44" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000" complete_cpuset="0xff000000" online_cpuset="0xff000000" allowed_cpuset="0xff000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000" complete_cpuset="0xff000000" online_cpuset="0xff000000" allowed_cpuset="0xff000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="48" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="52" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,0x0" complete_cpuset="0x000000ff,0x0" online_cpuset="0x000000ff,0x0" allowed_cpuset="0x000000ff,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,0x0" complete_cpuset="0x000000ff,0x0" online_cpuset="0x000000ff,0x0" allowed_cpuset="0x000000ff,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="64" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="68" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,0x0" complete_cpuset="0x0000ff00,0x0" online_cpuset="0x0000ff00,0x0" allowed_cpuset="0x0000ff00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,0x0" complete_cpuset="0x0000ff00,0x0" online_cpuset="0x0000ff00,0x0" allowed_cpuset="0x0000ff00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="72" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="76" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,0x0" complete_cpuset="0x00ff0000,0x0" online_cpuset="0x00ff0000,0x0" allowed_cpuset="0x00ff0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,0x0" complete_cpuset="0x00ff0000,0x0" online_cpuset="0x00ff0000,0x0" allowed_cpuset="0x00ff0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="80" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="84" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000,0x0" complete_cpuset="0xff000000,0x0" online_cpuset="0xff000000,0x0" allowed_cpuset="0xff000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,0x0" complete_cpuset="0xff000000,0x0" online_cpuset="0xff000000,0x0" allowed_cpuset="0xff000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="88" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="92" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-01]">
+          <object type="Bridge" os_index="0" bridge_type="1-1" depth="1" bridge_pci="0000:[01-01]" pci_busid="0000:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="PCIDev" os_index="4096" pci_busid="0000:01:00.0" pci_type="0108 [144d:a822] [1014:0621] 01" pci_link_speed="0.000000"/>
+          </object>
+        </object>
+        <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0002:[00-02]">
+          <object type="Bridge" os_index="2097152" bridge_type="1-1" depth="1" bridge_pci="0002:[01-02]" pci_busid="0002:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="Bridge" os_index="2101248" bridge_type="1-1" depth="2" bridge_pci="0002:[02-02]" pci_busid="0002:01:00.0" pci_type="0604 [1a03:1150] [1a03:1150] 04" pci_link_speed="0.000000">
+              <object type="PCIDev" os_index="2105344" pci_busid="0002:02:00.0" pci_type="0300 [1a03:2000] [1a03:2000] 41" pci_link_speed="0.000000">
+                <object type="OSDev" name="card0" osdev_type="1"/>
+                <object type="OSDev" name="controlD64" osdev_type="1"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0003:[00-01]">
+          <object type="Bridge" os_index="3145728" bridge_type="1-1" depth="1" bridge_pci="0003:[01-01]" pci_busid="0003:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="PCIDev" os_index="3149824" pci_busid="0003:01:00.0" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+              <object type="OSDev" name="hsi0" osdev_type="2">
+                <info name="Address" value="00:00:00:86:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:7f:54:b6"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" name="mlx5_0" osdev_type="3">
+                <info name="NodeGUID" value="ec0d:9a03:007f:54b6"/>
+                <info name="SysImageGUID" value="ec0d:9a03:007f:54b6"/>
+                <info name="Port1State" value="4"/>
+                <info name="Port1LID" value="0x1379"/>
+                <info name="Port1LMC" value="0"/>
+                <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:007f:54b6"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="3149825" pci_busid="0003:01:00.1" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+              <object type="OSDev" name="hsi1" osdev_type="2">
+                <info name="Address" value="00:00:08:86:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:7f:54:b7"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" name="mlx5_1" osdev_type="3">
+                <info name="NodeGUID" value="ec0d:9a03:007f:54b7"/>
+                <info name="SysImageGUID" value="ec0d:9a03:007f:54b6"/>
+                <info name="Port1State" value="4"/>
+                <info name="Port1LID" value="0x137a"/>
+                <info name="Port1LMC" value="0"/>
+                <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:007f:54b7"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="4" bridge_type="0-1" depth="0" bridge_pci="0004:[00-0a]">
+          <object type="Bridge" os_index="4194304" bridge_type="1-1" depth="1" bridge_pci="0004:[01-0a]" pci_busid="0004:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="Bridge" os_index="4198400" bridge_type="1-1" depth="2" bridge_pci="0004:[02-0a]" pci_busid="0004:01:00.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+              <object type="Bridge" os_index="4202528" bridge_type="1-1" depth="3" bridge_pci="0004:[03-03]" pci_busid="0004:02:02.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+                <object type="PCIDev" os_index="4206592" pci_busid="0004:03:00.0" pci_type="0106 [1b4b:9235] [1014:0612] 11" pci_link_speed="0.000000">
+                  <object type="OSDev" name="sda" osdev_type="0">
+                    <info name="LinuxDeviceID" value="8:0"/>
+                    <info name="Vendor" value="Seagate"/>
+                    <info name="Model" value="ST2000NX0253_00LY418_00LY417IBM"/>
+                    <info name="Revision" value="BE35"/>
+                    <info name="SerialNumber" value="S460DQXY"/>
+                    <info name="Type" value="Disk"/>
+                  </object>
+                  <object type="OSDev" name="sdb" osdev_type="0">
+                    <info name="LinuxDeviceID" value="8:16"/>
+                    <info name="Vendor" value="Seagate"/>
+                    <info name="Model" value="ST2000NX0253_00LY418_00LY417IBM"/>
+                    <info name="Revision" value="BE35"/>
+                    <info name="SerialNumber" value="S460J519"/>
+                    <info name="Type" value="Disk"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Bridge" os_index="4202656" bridge_type="1-1" depth="3" bridge_pci="0004:[04-04]" pci_busid="0004:02:0a.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+                <object type="PCIDev" os_index="4210688" pci_busid="0004:04:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+                  <object type="OSDev" name="card1" osdev_type="1"/>
+                  <object type="OSDev" name="renderD128" osdev_type="1"/>
+                </object>
+              </object>
+              <object type="Bridge" os_index="4202672" bridge_type="1-1" depth="3" bridge_pci="0004:[05-05]" pci_busid="0004:02:0b.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+                <object type="PCIDev" os_index="4214784" pci_busid="0004:05:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+                  <object type="OSDev" name="card2" osdev_type="1"/>
+                  <object type="OSDev" name="renderD129" osdev_type="1"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="5" bridge_type="0-1" depth="0" bridge_pci="0005:[00-01]">
+          <object type="Bridge" os_index="5242880" bridge_type="1-1" depth="1" bridge_pci="0005:[01-01]" pci_busid="0005:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="PCIDev" os_index="5246976" pci_busid="0005:01:00.0" pci_type="0200 [14e4:1657] [14e4:1981] 01" pci_link_speed="0.000000">
+              <object type="OSDev" name="enP5p1s0f0" osdev_type="2">
+                <info name="Address" value="70:e2:84:14:41:d6"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="5246977" pci_busid="0005:01:00.1" pci_type="0200 [14e4:1657] [14e4:1657] 01" pci_link_speed="0.000000">
+              <object type="OSDev" name="prov" osdev_type="2">
+                <info name="Address" value="70:e2:84:14:41:d7"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="8" cpuset="0xffffffff,0xffffffff,,0x0" complete_cpuset="0xffffffff,0xffffffff,,0x0" online_cpuset="0xffffffff,0xffffffff,,0x0" allowed_cpuset="0xffffffff,0xffffffff,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" local_memory="274469093376">
+        <page_type size="65536" count="4188066"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Package" os_index="8" cpuset="0xffffffff,0xffffffff,,0x0" complete_cpuset="0xffffffff,0xffffffff,,0x0" online_cpuset="0xffffffff,0xffffffff,,0x0" allowed_cpuset="0xffffffff,0xffffffff,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+          <info name="CPUModel" value="POWER9 (raw), altivec supported"/>
+          <info name="CPURevision" value="2.1 (pvr 004e 1201)"/>
+          <object type="Cache" cpuset="0x000000ff,,0x0" complete_cpuset="0x000000ff,,0x0" online_cpuset="0x000000ff,,0x0" allowed_cpuset="0x000000ff,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,0x0" complete_cpuset="0x000000ff,,0x0" online_cpuset="0x000000ff,,0x0" allowed_cpuset="0x000000ff,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2064" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2068" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,,0x0" complete_cpuset="0x0000ff00,,0x0" online_cpuset="0x0000ff00,,0x0" allowed_cpuset="0x0000ff00,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,,0x0" complete_cpuset="0x0000ff00,,0x0" online_cpuset="0x0000ff00,,0x0" allowed_cpuset="0x0000ff00,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2072" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2076" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,0x0" online_cpuset="0x00ff0000,,0x0" allowed_cpuset="0x00ff0000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,0x0" online_cpuset="0x00ff0000,,0x0" allowed_cpuset="0x00ff0000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2080" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2084" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000,,0x0" complete_cpuset="0xff000000,,0x0" online_cpuset="0xff000000,,0x0" allowed_cpuset="0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,,0x0" complete_cpuset="0xff000000,,0x0" online_cpuset="0xff000000,,0x0" allowed_cpuset="0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2088" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2092" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,,0x0" complete_cpuset="0x000000ff,,,0x0" online_cpuset="0x000000ff,,,0x0" allowed_cpuset="0x000000ff,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,,0x0" complete_cpuset="0x000000ff,,,0x0" online_cpuset="0x000000ff,,,0x0" allowed_cpuset="0x000000ff,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2096" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="96" cpuset="0x00000001,,,0x0" complete_cpuset="0x00000001,,,0x0" online_cpuset="0x00000001,,,0x0" allowed_cpuset="0x00000001,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="97" cpuset="0x00000002,,,0x0" complete_cpuset="0x00000002,,,0x0" online_cpuset="0x00000002,,,0x0" allowed_cpuset="0x00000002,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="98" cpuset="0x00000004,,,0x0" complete_cpuset="0x00000004,,,0x0" online_cpuset="0x00000004,,,0x0" allowed_cpuset="0x00000004,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="99" cpuset="0x00000008,,,0x0" complete_cpuset="0x00000008,,,0x0" online_cpuset="0x00000008,,,0x0" allowed_cpuset="0x00000008,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2100" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="100" cpuset="0x00000010,,,0x0" complete_cpuset="0x00000010,,,0x0" online_cpuset="0x00000010,,,0x0" allowed_cpuset="0x00000010,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="101" cpuset="0x00000020,,,0x0" complete_cpuset="0x00000020,,,0x0" online_cpuset="0x00000020,,,0x0" allowed_cpuset="0x00000020,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="102" cpuset="0x00000040,,,0x0" complete_cpuset="0x00000040,,,0x0" online_cpuset="0x00000040,,,0x0" allowed_cpuset="0x00000040,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="103" cpuset="0x00000080,,,0x0" complete_cpuset="0x00000080,,,0x0" online_cpuset="0x00000080,,,0x0" allowed_cpuset="0x00000080,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,,,0x0" complete_cpuset="0x0000ff00,,,0x0" online_cpuset="0x0000ff00,,,0x0" allowed_cpuset="0x0000ff00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,,,0x0" complete_cpuset="0x0000ff00,,,0x0" online_cpuset="0x0000ff00,,,0x0" allowed_cpuset="0x0000ff00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2104" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="104" cpuset="0x00000100,,,0x0" complete_cpuset="0x00000100,,,0x0" online_cpuset="0x00000100,,,0x0" allowed_cpuset="0x00000100,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="105" cpuset="0x00000200,,,0x0" complete_cpuset="0x00000200,,,0x0" online_cpuset="0x00000200,,,0x0" allowed_cpuset="0x00000200,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="106" cpuset="0x00000400,,,0x0" complete_cpuset="0x00000400,,,0x0" online_cpuset="0x00000400,,,0x0" allowed_cpuset="0x00000400,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="107" cpuset="0x00000800,,,0x0" complete_cpuset="0x00000800,,,0x0" online_cpuset="0x00000800,,,0x0" allowed_cpuset="0x00000800,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2108" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="108" cpuset="0x00001000,,,0x0" complete_cpuset="0x00001000,,,0x0" online_cpuset="0x00001000,,,0x0" allowed_cpuset="0x00001000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="109" cpuset="0x00002000,,,0x0" complete_cpuset="0x00002000,,,0x0" online_cpuset="0x00002000,,,0x0" allowed_cpuset="0x00002000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="110" cpuset="0x00004000,,,0x0" complete_cpuset="0x00004000,,,0x0" online_cpuset="0x00004000,,,0x0" allowed_cpuset="0x00004000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="111" cpuset="0x00008000,,,0x0" complete_cpuset="0x00008000,,,0x0" online_cpuset="0x00008000,,,0x0" allowed_cpuset="0x00008000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,,,0x0" complete_cpuset="0x00ff0000,,,0x0" online_cpuset="0x00ff0000,,,0x0" allowed_cpuset="0x00ff0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,,,0x0" complete_cpuset="0x00ff0000,,,0x0" online_cpuset="0x00ff0000,,,0x0" allowed_cpuset="0x00ff0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2128" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="112" cpuset="0x00010000,,,0x0" complete_cpuset="0x00010000,,,0x0" online_cpuset="0x00010000,,,0x0" allowed_cpuset="0x00010000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="113" cpuset="0x00020000,,,0x0" complete_cpuset="0x00020000,,,0x0" online_cpuset="0x00020000,,,0x0" allowed_cpuset="0x00020000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="114" cpuset="0x00040000,,,0x0" complete_cpuset="0x00040000,,,0x0" online_cpuset="0x00040000,,,0x0" allowed_cpuset="0x00040000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="115" cpuset="0x00080000,,,0x0" complete_cpuset="0x00080000,,,0x0" online_cpuset="0x00080000,,,0x0" allowed_cpuset="0x00080000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2132" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="116" cpuset="0x00100000,,,0x0" complete_cpuset="0x00100000,,,0x0" online_cpuset="0x00100000,,,0x0" allowed_cpuset="0x00100000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="117" cpuset="0x00200000,,,0x0" complete_cpuset="0x00200000,,,0x0" online_cpuset="0x00200000,,,0x0" allowed_cpuset="0x00200000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="118" cpuset="0x00400000,,,0x0" complete_cpuset="0x00400000,,,0x0" online_cpuset="0x00400000,,,0x0" allowed_cpuset="0x00400000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="119" cpuset="0x00800000,,,0x0" complete_cpuset="0x00800000,,,0x0" online_cpuset="0x00800000,,,0x0" allowed_cpuset="0x00800000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000,,,0x0" complete_cpuset="0xff000000,,,0x0" online_cpuset="0xff000000,,,0x0" allowed_cpuset="0xff000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,,,0x0" complete_cpuset="0xff000000,,,0x0" online_cpuset="0xff000000,,,0x0" allowed_cpuset="0xff000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2136" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="120" cpuset="0x01000000,,,0x0" complete_cpuset="0x01000000,,,0x0" online_cpuset="0x01000000,,,0x0" allowed_cpuset="0x01000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="121" cpuset="0x02000000,,,0x0" complete_cpuset="0x02000000,,,0x0" online_cpuset="0x02000000,,,0x0" allowed_cpuset="0x02000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="122" cpuset="0x04000000,,,0x0" complete_cpuset="0x04000000,,,0x0" online_cpuset="0x04000000,,,0x0" allowed_cpuset="0x04000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="123" cpuset="0x08000000,,,0x0" complete_cpuset="0x08000000,,,0x0" online_cpuset="0x08000000,,,0x0" allowed_cpuset="0x08000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2140" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="124" cpuset="0x10000000,,,0x0" complete_cpuset="0x10000000,,,0x0" online_cpuset="0x10000000,,,0x0" allowed_cpuset="0x10000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="125" cpuset="0x20000000,,,0x0" complete_cpuset="0x20000000,,,0x0" online_cpuset="0x20000000,,,0x0" allowed_cpuset="0x20000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="126" cpuset="0x40000000,,,0x0" complete_cpuset="0x40000000,,,0x0" online_cpuset="0x40000000,,,0x0" allowed_cpuset="0x40000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="127" cpuset="0x80000000,,,0x0" complete_cpuset="0x80000000,,,0x0" online_cpuset="0x80000000,,,0x0" allowed_cpuset="0x80000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="8" bridge_type="0-1" depth="0" bridge_pci="0030:[00-01]">
+          <object type="Bridge" os_index="50331648" bridge_type="1-1" depth="1" bridge_pci="0030:[01-01]" pci_busid="0030:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="PCIDev" os_index="50335744" pci_busid="0030:01:00.0" pci_type="0200 [14e4:168a] [1014:0493] 10" pci_link_speed="0.000000">
+              <object type="OSDev" name="nfs" osdev_type="2">
+                <info name="Address" value="98:be:94:73:cb:34"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="50335745" pci_busid="0030:01:00.1" pci_type="0200 [14e4:168a] [1014:0493] 10" pci_link_speed="0.000000">
+              <object type="OSDev" name="pub" osdev_type="2">
+                <info name="Address" value="98:be:94:73:cb:35"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="50335746" pci_busid="0030:01:00.2" pci_type="0200 [14e4:168a] [1014:0494] 10" pci_link_speed="0.000000">
+              <object type="OSDev" name="enP48p1s0f2" osdev_type="2">
+                <info name="Address" value="98:be:94:73:cb:36"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="50335747" pci_busid="0030:01:00.3" pci_type="0200 [14e4:168a] [1014:0494] 10" pci_link_speed="0.000000">
+              <object type="OSDev" name="enP48p1s0f3" osdev_type="2">
+                <info name="Address" value="98:be:94:73:cb:37"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="9" bridge_type="0-1" depth="0" bridge_pci="0033:[00-01]">
+          <object type="Bridge" os_index="53477376" bridge_type="1-1" depth="1" bridge_pci="0033:[01-01]" pci_busid="0033:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="PCIDev" os_index="53481472" pci_busid="0033:01:00.0" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+              <object type="OSDev" name="hsi2" osdev_type="2">
+                <info name="Address" value="00:00:04:86:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:7f:54:b8"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" name="mlx5_2" osdev_type="3">
+                <info name="NodeGUID" value="ec0d:9a03:007f:54b8"/>
+                <info name="SysImageGUID" value="ec0d:9a03:007f:54b6"/>
+                <info name="Port1State" value="4"/>
+                <info name="Port1LID" value="0x137c"/>
+                <info name="Port1LMC" value="0"/>
+                <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:007f:54b8"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="53481473" pci_busid="0033:01:00.1" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+              <object type="OSDev" name="hsi3" osdev_type="2">
+                <info name="Address" value="00:00:0c:86:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:7f:54:b9"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" name="mlx5_3" osdev_type="3">
+                <info name="NodeGUID" value="ec0d:9a03:007f:54b9"/>
+                <info name="SysImageGUID" value="ec0d:9a03:007f:54b6"/>
+                <info name="Port1State" value="4"/>
+                <info name="Port1LID" value="0x137b"/>
+                <info name="Port1LMC" value="0"/>
+                <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:007f:54b9"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="11" bridge_type="0-1" depth="0" bridge_pci="0035:[00-09]">
+          <object type="Bridge" os_index="55574528" bridge_type="1-1" depth="1" bridge_pci="0035:[01-09]" pci_busid="0035:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="Bridge" os_index="55578624" bridge_type="1-1" depth="2" bridge_pci="0035:[02-09]" pci_busid="0035:01:00.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+              <object type="Bridge" os_index="55582784" bridge_type="1-1" depth="3" bridge_pci="0035:[03-03]" pci_busid="0035:02:04.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+                <object type="PCIDev" os_index="55586816" pci_busid="0035:03:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+                  <object type="OSDev" name="card3" osdev_type="1"/>
+                  <object type="OSDev" name="renderD130" osdev_type="1"/>
+                </object>
+              </object>
+              <object type="Bridge" os_index="55582800" bridge_type="1-1" depth="3" bridge_pci="0035:[04-04]" pci_busid="0035:02:05.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+                <object type="PCIDev" os_index="55590912" pci_busid="0035:04:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+                  <object type="OSDev" name="renderD131" osdev_type="1"/>
+                  <object type="OSDev" name="card4" osdev_type="1"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="NUMANode" os_index="252" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x10000000,,,,,,,0x0" complete_nodeset="0x10000000,,,,,,,0x0" allowed_nodeset="0x10000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="253" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x20000000,,,,,,,0x0" complete_nodeset="0x20000000,,,,,,,0x0" allowed_nodeset="0x20000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="254" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x40000000,,,,,,,0x0" complete_nodeset="0x40000000,,,,,,,0x0" allowed_nodeset="0x40000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="255" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x80000000,,,,,,,0x0" complete_nodeset="0x80000000,,,,,,,0x0" allowed_nodeset="0x80000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+  </object>
+</topology>

--- a/t/data/hwloc-data/004N/exclusive/04-brokers-sierra/2.xml
+++ b/t/data/hwloc-data/004N/exclusive/04-brokers-sierra/2.xml
@@ -1,0 +1,762 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0xf0000000,,,,,,,0x00000101" complete_nodeset="0xf0000000,,,,,,,0x00000101" allowed_nodeset="0xf0000000,,,,,,,0x00000101">
+    <page_type size="65536" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <page_type size="1073741824" count="0"/>
+    <info name="PlatformName" value="PowerNV"/>
+    <info name="PlatformModel" value="PowerNV 8335-GTW"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="4.11.0-44.2.1.el7a.ppc64le"/>
+    <info name="OSVersion" value="#1 SMP Thu Nov 9 02:48:01 EST 2017"/>
+    <info name="HostName" value="sierra414"/>
+    <info name="Architecture" value="ppc64le"/>
+    <info name="hwlocVersion" value="1.11.7"/>
+    <info name="ProcessName" value="lstopo"/>
+    <distances nbobjs="6" relative_depth="2" latency_base="10.000000">
+      <latency value="1.000000"/>
+      <latency value="4.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="4.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+    </distances>
+    <object type="Group" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0x00000101" complete_nodeset="0x00000101" allowed_nodeset="0x00000101" depth="0">
+      <object type="NUMANode" os_index="0" cpuset="0x00ffffff,0xffffffff,0xffffffff" complete_cpuset="0x00ffffff,0xffffffff,0xffffffff" online_cpuset="0x00ffffff,0xffffffff,0xffffffff" allowed_cpuset="0x00ffffff,0xffffffff,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="137123397632">
+        <page_type size="65536" count="2092337"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Package" os_index="0" cpuset="0x00ffffff,0xffffffff,0xffffffff" complete_cpuset="0x00ffffff,0xffffffff,0xffffffff" online_cpuset="0x00ffffff,0xffffffff,0xffffffff" allowed_cpuset="0x00ffffff,0xffffffff,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <info name="CPUModel" value="POWER9 (raw), altivec supported"/>
+          <info name="CPURevision" value="2.1 (pvr 004e 1201)"/>
+          <object type="Cache" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="0" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000ff0" complete_cpuset="0x00000ff0" online_cpuset="0x00000ff0" allowed_cpuset="0x00000ff0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00000ff0" complete_cpuset="0x00000ff0" online_cpuset="0x00000ff0" allowed_cpuset="0x00000ff0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="8" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="12" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000ff000" complete_cpuset="0x000ff000" online_cpuset="0x000ff000" allowed_cpuset="0x000ff000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000ff000" complete_cpuset="0x000ff000" online_cpuset="0x000ff000" allowed_cpuset="0x000ff000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="16" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="20" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0ff00000" complete_cpuset="0x0ff00000" online_cpuset="0x0ff00000" allowed_cpuset="0x0ff00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0ff00000" complete_cpuset="0x0ff00000" online_cpuset="0x0ff00000" allowed_cpuset="0x0ff00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="24" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="28" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000000f,0xf0000000" complete_cpuset="0x0000000f,0xf0000000" online_cpuset="0x0000000f,0xf0000000" allowed_cpuset="0x0000000f,0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000000f,0xf0000000" complete_cpuset="0x0000000f,0xf0000000" online_cpuset="0x0000000f,0xf0000000" allowed_cpuset="0x0000000f,0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="32" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="36" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000ff0,0x0" complete_cpuset="0x00000ff0,0x0" online_cpuset="0x00000ff0,0x0" allowed_cpuset="0x00000ff0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00000ff0,0x0" complete_cpuset="0x00000ff0,0x0" online_cpuset="0x00000ff0,0x0" allowed_cpuset="0x00000ff0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="40" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="44" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000ff000,0x0" complete_cpuset="0x000ff000,0x0" online_cpuset="0x000ff000,0x0" allowed_cpuset="0x000ff000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000ff000,0x0" complete_cpuset="0x000ff000,0x0" online_cpuset="0x000ff000,0x0" allowed_cpuset="0x000ff000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="48" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="52" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0ff00000,0x0" complete_cpuset="0x0ff00000,0x0" online_cpuset="0x0ff00000,0x0" allowed_cpuset="0x0ff00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0ff00000,0x0" complete_cpuset="0x0ff00000,0x0" online_cpuset="0x0ff00000,0x0" allowed_cpuset="0x0ff00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="56" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="60" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000000f,0xf0000000,0x0" complete_cpuset="0x0000000f,0xf0000000,0x0" online_cpuset="0x0000000f,0xf0000000,0x0" allowed_cpuset="0x0000000f,0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000000f,0xf0000000,0x0" complete_cpuset="0x0000000f,0xf0000000,0x0" online_cpuset="0x0000000f,0xf0000000,0x0" allowed_cpuset="0x0000000f,0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="64" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="68" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000ff0,,0x0" complete_cpuset="0x00000ff0,,0x0" online_cpuset="0x00000ff0,,0x0" allowed_cpuset="0x00000ff0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00000ff0,,0x0" complete_cpuset="0x00000ff0,,0x0" online_cpuset="0x00000ff0,,0x0" allowed_cpuset="0x00000ff0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="72" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="76" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000ff000,,0x0" complete_cpuset="0x000ff000,,0x0" online_cpuset="0x000ff000,,0x0" allowed_cpuset="0x000ff000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000ff000,,0x0" complete_cpuset="0x000ff000,,0x0" online_cpuset="0x000ff000,,0x0" allowed_cpuset="0x000ff000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="80" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="84" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="92" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-01]">
+          <object type="Bridge" os_index="0" bridge_type="1-1" depth="1" bridge_pci="0000:[01-01]" pci_busid="0000:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="PCIDev" os_index="4096" pci_busid="0000:01:00.0" pci_type="0108 [144d:a822] [1014:0621] 01" pci_link_speed="0.000000"/>
+          </object>
+        </object>
+        <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0002:[00-02]">
+          <object type="Bridge" os_index="2097152" bridge_type="1-1" depth="1" bridge_pci="0002:[01-02]" pci_busid="0002:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="Bridge" os_index="2101248" bridge_type="1-1" depth="2" bridge_pci="0002:[02-02]" pci_busid="0002:01:00.0" pci_type="0604 [1a03:1150] [1a03:1150] 04" pci_link_speed="0.000000">
+              <object type="PCIDev" os_index="2105344" pci_busid="0002:02:00.0" pci_type="0300 [1a03:2000] [1a03:2000] 41" pci_link_speed="0.000000">
+                <object type="OSDev" name="card4" osdev_type="1"/>
+                <object type="OSDev" name="controlD68" osdev_type="1"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0003:[00-01]">
+          <object type="Bridge" os_index="3145728" bridge_type="1-1" depth="1" bridge_pci="0003:[01-01]" pci_busid="0003:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="PCIDev" os_index="3149824" pci_busid="0003:01:00.0" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+              <object type="OSDev" name="hsi0" osdev_type="2">
+                <info name="Address" value="00:00:00:86:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:6f:71:96"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" name="mlx5_0" osdev_type="3">
+                <info name="NodeGUID" value="ec0d:9a03:006f:7196"/>
+                <info name="SysImageGUID" value="ec0d:9a03:006f:7196"/>
+                <info name="Port1State" value="4"/>
+                <info name="Port1LID" value="0xea9"/>
+                <info name="Port1LMC" value="0"/>
+                <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:006f:7196"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="3149825" pci_busid="0003:01:00.1" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+              <object type="OSDev" name="hsi1" osdev_type="2">
+                <info name="Address" value="00:00:08:86:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:6f:71:97"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" name="mlx5_1" osdev_type="3">
+                <info name="NodeGUID" value="ec0d:9a03:006f:7197"/>
+                <info name="SysImageGUID" value="ec0d:9a03:006f:7196"/>
+                <info name="Port1State" value="4"/>
+                <info name="Port1LID" value="0xeaa"/>
+                <info name="Port1LMC" value="0"/>
+                <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:006f:7197"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="4" bridge_type="0-1" depth="0" bridge_pci="0004:[00-0a]">
+          <object type="Bridge" os_index="4194304" bridge_type="1-1" depth="1" bridge_pci="0004:[01-0a]" pci_busid="0004:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="Bridge" os_index="4198400" bridge_type="1-1" depth="2" bridge_pci="0004:[02-0a]" pci_busid="0004:01:00.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+              <object type="Bridge" os_index="4202528" bridge_type="1-1" depth="3" bridge_pci="0004:[03-03]" pci_busid="0004:02:02.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+                <object type="PCIDev" os_index="4206592" pci_busid="0004:03:00.0" pci_type="0106 [1b4b:9235] [1014:0612] 11" pci_link_speed="0.000000"/>
+              </object>
+              <object type="Bridge" os_index="4202656" bridge_type="1-1" depth="3" bridge_pci="0004:[04-04]" pci_busid="0004:02:0a.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+                <object type="PCIDev" os_index="4210688" pci_busid="0004:04:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+                  <object type="OSDev" name="renderD128" osdev_type="1"/>
+                  <object type="OSDev" name="card0" osdev_type="1"/>
+                </object>
+              </object>
+              <object type="Bridge" os_index="4202672" bridge_type="1-1" depth="3" bridge_pci="0004:[05-05]" pci_busid="0004:02:0b.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+                <object type="PCIDev" os_index="4214784" pci_busid="0004:05:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+                  <object type="OSDev" name="card1" osdev_type="1"/>
+                  <object type="OSDev" name="renderD129" osdev_type="1"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="5" bridge_type="0-1" depth="0" bridge_pci="0005:[00-01]">
+          <object type="Bridge" os_index="5242880" bridge_type="1-1" depth="1" bridge_pci="0005:[01-01]" pci_busid="0005:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="PCIDev" os_index="5246976" pci_busid="0005:01:00.0" pci_type="0200 [14e4:1657] [14e4:1981] 01" pci_link_speed="0.000000">
+              <object type="OSDev" name="enP5p1s0f0" osdev_type="2">
+                <info name="Address" value="70:e2:84:14:57:cd"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="5246977" pci_busid="0005:01:00.1" pci_type="0200 [14e4:1657] [14e4:1657] 01" pci_link_speed="0.000000">
+              <object type="OSDev" name="enP5p1s0f1" osdev_type="2">
+                <info name="Address" value="70:e2:84:14:57:ce"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="8" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" local_memory="137166061568">
+        <page_type size="65536" count="2092988"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Package" os_index="8" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+          <info name="CPUModel" value="POWER9 (raw), altivec supported"/>
+          <info name="CPURevision" value="2.1 (pvr 004e 1201)"/>
+          <object type="Cache" cpuset="0xff000000,,0x0" complete_cpuset="0xff000000,,0x0" online_cpuset="0xff000000,,0x0" allowed_cpuset="0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,,0x0" complete_cpuset="0xff000000,,0x0" online_cpuset="0xff000000,,0x0" allowed_cpuset="0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2048" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2052" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,,0x0" complete_cpuset="0x000000ff,,,0x0" online_cpuset="0x000000ff,,,0x0" allowed_cpuset="0x000000ff,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,,0x0" complete_cpuset="0x000000ff,,,0x0" online_cpuset="0x000000ff,,,0x0" allowed_cpuset="0x000000ff,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2056" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="96" cpuset="0x00000001,,,0x0" complete_cpuset="0x00000001,,,0x0" online_cpuset="0x00000001,,,0x0" allowed_cpuset="0x00000001,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="97" cpuset="0x00000002,,,0x0" complete_cpuset="0x00000002,,,0x0" online_cpuset="0x00000002,,,0x0" allowed_cpuset="0x00000002,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="98" cpuset="0x00000004,,,0x0" complete_cpuset="0x00000004,,,0x0" online_cpuset="0x00000004,,,0x0" allowed_cpuset="0x00000004,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="99" cpuset="0x00000008,,,0x0" complete_cpuset="0x00000008,,,0x0" online_cpuset="0x00000008,,,0x0" allowed_cpuset="0x00000008,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2060" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="100" cpuset="0x00000010,,,0x0" complete_cpuset="0x00000010,,,0x0" online_cpuset="0x00000010,,,0x0" allowed_cpuset="0x00000010,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="101" cpuset="0x00000020,,,0x0" complete_cpuset="0x00000020,,,0x0" online_cpuset="0x00000020,,,0x0" allowed_cpuset="0x00000020,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="102" cpuset="0x00000040,,,0x0" complete_cpuset="0x00000040,,,0x0" online_cpuset="0x00000040,,,0x0" allowed_cpuset="0x00000040,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="103" cpuset="0x00000080,,,0x0" complete_cpuset="0x00000080,,,0x0" online_cpuset="0x00000080,,,0x0" allowed_cpuset="0x00000080,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,,,0x0" complete_cpuset="0x0000ff00,,,0x0" online_cpuset="0x0000ff00,,,0x0" allowed_cpuset="0x0000ff00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,,,0x0" complete_cpuset="0x0000ff00,,,0x0" online_cpuset="0x0000ff00,,,0x0" allowed_cpuset="0x0000ff00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2064" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="104" cpuset="0x00000100,,,0x0" complete_cpuset="0x00000100,,,0x0" online_cpuset="0x00000100,,,0x0" allowed_cpuset="0x00000100,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="105" cpuset="0x00000200,,,0x0" complete_cpuset="0x00000200,,,0x0" online_cpuset="0x00000200,,,0x0" allowed_cpuset="0x00000200,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="106" cpuset="0x00000400,,,0x0" complete_cpuset="0x00000400,,,0x0" online_cpuset="0x00000400,,,0x0" allowed_cpuset="0x00000400,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="107" cpuset="0x00000800,,,0x0" complete_cpuset="0x00000800,,,0x0" online_cpuset="0x00000800,,,0x0" allowed_cpuset="0x00000800,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2068" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="108" cpuset="0x00001000,,,0x0" complete_cpuset="0x00001000,,,0x0" online_cpuset="0x00001000,,,0x0" allowed_cpuset="0x00001000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="109" cpuset="0x00002000,,,0x0" complete_cpuset="0x00002000,,,0x0" online_cpuset="0x00002000,,,0x0" allowed_cpuset="0x00002000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="110" cpuset="0x00004000,,,0x0" complete_cpuset="0x00004000,,,0x0" online_cpuset="0x00004000,,,0x0" allowed_cpuset="0x00004000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="111" cpuset="0x00008000,,,0x0" complete_cpuset="0x00008000,,,0x0" online_cpuset="0x00008000,,,0x0" allowed_cpuset="0x00008000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,,,0x0" complete_cpuset="0x00ff0000,,,0x0" online_cpuset="0x00ff0000,,,0x0" allowed_cpuset="0x00ff0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,,,0x0" complete_cpuset="0x00ff0000,,,0x0" online_cpuset="0x00ff0000,,,0x0" allowed_cpuset="0x00ff0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2072" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="112" cpuset="0x00010000,,,0x0" complete_cpuset="0x00010000,,,0x0" online_cpuset="0x00010000,,,0x0" allowed_cpuset="0x00010000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="113" cpuset="0x00020000,,,0x0" complete_cpuset="0x00020000,,,0x0" online_cpuset="0x00020000,,,0x0" allowed_cpuset="0x00020000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="114" cpuset="0x00040000,,,0x0" complete_cpuset="0x00040000,,,0x0" online_cpuset="0x00040000,,,0x0" allowed_cpuset="0x00040000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="115" cpuset="0x00080000,,,0x0" complete_cpuset="0x00080000,,,0x0" online_cpuset="0x00080000,,,0x0" allowed_cpuset="0x00080000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2076" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="116" cpuset="0x00100000,,,0x0" complete_cpuset="0x00100000,,,0x0" online_cpuset="0x00100000,,,0x0" allowed_cpuset="0x00100000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="117" cpuset="0x00200000,,,0x0" complete_cpuset="0x00200000,,,0x0" online_cpuset="0x00200000,,,0x0" allowed_cpuset="0x00200000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="118" cpuset="0x00400000,,,0x0" complete_cpuset="0x00400000,,,0x0" online_cpuset="0x00400000,,,0x0" allowed_cpuset="0x00400000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="119" cpuset="0x00800000,,,0x0" complete_cpuset="0x00800000,,,0x0" online_cpuset="0x00800000,,,0x0" allowed_cpuset="0x00800000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000,,,0x0" complete_cpuset="0xff000000,,,0x0" online_cpuset="0xff000000,,,0x0" allowed_cpuset="0xff000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,,,0x0" complete_cpuset="0xff000000,,,0x0" online_cpuset="0xff000000,,,0x0" allowed_cpuset="0xff000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2080" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="120" cpuset="0x01000000,,,0x0" complete_cpuset="0x01000000,,,0x0" online_cpuset="0x01000000,,,0x0" allowed_cpuset="0x01000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="121" cpuset="0x02000000,,,0x0" complete_cpuset="0x02000000,,,0x0" online_cpuset="0x02000000,,,0x0" allowed_cpuset="0x02000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="122" cpuset="0x04000000,,,0x0" complete_cpuset="0x04000000,,,0x0" online_cpuset="0x04000000,,,0x0" allowed_cpuset="0x04000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="123" cpuset="0x08000000,,,0x0" complete_cpuset="0x08000000,,,0x0" online_cpuset="0x08000000,,,0x0" allowed_cpuset="0x08000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2084" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="124" cpuset="0x10000000,,,0x0" complete_cpuset="0x10000000,,,0x0" online_cpuset="0x10000000,,,0x0" allowed_cpuset="0x10000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="125" cpuset="0x20000000,,,0x0" complete_cpuset="0x20000000,,,0x0" online_cpuset="0x20000000,,,0x0" allowed_cpuset="0x20000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="126" cpuset="0x40000000,,,0x0" complete_cpuset="0x40000000,,,0x0" online_cpuset="0x40000000,,,0x0" allowed_cpuset="0x40000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="127" cpuset="0x80000000,,,0x0" complete_cpuset="0x80000000,,,0x0" online_cpuset="0x80000000,,,0x0" allowed_cpuset="0x80000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,,,0x0" complete_cpuset="0x000000ff,,,,0x0" online_cpuset="0x000000ff,,,,0x0" allowed_cpuset="0x000000ff,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,,,0x0" complete_cpuset="0x000000ff,,,,0x0" online_cpuset="0x000000ff,,,,0x0" allowed_cpuset="0x000000ff,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,,,0x0" complete_cpuset="0x0000000f,,,,0x0" online_cpuset="0x0000000f,,,,0x0" allowed_cpuset="0x0000000f,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000000f,,,,0x0" complete_cpuset="0x0000000f,,,,0x0" online_cpuset="0x0000000f,,,,0x0" allowed_cpuset="0x0000000f,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2088" cpuset="0x0000000f,,,,0x0" complete_cpuset="0x0000000f,,,,0x0" online_cpuset="0x0000000f,,,,0x0" allowed_cpuset="0x0000000f,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="128" cpuset="0x00000001,,,,0x0" complete_cpuset="0x00000001,,,,0x0" online_cpuset="0x00000001,,,,0x0" allowed_cpuset="0x00000001,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="129" cpuset="0x00000002,,,,0x0" complete_cpuset="0x00000002,,,,0x0" online_cpuset="0x00000002,,,,0x0" allowed_cpuset="0x00000002,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="130" cpuset="0x00000004,,,,0x0" complete_cpuset="0x00000004,,,,0x0" online_cpuset="0x00000004,,,,0x0" allowed_cpuset="0x00000004,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="131" cpuset="0x00000008,,,,0x0" complete_cpuset="0x00000008,,,,0x0" online_cpuset="0x00000008,,,,0x0" allowed_cpuset="0x00000008,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,,,0x0" complete_cpuset="0x000000f0,,,,0x0" online_cpuset="0x000000f0,,,,0x0" allowed_cpuset="0x000000f0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000000f0,,,,0x0" complete_cpuset="0x000000f0,,,,0x0" online_cpuset="0x000000f0,,,,0x0" allowed_cpuset="0x000000f0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2092" cpuset="0x000000f0,,,,0x0" complete_cpuset="0x000000f0,,,,0x0" online_cpuset="0x000000f0,,,,0x0" allowed_cpuset="0x000000f0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="132" cpuset="0x00000010,,,,0x0" complete_cpuset="0x00000010,,,,0x0" online_cpuset="0x00000010,,,,0x0" allowed_cpuset="0x00000010,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="133" cpuset="0x00000020,,,,0x0" complete_cpuset="0x00000020,,,,0x0" online_cpuset="0x00000020,,,,0x0" allowed_cpuset="0x00000020,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="134" cpuset="0x00000040,,,,0x0" complete_cpuset="0x00000040,,,,0x0" online_cpuset="0x00000040,,,,0x0" allowed_cpuset="0x00000040,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="135" cpuset="0x00000080,,,,0x0" complete_cpuset="0x00000080,,,,0x0" online_cpuset="0x00000080,,,,0x0" allowed_cpuset="0x00000080,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,,,,0x0" complete_cpuset="0x0000ff00,,,,0x0" online_cpuset="0x0000ff00,,,,0x0" allowed_cpuset="0x0000ff00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,,,,0x0" complete_cpuset="0x0000ff00,,,,0x0" online_cpuset="0x0000ff00,,,,0x0" allowed_cpuset="0x0000ff00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2096" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="136" cpuset="0x00000100,,,,0x0" complete_cpuset="0x00000100,,,,0x0" online_cpuset="0x00000100,,,,0x0" allowed_cpuset="0x00000100,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="137" cpuset="0x00000200,,,,0x0" complete_cpuset="0x00000200,,,,0x0" online_cpuset="0x00000200,,,,0x0" allowed_cpuset="0x00000200,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="138" cpuset="0x00000400,,,,0x0" complete_cpuset="0x00000400,,,,0x0" online_cpuset="0x00000400,,,,0x0" allowed_cpuset="0x00000400,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="139" cpuset="0x00000800,,,,0x0" complete_cpuset="0x00000800,,,,0x0" online_cpuset="0x00000800,,,,0x0" allowed_cpuset="0x00000800,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,,,,0x0" complete_cpuset="0x0000f000,,,,0x0" online_cpuset="0x0000f000,,,,0x0" allowed_cpuset="0x0000f000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000f000,,,,0x0" complete_cpuset="0x0000f000,,,,0x0" online_cpuset="0x0000f000,,,,0x0" allowed_cpuset="0x0000f000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2100" cpuset="0x0000f000,,,,0x0" complete_cpuset="0x0000f000,,,,0x0" online_cpuset="0x0000f000,,,,0x0" allowed_cpuset="0x0000f000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="140" cpuset="0x00001000,,,,0x0" complete_cpuset="0x00001000,,,,0x0" online_cpuset="0x00001000,,,,0x0" allowed_cpuset="0x00001000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="141" cpuset="0x00002000,,,,0x0" complete_cpuset="0x00002000,,,,0x0" online_cpuset="0x00002000,,,,0x0" allowed_cpuset="0x00002000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="142" cpuset="0x00004000,,,,0x0" complete_cpuset="0x00004000,,,,0x0" online_cpuset="0x00004000,,,,0x0" allowed_cpuset="0x00004000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="143" cpuset="0x00008000,,,,0x0" complete_cpuset="0x00008000,,,,0x0" online_cpuset="0x00008000,,,,0x0" allowed_cpuset="0x00008000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,,,,0x0" complete_cpuset="0x00ff0000,,,,0x0" online_cpuset="0x00ff0000,,,,0x0" allowed_cpuset="0x00ff0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,,,,0x0" complete_cpuset="0x00ff0000,,,,0x0" online_cpuset="0x00ff0000,,,,0x0" allowed_cpuset="0x00ff0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,,,,0x0" complete_cpuset="0x000f0000,,,,0x0" online_cpuset="0x000f0000,,,,0x0" allowed_cpuset="0x000f0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000f0000,,,,0x0" complete_cpuset="0x000f0000,,,,0x0" online_cpuset="0x000f0000,,,,0x0" allowed_cpuset="0x000f0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2104" cpuset="0x000f0000,,,,0x0" complete_cpuset="0x000f0000,,,,0x0" online_cpuset="0x000f0000,,,,0x0" allowed_cpuset="0x000f0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="144" cpuset="0x00010000,,,,0x0" complete_cpuset="0x00010000,,,,0x0" online_cpuset="0x00010000,,,,0x0" allowed_cpuset="0x00010000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="145" cpuset="0x00020000,,,,0x0" complete_cpuset="0x00020000,,,,0x0" online_cpuset="0x00020000,,,,0x0" allowed_cpuset="0x00020000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="146" cpuset="0x00040000,,,,0x0" complete_cpuset="0x00040000,,,,0x0" online_cpuset="0x00040000,,,,0x0" allowed_cpuset="0x00040000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="147" cpuset="0x00080000,,,,0x0" complete_cpuset="0x00080000,,,,0x0" online_cpuset="0x00080000,,,,0x0" allowed_cpuset="0x00080000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2108" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="148" cpuset="0x00100000,,,,0x0" complete_cpuset="0x00100000,,,,0x0" online_cpuset="0x00100000,,,,0x0" allowed_cpuset="0x00100000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="149" cpuset="0x00200000,,,,0x0" complete_cpuset="0x00200000,,,,0x0" online_cpuset="0x00200000,,,,0x0" allowed_cpuset="0x00200000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="150" cpuset="0x00400000,,,,0x0" complete_cpuset="0x00400000,,,,0x0" online_cpuset="0x00400000,,,,0x0" allowed_cpuset="0x00400000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="151" cpuset="0x00800000,,,,0x0" complete_cpuset="0x00800000,,,,0x0" online_cpuset="0x00800000,,,,0x0" allowed_cpuset="0x00800000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000,,,,0x0" complete_cpuset="0xff000000,,,,0x0" online_cpuset="0xff000000,,,,0x0" allowed_cpuset="0xff000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,,,,0x0" complete_cpuset="0xff000000,,,,0x0" online_cpuset="0xff000000,,,,0x0" allowed_cpuset="0xff000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,,,,0x0" complete_cpuset="0x0f000000,,,,0x0" online_cpuset="0x0f000000,,,,0x0" allowed_cpuset="0x0f000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0f000000,,,,0x0" complete_cpuset="0x0f000000,,,,0x0" online_cpuset="0x0f000000,,,,0x0" allowed_cpuset="0x0f000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2112" cpuset="0x0f000000,,,,0x0" complete_cpuset="0x0f000000,,,,0x0" online_cpuset="0x0f000000,,,,0x0" allowed_cpuset="0x0f000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="152" cpuset="0x01000000,,,,0x0" complete_cpuset="0x01000000,,,,0x0" online_cpuset="0x01000000,,,,0x0" allowed_cpuset="0x01000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="153" cpuset="0x02000000,,,,0x0" complete_cpuset="0x02000000,,,,0x0" online_cpuset="0x02000000,,,,0x0" allowed_cpuset="0x02000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="154" cpuset="0x04000000,,,,0x0" complete_cpuset="0x04000000,,,,0x0" online_cpuset="0x04000000,,,,0x0" allowed_cpuset="0x04000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="155" cpuset="0x08000000,,,,0x0" complete_cpuset="0x08000000,,,,0x0" online_cpuset="0x08000000,,,,0x0" allowed_cpuset="0x08000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,,,,0x0" complete_cpuset="0xf0000000,,,,0x0" online_cpuset="0xf0000000,,,,0x0" allowed_cpuset="0xf0000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0xf0000000,,,,0x0" complete_cpuset="0xf0000000,,,,0x0" online_cpuset="0xf0000000,,,,0x0" allowed_cpuset="0xf0000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2116" cpuset="0xf0000000,,,,0x0" complete_cpuset="0xf0000000,,,,0x0" online_cpuset="0xf0000000,,,,0x0" allowed_cpuset="0xf0000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="156" cpuset="0x10000000,,,,0x0" complete_cpuset="0x10000000,,,,0x0" online_cpuset="0x10000000,,,,0x0" allowed_cpuset="0x10000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="157" cpuset="0x20000000,,,,0x0" complete_cpuset="0x20000000,,,,0x0" online_cpuset="0x20000000,,,,0x0" allowed_cpuset="0x20000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="158" cpuset="0x40000000,,,,0x0" complete_cpuset="0x40000000,,,,0x0" online_cpuset="0x40000000,,,,0x0" allowed_cpuset="0x40000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="159" cpuset="0x80000000,,,,0x0" complete_cpuset="0x80000000,,,,0x0" online_cpuset="0x80000000,,,,0x0" allowed_cpuset="0x80000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,,,,0x0" complete_cpuset="0x000000ff,,,,,0x0" online_cpuset="0x000000ff,,,,,0x0" allowed_cpuset="0x000000ff,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,,,,0x0" complete_cpuset="0x000000ff,,,,,0x0" online_cpuset="0x000000ff,,,,,0x0" allowed_cpuset="0x000000ff,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,,,,0x0" complete_cpuset="0x0000000f,,,,,0x0" online_cpuset="0x0000000f,,,,,0x0" allowed_cpuset="0x0000000f,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000000f,,,,,0x0" complete_cpuset="0x0000000f,,,,,0x0" online_cpuset="0x0000000f,,,,,0x0" allowed_cpuset="0x0000000f,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2120" cpuset="0x0000000f,,,,,0x0" complete_cpuset="0x0000000f,,,,,0x0" online_cpuset="0x0000000f,,,,,0x0" allowed_cpuset="0x0000000f,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="160" cpuset="0x00000001,,,,,0x0" complete_cpuset="0x00000001,,,,,0x0" online_cpuset="0x00000001,,,,,0x0" allowed_cpuset="0x00000001,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="161" cpuset="0x00000002,,,,,0x0" complete_cpuset="0x00000002,,,,,0x0" online_cpuset="0x00000002,,,,,0x0" allowed_cpuset="0x00000002,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="162" cpuset="0x00000004,,,,,0x0" complete_cpuset="0x00000004,,,,,0x0" online_cpuset="0x00000004,,,,,0x0" allowed_cpuset="0x00000004,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="163" cpuset="0x00000008,,,,,0x0" complete_cpuset="0x00000008,,,,,0x0" online_cpuset="0x00000008,,,,,0x0" allowed_cpuset="0x00000008,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,,,,0x0" complete_cpuset="0x000000f0,,,,,0x0" online_cpuset="0x000000f0,,,,,0x0" allowed_cpuset="0x000000f0,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000000f0,,,,,0x0" complete_cpuset="0x000000f0,,,,,0x0" online_cpuset="0x000000f0,,,,,0x0" allowed_cpuset="0x000000f0,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2124" cpuset="0x000000f0,,,,,0x0" complete_cpuset="0x000000f0,,,,,0x0" online_cpuset="0x000000f0,,,,,0x0" allowed_cpuset="0x000000f0,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="164" cpuset="0x00000010,,,,,0x0" complete_cpuset="0x00000010,,,,,0x0" online_cpuset="0x00000010,,,,,0x0" allowed_cpuset="0x00000010,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="165" cpuset="0x00000020,,,,,0x0" complete_cpuset="0x00000020,,,,,0x0" online_cpuset="0x00000020,,,,,0x0" allowed_cpuset="0x00000020,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="166" cpuset="0x00000040,,,,,0x0" complete_cpuset="0x00000040,,,,,0x0" online_cpuset="0x00000040,,,,,0x0" allowed_cpuset="0x00000040,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="167" cpuset="0x00000080,,,,,0x0" complete_cpuset="0x00000080,,,,,0x0" online_cpuset="0x00000080,,,,,0x0" allowed_cpuset="0x00000080,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,,,,,0x0" complete_cpuset="0x0000ff00,,,,,0x0" online_cpuset="0x0000ff00,,,,,0x0" allowed_cpuset="0x0000ff00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,,,,,0x0" complete_cpuset="0x0000ff00,,,,,0x0" online_cpuset="0x0000ff00,,,,,0x0" allowed_cpuset="0x0000ff00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,,,,0x0" complete_cpuset="0x00000f00,,,,,0x0" online_cpuset="0x00000f00,,,,,0x0" allowed_cpuset="0x00000f00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00000f00,,,,,0x0" complete_cpuset="0x00000f00,,,,,0x0" online_cpuset="0x00000f00,,,,,0x0" allowed_cpuset="0x00000f00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2128" cpuset="0x00000f00,,,,,0x0" complete_cpuset="0x00000f00,,,,,0x0" online_cpuset="0x00000f00,,,,,0x0" allowed_cpuset="0x00000f00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="168" cpuset="0x00000100,,,,,0x0" complete_cpuset="0x00000100,,,,,0x0" online_cpuset="0x00000100,,,,,0x0" allowed_cpuset="0x00000100,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="169" cpuset="0x00000200,,,,,0x0" complete_cpuset="0x00000200,,,,,0x0" online_cpuset="0x00000200,,,,,0x0" allowed_cpuset="0x00000200,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="170" cpuset="0x00000400,,,,,0x0" complete_cpuset="0x00000400,,,,,0x0" online_cpuset="0x00000400,,,,,0x0" allowed_cpuset="0x00000400,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="171" cpuset="0x00000800,,,,,0x0" complete_cpuset="0x00000800,,,,,0x0" online_cpuset="0x00000800,,,,,0x0" allowed_cpuset="0x00000800,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,,,,,0x0" complete_cpuset="0x0000f000,,,,,0x0" online_cpuset="0x0000f000,,,,,0x0" allowed_cpuset="0x0000f000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000f000,,,,,0x0" complete_cpuset="0x0000f000,,,,,0x0" online_cpuset="0x0000f000,,,,,0x0" allowed_cpuset="0x0000f000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2132" cpuset="0x0000f000,,,,,0x0" complete_cpuset="0x0000f000,,,,,0x0" online_cpuset="0x0000f000,,,,,0x0" allowed_cpuset="0x0000f000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="172" cpuset="0x00001000,,,,,0x0" complete_cpuset="0x00001000,,,,,0x0" online_cpuset="0x00001000,,,,,0x0" allowed_cpuset="0x00001000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="173" cpuset="0x00002000,,,,,0x0" complete_cpuset="0x00002000,,,,,0x0" online_cpuset="0x00002000,,,,,0x0" allowed_cpuset="0x00002000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="174" cpuset="0x00004000,,,,,0x0" complete_cpuset="0x00004000,,,,,0x0" online_cpuset="0x00004000,,,,,0x0" allowed_cpuset="0x00004000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="175" cpuset="0x00008000,,,,,0x0" complete_cpuset="0x00008000,,,,,0x0" online_cpuset="0x00008000,,,,,0x0" allowed_cpuset="0x00008000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="9" bridge_type="0-1" depth="0" bridge_pci="0033:[00-01]">
+          <object type="Bridge" os_index="53477376" bridge_type="1-1" depth="1" bridge_pci="0033:[01-01]" pci_busid="0033:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="PCIDev" os_index="53481472" pci_busid="0033:01:00.0" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+              <object type="OSDev" name="hsi2" osdev_type="2">
+                <info name="Address" value="00:00:04:86:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:6f:71:98"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" name="mlx5_2" osdev_type="3">
+                <info name="NodeGUID" value="ec0d:9a03:006f:7198"/>
+                <info name="SysImageGUID" value="ec0d:9a03:006f:7196"/>
+                <info name="Port1State" value="4"/>
+                <info name="Port1LID" value="0xf1b"/>
+                <info name="Port1LMC" value="0"/>
+                <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:006f:7198"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="53481473" pci_busid="0033:01:00.1" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+              <object type="OSDev" name="hsi3" osdev_type="2">
+                <info name="Address" value="00:00:0c:86:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:6f:71:99"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" name="mlx5_3" osdev_type="3">
+                <info name="NodeGUID" value="ec0d:9a03:006f:7199"/>
+                <info name="SysImageGUID" value="ec0d:9a03:006f:7196"/>
+                <info name="Port1State" value="4"/>
+                <info name="Port1LID" value="0xf1a"/>
+                <info name="Port1LMC" value="0"/>
+                <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:006f:7199"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="11" bridge_type="0-1" depth="0" bridge_pci="0035:[00-09]">
+          <object type="Bridge" os_index="55574528" bridge_type="1-1" depth="1" bridge_pci="0035:[01-09]" pci_busid="0035:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="Bridge" os_index="55578624" bridge_type="1-1" depth="2" bridge_pci="0035:[02-09]" pci_busid="0035:01:00.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+              <object type="Bridge" os_index="55582784" bridge_type="1-1" depth="3" bridge_pci="0035:[03-03]" pci_busid="0035:02:04.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+                <object type="PCIDev" os_index="55586816" pci_busid="0035:03:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+                  <object type="OSDev" name="card2" osdev_type="1"/>
+                  <object type="OSDev" name="renderD130" osdev_type="1"/>
+                </object>
+              </object>
+              <object type="Bridge" os_index="55582800" bridge_type="1-1" depth="3" bridge_pci="0035:[04-04]" pci_busid="0035:02:05.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+                <object type="PCIDev" os_index="55590912" pci_busid="0035:04:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+                  <object type="OSDev" name="card3" osdev_type="1"/>
+                  <object type="OSDev" name="renderD131" osdev_type="1"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="NUMANode" os_index="252" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x10000000,,,,,,,0x0" complete_nodeset="0x10000000,,,,,,,0x0" allowed_nodeset="0x10000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="253" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x20000000,,,,,,,0x0" complete_nodeset="0x20000000,,,,,,,0x0" allowed_nodeset="0x20000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="254" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x40000000,,,,,,,0x0" complete_nodeset="0x40000000,,,,,,,0x0" allowed_nodeset="0x40000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="255" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x80000000,,,,,,,0x0" complete_nodeset="0x80000000,,,,,,,0x0" allowed_nodeset="0x80000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+  </object>
+</topology>

--- a/t/data/hwloc-data/004N/exclusive/04-brokers-sierra/3.xml
+++ b/t/data/hwloc-data/004N/exclusive/04-brokers-sierra/3.xml
@@ -1,0 +1,762 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0xf0000000,,,,,,,0x00000101" complete_nodeset="0xf0000000,,,,,,,0x00000101" allowed_nodeset="0xf0000000,,,,,,,0x00000101">
+    <page_type size="65536" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <page_type size="1073741824" count="0"/>
+    <info name="PlatformName" value="PowerNV"/>
+    <info name="PlatformModel" value="PowerNV 8335-GTW"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="4.11.0-44.2.1.el7a.ppc64le"/>
+    <info name="OSVersion" value="#1 SMP Thu Nov 9 02:48:01 EST 2017"/>
+    <info name="HostName" value="sierra408"/>
+    <info name="Architecture" value="ppc64le"/>
+    <info name="hwlocVersion" value="1.11.7"/>
+    <info name="ProcessName" value="lstopo"/>
+    <distances nbobjs="6" relative_depth="2" latency_base="10.000000">
+      <latency value="1.000000"/>
+      <latency value="4.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="4.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+    </distances>
+    <object type="Group" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0x00000101" complete_nodeset="0x00000101" allowed_nodeset="0x00000101" depth="0">
+      <object type="NUMANode" os_index="0" cpuset="0x00ffffff,0xffffffff,0xffffffff" complete_cpuset="0x00ffffff,0xffffffff,0xffffffff" online_cpuset="0x00ffffff,0xffffffff,0xffffffff" allowed_cpuset="0x00ffffff,0xffffffff,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="137123266560">
+        <page_type size="65536" count="2092335"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Package" os_index="0" cpuset="0x00ffffff,0xffffffff,0xffffffff" complete_cpuset="0x00ffffff,0xffffffff,0xffffffff" online_cpuset="0x00ffffff,0xffffffff,0xffffffff" allowed_cpuset="0x00ffffff,0xffffffff,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <info name="CPUModel" value="POWER9 (raw), altivec supported"/>
+          <info name="CPURevision" value="2.1 (pvr 004e 1201)"/>
+          <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="8" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="12" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="16" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="20" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000" complete_cpuset="0x00ff0000" online_cpuset="0x00ff0000" allowed_cpuset="0x00ff0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000" complete_cpuset="0x00ff0000" online_cpuset="0x00ff0000" allowed_cpuset="0x00ff0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="24" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="28" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000" complete_cpuset="0xff000000" online_cpuset="0xff000000" allowed_cpuset="0xff000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000" complete_cpuset="0xff000000" online_cpuset="0xff000000" allowed_cpuset="0xff000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="32" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="36" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,0x0" complete_cpuset="0x000000ff,0x0" online_cpuset="0x000000ff,0x0" allowed_cpuset="0x000000ff,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,0x0" complete_cpuset="0x000000ff,0x0" online_cpuset="0x000000ff,0x0" allowed_cpuset="0x000000ff,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="40" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="44" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,0x0" complete_cpuset="0x0000ff00,0x0" online_cpuset="0x0000ff00,0x0" allowed_cpuset="0x0000ff00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,0x0" complete_cpuset="0x0000ff00,0x0" online_cpuset="0x0000ff00,0x0" allowed_cpuset="0x0000ff00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="48" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="52" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,0x0" complete_cpuset="0x00ff0000,0x0" online_cpuset="0x00ff0000,0x0" allowed_cpuset="0x00ff0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,0x0" complete_cpuset="0x00ff0000,0x0" online_cpuset="0x00ff0000,0x0" allowed_cpuset="0x00ff0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="56" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="60" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000,0x0" complete_cpuset="0xff000000,0x0" online_cpuset="0xff000000,0x0" allowed_cpuset="0xff000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,0x0" complete_cpuset="0xff000000,0x0" online_cpuset="0xff000000,0x0" allowed_cpuset="0xff000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="64" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="68" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,0x0" complete_cpuset="0x000000ff,,0x0" online_cpuset="0x000000ff,,0x0" allowed_cpuset="0x000000ff,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,0x0" complete_cpuset="0x000000ff,,0x0" online_cpuset="0x000000ff,,0x0" allowed_cpuset="0x000000ff,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="72" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="76" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,,0x0" complete_cpuset="0x0000ff00,,0x0" online_cpuset="0x0000ff00,,0x0" allowed_cpuset="0x0000ff00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,,0x0" complete_cpuset="0x0000ff00,,0x0" online_cpuset="0x0000ff00,,0x0" allowed_cpuset="0x0000ff00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="80" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="84" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,0x0" online_cpuset="0x00ff0000,,0x0" allowed_cpuset="0x00ff0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,0x0" online_cpuset="0x00ff0000,,0x0" allowed_cpuset="0x00ff0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="88" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="92" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                    <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                    <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-01]">
+          <object type="Bridge" os_index="0" bridge_type="1-1" depth="1" bridge_pci="0000:[01-01]" pci_busid="0000:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="PCIDev" os_index="4096" pci_busid="0000:01:00.0" pci_type="0108 [144d:a822] [1014:0621] 01" pci_link_speed="0.000000"/>
+          </object>
+        </object>
+        <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0002:[00-02]">
+          <object type="Bridge" os_index="2097152" bridge_type="1-1" depth="1" bridge_pci="0002:[01-02]" pci_busid="0002:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="Bridge" os_index="2101248" bridge_type="1-1" depth="2" bridge_pci="0002:[02-02]" pci_busid="0002:01:00.0" pci_type="0604 [1a03:1150] [1a03:1150] 04" pci_link_speed="0.000000">
+              <object type="PCIDev" os_index="2105344" pci_busid="0002:02:00.0" pci_type="0300 [1a03:2000] [1a03:2000] 41" pci_link_speed="0.000000">
+                <object type="OSDev" name="card4" osdev_type="1"/>
+                <object type="OSDev" name="controlD68" osdev_type="1"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0003:[00-01]">
+          <object type="Bridge" os_index="3145728" bridge_type="1-1" depth="1" bridge_pci="0003:[01-01]" pci_busid="0003:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="PCIDev" os_index="3149824" pci_busid="0003:01:00.0" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+              <object type="OSDev" name="hsi0" osdev_type="2">
+                <info name="Address" value="00:00:00:86:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:6f:6a:1a"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" name="mlx5_0" osdev_type="3">
+                <info name="NodeGUID" value="ec0d:9a03:006f:6a1a"/>
+                <info name="SysImageGUID" value="ec0d:9a03:006f:6a1a"/>
+                <info name="Port1State" value="4"/>
+                <info name="Port1LID" value="0xeba"/>
+                <info name="Port1LMC" value="0"/>
+                <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:006f:6a1a"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="3149825" pci_busid="0003:01:00.1" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+              <object type="OSDev" name="hsi1" osdev_type="2">
+                <info name="Address" value="00:00:08:86:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:6f:6a:1b"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" name="mlx5_1" osdev_type="3">
+                <info name="NodeGUID" value="ec0d:9a03:006f:6a1b"/>
+                <info name="SysImageGUID" value="ec0d:9a03:006f:6a1a"/>
+                <info name="Port1State" value="4"/>
+                <info name="Port1LID" value="0xebb"/>
+                <info name="Port1LMC" value="0"/>
+                <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:006f:6a1b"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="4" bridge_type="0-1" depth="0" bridge_pci="0004:[00-0a]">
+          <object type="Bridge" os_index="4194304" bridge_type="1-1" depth="1" bridge_pci="0004:[01-0a]" pci_busid="0004:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="Bridge" os_index="4198400" bridge_type="1-1" depth="2" bridge_pci="0004:[02-0a]" pci_busid="0004:01:00.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+              <object type="Bridge" os_index="4202528" bridge_type="1-1" depth="3" bridge_pci="0004:[03-03]" pci_busid="0004:02:02.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+                <object type="PCIDev" os_index="4206592" pci_busid="0004:03:00.0" pci_type="0106 [1b4b:9235] [1014:0612] 11" pci_link_speed="0.000000"/>
+              </object>
+              <object type="Bridge" os_index="4202656" bridge_type="1-1" depth="3" bridge_pci="0004:[04-04]" pci_busid="0004:02:0a.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+                <object type="PCIDev" os_index="4210688" pci_busid="0004:04:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+                  <object type="OSDev" name="renderD128" osdev_type="1"/>
+                  <object type="OSDev" name="card0" osdev_type="1"/>
+                </object>
+              </object>
+              <object type="Bridge" os_index="4202672" bridge_type="1-1" depth="3" bridge_pci="0004:[05-05]" pci_busid="0004:02:0b.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+                <object type="PCIDev" os_index="4214784" pci_busid="0004:05:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+                  <object type="OSDev" name="card1" osdev_type="1"/>
+                  <object type="OSDev" name="renderD129" osdev_type="1"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="5" bridge_type="0-1" depth="0" bridge_pci="0005:[00-01]">
+          <object type="Bridge" os_index="5242880" bridge_type="1-1" depth="1" bridge_pci="0005:[01-01]" pci_busid="0005:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="PCIDev" os_index="5246976" pci_busid="0005:01:00.0" pci_type="0200 [14e4:1657] [14e4:1981] 01" pci_link_speed="0.000000">
+              <object type="OSDev" name="enP5p1s0f0" osdev_type="2">
+                <info name="Address" value="70:e2:84:14:58:4b"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="5246977" pci_busid="0005:01:00.1" pci_type="0200 [14e4:1657] [14e4:1657] 01" pci_link_speed="0.000000">
+              <object type="OSDev" name="enP5p1s0f1" osdev_type="2">
+                <info name="Address" value="70:e2:84:14:58:4c"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="8" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" local_memory="137166061568">
+        <page_type size="65536" count="2092988"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Package" os_index="8" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+          <info name="CPUModel" value="POWER9 (raw), altivec supported"/>
+          <info name="CPURevision" value="2.1 (pvr 004e 1201)"/>
+          <object type="Cache" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2052" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000000f,0xf0000000,,0x0" complete_cpuset="0x0000000f,0xf0000000,,0x0" online_cpuset="0x0000000f,0xf0000000,,0x0" allowed_cpuset="0x0000000f,0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000000f,0xf0000000,,0x0" complete_cpuset="0x0000000f,0xf0000000,,0x0" online_cpuset="0x0000000f,0xf0000000,,0x0" allowed_cpuset="0x0000000f,0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2056" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2060" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="96" cpuset="0x00000001,,,0x0" complete_cpuset="0x00000001,,,0x0" online_cpuset="0x00000001,,,0x0" allowed_cpuset="0x00000001,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="97" cpuset="0x00000002,,,0x0" complete_cpuset="0x00000002,,,0x0" online_cpuset="0x00000002,,,0x0" allowed_cpuset="0x00000002,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="98" cpuset="0x00000004,,,0x0" complete_cpuset="0x00000004,,,0x0" online_cpuset="0x00000004,,,0x0" allowed_cpuset="0x00000004,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="99" cpuset="0x00000008,,,0x0" complete_cpuset="0x00000008,,,0x0" online_cpuset="0x00000008,,,0x0" allowed_cpuset="0x00000008,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000ff0,,,0x0" complete_cpuset="0x00000ff0,,,0x0" online_cpuset="0x00000ff0,,,0x0" allowed_cpuset="0x00000ff0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00000ff0,,,0x0" complete_cpuset="0x00000ff0,,,0x0" online_cpuset="0x00000ff0,,,0x0" allowed_cpuset="0x00000ff0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2064" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="100" cpuset="0x00000010,,,0x0" complete_cpuset="0x00000010,,,0x0" online_cpuset="0x00000010,,,0x0" allowed_cpuset="0x00000010,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="101" cpuset="0x00000020,,,0x0" complete_cpuset="0x00000020,,,0x0" online_cpuset="0x00000020,,,0x0" allowed_cpuset="0x00000020,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="102" cpuset="0x00000040,,,0x0" complete_cpuset="0x00000040,,,0x0" online_cpuset="0x00000040,,,0x0" allowed_cpuset="0x00000040,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="103" cpuset="0x00000080,,,0x0" complete_cpuset="0x00000080,,,0x0" online_cpuset="0x00000080,,,0x0" allowed_cpuset="0x00000080,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2068" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="104" cpuset="0x00000100,,,0x0" complete_cpuset="0x00000100,,,0x0" online_cpuset="0x00000100,,,0x0" allowed_cpuset="0x00000100,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="105" cpuset="0x00000200,,,0x0" complete_cpuset="0x00000200,,,0x0" online_cpuset="0x00000200,,,0x0" allowed_cpuset="0x00000200,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="106" cpuset="0x00000400,,,0x0" complete_cpuset="0x00000400,,,0x0" online_cpuset="0x00000400,,,0x0" allowed_cpuset="0x00000400,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="107" cpuset="0x00000800,,,0x0" complete_cpuset="0x00000800,,,0x0" online_cpuset="0x00000800,,,0x0" allowed_cpuset="0x00000800,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000ff000,,,0x0" complete_cpuset="0x000ff000,,,0x0" online_cpuset="0x000ff000,,,0x0" allowed_cpuset="0x000ff000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000ff000,,,0x0" complete_cpuset="0x000ff000,,,0x0" online_cpuset="0x000ff000,,,0x0" allowed_cpuset="0x000ff000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2072" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="108" cpuset="0x00001000,,,0x0" complete_cpuset="0x00001000,,,0x0" online_cpuset="0x00001000,,,0x0" allowed_cpuset="0x00001000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="109" cpuset="0x00002000,,,0x0" complete_cpuset="0x00002000,,,0x0" online_cpuset="0x00002000,,,0x0" allowed_cpuset="0x00002000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="110" cpuset="0x00004000,,,0x0" complete_cpuset="0x00004000,,,0x0" online_cpuset="0x00004000,,,0x0" allowed_cpuset="0x00004000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="111" cpuset="0x00008000,,,0x0" complete_cpuset="0x00008000,,,0x0" online_cpuset="0x00008000,,,0x0" allowed_cpuset="0x00008000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2076" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="112" cpuset="0x00010000,,,0x0" complete_cpuset="0x00010000,,,0x0" online_cpuset="0x00010000,,,0x0" allowed_cpuset="0x00010000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="113" cpuset="0x00020000,,,0x0" complete_cpuset="0x00020000,,,0x0" online_cpuset="0x00020000,,,0x0" allowed_cpuset="0x00020000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="114" cpuset="0x00040000,,,0x0" complete_cpuset="0x00040000,,,0x0" online_cpuset="0x00040000,,,0x0" allowed_cpuset="0x00040000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="115" cpuset="0x00080000,,,0x0" complete_cpuset="0x00080000,,,0x0" online_cpuset="0x00080000,,,0x0" allowed_cpuset="0x00080000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0ff00000,,,0x0" complete_cpuset="0x0ff00000,,,0x0" online_cpuset="0x0ff00000,,,0x0" allowed_cpuset="0x0ff00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0ff00000,,,0x0" complete_cpuset="0x0ff00000,,,0x0" online_cpuset="0x0ff00000,,,0x0" allowed_cpuset="0x0ff00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2080" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="116" cpuset="0x00100000,,,0x0" complete_cpuset="0x00100000,,,0x0" online_cpuset="0x00100000,,,0x0" allowed_cpuset="0x00100000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="117" cpuset="0x00200000,,,0x0" complete_cpuset="0x00200000,,,0x0" online_cpuset="0x00200000,,,0x0" allowed_cpuset="0x00200000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="118" cpuset="0x00400000,,,0x0" complete_cpuset="0x00400000,,,0x0" online_cpuset="0x00400000,,,0x0" allowed_cpuset="0x00400000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="119" cpuset="0x00800000,,,0x0" complete_cpuset="0x00800000,,,0x0" online_cpuset="0x00800000,,,0x0" allowed_cpuset="0x00800000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2084" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="120" cpuset="0x01000000,,,0x0" complete_cpuset="0x01000000,,,0x0" online_cpuset="0x01000000,,,0x0" allowed_cpuset="0x01000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="121" cpuset="0x02000000,,,0x0" complete_cpuset="0x02000000,,,0x0" online_cpuset="0x02000000,,,0x0" allowed_cpuset="0x02000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="122" cpuset="0x04000000,,,0x0" complete_cpuset="0x04000000,,,0x0" online_cpuset="0x04000000,,,0x0" allowed_cpuset="0x04000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="123" cpuset="0x08000000,,,0x0" complete_cpuset="0x08000000,,,0x0" online_cpuset="0x08000000,,,0x0" allowed_cpuset="0x08000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2092" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="124" cpuset="0x10000000,,,0x0" complete_cpuset="0x10000000,,,0x0" online_cpuset="0x10000000,,,0x0" allowed_cpuset="0x10000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="125" cpuset="0x20000000,,,0x0" complete_cpuset="0x20000000,,,0x0" online_cpuset="0x20000000,,,0x0" allowed_cpuset="0x20000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="126" cpuset="0x40000000,,,0x0" complete_cpuset="0x40000000,,,0x0" online_cpuset="0x40000000,,,0x0" allowed_cpuset="0x40000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="127" cpuset="0x80000000,,,0x0" complete_cpuset="0x80000000,,,0x0" online_cpuset="0x80000000,,,0x0" allowed_cpuset="0x80000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,,,0x0" complete_cpuset="0x000000ff,,,,0x0" online_cpuset="0x000000ff,,,,0x0" allowed_cpuset="0x000000ff,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,,,0x0" complete_cpuset="0x000000ff,,,,0x0" online_cpuset="0x000000ff,,,,0x0" allowed_cpuset="0x000000ff,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,,,0x0" complete_cpuset="0x0000000f,,,,0x0" online_cpuset="0x0000000f,,,,0x0" allowed_cpuset="0x0000000f,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000000f,,,,0x0" complete_cpuset="0x0000000f,,,,0x0" online_cpuset="0x0000000f,,,,0x0" allowed_cpuset="0x0000000f,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2096" cpuset="0x0000000f,,,,0x0" complete_cpuset="0x0000000f,,,,0x0" online_cpuset="0x0000000f,,,,0x0" allowed_cpuset="0x0000000f,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="128" cpuset="0x00000001,,,,0x0" complete_cpuset="0x00000001,,,,0x0" online_cpuset="0x00000001,,,,0x0" allowed_cpuset="0x00000001,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="129" cpuset="0x00000002,,,,0x0" complete_cpuset="0x00000002,,,,0x0" online_cpuset="0x00000002,,,,0x0" allowed_cpuset="0x00000002,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="130" cpuset="0x00000004,,,,0x0" complete_cpuset="0x00000004,,,,0x0" online_cpuset="0x00000004,,,,0x0" allowed_cpuset="0x00000004,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="131" cpuset="0x00000008,,,,0x0" complete_cpuset="0x00000008,,,,0x0" online_cpuset="0x00000008,,,,0x0" allowed_cpuset="0x00000008,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,,,0x0" complete_cpuset="0x000000f0,,,,0x0" online_cpuset="0x000000f0,,,,0x0" allowed_cpuset="0x000000f0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000000f0,,,,0x0" complete_cpuset="0x000000f0,,,,0x0" online_cpuset="0x000000f0,,,,0x0" allowed_cpuset="0x000000f0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2100" cpuset="0x000000f0,,,,0x0" complete_cpuset="0x000000f0,,,,0x0" online_cpuset="0x000000f0,,,,0x0" allowed_cpuset="0x000000f0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="132" cpuset="0x00000010,,,,0x0" complete_cpuset="0x00000010,,,,0x0" online_cpuset="0x00000010,,,,0x0" allowed_cpuset="0x00000010,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="133" cpuset="0x00000020,,,,0x0" complete_cpuset="0x00000020,,,,0x0" online_cpuset="0x00000020,,,,0x0" allowed_cpuset="0x00000020,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="134" cpuset="0x00000040,,,,0x0" complete_cpuset="0x00000040,,,,0x0" online_cpuset="0x00000040,,,,0x0" allowed_cpuset="0x00000040,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="135" cpuset="0x00000080,,,,0x0" complete_cpuset="0x00000080,,,,0x0" online_cpuset="0x00000080,,,,0x0" allowed_cpuset="0x00000080,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,,,,0x0" complete_cpuset="0x0000ff00,,,,0x0" online_cpuset="0x0000ff00,,,,0x0" allowed_cpuset="0x0000ff00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,,,,0x0" complete_cpuset="0x0000ff00,,,,0x0" online_cpuset="0x0000ff00,,,,0x0" allowed_cpuset="0x0000ff00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2104" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="136" cpuset="0x00000100,,,,0x0" complete_cpuset="0x00000100,,,,0x0" online_cpuset="0x00000100,,,,0x0" allowed_cpuset="0x00000100,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="137" cpuset="0x00000200,,,,0x0" complete_cpuset="0x00000200,,,,0x0" online_cpuset="0x00000200,,,,0x0" allowed_cpuset="0x00000200,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="138" cpuset="0x00000400,,,,0x0" complete_cpuset="0x00000400,,,,0x0" online_cpuset="0x00000400,,,,0x0" allowed_cpuset="0x00000400,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="139" cpuset="0x00000800,,,,0x0" complete_cpuset="0x00000800,,,,0x0" online_cpuset="0x00000800,,,,0x0" allowed_cpuset="0x00000800,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,,,,0x0" complete_cpuset="0x0000f000,,,,0x0" online_cpuset="0x0000f000,,,,0x0" allowed_cpuset="0x0000f000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000f000,,,,0x0" complete_cpuset="0x0000f000,,,,0x0" online_cpuset="0x0000f000,,,,0x0" allowed_cpuset="0x0000f000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2108" cpuset="0x0000f000,,,,0x0" complete_cpuset="0x0000f000,,,,0x0" online_cpuset="0x0000f000,,,,0x0" allowed_cpuset="0x0000f000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="140" cpuset="0x00001000,,,,0x0" complete_cpuset="0x00001000,,,,0x0" online_cpuset="0x00001000,,,,0x0" allowed_cpuset="0x00001000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="141" cpuset="0x00002000,,,,0x0" complete_cpuset="0x00002000,,,,0x0" online_cpuset="0x00002000,,,,0x0" allowed_cpuset="0x00002000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="142" cpuset="0x00004000,,,,0x0" complete_cpuset="0x00004000,,,,0x0" online_cpuset="0x00004000,,,,0x0" allowed_cpuset="0x00004000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="143" cpuset="0x00008000,,,,0x0" complete_cpuset="0x00008000,,,,0x0" online_cpuset="0x00008000,,,,0x0" allowed_cpuset="0x00008000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,,,,0x0" complete_cpuset="0x00ff0000,,,,0x0" online_cpuset="0x00ff0000,,,,0x0" allowed_cpuset="0x00ff0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,,,,0x0" complete_cpuset="0x00ff0000,,,,0x0" online_cpuset="0x00ff0000,,,,0x0" allowed_cpuset="0x00ff0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,,,,0x0" complete_cpuset="0x000f0000,,,,0x0" online_cpuset="0x000f0000,,,,0x0" allowed_cpuset="0x000f0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000f0000,,,,0x0" complete_cpuset="0x000f0000,,,,0x0" online_cpuset="0x000f0000,,,,0x0" allowed_cpuset="0x000f0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2112" cpuset="0x000f0000,,,,0x0" complete_cpuset="0x000f0000,,,,0x0" online_cpuset="0x000f0000,,,,0x0" allowed_cpuset="0x000f0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="144" cpuset="0x00010000,,,,0x0" complete_cpuset="0x00010000,,,,0x0" online_cpuset="0x00010000,,,,0x0" allowed_cpuset="0x00010000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="145" cpuset="0x00020000,,,,0x0" complete_cpuset="0x00020000,,,,0x0" online_cpuset="0x00020000,,,,0x0" allowed_cpuset="0x00020000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="146" cpuset="0x00040000,,,,0x0" complete_cpuset="0x00040000,,,,0x0" online_cpuset="0x00040000,,,,0x0" allowed_cpuset="0x00040000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="147" cpuset="0x00080000,,,,0x0" complete_cpuset="0x00080000,,,,0x0" online_cpuset="0x00080000,,,,0x0" allowed_cpuset="0x00080000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2116" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="148" cpuset="0x00100000,,,,0x0" complete_cpuset="0x00100000,,,,0x0" online_cpuset="0x00100000,,,,0x0" allowed_cpuset="0x00100000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="149" cpuset="0x00200000,,,,0x0" complete_cpuset="0x00200000,,,,0x0" online_cpuset="0x00200000,,,,0x0" allowed_cpuset="0x00200000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="150" cpuset="0x00400000,,,,0x0" complete_cpuset="0x00400000,,,,0x0" online_cpuset="0x00400000,,,,0x0" allowed_cpuset="0x00400000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="151" cpuset="0x00800000,,,,0x0" complete_cpuset="0x00800000,,,,0x0" online_cpuset="0x00800000,,,,0x0" allowed_cpuset="0x00800000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000,,,,0x0" complete_cpuset="0xff000000,,,,0x0" online_cpuset="0xff000000,,,,0x0" allowed_cpuset="0xff000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,,,,0x0" complete_cpuset="0xff000000,,,,0x0" online_cpuset="0xff000000,,,,0x0" allowed_cpuset="0xff000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,,,,0x0" complete_cpuset="0x0f000000,,,,0x0" online_cpuset="0x0f000000,,,,0x0" allowed_cpuset="0x0f000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0f000000,,,,0x0" complete_cpuset="0x0f000000,,,,0x0" online_cpuset="0x0f000000,,,,0x0" allowed_cpuset="0x0f000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2120" cpuset="0x0f000000,,,,0x0" complete_cpuset="0x0f000000,,,,0x0" online_cpuset="0x0f000000,,,,0x0" allowed_cpuset="0x0f000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="152" cpuset="0x01000000,,,,0x0" complete_cpuset="0x01000000,,,,0x0" online_cpuset="0x01000000,,,,0x0" allowed_cpuset="0x01000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="153" cpuset="0x02000000,,,,0x0" complete_cpuset="0x02000000,,,,0x0" online_cpuset="0x02000000,,,,0x0" allowed_cpuset="0x02000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="154" cpuset="0x04000000,,,,0x0" complete_cpuset="0x04000000,,,,0x0" online_cpuset="0x04000000,,,,0x0" allowed_cpuset="0x04000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="155" cpuset="0x08000000,,,,0x0" complete_cpuset="0x08000000,,,,0x0" online_cpuset="0x08000000,,,,0x0" allowed_cpuset="0x08000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,,,,0x0" complete_cpuset="0xf0000000,,,,0x0" online_cpuset="0xf0000000,,,,0x0" allowed_cpuset="0xf0000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0xf0000000,,,,0x0" complete_cpuset="0xf0000000,,,,0x0" online_cpuset="0xf0000000,,,,0x0" allowed_cpuset="0xf0000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2124" cpuset="0xf0000000,,,,0x0" complete_cpuset="0xf0000000,,,,0x0" online_cpuset="0xf0000000,,,,0x0" allowed_cpuset="0xf0000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="156" cpuset="0x10000000,,,,0x0" complete_cpuset="0x10000000,,,,0x0" online_cpuset="0x10000000,,,,0x0" allowed_cpuset="0x10000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="157" cpuset="0x20000000,,,,0x0" complete_cpuset="0x20000000,,,,0x0" online_cpuset="0x20000000,,,,0x0" allowed_cpuset="0x20000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="158" cpuset="0x40000000,,,,0x0" complete_cpuset="0x40000000,,,,0x0" online_cpuset="0x40000000,,,,0x0" allowed_cpuset="0x40000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="159" cpuset="0x80000000,,,,0x0" complete_cpuset="0x80000000,,,,0x0" online_cpuset="0x80000000,,,,0x0" allowed_cpuset="0x80000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,,,,0x0" complete_cpuset="0x000000ff,,,,,0x0" online_cpuset="0x000000ff,,,,,0x0" allowed_cpuset="0x000000ff,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,,,,0x0" complete_cpuset="0x000000ff,,,,,0x0" online_cpuset="0x000000ff,,,,,0x0" allowed_cpuset="0x000000ff,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,,,,0x0" complete_cpuset="0x0000000f,,,,,0x0" online_cpuset="0x0000000f,,,,,0x0" allowed_cpuset="0x0000000f,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000000f,,,,,0x0" complete_cpuset="0x0000000f,,,,,0x0" online_cpuset="0x0000000f,,,,,0x0" allowed_cpuset="0x0000000f,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2128" cpuset="0x0000000f,,,,,0x0" complete_cpuset="0x0000000f,,,,,0x0" online_cpuset="0x0000000f,,,,,0x0" allowed_cpuset="0x0000000f,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="160" cpuset="0x00000001,,,,,0x0" complete_cpuset="0x00000001,,,,,0x0" online_cpuset="0x00000001,,,,,0x0" allowed_cpuset="0x00000001,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="161" cpuset="0x00000002,,,,,0x0" complete_cpuset="0x00000002,,,,,0x0" online_cpuset="0x00000002,,,,,0x0" allowed_cpuset="0x00000002,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="162" cpuset="0x00000004,,,,,0x0" complete_cpuset="0x00000004,,,,,0x0" online_cpuset="0x00000004,,,,,0x0" allowed_cpuset="0x00000004,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="163" cpuset="0x00000008,,,,,0x0" complete_cpuset="0x00000008,,,,,0x0" online_cpuset="0x00000008,,,,,0x0" allowed_cpuset="0x00000008,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,,,,0x0" complete_cpuset="0x000000f0,,,,,0x0" online_cpuset="0x000000f0,,,,,0x0" allowed_cpuset="0x000000f0,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x000000f0,,,,,0x0" complete_cpuset="0x000000f0,,,,,0x0" online_cpuset="0x000000f0,,,,,0x0" allowed_cpuset="0x000000f0,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2132" cpuset="0x000000f0,,,,,0x0" complete_cpuset="0x000000f0,,,,,0x0" online_cpuset="0x000000f0,,,,,0x0" allowed_cpuset="0x000000f0,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="164" cpuset="0x00000010,,,,,0x0" complete_cpuset="0x00000010,,,,,0x0" online_cpuset="0x00000010,,,,,0x0" allowed_cpuset="0x00000010,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="165" cpuset="0x00000020,,,,,0x0" complete_cpuset="0x00000020,,,,,0x0" online_cpuset="0x00000020,,,,,0x0" allowed_cpuset="0x00000020,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="166" cpuset="0x00000040,,,,,0x0" complete_cpuset="0x00000040,,,,,0x0" online_cpuset="0x00000040,,,,,0x0" allowed_cpuset="0x00000040,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="167" cpuset="0x00000080,,,,,0x0" complete_cpuset="0x00000080,,,,,0x0" online_cpuset="0x00000080,,,,,0x0" allowed_cpuset="0x00000080,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,,,,,0x0" complete_cpuset="0x0000ff00,,,,,0x0" online_cpuset="0x0000ff00,,,,,0x0" allowed_cpuset="0x0000ff00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,,,,,0x0" complete_cpuset="0x0000ff00,,,,,0x0" online_cpuset="0x0000ff00,,,,,0x0" allowed_cpuset="0x0000ff00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,,,,0x0" complete_cpuset="0x00000f00,,,,,0x0" online_cpuset="0x00000f00,,,,,0x0" allowed_cpuset="0x00000f00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x00000f00,,,,,0x0" complete_cpuset="0x00000f00,,,,,0x0" online_cpuset="0x00000f00,,,,,0x0" allowed_cpuset="0x00000f00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2136" cpuset="0x00000f00,,,,,0x0" complete_cpuset="0x00000f00,,,,,0x0" online_cpuset="0x00000f00,,,,,0x0" allowed_cpuset="0x00000f00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="168" cpuset="0x00000100,,,,,0x0" complete_cpuset="0x00000100,,,,,0x0" online_cpuset="0x00000100,,,,,0x0" allowed_cpuset="0x00000100,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="169" cpuset="0x00000200,,,,,0x0" complete_cpuset="0x00000200,,,,,0x0" online_cpuset="0x00000200,,,,,0x0" allowed_cpuset="0x00000200,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="170" cpuset="0x00000400,,,,,0x0" complete_cpuset="0x00000400,,,,,0x0" online_cpuset="0x00000400,,,,,0x0" allowed_cpuset="0x00000400,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="171" cpuset="0x00000800,,,,,0x0" complete_cpuset="0x00000800,,,,,0x0" online_cpuset="0x00000800,,,,,0x0" allowed_cpuset="0x00000800,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,,,,,0x0" complete_cpuset="0x0000f000,,,,,0x0" online_cpuset="0x0000f000,,,,,0x0" allowed_cpuset="0x0000f000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Cache" cpuset="0x0000f000,,,,,0x0" complete_cpuset="0x0000f000,,,,,0x0" online_cpuset="0x0000f000,,,,,0x0" allowed_cpuset="0x0000f000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="2">
+                  <object type="Core" os_index="2140" cpuset="0x0000f000,,,,,0x0" complete_cpuset="0x0000f000,,,,,0x0" online_cpuset="0x0000f000,,,,,0x0" allowed_cpuset="0x0000f000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                    <object type="PU" os_index="172" cpuset="0x00001000,,,,,0x0" complete_cpuset="0x00001000,,,,,0x0" online_cpuset="0x00001000,,,,,0x0" allowed_cpuset="0x00001000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="173" cpuset="0x00002000,,,,,0x0" complete_cpuset="0x00002000,,,,,0x0" online_cpuset="0x00002000,,,,,0x0" allowed_cpuset="0x00002000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="174" cpuset="0x00004000,,,,,0x0" complete_cpuset="0x00004000,,,,,0x0" online_cpuset="0x00004000,,,,,0x0" allowed_cpuset="0x00004000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                    <object type="PU" os_index="175" cpuset="0x00008000,,,,,0x0" complete_cpuset="0x00008000,,,,,0x0" online_cpuset="0x00008000,,,,,0x0" allowed_cpuset="0x00008000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="9" bridge_type="0-1" depth="0" bridge_pci="0033:[00-01]">
+          <object type="Bridge" os_index="53477376" bridge_type="1-1" depth="1" bridge_pci="0033:[01-01]" pci_busid="0033:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="PCIDev" os_index="53481472" pci_busid="0033:01:00.0" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+              <object type="OSDev" name="hsi2" osdev_type="2">
+                <info name="Address" value="00:00:04:86:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:6f:6a:1c"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" name="mlx5_2" osdev_type="3">
+                <info name="NodeGUID" value="ec0d:9a03:006f:6a1c"/>
+                <info name="SysImageGUID" value="ec0d:9a03:006f:6a1a"/>
+                <info name="Port1State" value="4"/>
+                <info name="Port1LID" value="0xf2a"/>
+                <info name="Port1LMC" value="0"/>
+                <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:006f:6a1c"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="53481473" pci_busid="0033:01:00.1" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+              <object type="OSDev" name="hsi3" osdev_type="2">
+                <info name="Address" value="00:00:0c:86:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:6f:6a:1d"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" name="mlx5_3" osdev_type="3">
+                <info name="NodeGUID" value="ec0d:9a03:006f:6a1d"/>
+                <info name="SysImageGUID" value="ec0d:9a03:006f:6a1a"/>
+                <info name="Port1State" value="4"/>
+                <info name="Port1LID" value="0xf2c"/>
+                <info name="Port1LMC" value="0"/>
+                <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:006f:6a1d"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="11" bridge_type="0-1" depth="0" bridge_pci="0035:[00-09]">
+          <object type="Bridge" os_index="55574528" bridge_type="1-1" depth="1" bridge_pci="0035:[01-09]" pci_busid="0035:00:00.0" pci_type="0604 [1014:04c1] [0000:0000] 00" pci_link_speed="0.000000">
+            <object type="Bridge" os_index="55578624" bridge_type="1-1" depth="2" bridge_pci="0035:[02-09]" pci_busid="0035:01:00.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+              <object type="Bridge" os_index="55582784" bridge_type="1-1" depth="3" bridge_pci="0035:[03-03]" pci_busid="0035:02:04.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+                <object type="PCIDev" os_index="55586816" pci_busid="0035:03:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+                  <object type="OSDev" name="card2" osdev_type="1"/>
+                  <object type="OSDev" name="renderD130" osdev_type="1"/>
+                </object>
+              </object>
+              <object type="Bridge" os_index="55582800" bridge_type="1-1" depth="3" bridge_pci="0035:[04-04]" pci_busid="0035:02:05.0" pci_type="0604 [10b5:8725] [10b5:8725] ca" pci_link_speed="0.000000">
+                <object type="PCIDev" os_index="55590912" pci_busid="0035:04:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+                  <object type="OSDev" name="card3" osdev_type="1"/>
+                  <object type="OSDev" name="renderD131" osdev_type="1"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="NUMANode" os_index="252" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x10000000,,,,,,,0x0" complete_nodeset="0x10000000,,,,,,,0x0" allowed_nodeset="0x10000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="253" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x20000000,,,,,,,0x0" complete_nodeset="0x20000000,,,,,,,0x0" allowed_nodeset="0x20000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="254" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x40000000,,,,,,,0x0" complete_nodeset="0x40000000,,,,,,,0x0" allowed_nodeset="0x40000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="255" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x80000000,,,,,,,0x0" complete_nodeset="0x80000000,,,,,,,0x0" allowed_nodeset="0x80000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+  </object>
+</topology>

--- a/t/t1001-rs2rank-basic.t
+++ b/t/t1001-rs2rank-basic.t
@@ -12,6 +12,7 @@ basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # each of the 4 brokers manages an exclusive set of cores (4) of the cab node 
 excl_1N4B=$basepath/001N/exclusive/04-brokers
 excl_1N4B_nc=4
+
 # full 16-core cab node resources controlled by 4 brokers
 shrd_1N4B=$basepath/001N/shared/04-brokers
 shrd_1N4B_nc=16
@@ -21,6 +22,9 @@ excl_4N4B_m_RDL=$basepath/004N/exclusive/cab.hwloc1.lua
 excl_4N4B_um_RDL=$basepath/004N/exclusive/cab.hwloc2.lua
 excl_4N4B_um_RDL2=$basepath/004N/exclusive/cab.hwloc3.lua
 excl_4N4B_nc=16
+
+excl_4N4B_sierra=$basepath/004N/exclusive/04-brokers-sierra
+excl_4N4B_nc_sierra=32
 
 #
 # test_under_flux is under sharness.d/
@@ -108,4 +112,17 @@ test_expect_success 'rs2rank: works with a matched RDL' '
     verify_1N_nproc_sleep_jobs ${excl_4N4B_nc} 
 '
 
+test_expect_success 'rs2rank: can handle sierra nodes with group type' '
+    adjust_session_info 4 &&
+    flux module remove sched &&
+    flux hwloc reload ${excl_4N4B_sierra} &&
+    flux module load sched sched-once=true &&
+    timed_wait_job 5 &&
+    submit_1N_nproc_sleep_jobs ${excl_4N4B_nc_sierra} 0 &&
+    timed_sync_wait_job 10 &&
+    verify_1N_nproc_sleep_jobs ${excl_4N4B_nc_sierra}
+'
+
+
 test_done
+


### PR DESCRIPTION
Per discussion at https://github.com/flux-framework/flux-sched/issues/308:

Incorporate @trws' patch to handle group type.

Add a test case using hwloc xml files collected from Sierra nodes.