### PR TITLE
sharness: update flux-sharness.sh script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,6 @@ addons:
       - ccache
       - apport # for coredumps
       - gdb
-      - libhwloc-dev
       - libmunge-dev
       - munge
       - lcov

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ flux-sched requires the following packages to build:
 
 ```
 libboost-dev >= 1.53
+libhwloc-dev >= 1.11.1
 ```
 
 The sched module contains

--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,7 @@ AC_CHECK_LIB([dl], [dlerror],
               AC_DEFINE([HAVE_LIBDL], [1],
                         [Define if you have libdl])],
              [AC_MSG_ERROR([Please install dl])])
-PKG_CHECK_MODULES([HWLOC], [hwloc], [], [])
+PKG_CHECK_MODULES([HWLOC], [hwloc >= 1.11.1], [], [])
 PKG_CHECK_MODULES([JANSSON], [jansson >= 2.6], [], [])
 PKG_CHECK_MODULES([XML2], [libxml-2.0])
 AX_PROG_LUA([5.1],[5.3])

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -24,6 +24,37 @@ test_size_large() {
     echo ${size}
 }
 
+
+#
+#  Tests using test_under_flux() and which load their own modules should
+#   ensure those modules are unloaded at the end of the test for proper
+#   cleanup and test coverage (also as a general principle, module unload
+#   should be something explicitly tested).
+#
+#  The functions below ensure that every module loaded at "test_done" time
+#   when test_under_flux() was used was also loaded before test_under_flux
+#   was called.
+#
+flux_module_list() {
+    flux module list | awk '!/^Module/{print $1}' | sort
+}
+
+check_module_list() {
+    flux_module_list > module-list.final
+    while read module; do
+       grep "^$module$" module-list.initial >/dev/null 2>&1 \
+            || bad="${bad}${bad:+ }$module"
+    done < module-list.final
+    if test -n "$bad"; then
+        test -n "$logfile" \
+            && say_color error >&3 \
+                 "Error: manually loaded module(s) not unloaded: $bad"
+        # This function is run under test_eval_ so redirect
+        #  error message to &5 (saved stdout) so text doesn't disappear:
+        error >&5 2>&1 "manually loaded module(s) not unloaded: $bad"
+    fi
+}
+
 #
 #  Reinvoke a test file under a flux comms instance
 #
@@ -34,16 +65,19 @@ test_under_flux() {
     personality=${2:-full}
     log_file="$TEST_NAME.broker.log"
     if test -n "$TEST_UNDER_FLUX_ACTIVE" ; then
-        cleanup rm "${SHARNESS_TEST_DIRECTORY:-..}/$log_file"
+        test "$debug" = "t" || cleanup rm "${SHARNESS_TEST_DIRECTORY:-..}/$log_file"
+        flux_module_list > module-list.initial
+        cleanup check_module_list
         return
     fi
-    quiet="-o -q,-Slog-filename=${log_file},-Slog-forward-level=7"
     if test "$verbose" = "t" -o -n "$FLUX_TESTS_DEBUG" ; then
         flags="${flags} --verbose"
-        quiet=""
     fi
     if test "$debug" = "t" -o -n "$FLUX_TESTS_DEBUG" ; then
         flags="${flags} --debug"
+    fi
+    if test "$chain_lint" = "t"; then
+        flags="${flags} --chain-lint"
     fi
     if test -n "$logfile" -o -n "$FLUX_TESTS_LOGFILE" ; then
         flags="${flags} --logfile"
@@ -51,22 +85,29 @@ test_under_flux() {
     if test -n "$SHARNESS_TEST_DIRECTORY"; then
         cd $SHARNESS_TEST_DIRECTORY
     fi
+    timeout="-o -Sinit.rc2_timeout=300"
+    if test -n "$FLUX_TEST_DISABLE_TIMEOUT"; then
+        timeout=""
+    fi
 
     if test "$personality" = "minimal"; then
         export FLUX_RC1_PATH=""
         export FLUX_RC3_PATH=""
     elif test "$personality" != "full"; then
         export FLUX_RC1_PATH=$FLUX_SOURCE_DIR/t/rc/rc1-$personality
-        export FLUX_RC3_PATH=""
-        test -x $FLUX_RC1_PATH || error "$FLUX_RC1_PATH"
+        export FLUX_RC3_PATH=$FLUX_SOURCE_DIR/t/rc/rc3-$personality
+        test -x $FLUX_RC1_PATH || error "cannot execute $FLUX_RC1_PATH"
+        test -x $FLUX_RC3_PATH || error "cannot execute $FLUX_RC3_PATH"
     else
         unset FLUX_RC1_PATH
         unset FLUX_RC3_PATH
     fi
 
+    logopts="-o -Slog-filename=${log_file},-Slog-forward-level=7"
     TEST_UNDER_FLUX_ACTIVE=t \
     TERM=${ORIGINAL_TERM} \
-      exec flux start --size=${size} ${quiet} "sh $0 ${flags}"
+      exec flux start --bootstrap=selfpmi --size=${size} ${logopts} ${timeout} \
+                     "sh $0 ${flags}"
 }
 
 mock_bootstrap_instance() {
@@ -98,4 +139,7 @@ if ! lua -e 'require "posix"'; then
     error "failed to find lua posix module in path"
 fi
 
+#  Some tests in flux don't work with --chain-lint, add a prereq for
+#   --no-chain-lint:
+test "$chain_lint" = "t" || test_set_prereq NO_CHAIN_LINT
 # vi: ts=4 sw=4 expandtab

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -48,4 +48,8 @@ test_expect_success 'get_instance_size works' '
 	test "$(get_instance_size)" = "$SIZE" &&
 	test "$(get_instance_size)" = "$(get_instance_size)"
 '
+
+test_expect_success 'sched: module remove' '
+	flux module remove sched
+'
 test_done

--- a/t/t0003-basic-install.t
+++ b/t/t0003-basic-install.t
@@ -30,4 +30,8 @@ test_expect_success 'sched: module remove/load works with installed sched' '
 	flux module load sched
 '
 
+test_expect_success 'sched: module unload' '
+	flux module remove sched
+'
+
 test_done

--- a/t/t1000-jsc.t
+++ b/t/t1000-jsc.t
@@ -104,4 +104,8 @@ EOF
     test_cmp expected4.sort output.$(get_session).cp.sort 
 '
 
+test_expect_success 'jsc: unloaded sched module' '
+    flux module remove sched
+'
+
 test_done

--- a/t/t1001-rs2rank-basic.t
+++ b/t/t1001-rs2rank-basic.t
@@ -123,6 +123,10 @@ test_expect_success 'rs2rank: can handle sierra nodes with group type' '
     verify_1N_nproc_sleep_jobs ${excl_4N4B_nc_sierra}
 '
 
+test_expect_success 'rs2rank: unloaded sched module' '
+    flux module remove sched
+'
+
 
 test_done
 

--- a/t/t1005-sched-params.t
+++ b/t/t1005-sched-params.t
@@ -106,4 +106,9 @@ sched-params=queue-depth=2048,delay-sched=false &&
     verify_1N_nproc_sleep_jobs ${excl_4N4B_nc} 
 '
 
+test_expect_success 'sched-params: unloaded sched module' '
+    flux module remove sched
+'
+
+
 test_done

--- a/t/t1007-exclude.t
+++ b/t/t1007-exclude.t
@@ -97,4 +97,8 @@ test_expect_success 'attempting to exclude or include an invalid node must fail'
     test_must_fail flux wreck include foo
 '
 
+test_expect_success 'unloaded sched module' '
+    flux module remove sched
+'
+
 test_done

--- a/t/t2000-fcfs.t
+++ b/t/t2000-fcfs.t
@@ -48,4 +48,12 @@ test_expect_success 'jobs scheduled in correct order' '
     diff -u ${expected_order} ./actual
 '
 
+test_expect_success 'sim: unloaded' '
+    flux module remove sched &&
+    flux module remove sim_exec &&
+    flux module remove submit &&
+    flux module remove sim
+'
+
+
 test_done

--- a/t/t2001-fcfs-aware.t
+++ b/t/t2001-fcfs-aware.t
@@ -48,4 +48,11 @@ test_expect_success 'jobs scheduled in correct order' '
     test_cmp ${expected_order} ./actual
 '
 
+test_expect_success 'sim: unloaded' '
+    flux module remove sim_exec &&
+    flux module remove submit &&
+    flux module remove sim &&
+    flux module remove sched
+'
+
 test_done

--- a/t/t2002-easy.t
+++ b/t/t2002-easy.t
@@ -47,4 +47,12 @@ test_expect_success 'jobs scheduled in correct order' '
    diff -u ${expected_order} ./actual
 '
 
+test_expect_success 'sim: unloaded' '
+    flux module remove sched
+    flux module remove sim_exec &&
+    flux module remove submit &&
+    flux module remove sim
+'
+
+
 test_done

--- a/t/t2003-fcfs-inorder.t
+++ b/t/t2003-fcfs-inorder.t
@@ -48,4 +48,11 @@ test_expect_success 'jobs scheduled in correct order with queue-depth=1' '
     diff -u ${expected_order} ./actual
 '
 
+test_expect_success 'sim: unloaded' '
+    flux module remove sim_exec &&
+    flux module remove submit &&
+    flux module remove sim &&
+    flux module remove sched
+'
+
 test_done


### PR DESCRIPTION
This PR syncs `t/sharness.d/flux-sharness.sh` with the version in flux-core.

The `flux-broker --quiet` option was removed recently flux-core, but sched's version of `flux-sharness.sh`  was still using it, resulting in sadness.  Rather than making a small change to sched's verison, I copied over core's version including some other changes.

One such change is a test that any modules loaded within a sharness script are unloaded when the script exits.  This necessitated trivial additions to some tests.