### PR TITLE
Refactor the new scheduling infrastructure code + cleanup

### DIFF
--- a/resource/Makefile.am
+++ b/resource/Makefile.am
@@ -44,6 +44,7 @@ utilities_resource_query_SOURCES = \
     dfu_traverse_impl.cpp \
     resource_gen.cpp \
     resource_gen_spec.cpp \
+    color.cpp \
     scoring_api.cpp \
     edge_eval_api.cpp \
     utilities/command.hpp \
@@ -52,6 +53,7 @@ utilities_resource_query_SOURCES = \
     resource_data.hpp \
     resource_gen.hpp \
     resource_gen_spec.hpp \
+    color.hpp \
     dfu_traverse.hpp \
     dfu_traverse_impl.hpp \
     dfu_match_cb.hpp \

--- a/resource/Makefile.am
+++ b/resource/Makefile.am
@@ -40,6 +40,9 @@ utilities_grug2dot_LDADD = \
 utilities_resource_query_SOURCES = \
     utilities/resource-query.cpp \
     utilities/command.cpp \
+    resource_data.cpp \
+    infra_data.cpp \
+    sched_data.cpp \
     dfu_traverse.cpp \
     dfu_traverse_impl.cpp \
     resource_gen.cpp \
@@ -50,6 +53,9 @@ utilities_resource_query_SOURCES = \
     utilities/command.hpp \
     dfu_match_id_based.hpp \
     resource_graph.hpp \
+    data_std.hpp \
+    infra_data.hpp \
+    sched_data.hpp \
     resource_data.hpp \
     resource_gen.hpp \
     resource_gen_spec.hpp \

--- a/resource/Makefile.am
+++ b/resource/Makefile.am
@@ -44,6 +44,8 @@ utilities_resource_query_SOURCES = \
     dfu_traverse_impl.cpp \
     resource_gen.cpp \
     resource_gen_spec.cpp \
+    scoring_api.cpp \
+    edge_eval_api.cpp \
     utilities/command.hpp \
     dfu_match_id_based.hpp \
     resource_graph.hpp \
@@ -56,6 +58,8 @@ utilities_resource_query_SOURCES = \
     matcher_data.hpp \
     system_defaults.hpp \
     scoring_api.hpp \
+    edge_eval_api.hpp \
+    fold.hpp \
     planner/planner.h
 utilities_resource_query_CXXFLAGS = \
     $(AM_CXXFLAGS) \

--- a/resource/color.cpp
+++ b/resource/color.cpp
@@ -1,0 +1,74 @@
+/*****************************************************************************\
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include "color.hpp"
+
+namespace Flux {
+namespace resource_model {
+
+void color_t::reset ()
+{
+    m_color_base += static_cast<uint64_t>(color_offset_t::NEW_BASE);
+}
+
+bool color_t::is_white (uint64_t c) const
+{
+    return c <= (m_color_base
+                 + static_cast<uint64_t>(color_offset_t::WHITE_OFFSET));
+}
+
+bool color_t::is_gray (uint64_t c) const
+{
+    return c == (m_color_base
+                 + static_cast<uint64_t>(color_offset_t::GRAY_OFFSET));
+}
+
+bool color_t::is_black (uint64_t c) const
+{
+    return c == (m_color_base
+                 + static_cast<uint64_t>(color_offset_t::BLACK_OFFSET));
+}
+
+uint64_t color_t::white () const
+{
+    return m_color_base
+           + static_cast<uint64_t>(color_offset_t::WHITE_OFFSET);
+}
+
+uint64_t color_t::gray () const
+{
+    return m_color_base
+           + static_cast<uint64_t>(color_offset_t::GRAY_OFFSET);
+}
+
+uint64_t color_t::black () const
+{
+    return m_color_base
+           + static_cast<uint64_t>(color_offset_t::BLACK_OFFSET);
+}
+
+} // resource_model
+} // Flux
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/color.hpp
+++ b/resource/color.hpp
@@ -1,0 +1,63 @@
+/*****************************************************************************\
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef COLOR_H
+#define COLOR_H
+
+#include <cstdint>
+
+namespace Flux {
+namespace resource_model {
+
+class color_t {
+public:
+    enum class color_offset_t : uint64_t {
+        WHITE_OFFSET = 0,
+        GRAY_OFFSET = 1,
+        BLACK_OFFSET = 2,
+        NEW_BASE = 3
+    };
+
+    // compiler will generate correct constructors and destructor
+
+    void reset ();
+
+    bool is_white (uint64_t c) const;
+    bool is_gray (uint64_t c) const;
+    bool is_black (uint64_t c) const;
+
+    uint64_t white () const;
+    uint64_t gray () const;
+    uint64_t black () const;
+
+private:
+    uint64_t m_color_base = 0;
+};
+
+} // resource_model
+} // Flux
+
+#endif // COLOR_H
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/data_std.hpp
+++ b/resource/data_std.hpp
@@ -1,0 +1,51 @@
+/*****************************************************************************\
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef DATA_STD_H
+#define DATA_STD_H
+
+#include <set>
+#include <string>
+
+namespace Flux {
+namespace resource_model {
+
+// We create an x_checker planner for each resource vertex for quick exclusivity
+// checking. We update x_checker for all of the vertices involved in each
+// job allocation/reservation -- subtract 1 from x_checker planner for the
+// scheduled span. Any vertex with less than X_CHECKER_NJOBS available in its
+// x_checker cannot be exclusively allocated or reserved.
+const char * const X_CHECKER_JOBS_STR = "jobs";
+const int64_t X_CHECKER_NJOBS = 0x40000000;
+
+typedef std::string subsystem_t;
+typedef std::map<subsystem_t, std::string> multi_subsystems_t;
+typedef std::map<subsystem_t, std::set<std::string>> multi_subsystemsS;
+
+} // Flux
+} // Flux::resource_model
+
+#endif // DATA_STD_H
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/data_std.hpp
+++ b/resource/data_std.hpp
@@ -37,9 +37,9 @@ namespace resource_model {
 const char * const X_CHECKER_JOBS_STR = "jobs";
 const int64_t X_CHECKER_NJOBS = 0x40000000;
 
-typedef std::string subsystem_t;
-typedef std::map<subsystem_t, std::string> multi_subsystems_t;
-typedef std::map<subsystem_t, std::set<std::string>> multi_subsystemsS;
+using subsystem_t = std::string;
+using multi_subsystems_t = std::map<subsystem_t, std::string>;
+using multi_subsystemsS = std::map<subsystem_t, std::set<std::string>>;
 
 } // Flux
 } // Flux::resource_model

--- a/resource/edge_eval_api.cpp
+++ b/resource/edge_eval_api.cpp
@@ -1,0 +1,204 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include "edge_eval_api.hpp"
+
+namespace Flux {
+namespace resource_model {
+
+
+/****************************************************************************
+ *                                                                          *
+ *                  Edge Evaluator Public Method Definitions                *
+ *                                                                          *
+ ****************************************************************************/
+
+eval_edg_t::eval_edg_t (unsigned int c, unsigned int n, unsigned int x, edg_t e)
+                        : count (c), needs (n), exclusive (x), edge (e)
+{
+
+}
+
+eval_edg_t::eval_edg_t (unsigned int c, unsigned int n, unsigned int x)
+                        : count (c), needs (n), exclusive (x)
+{
+
+}
+
+
+eval_egroup_t::eval_egroup_t ()
+{
+
+}
+
+eval_egroup_t::eval_egroup_t (int64_t s, unsigned int c, unsigned int n,
+                              unsigned int x, bool r)
+                              : score (s), count (c), needs (n), exclusive (x),
+                                root (r)
+{
+
+}
+
+eval_egroup_t::eval_egroup_t (const eval_egroup_t &o)
+{
+    score = o.score;
+    count = o.count;
+    needs = o.needs;
+    exclusive = o.exclusive;
+    root = o.root;
+    edges = o.edges;
+}
+
+eval_egroup_t &eval_egroup_t::operator= (const eval_egroup_t &o)
+{
+    score = o.score;
+    count = o.count;
+    needs = o.needs;
+    exclusive = o.exclusive;
+    root = o.root;
+    edges = o.edges;
+    return *this;
+}
+
+
+namespace detail {
+
+evals_t::evals_t ()
+{
+
+}
+
+evals_t::evals_t (int64_t cutline, const std::string &res_type)
+                  : m_resrc_type (res_type), m_cutline (cutline)
+{
+
+}
+
+
+evals_t::evals_t (const std::string &res_type)
+                  : m_resrc_type (res_type)
+{
+
+}
+
+evals_t::evals_t (const evals_t &o)
+{
+    m_eval_egroups = o.m_eval_egroups;
+    m_resrc_type = o.m_resrc_type;
+    m_cutline = o.m_cutline;
+    m_qual_count = o.m_qual_count;
+    m_total_count = o.m_total_count;
+    m_best_k = o.m_best_k;
+    m_best_i = o.m_best_i;
+}
+
+evals_t::~evals_t ()
+{
+    m_eval_egroups.clear ();
+}
+
+evals_t &evals_t::operator= (const evals_t &o)
+{
+    m_eval_egroups = o.m_eval_egroups;
+    m_resrc_type = o.m_resrc_type;
+    m_cutline = o.m_cutline;
+    m_qual_count = o.m_qual_count;
+    m_total_count = o.m_total_count;
+    m_best_k = o.m_best_k;
+    m_best_i = o.m_best_i;
+    return *this;
+}
+
+unsigned int evals_t::add (const eval_egroup_t &eg)
+{
+    m_total_count += eg.count;
+    if (eg.score > m_cutline)
+        m_qual_count += eg.count;
+    m_eval_egroups.push_back (eg);
+    return m_qual_count;
+}
+
+const eval_egroup_t &evals_t::at (unsigned int i) const
+{
+    return m_eval_egroups.at (i);
+}
+
+unsigned int evals_t::qualified_count () const
+{
+    return m_qual_count;
+}
+
+unsigned int evals_t::total_count () const
+{
+    return m_total_count;
+}
+
+int64_t evals_t::cutline () const
+{
+    return m_cutline;
+}
+
+int64_t evals_t::set_cutline (int64_t cutline)
+{
+    int64_t rc = m_cutline;
+    m_cutline = cutline;
+    return rc;
+}
+
+unsigned int evals_t::best_k () const
+{
+    return m_best_k;
+}
+
+unsigned int evals_t::best_i () const
+{
+    return m_best_i;
+}
+
+int evals_t::merge (evals_t &o)
+{
+    if (m_cutline != o.m_cutline || m_resrc_type != o.m_resrc_type) {
+        errno = EINVAL;
+        return -1;
+    }
+    m_qual_count += o.m_qual_count;
+    m_total_count += o.m_total_count;
+    m_cutline = o.m_cutline;
+    m_eval_egroups.insert (m_eval_egroups.end (), o.m_eval_egroups.begin (),
+                           o.m_eval_egroups.end ());
+    return 0;
+}
+
+void evals_t::rewind_iter_cur ()
+{
+    iter_cur = m_eval_egroups.begin ();
+}
+
+} // Flux::resource_model::detail
+} // Flux::resource_model
+} // Flux
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/edge_eval_api.hpp
+++ b/resource/edge_eval_api.hpp
@@ -1,0 +1,152 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef EDGE_EVAL_API_HPP
+#define EDGE_EVAL_API_HPP
+
+#include <vector>
+#include <string>
+#include "resource_graph.hpp"
+
+namespace Flux {
+namespace resource_model {
+
+struct eval_edg_t {
+    eval_edg_t (unsigned int c, unsigned int n, unsigned int x, edg_t e);
+    eval_edg_t (unsigned int c, unsigned int n, unsigned int x);
+    // compiler willl generate a correct copy constructor
+
+    unsigned int count = 0;
+    unsigned int needs = 0;
+    unsigned int exclusive = 0;
+    edg_t edge;
+};
+
+struct eval_egroup_t {
+    eval_egroup_t ();
+    eval_egroup_t (int64_t s, unsigned int c, unsigned int n,
+                   unsigned int x, bool r);
+    eval_egroup_t (const eval_egroup_t &o);
+    eval_egroup_t &operator= (const eval_egroup_t &o);
+
+    int64_t score = -1;
+    unsigned int count = 0;
+    unsigned int needs = 0;
+    unsigned int exclusive = 0;
+    bool root = false;
+    std::vector<eval_edg_t> edges;
+};
+
+namespace detail {
+
+class evals_t {
+public:
+    evals_t ();
+    evals_t (int64_t cutline, const std::string &res_type);
+    evals_t (const std::string &res_type);
+    evals_t (const evals_t &o);
+    ~evals_t ();
+    evals_t &operator= (const evals_t &o);
+
+    unsigned int add (const eval_egroup_t &eg);
+    // This can throw out_of_range exception
+    const eval_egroup_t &at (unsigned int i) const;
+    unsigned int qualified_count () const;
+    unsigned int total_count () const;
+    int64_t cutline () const;
+    int64_t set_cutline (int64_t cutline);
+    unsigned int best_k () const;
+    unsigned int best_i () const;
+    int merge (evals_t &o);
+    void rewind_iter_cur ();
+
+    template<class compare_op>
+    int choose_best_k (unsigned int k, compare_op comp)
+    {
+        if (k == 0 || k > m_qual_count) {
+            errno = EINVAL;
+            return -1;
+        }
+
+        unsigned int i = 0;
+        int old = (int)m_best_k;
+        int to_be_selected = k;
+        std::sort (m_eval_egroups.begin (), m_eval_egroups.end (), comp);
+        while (to_be_selected > 0) {
+            if (to_be_selected <= (int)m_eval_egroups[i].count)
+                m_eval_egroups[i].needs = to_be_selected;
+            else
+                m_eval_egroups[i].needs = m_eval_egroups[i].count;
+
+            to_be_selected -= m_eval_egroups[i].count;
+            i++;
+        }
+        m_best_k = k;
+        m_best_i = i;
+        return old;
+    }
+
+    template<class binary_op>
+    int64_t accum_best_k (binary_op accum, int init=0)
+    {
+        if (m_best_k == 0 || m_best_i == 0) {
+            errno = EINVAL;
+            return -1;
+        }
+        int64_t score_accum = init;
+        for (unsigned int i = 0; i < m_best_i; i++)
+            score_accum = accum (score_accum, m_eval_egroups[i]);
+        return score_accum;
+    }
+
+    template<class output_it, class unary_op>
+    output_it transform (output_it o_it, unary_op uop)
+    {
+        return std::transform (m_eval_egroups.begin (),
+                               m_eval_egroups.end (),
+                               o_it, uop);
+    }
+
+    std::vector<eval_egroup_t>::iterator iter_cur;
+
+private:
+    std::vector<eval_egroup_t> m_eval_egroups;
+    std::string m_resrc_type;
+    int64_t m_cutline = 0;
+    unsigned int m_qual_count = 0;
+    unsigned int m_total_count = 0;
+    unsigned int m_best_k = 0;      //<! best-k to be selected
+    unsigned int m_best_i = 0;      //<! first i elements in has best-k
+};
+
+} // namespace detail
+
+} // namesapce resource_model
+} // namespace Flux
+
+#endif // EDGE_EVAL_API_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/fold.hpp
+++ b/resource/fold.hpp
@@ -1,0 +1,89 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef FOLD_HPP
+#define FOLD_HPP
+
+#include <boost/icl/interval.hpp>
+#include <boost/icl/interval_set.hpp>
+#include "edge_eval_api.hpp"
+
+namespace Flux {
+namespace resource_model {
+
+namespace fold {
+struct greater {
+    bool operator() (const eval_egroup_t &a, const eval_egroup_t &b) const
+    {
+        return a.score > b.score;
+    }
+};
+
+struct less {
+    bool operator() (const eval_egroup_t &a, const eval_egroup_t &b) const
+    {
+        return a.score < b.score;
+    }
+};
+
+struct interval_greater {
+    bool operator() (const eval_egroup_t &a, const eval_egroup_t &b) const
+    {
+        return *(ivset.find (a.score)) > *(ivset.find (b.score));
+    }
+    boost::icl::interval_set<int64_t> ivset;
+};
+
+struct interval_less {
+    bool operator() (const eval_egroup_t &a, const eval_egroup_t &b) const
+    {
+        return *(ivset.find (a.score)) < *(ivset.find (b.score));
+    }
+    boost::icl::interval_set<int64_t> ivset;
+};
+
+struct plus {
+    const int64_t operator() (const int64_t result,
+                              const eval_egroup_t &a) const
+    {
+        return result + a.score;
+    }
+};
+inline boost::icl::interval_set<int64_t>::interval_type to_interval (
+                                                     const eval_egroup_t &ev)
+{
+    using namespace boost::icl;
+    int64_t tmp = ev.score;
+    return interval_set<int64_t>::interval_type::closed (tmp, tmp);
+}
+} // namespace fold
+
+} // namespace resource_model
+} // namesapce Flux
+
+#endif // FOLD_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/infra_data.cpp
+++ b/resource/infra_data.cpp
@@ -1,0 +1,166 @@
+/*****************************************************************************\
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include "infra_data.hpp"
+
+namespace Flux {
+namespace resource_model {
+
+
+/****************************************************************************
+ *                                                                          *
+ *   Public Methods on the Data Belonging to the Scheduler Infrastructure   *
+ *                                                                          *
+ ****************************************************************************/
+
+infra_base_t::infra_base_t ()
+{
+
+}
+
+infra_base_t::infra_base_t (const infra_base_t &o)
+{
+    member_of = o.member_of;
+}
+
+infra_base_t &infra_base_t::operator= (const infra_base_t &o)
+{
+    member_of = o.member_of;
+    return *this;
+}
+
+infra_base_t::~infra_base_t ()
+{
+
+}
+
+
+/****************************************************************************
+ *                                                                          *
+ *        Public Methods on Infrastructure Data for Resource Pool           *
+ *                                                                          *
+ ****************************************************************************/
+
+pool_infra_t::pool_infra_t ()
+{
+
+}
+
+pool_infra_t::pool_infra_t (const pool_infra_t &o): infra_base_t (o)
+{
+   // don't copy the content of infrastructure tables and subtree
+   // planner objects.
+   colors = o.colors;
+   for (auto &kv : o.subplans) {
+       planner_t *p = kv.second;
+       if (!p)
+           continue;
+       int64_t base_time = planner_base_time (p);
+       uint64_t duration = planner_duration (p);
+       size_t len = planner_resources_len (p);
+       subplans[kv.first] = planner_new (base_time, duration,
+                                planner_resource_totals (p),
+                                planner_resource_types (p), len);
+   }
+}
+
+pool_infra_t &pool_infra_t::operator= (const pool_infra_t &o)
+{
+    // don't copy the content of infrastructure tables and subtree
+    // planner objects.
+    infra_base_t::operator= (o);
+    colors = o.colors;
+    for (auto &kv : o.subplans) {
+        planner_t *p = kv.second;
+        if (!p)
+            continue;
+        int64_t base_time = planner_base_time (p);
+        uint64_t duration = planner_duration (p);
+        size_t len = planner_resources_len (p);
+        subplans[kv.first] = planner_new (base_time, duration,
+                                 planner_resource_totals (p),
+                                 planner_resource_types (p), len);
+    }
+    return *this;
+}
+
+pool_infra_t::~pool_infra_t ()
+{
+    for (auto &kv : subplans)
+        planner_destroy (&(kv.second));
+}
+
+void pool_infra_t::scrub ()
+{
+    job2span.clear ();
+    for (auto &kv : subplans)
+        planner_destroy (&(kv.second));
+    colors.clear ();
+}
+
+
+/****************************************************************************
+ *                                                                          *
+ *      Public Methods on Infrastructure Data for Resource Relation         *
+ *                                                                          *
+ ****************************************************************************/
+
+relation_infra_t::relation_infra_t ()
+{
+
+}
+
+relation_infra_t::relation_infra_t (const relation_infra_t &o): infra_base_t (o)
+{
+    needs = o.needs;
+    best_k_cnt = o.best_k_cnt;
+    exclusive = o.exclusive;
+}
+
+relation_infra_t &relation_infra_t::operator= (const relation_infra_t &o)
+{
+    infra_base_t::operator= (o);
+    needs = o.needs;
+    best_k_cnt = o.best_k_cnt;
+    exclusive = o.exclusive;
+    return *this;
+}
+
+relation_infra_t::~relation_infra_t ()
+{
+
+}
+
+void relation_infra_t::scrub ()
+{
+    needs = 0;
+    best_k_cnt = 0;
+    exclusive = 0;
+}
+
+
+} // resource_model
+} // Flux
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/infra_data.hpp
+++ b/resource/infra_data.hpp
@@ -1,0 +1,78 @@
+/*****************************************************************************\
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef INFRA_DATA_HPP
+#define INFRA_DATA_HPP
+
+#include <map>
+#include <cstdint>
+#include "data_std.hpp"
+#include "planner/planner.h"
+
+namespace Flux {
+namespace resource_model {
+
+/*! Base type to organize the data supporting scheduling infrastructure's
+ * operations (e.g., graph organization, coloring and edge evaluation).
+ */
+struct infra_base_t {
+    infra_base_t ();
+    infra_base_t (const infra_base_t &o);
+    infra_base_t &operator= (const infra_base_t &o);
+    virtual ~infra_base_t ();
+    virtual void scrub () = 0;
+
+    multi_subsystems_t member_of;
+};
+
+struct pool_infra_t : public infra_base_t {
+    pool_infra_t ();
+    pool_infra_t (const pool_infra_t &o);
+    pool_infra_t &operator= (const pool_infra_t &o);
+    virtual ~pool_infra_t ();
+    virtual void scrub ();
+
+    std::map<int64_t, int64_t> job2span;
+    std::map<subsystem_t, planner_t *> subplans;
+    std::map<subsystem_t, uint64_t> colors;
+};
+
+struct relation_infra_t : public infra_base_t {
+    relation_infra_t ();
+    relation_infra_t (const relation_infra_t &o);
+    relation_infra_t &operator= (const relation_infra_t &o);
+    virtual ~relation_infra_t ();
+    virtual void scrub ();
+
+    uint64_t needs = 0;
+    uint64_t best_k_cnt = 0;
+    int exclusive = 0;
+};
+
+} // Flux::resource_model
+} // Flux
+
+#endif // INFRA_DATA_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/resource_data.cpp
+++ b/resource/resource_data.cpp
@@ -1,0 +1,113 @@
+/*****************************************************************************\
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include "resource_data.hpp"
+
+namespace Flux {
+namespace resource_model {
+
+
+/****************************************************************************
+ *                                                                          *
+ *                     Resource Pool Method Definitions                     *
+ *                                                                          *
+ ****************************************************************************/
+
+resource_pool_t::resource_pool_t ()
+{
+
+}
+
+resource_pool_t::resource_pool_t (const resource_pool_t &o)
+{
+    type = o.type;
+    paths = o.paths;
+    basename = o.basename;
+    name = o.name;
+    properties = o.properties;
+    id = o.id;
+    memcpy (uuid, o.uuid, sizeof (uuid));
+    size = o.size;
+    unit = o.unit;
+    schedule = o.schedule;
+    idata = o.idata;
+}
+
+resource_pool_t &resource_pool_t::operator= (const resource_pool_t &o)
+{
+    type = o.type;
+    paths = o.paths;
+    basename = o.basename;
+    name = o.name;
+    properties = o.properties;
+    id = o.id;
+    memcpy (uuid, o.uuid, sizeof (uuid));
+    size = o.size;
+    unit = o.unit;
+    schedule = o.schedule;
+    idata = o.idata;
+    return *this;
+}
+
+resource_pool_t::~resource_pool_t ()
+{
+
+}
+
+
+/****************************************************************************
+ *                                                                          *
+ *                     Resource Relation Method Definitions                 *
+ *                                                                          *
+ ****************************************************************************/
+
+resource_relation_t::resource_relation_t ()
+{
+
+}
+
+resource_relation_t::resource_relation_t (const resource_relation_t &o)
+{
+    name = o.name;
+    idata = o.idata;
+}
+
+resource_relation_t &resource_relation_t::operator= (
+                                              const resource_relation_t &o)
+{
+    name = o.name;
+    idata = o.idata;
+    return *this;
+}
+
+resource_relation_t::~resource_relation_t ()
+{
+
+}
+
+
+} // Flux::resource_model
+} // Flux
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/resource_data.hpp
+++ b/resource/resource_data.hpp
@@ -29,236 +29,20 @@
 #include <map>
 #include <set>
 #include "color.hpp"
+#include "data_std.hpp"
+#include "sched_data.hpp"
+#include "infra_data.hpp"
 #include "planner/planner.h"
 
 namespace Flux {
 namespace resource_model {
 
-// We create an x_checker planner for each resource vertex for quick exclusivity
-// checking. We update x_checker for all of the vertices involved in each
-// job allocation/reservation -- subtract 1 from x_checker planner for the
-// scheduled span. Any vertex with less than X_CHECKER_NJOBS available in its
-// x_checker cannot be exclusively allocated or reserved.
-const char * const X_CHECKER_JOBS_STR = "jobs";
-const int64_t X_CHECKER_NJOBS = 0x40000000;
-
-typedef std::string subsystem_t;
-typedef std::map<subsystem_t, std::string> multi_subsystems_t;
-typedef std::map<subsystem_t, std::set<std::string>> multi_subsystemsS;
-
-//! Type to keep track of current schedule state
-struct schedule_t {
-    schedule_t () { }
-    schedule_t (const schedule_t &o)
-    {
-        int64_t base_time = 0;
-        uint64_t duration = 0;
-        size_t len = 0;
-
-        // copy constructor does not copy the contents
-        // of the schedule tables and of the planner objects.
-        if (o.plans) {
-            base_time = planner_base_time (o.plans);
-            duration = planner_duration (o.plans);
-            len = planner_resources_len (o.plans);
-            plans = planner_new (base_time, duration,
-                                 planner_resource_totals (o.plans),
-                                 planner_resource_types (o.plans), len);
-        }
-        if (o.x_checker) {
-            base_time = planner_base_time (o.x_checker);
-            duration = planner_duration (o.x_checker);
-            len = planner_resources_len (o.x_checker);
-            x_checker = planner_new (base_time, duration,
-                                     planner_resource_totals (o.x_checker),
-                                     planner_resource_types (o.x_checker), len);
-        }
-    }
-    schedule_t &operator= (const schedule_t &o)
-    {
-        int64_t base_time = 0;
-        uint64_t duration = 0;
-        size_t len = 0;
-
-        // assign operator does not copy the contents
-        // of the schedule tables and of the planner objects.
-        if (o.plans) {
-            base_time = planner_base_time (o.plans);
-            duration = planner_duration (o.plans);
-            len = planner_resources_len (o.plans);
-            plans = planner_new (base_time, duration,
-                                 planner_resource_totals (o.plans),
-                                 planner_resource_types (o.plans), len);
-        }
-        if (o.x_checker) {
-            base_time = planner_base_time (o.x_checker);
-            duration = planner_duration (o.x_checker);
-            len = planner_resources_len (o.x_checker);
-            x_checker = planner_new (base_time, duration,
-                                     planner_resource_totals (o.x_checker),
-                                     planner_resource_types (o.x_checker), len);
-        }
-        return *this;
-    }
-    ~schedule_t ()
-    {
-        if (plans)
-            planner_destroy (&plans);
-        if (x_checker)
-            planner_destroy (&x_checker);
-    }
-
-    std::map<int64_t, int64_t> tags;
-    std::map<int64_t, int64_t> allocations;
-    std::map<int64_t, int64_t> reservations;
-    std::map<int64_t, int64_t> x_spans;
-    planner_t *plans = NULL;
-    planner_t *x_checker = NULL;
-};
-
-/*! Base type to organize the data supporting scheduling infrastructure's
- * operations (e.g., graph organization, coloring and edge evaluation).
- */
-struct infra_base_t {
-    infra_base_t () { }
-    infra_base_t (const infra_base_t &o)
-    {
-        member_of = o.member_of;
-    }
-    infra_base_t &operator= (const infra_base_t &o)
-    {
-        member_of = o.member_of;
-        return *this;
-    }
-    virtual ~infra_base_t () { }
-    virtual void scrub () = 0;
-
-    multi_subsystems_t member_of;
-};
-
-struct pool_infra_t : public infra_base_t {
-    pool_infra_t () { }
-    pool_infra_t (const pool_infra_t &o): infra_base_t (o)
-    {
-        // don't copy the content of infrastructure tables and subtree
-        // planner objects.
-        colors = o.colors;
-        for (auto &kv : o.subplans) {
-            planner_t *p = kv.second;
-            if (!p)
-                continue;
-            int64_t base_time = planner_base_time (p);
-            uint64_t duration = planner_duration (p);
-            size_t len = planner_resources_len (p);
-            subplans[kv.first] = planner_new (base_time, duration,
-                                     planner_resource_totals (p),
-                                     planner_resource_types (p), len);
-        }
-    }
-    pool_infra_t &operator= (const pool_infra_t &o)
-    {
-        // don't copy the content of infrastructure tables and subtree
-        // planner objects.
-        infra_base_t::operator= (o);
-        colors = o.colors;
-        for (auto &kv : o.subplans) {
-            planner_t *p = kv.second;
-            if (!p)
-                continue;
-            int64_t base_time = planner_base_time (p);
-            uint64_t duration = planner_duration (p);
-            size_t len = planner_resources_len (p);
-            subplans[kv.first] = planner_new (base_time, duration,
-                                     planner_resource_totals (p),
-                                     planner_resource_types (p), len);
-        }
-        return *this;
-    }
-    virtual ~pool_infra_t ()
-    {
-        for (auto &kv : subplans)
-            planner_destroy (&(kv.second));
-    }
-    virtual void scrub ()
-    {
-        job2span.clear ();
-        for (auto &kv : subplans)
-            planner_destroy (&(kv.second));
-        colors.clear ();
-    }
-
-    std::map<int64_t, int64_t> job2span;
-    std::map<subsystem_t, planner_t *> subplans;
-    std::map<subsystem_t, uint64_t> colors;
-};
-
-struct relation_infra_t : public infra_base_t {
-    relation_infra_t () { }
-    relation_infra_t (const relation_infra_t &o): infra_base_t (o)
-    {
-        needs = o.needs;
-        best_k_cnt = o.best_k_cnt;
-        exclusive = o.exclusive;
-    }
-    relation_infra_t &operator= (const relation_infra_t &o)
-    {
-        infra_base_t::operator= (o);
-        needs = o.needs;
-        best_k_cnt = o.best_k_cnt;
-        exclusive = o.exclusive;
-        return *this;
-    }
-    virtual ~relation_infra_t ()
-    {
-
-    }
-    virtual void scrub ()
-    {
-        needs = 0;
-        best_k_cnt = 0;
-        exclusive = 0;
-    }
-
-    uint64_t needs = 0;
-    uint64_t best_k_cnt = 0;
-    int exclusive = 0;
-};
-
 //! Resource pool data type
 struct resource_pool_t {
-    resource_pool_t () { }
-    resource_pool_t (const resource_pool_t &o)
-    {
-        type = o.type;
-        paths = o.paths;
-        basename = o.basename;
-        name = o.name;
-        properties = o.properties;
-        id = o.id;
-        memcpy (uuid, o.uuid, sizeof (uuid));
-        size = o.size;
-        unit = o.unit;
-        schedule = o.schedule;
-        idata = o.idata;
-    }
-    resource_pool_t &operator= (const resource_pool_t &o)
-    {
-        type = o.type;
-        paths = o.paths;
-        basename = o.basename;
-        name = o.name;
-        properties = o.properties;
-        id = o.id;
-        memcpy (uuid, o.uuid, sizeof (uuid));
-        size = o.size;
-        unit = o.unit;
-        schedule = o.schedule;
-        idata = o.idata;
-        return *this;
-    }
-    ~resource_pool_t ()
-    {
-    }
+    resource_pool_t ();
+    resource_pool_t (const resource_pool_t &o);
+    resource_pool_t &operator= (const resource_pool_t &o);
+    ~resource_pool_t ();
 
     // Resource pool data
     std::string type;
@@ -282,19 +66,10 @@ struct resource_pool_t {
  *  relationship within the same subsystem.
  */
 struct resource_relation_t {
-    resource_relation_t () { }
-    resource_relation_t (const resource_relation_t &o)
-    {
-        name = o.name;
-        idata = o.idata;
-    }
-    resource_relation_t &operator= (const resource_relation_t &o)
-    {
-        name = o.name;
-        idata = o.idata;
-        return *this;
-    }
-    ~resource_relation_t () { }
+    resource_relation_t ();
+    resource_relation_t (const resource_relation_t &o);
+    resource_relation_t &operator= (const resource_relation_t &o);
+    ~resource_relation_t ();
 
     std::string name;
     relation_infra_t idata; //!< scheduling infrastructure data

--- a/resource/resource_data.hpp
+++ b/resource/resource_data.hpp
@@ -28,6 +28,7 @@
 #include <cstring>
 #include <map>
 #include <set>
+#include "color.hpp"
 #include "planner/planner.h"
 
 namespace Flux {
@@ -44,54 +45,6 @@ const int64_t X_CHECKER_NJOBS = 0x40000000;
 typedef std::string subsystem_t;
 typedef std::map<subsystem_t, std::string> multi_subsystems_t;
 typedef std::map<subsystem_t, std::set<std::string>> multi_subsystemsS;
-
-class color_t {
-public:
-    enum class color_offset_t : uint64_t {
-        WHITE_OFFSET = 0,
-        GRAY_OFFSET = 1,
-        BLACK_OFFSET = 2,
-        NEW_BASE = 3
-    };
-
-    void reset ()
-    {
-        m_color_base += static_cast<uint64_t>(color_offset_t::NEW_BASE);
-    }
-    bool is_white (uint64_t c) const
-    {
-        return c <= (m_color_base
-                     + static_cast<uint64_t>(color_offset_t::WHITE_OFFSET));
-    }
-    uint64_t white () const
-    {
-        return m_color_base
-               + static_cast<uint64_t>(color_offset_t::WHITE_OFFSET);
-    }
-    bool is_gray (uint64_t c) const
-    {
-        return c == (m_color_base
-                     + static_cast<uint64_t>(color_offset_t::GRAY_OFFSET));
-    }
-    uint64_t gray () const
-    {
-        return m_color_base
-               + static_cast<uint64_t>(color_offset_t::GRAY_OFFSET);
-    }
-    bool is_black (uint64_t c) const
-    {
-        return c == (m_color_base
-                     + static_cast<uint64_t>(color_offset_t::BLACK_OFFSET));
-    }
-    uint64_t black () const
-    {
-        return m_color_base
-               + static_cast<uint64_t>(color_offset_t::BLACK_OFFSET);
-    }
-
-private:
-    uint64_t m_color_base = 0;
-};
 
 //! Type to keep track of current schedule state
 struct schedule_t {

--- a/resource/resource_gen_spec.hpp
+++ b/resource/resource_gen_spec.hpp
@@ -64,30 +64,27 @@ struct relation_gen_t {
     int as_src_uplvl;
 };
 
-typedef boost::adjacency_list<
-    boost::vecS,
-    boost::vecS,
-    boost::directedS,
-    resource_pool_gen_t,
-    relation_gen_t
-> gg_t;
+using gg_t = boost::adjacency_list<boost::vecS,
+                                   boost::vecS,
+                                   boost::directedS,
+                                   resource_pool_gen_t,
+                                   relation_gen_t>;
+using pgen_t = std::string resource_pool_gen_t::*;
+using rgen_t = std::string relation_gen_t::*;
+using ggv_t = boost::graph_traits<gg_t>::vertex_descriptor;
+using gge_t = boost::graph_traits<gg_t>::edge_descriptor;
 
-typedef std::string resource_pool_gen_t::* pgen_t;
-typedef std::string relation_gen_t::* rgen_t;
-typedef boost::graph_traits<gg_t>::vertex_descriptor ggv_t;
-typedef boost::graph_traits<gg_t>::edge_descriptor gge_t;
-
-typedef boost::property_map<gg_t, pgen_t>::type vtx_type_map_t;
-typedef boost::property_map<gg_t, pgen_t>::type vtx_basename_map_t;
-typedef boost::property_map<gg_t, long resource_pool_gen_t::* >::type vtx_size_map_t;
-typedef boost::property_map<gg_t, pgen_t>::type vtx_unit_map_t;
-typedef boost::property_map<gg_t, pgen_t>::type vtx_subsystem_map_t;
-typedef boost::property_map<gg_t, rgen_t>::type edg_e_subsystem_map_t;
-typedef boost::property_map<gg_t, rgen_t>::type edg_relation_map_t;
-typedef boost::property_map<gg_t, rgen_t>::type edg_rrelation_map_t;
-typedef boost::property_map<gg_t, rgen_t>::type edg_gen_method_map_t;
-typedef boost::property_map<gg_t, rgen_t>::type edg_id_method_map_t;
-typedef boost::property_map<gg_t, int relation_gen_t::* >::type edg_multi_scale_map_t;
+using vtx_type_map_t = boost::property_map<gg_t, pgen_t>::type;
+using vtx_basename_map_t = boost::property_map<gg_t, pgen_t>::type;
+using vtx_size_map_t = boost::property_map<gg_t, long resource_pool_gen_t::* >::type;
+using vtx_unit_map_t = boost::property_map<gg_t, pgen_t>::type;
+using vtx_subsystem_map_t = boost::property_map<gg_t, pgen_t>::type;
+using edg_e_subsystem_map_t = boost::property_map<gg_t, rgen_t>::type;
+using edg_relation_map_t = boost::property_map<gg_t, rgen_t>::type;
+using edg_rrelation_map_t = boost::property_map<gg_t, rgen_t>::type;
+using edg_gen_method_map_t = boost::property_map<gg_t, rgen_t>::type;
+using edg_id_method_map_t = boost::property_map<gg_t, rgen_t>::type;
+using edg_multi_scale_map_t = boost::property_map<gg_t, int relation_gen_t::* >::type;
 
 class resource_gen_spec_t {
 public:

--- a/resource/resource_graph.hpp
+++ b/resource/resource_graph.hpp
@@ -37,13 +37,16 @@ namespace resource_model {
 
 enum class emit_format_t { GRAPHVIZ_DOT, GRAPH_ML, };
 
-typedef pool_infra_t resource_pool_t::* pinfra_t;
-typedef std::string resource_pool_t::* pname_t;
-typedef std::string resource_relation_t::* rname_t;
-typedef relation_infra_t resource_relation_t::* rinfra_t;
-
-typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::directedS, resource_pool_t,
-                       resource_relation_t, std::string>  resource_graph_t;
+using pinfra_t = pool_infra_t resource_pool_t::*;
+using pname_t  = std::string resource_pool_t::*;
+using rname_t  = std::string resource_relation_t::*;
+using rinfra_t = relation_infra_t resource_relation_t::*;
+using resource_graph_t = boost::adjacency_list<boost::vecS,
+                                               boost::vecS,
+                                               boost::directedS,
+                                               resource_pool_t,
+                                               resource_relation_t,
+                                               std::string>;
 
 /*! For each chosen subsystem, a selector has std::set<string>.
  *  If edge/vertex's member_of[subsystem] matches with one
@@ -85,25 +88,26 @@ private:
     inframap m_imap;
 };
 
-typedef boost::property_map<resource_graph_t, pinfra_t>::type    vtx_infra_map_t;
-typedef boost::property_map<resource_graph_t, rinfra_t>::type    edg_infra_map_t;
-typedef boost::graph_traits<resource_graph_t>::vertex_descriptor vtx_t;
-typedef boost::graph_traits<resource_graph_t>::edge_descriptor   edg_t;
-typedef boost::graph_traits<resource_graph_t>::vertex_iterator   vtx_iterator_t;
-typedef boost::graph_traits<resource_graph_t>::edge_iterator     edg_iterator_t;
-typedef boost::graph_traits<resource_graph_t>::out_edge_iterator out_edg_iterator_t;
-typedef boost::filtered_graph<resource_graph_t,
-                       subsystem_selector_t<edg_t, edg_infra_map_t>,
-                       subsystem_selector_t<vtx_t, vtx_infra_map_t>>
-                                                          f_resource_graph_t;
-typedef boost::property_map<f_resource_graph_t, rinfra_t>::type  f_edg_infra_map_t;
-typedef boost::property_map<f_resource_graph_t, pinfra_t>::type  f_vtx_infra_map_t;
-typedef boost::property_map<f_resource_graph_t, pname_t>::type   f_res_name_map_t;
-typedef boost::property_map<f_resource_graph_t, rname_t>::type   f_rel_name_map_t;
-typedef boost::property_map<f_resource_graph_t, pinfra_t>::type  f_vtx_infra_map_t;
-typedef boost::graph_traits<f_resource_graph_t>::vertex_iterator f_vtx_iterator_t;
-typedef boost::graph_traits<f_resource_graph_t>::edge_iterator   f_edg_iterator_t;
-typedef boost::graph_traits<f_resource_graph_t>::out_edge_iterator f_out_edg_iterator_t;
+using vtx_infra_map_t = boost::property_map<resource_graph_t, pinfra_t>::type;
+using edg_infra_map_t = boost::property_map<resource_graph_t, rinfra_t>::type;
+using vtx_t = boost::graph_traits<resource_graph_t>::vertex_descriptor;
+using edg_t = boost::graph_traits<resource_graph_t>::edge_descriptor;
+using vtx_iterator_t = boost::graph_traits<resource_graph_t>::vertex_iterator;
+using edg_iterator_t = boost::graph_traits<resource_graph_t>::edge_iterator;
+using out_edg_iterator_t = boost::graph_traits<resource_graph_t>::out_edge_iterator;
+using f_resource_graph_t = boost::filtered_graph<resource_graph_t,
+                                                 subsystem_selector_t<edg_t,
+                                                               edg_infra_map_t>,
+                                                 subsystem_selector_t<vtx_t,
+                                                               vtx_infra_map_t>>;
+using f_edg_infra_map_t = boost::property_map<f_resource_graph_t, rinfra_t>::type;
+using f_vtx_infra_map_t = boost::property_map<f_resource_graph_t, pinfra_t>::type;
+using f_res_name_map_t = boost::property_map<f_resource_graph_t, pname_t>::type;
+using f_rel_name_map_t = boost::property_map<f_resource_graph_t, rname_t>::type;
+using f_vtx_infra_map_t = boost::property_map<f_resource_graph_t, pinfra_t>::type;
+using f_vtx_iterator_t = boost::graph_traits<f_resource_graph_t>::vertex_iterator;
+using f_edg_iterator_t = boost::graph_traits<f_resource_graph_t>::edge_iterator;
+using f_out_edg_iterator_t = boost::graph_traits<f_resource_graph_t>::out_edge_iterator;
 
 /*! Resource graph data store.
  *  Adjacency_list graph, roots of this graph and various indexing.

--- a/resource/sched_data.cpp
+++ b/resource/sched_data.cpp
@@ -1,0 +1,99 @@
+/*****************************************************************************\
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include "sched_data.hpp"
+
+namespace Flux {
+namespace resource_model {
+
+schedule_t::schedule_t ()
+{
+
+}
+
+schedule_t::schedule_t (const schedule_t &o)
+{
+    int64_t base_time = 0;
+    uint64_t duration = 0;
+    size_t len = 0;
+
+    // copy constructor does not copy the contents
+    // of the schedule tables and of the planner objects.
+    if (o.plans) {
+        base_time = planner_base_time (o.plans);
+        duration = planner_duration (o.plans);
+        len = planner_resources_len (o.plans);
+        plans = planner_new (base_time, duration,
+                             planner_resource_totals (o.plans),
+                             planner_resource_types (o.plans), len);
+    }
+    if (o.x_checker) {
+        base_time = planner_base_time (o.x_checker);
+        duration = planner_duration (o.x_checker);
+        len = planner_resources_len (o.x_checker);
+        x_checker = planner_new (base_time, duration,
+                                 planner_resource_totals (o.x_checker),
+                                 planner_resource_types (o.x_checker), len);
+    }
+}
+
+schedule_t &schedule_t::operator= (const schedule_t &o)
+{
+    int64_t base_time = 0;
+    uint64_t duration = 0;
+    size_t len = 0;
+
+    // assign operator does not copy the contents
+    // of the schedule tables and of the planner objects.
+    if (o.plans) {
+        base_time = planner_base_time (o.plans);
+        duration = planner_duration (o.plans);
+        len = planner_resources_len (o.plans);
+        plans = planner_new (base_time, duration,
+                             planner_resource_totals (o.plans),
+                             planner_resource_types (o.plans), len);
+    }
+    if (o.x_checker) {
+        base_time = planner_base_time (o.x_checker);
+        duration = planner_duration (o.x_checker);
+        len = planner_resources_len (o.x_checker);
+        x_checker = planner_new (base_time, duration,
+                                 planner_resource_totals (o.x_checker),
+                                 planner_resource_types (o.x_checker), len);
+    }
+    return *this;
+}
+
+schedule_t::~schedule_t ()
+{
+    if (plans)
+        planner_destroy (&plans);
+    if (x_checker)
+        planner_destroy (&x_checker);
+}
+
+} // resource_model
+} // Flux
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/sched_data.hpp
+++ b/resource/sched_data.hpp
@@ -1,0 +1,52 @@
+/*****************************************************************************\
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef SCHED_DATA_H
+#define SCHED_DATA_H
+
+#include <map>
+#include <cstdint>
+#include "planner/planner.h"
+
+namespace Flux {
+namespace resource_model {
+
+//! Type to keep track of current schedule state
+struct schedule_t {
+    schedule_t ();
+    schedule_t (const schedule_t &o);
+    schedule_t &operator= (const schedule_t &o);
+    ~schedule_t ();
+
+    std::map<int64_t, int64_t> tags;
+    std::map<int64_t, int64_t> allocations;
+    std::map<int64_t, int64_t> reservations;
+    std::map<int64_t, int64_t> x_spans;
+    planner_t *plans = NULL;
+    planner_t *x_checker = NULL;
+};
+
+} // Flux::resource_model
+} // Flux
+
+#endif // SCHED_DATA_H
+

--- a/resource/scoring_api.cpp
+++ b/resource/scoring_api.cpp
@@ -1,0 +1,260 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include "scoring_api.hpp"
+
+namespace Flux {
+namespace resource_model {
+
+
+/****************************************************************************
+ *                                                                          *
+ *                    Scoring API Private Method Definitions                *
+ *                                                                          *
+ ****************************************************************************/
+
+void scoring_api_t::handle_new_keys (const subsystem_t &s,
+                                     const std::string &r)
+{
+    handle_new_subsystem (s);
+    handle_new_resrc_type (s, r);
+}
+
+void scoring_api_t::handle_new_subsystem (const subsystem_t &s)
+{
+    if (m_ssys_map.find (s) == m_ssys_map.end ()) {
+        auto o = new std::map<const std::string, detail::evals_t *>();
+        m_ssys_map.insert (std::make_pair (s, o));
+    }
+}
+
+void scoring_api_t::handle_new_resrc_type (const subsystem_t &s,
+                                           const std::string &r)
+{
+    if (m_ssys_map[s]->find (r) == m_ssys_map[s]->end ()) {
+        auto e = new detail::evals_t (r);
+        m_ssys_map[s]->insert (std::make_pair (r, e));
+    }
+}
+
+
+/****************************************************************************
+ *                                                                          *
+ *                    Scoring API Public Method Definitions                 *
+ *                                                                          *
+ ****************************************************************************/
+
+scoring_api_t::scoring_api_t ()
+{
+
+}
+
+scoring_api_t::scoring_api_t (const scoring_api_t &o)
+{
+    for (auto &p : o.m_ssys_map) {
+        const subsystem_t &s = p.first;
+        auto obj = new std::map<const std::string, detail::evals_t *>();
+        m_ssys_map.insert (std::make_pair (s, obj));
+        auto &tmap = *(p.second);
+        for (auto &p2 : tmap) {
+            const std::string &res_type = p2.first;
+            detail::evals_t *ne = new detail::evals_t ();
+            *ne = *(p2.second);
+            (*m_ssys_map[s]).insert (std::make_pair (res_type, ne));
+        }
+    }
+}
+
+const scoring_api_t &scoring_api_t::operator= (const scoring_api_t &o)
+{
+    for (auto &p : o.m_ssys_map) {
+        const subsystem_t &s = p.first;
+        auto obj = new std::map<const std::string, detail::evals_t *>();
+        m_ssys_map.insert (std::make_pair (s, obj));
+        auto &tmap = *(p.second);
+        for (auto &p2 : tmap) {
+            const std::string &res_type = p2.first;
+            detail::evals_t *ne = new detail::evals_t ();
+            *ne = *(p2.second);
+            (*m_ssys_map[s]).insert (std::make_pair (res_type, ne));
+        }
+    }
+    return *this;
+}
+
+scoring_api_t::~scoring_api_t ()
+{
+    auto i = m_ssys_map.begin ();
+    while (i != m_ssys_map.end ()) {
+        auto tmap = i->second;
+        auto j = tmap->begin ();
+        while (j != tmap->end ()) {
+            delete j->second;
+            j = tmap->erase (j);
+        }
+        delete i->second;
+        i = m_ssys_map.erase (i);
+    }
+}
+
+int64_t scoring_api_t::cutline (const subsystem_t &s, const std::string &r)
+{
+    handle_new_keys (s, r);
+    auto res_evals = (*m_ssys_map[s])[r];
+    return res_evals->cutline ();
+}
+
+int64_t scoring_api_t::set_cutline (const subsystem_t &s, const std::string &r,
+                                    int64_t c)
+{
+    handle_new_keys (s, r);
+    auto res_evals = (*m_ssys_map[s])[r];
+    return res_evals->set_cutline (c);
+}
+
+void scoring_api_t::rewind_iter_cur (const subsystem_t &s, const std::string &r)
+{
+    handle_new_keys (s, r);
+    auto res_evals = (*m_ssys_map[s])[r];
+    return res_evals->rewind_iter_cur ();
+}
+
+std::vector<eval_egroup_t>::iterator scoring_api_t::iter_cur (
+    const subsystem_t &s, const std::string &r)
+{
+    handle_new_keys (s, r);
+    auto res_evals = (*m_ssys_map[s])[r];
+    return res_evals->iter_cur;
+}
+
+void scoring_api_t::incr_iter_cur (const subsystem_t &s, const std::string &r)
+{
+    handle_new_keys (s, r);
+    auto res_evals = (*m_ssys_map[s])[r];
+    res_evals->iter_cur++;
+}
+
+int scoring_api_t::add (const subsystem_t &s, const std::string &r,
+                        const eval_egroup_t &eg)
+{
+    handle_new_keys (s, r);
+    auto res_evals = (*m_ssys_map[s])[r];
+    return res_evals->add (eg);
+}
+
+//! Can throw an out_of_range exception
+const eval_egroup_t &scoring_api_t::at (const subsystem_t &s,
+                                        const std::string &r, unsigned int i)
+{
+    handle_new_keys (s, r);
+    auto res_evals = (*m_ssys_map[s])[r];
+    return res_evals->at(i);
+}
+
+unsigned int scoring_api_t::qualified_count (const subsystem_t &s,
+                                             const std::string &r)
+{
+    handle_new_keys (s, r);
+    auto res_evals = (*m_ssys_map[s])[r];
+    return res_evals->qualified_count ();
+}
+
+unsigned int scoring_api_t::total_count (const subsystem_t &s,
+                                         const std::string &r)
+{
+    handle_new_keys (s, r);
+    auto res_evals = (*m_ssys_map[s])[r];
+    return res_evals->total_count ();
+}
+
+unsigned int scoring_api_t::best_k (const subsystem_t &s, const std::string &r)
+{
+    handle_new_keys (s, r);
+    auto res_evals = (*m_ssys_map[s])[r];
+    return res_evals->best_k ();
+}
+
+unsigned int scoring_api_t::best_i (const subsystem_t &s, const std::string &r)
+{
+    handle_new_keys (s, r);
+    auto res_evals = (*m_ssys_map[s])[r];
+    return res_evals->best_i ();
+}
+
+bool scoring_api_t::hier_constrain_now ()
+{
+    return m_hier_constrain_now;
+}
+
+void scoring_api_t::merge (const scoring_api_t &o)
+{
+    for (auto &kv : o.m_ssys_map) {
+        const subsystem_t &s = kv.first;
+        auto &tmap = *(kv.second);
+        for (auto &kv2 : tmap) {
+            const std::string &r = kv2.first;
+            auto &ev = *(kv2.second);
+            handle_new_keys (s, r);
+            auto res_evals = (*m_ssys_map[s])[r];
+            res_evals->merge (ev);
+        }
+    }
+}
+
+void scoring_api_t::resrc_types (const subsystem_t &s,
+                                 std::vector<std::string> &v)
+{
+    handle_new_subsystem (s);
+    for (auto &kv : *(m_ssys_map[s]))
+        v.push_back (kv.first);
+}
+
+// overall_score and avail are temporary space such that
+// a child vertex visitor can pass the info to the parent vertex
+int64_t scoring_api_t::overall_score ()
+{
+    return m_overall_score;
+}
+
+void scoring_api_t::set_overall_score (int64_t overall)
+{
+    m_overall_score = overall;
+}
+
+unsigned int scoring_api_t::avail ()
+{
+    return m_avail;
+}
+
+void scoring_api_t::set_avail (unsigned int avail)
+{
+    m_avail = avail;
+}
+
+} // Flux::resource_model
+} // Flux
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/scoring_api.hpp
+++ b/resource/scoring_api.hpp
@@ -32,386 +32,48 @@
 #include <numeric>
 #include <functional>
 #include <algorithm>
-#include <boost/icl/interval.hpp>
-#include <boost/icl/interval_set.hpp>
 #include "resource_graph.hpp"
+#include "edge_eval_api.hpp"
+#include "fold.hpp"
 
 namespace Flux {
 namespace resource_model {
 
-struct eval_edg_t {
-    eval_edg_t (unsigned int c, unsigned int n, unsigned int x, edg_t e)
-        : count (c), needs (n), exclusive (x), edge (e) { }
-    eval_edg_t (unsigned int c, unsigned int n, unsigned int x)
-        : count (c), needs (n), exclusive (x) { }
-    unsigned int count = 0;
-    unsigned int needs = 0;
-    unsigned int exclusive = 0;
-    edg_t edge;
-};
-
-struct eval_egroup_t {
-    eval_egroup_t () { }
-    eval_egroup_t (int64_t s, unsigned int c, unsigned int n,
-                   unsigned int x, bool r)
-        : score (s), count (c), needs (n), exclusive (x), root (r) {}
-    eval_egroup_t (const eval_egroup_t &o)
-    {
-        score = o.score;
-        count = o.count;
-        needs = o.needs;
-        exclusive = o.exclusive;
-        root = o.root;
-        edges = o.edges;
-    }
-    eval_egroup_t &operator= (const eval_egroup_t &o)
-    {
-        score = o.score;
-        count = o.count;
-        needs = o.needs;
-        exclusive = o.exclusive;
-        root = o.root;
-        edges = o.edges;
-        return *this;
-    }
-
-    int64_t score = -1;
-    unsigned int count = 0;
-    unsigned int needs = 0;
-    unsigned int exclusive = 0;
-    bool root = false;
-    std::vector<eval_edg_t> edges;
-};
-
-namespace detail {
-class evals_t {
-public:
-    evals_t () { }
-    evals_t (int64_t cutline, const std::string &res_type)
-        : m_resrc_type (res_type), m_cutline (cutline) { }
-    evals_t (const std::string &res_type)
-        : m_resrc_type (res_type) { }
-    evals_t (const evals_t &o)
-    {
-        m_eval_egroups = o.m_eval_egroups;
-        m_resrc_type = o.m_resrc_type;
-        m_cutline = o.m_cutline;
-        m_qual_count = o.m_qual_count;
-        m_total_count = o.m_total_count;
-        m_best_k = o.m_best_k;
-        m_best_i = o.m_best_i;
-    }
-    ~evals_t ()
-    {
-        m_eval_egroups.clear ();
-    }
-    evals_t &operator= (const evals_t &o)
-    {
-        m_eval_egroups = o.m_eval_egroups;
-        m_resrc_type = o.m_resrc_type;
-        m_cutline = o.m_cutline;
-        m_qual_count = o.m_qual_count;
-        m_total_count = o.m_total_count;
-        m_best_k = o.m_best_k;
-        m_best_i = o.m_best_i;
-        return *this;
-    }
-
-    unsigned int add (const eval_egroup_t &eg)
-    {
-        m_total_count += eg.count;
-        if (eg.score > m_cutline)
-            m_qual_count += eg.count;
-        m_eval_egroups.push_back (eg);
-        return m_qual_count;
-    }
-
-    // This can throw out_of_range exception
-    const eval_egroup_t &at (unsigned int i) const
-    {
-        return m_eval_egroups.at (i);
-    }
-
-    unsigned int qualified_count () const
-    {
-        return m_qual_count;
-    }
-
-    unsigned int total_count () const
-    {
-        return m_total_count;
-    }
-
-    int64_t cutline () const
-    {
-        return m_cutline;
-    }
-
-    int64_t set_cutline (int64_t cutline)
-    {
-        int64_t rc = m_cutline;
-        m_cutline = cutline;
-        return rc;
-    }
-
-    template<class compare_op>
-    int choose_best_k (unsigned int k, compare_op comp)
-    {
-        if (k == 0 || k > m_qual_count) {
-            errno = EINVAL;
-            return -1;
-        }
-
-        unsigned int i = 0;
-        int old = (int)m_best_k;
-        int to_be_selected = k;
-        std::sort (m_eval_egroups.begin (), m_eval_egroups.end (), comp);
-        while (to_be_selected > 0) {
-            if (to_be_selected <= (int)m_eval_egroups[i].count)
-                m_eval_egroups[i].needs = to_be_selected;
-            else
-                m_eval_egroups[i].needs = m_eval_egroups[i].count;
-
-            to_be_selected -= m_eval_egroups[i].count;
-            i++;
-        }
-        m_best_k = k;
-        m_best_i = i;
-        return old;
-    }
-
-    template<class binary_op>
-    int64_t accum_best_k (binary_op accum, int init=0)
-    {
-        if (m_best_k == 0 || m_best_i == 0) {
-            errno = EINVAL;
-            return -1;
-        }
-        int64_t score_accum = init;
-        for (unsigned int i = 0; i < m_best_i; i++)
-            score_accum = accum (score_accum, m_eval_egroups[i]);
-        return score_accum;
-    }
-
-    template<class output_it, class unary_op>
-    output_it transform (output_it o_it, unary_op uop)
-    {
-        return std::transform (m_eval_egroups.begin (),
-                               m_eval_egroups.end (),
-                               o_it, uop);
-    }
-
-    unsigned int best_k () const
-    {
-        return m_best_k;
-    }
-
-    unsigned int best_i () const
-    {
-        return m_best_i;
-    }
-
-    int merge (evals_t &o)
-    {
-        if (m_cutline != o.m_cutline || m_resrc_type != o.m_resrc_type) {
-            errno = EINVAL;
-            return -1;
-        }
-        m_qual_count += o.m_qual_count;
-        m_total_count += o.m_total_count;
-        m_cutline = o.m_cutline;
-        m_eval_egroups.insert (m_eval_egroups.end (), o.m_eval_egroups.begin (),
-                               o.m_eval_egroups.end ());
-        return 0;
-    }
-
-    void rewind_iter_cur ()
-    {
-        iter_cur = m_eval_egroups.begin ();
-    }
-
-    std::vector<eval_egroup_t>::iterator iter_cur;
-
-private:
-    std::vector<eval_egroup_t> m_eval_egroups;
-    std::string m_resrc_type;
-    int64_t m_cutline = 0;
-    unsigned int m_qual_count = 0;
-    unsigned int m_total_count = 0;
-    unsigned int m_best_k = 0;      //<! best-k to be selected
-    unsigned int m_best_i = 0;      //<! first i elements in has best-k
-};
-} // namespace detail
-
-namespace fold {
-struct greater {
-    bool operator() (const eval_egroup_t &a, const eval_egroup_t &b) const
-    {
-        return a.score > b.score;
-    }
-};
-
-struct less {
-    bool operator() (const eval_egroup_t &a, const eval_egroup_t &b) const
-    {
-        return a.score < b.score;
-    }
-};
-
-struct interval_greater {
-    bool operator() (const eval_egroup_t &a, const eval_egroup_t &b) const
-    {
-        return *(ivset.find (a.score)) > *(ivset.find (b.score));
-    }
-    boost::icl::interval_set<int64_t> ivset;
-};
-
-struct interval_less {
-    bool operator() (const eval_egroup_t &a, const eval_egroup_t &b) const
-    {
-        return *(ivset.find (a.score)) < *(ivset.find (b.score));
-    }
-    boost::icl::interval_set<int64_t> ivset;
-};
-
-struct plus {
-    const int64_t operator() (const int64_t result,
-                              const eval_egroup_t &a) const
-    {
-        return result + a.score;
-    }
-};
-inline boost::icl::interval_set<int64_t>::interval_type to_interval (
-                                                     const eval_egroup_t &ev)
-{
-    using namespace boost::icl;
-    int64_t tmp = ev.score;
-    return interval_set<int64_t>::interval_type::closed (tmp, tmp);
-}
-} // namespace fold
-
 class scoring_api_t {
 public:
-    scoring_api_t () {}
-    scoring_api_t (const scoring_api_t &o)
-    {
-        for (auto &p : o.m_ssys_map) {
-            const subsystem_t &s = p.first;
-            auto obj = new std::map<const std::string, detail::evals_t *>();
-            m_ssys_map.insert (std::make_pair (s, obj));
-            auto &tmap = *(p.second);
-            for (auto &p2 : tmap) {
-                const std::string &res_type = p2.first;
-                detail::evals_t *ne = new detail::evals_t ();
-                *ne = *(p2.second);
-                (*m_ssys_map[s]).insert (std::make_pair (res_type, ne));
-            }
-        }
-    }
-    const scoring_api_t &operator= (const scoring_api_t &o)
-    {
-        for (auto &p : o.m_ssys_map) {
-            const subsystem_t &s = p.first;
-            auto obj = new std::map<const std::string, detail::evals_t *>();
-            m_ssys_map.insert (std::make_pair (s, obj));
-            auto &tmap = *(p.second);
-            for (auto &p2 : tmap) {
-                const std::string &res_type = p2.first;
-                detail::evals_t *ne = new detail::evals_t ();
-                *ne = *(p2.second);
-                (*m_ssys_map[s]).insert (std::make_pair (res_type, ne));
-            }
-        }
-        return *this;
-    }
+    scoring_api_t ();
+    scoring_api_t (const scoring_api_t &o);
+    const scoring_api_t &operator= (const scoring_api_t &o);
+    ~scoring_api_t ();
 
-    ~scoring_api_t ()
-    {
-        auto i = m_ssys_map.begin ();
-        while (i != m_ssys_map.end ()) {
-            auto tmap = i->second;
-            auto j = tmap->begin ();
-            while (j != tmap->end ()) {
-                delete j->second;
-                j = tmap->erase (j);
-            }
-            delete i->second;
-            i = m_ssys_map.erase (i);
-        }
-    }
-
-    int64_t cutline (const subsystem_t &s, const std::string &r)
-    {
-        handle_new_keys (s, r);
-        auto res_evals = (*m_ssys_map[s])[r];
-        return res_evals->cutline ();
-    }
-
-    int64_t set_cutline (const subsystem_t &s, const std::string &r,
-                         int64_t c)
-    {
-        handle_new_keys (s, r);
-        auto res_evals = (*m_ssys_map[s])[r];
-        return res_evals->set_cutline (c);
-    }
-
-    void rewind_iter_cur (const subsystem_t &s, const std::string &r)
-    {
-        handle_new_keys (s, r);
-        auto res_evals = (*m_ssys_map[s])[r];
-        return res_evals->rewind_iter_cur ();
-    }
-
+    int64_t cutline (const subsystem_t &s, const std::string &r);
+    int64_t set_cutline (const subsystem_t &s, const std::string &r, int64_t c);
+    void rewind_iter_cur (const subsystem_t &s, const std::string &r);
     std::vector<eval_egroup_t>::iterator iter_cur (const subsystem_t &s,
-                                                   const std::string &r)
-    {
-        handle_new_keys (s, r);
-        auto res_evals = (*m_ssys_map[s])[r];
-        return res_evals->iter_cur;
-    }
-
-    void incr_iter_cur (const subsystem_t &s, const std::string &r)
-    {
-        handle_new_keys (s, r);
-        auto res_evals = (*m_ssys_map[s])[r];
-        res_evals->iter_cur++;
-    }
-
-    int add (const subsystem_t &s, const std::string &r, const eval_egroup_t &eg)
-    {
-        handle_new_keys (s, r);
-        auto res_evals = (*m_ssys_map[s])[r];
-        return res_evals->add (eg);
-    }
-
+                                                   const std::string &r);
+    void incr_iter_cur (const subsystem_t &s, const std::string &r);
+    int add (const subsystem_t &s, const std::string &r,
+             const eval_egroup_t &eg);
     //! Can throw an out_of_range exception
     const eval_egroup_t &at (const subsystem_t &s, const std::string &r,
-              unsigned int i)
-    {
-        handle_new_keys (s, r);
-        auto res_evals = (*m_ssys_map[s])[r];
-        return res_evals->at(i);
-    }
-
-    unsigned int qualified_count (const subsystem_t &s, const std::string &r)
-    {
-        handle_new_keys (s, r);
-        auto res_evals = (*m_ssys_map[s])[r];
-        return res_evals->qualified_count ();
-    }
-
-    unsigned int total_count (const subsystem_t &s, const std::string &r)
-    {
-        handle_new_keys (s, r);
-        auto res_evals = (*m_ssys_map[s])[r];
-        return res_evals->total_count ();
-    }
+                             unsigned int i);
+    unsigned int qualified_count (const subsystem_t &s, const std::string &r);
+    unsigned int total_count (const subsystem_t &s, const std::string &r);
+    unsigned int best_k (const subsystem_t &s, const std::string &r);
+    unsigned int best_i (const subsystem_t &s, const std::string &r);
+    bool hier_constrain_now ();
+    void merge (const scoring_api_t &o);
+    void resrc_types (const subsystem_t &s, std::vector<std::string> &v);
+    int64_t overall_score ();
+    void set_overall_score (int64_t overall);
+    unsigned int avail ();
+    void set_avail (unsigned int avail);
 
     template<class compare_op = fold::greater, class binary_op = fold::plus>
     int64_t choose_accum_best_k (const subsystem_t &s, const std::string &r,
-                unsigned int k,
-                compare_op comp = fold::greater(),
-                binary_op accum = fold::plus ())
+                                 unsigned int k,
+                                 compare_op comp = fold::greater(),
+                                 binary_op accum = fold::plus ())
     {
         int64_t rc;
         handle_new_keys (s, r);
@@ -425,8 +87,8 @@ public:
 
     template<class compare_op = fold::greater, class binary_op = fold::plus>
     int64_t choose_accum_all (const subsystem_t &s, const std::string &r,
-                compare_op comp = fold::greater (),
-                binary_op accum = fold::plus ())
+                              compare_op comp = fold::greater (),
+                              binary_op accum = fold::plus ())
     {
         int64_t rc;
         handle_new_keys (s, r);
@@ -448,91 +110,10 @@ public:
         return res_evals->transform<output_it, unary_op> (o_it, uop);
     }
 
-    unsigned int best_k (const subsystem_t &s, const std::string &r)
-    {
-        handle_new_keys (s, r);
-        auto res_evals = (*m_ssys_map[s])[r];
-        return res_evals->best_k ();
-    }
-
-    unsigned int best_i (const subsystem_t &s, const std::string &r)
-    {
-        handle_new_keys (s, r);
-        auto res_evals = (*m_ssys_map[s])[r];
-        return res_evals->best_i ();
-    }
-
-    bool hier_constrain_now ()
-    {
-        return m_hier_constrain_now;
-    }
-
-    void merge (const scoring_api_t &o)
-    {
-        for (auto &kv : o.m_ssys_map) {
-            const subsystem_t &s = kv.first;
-            auto &tmap = *(kv.second);
-            for (auto &kv2 : tmap) {
-                const std::string &r = kv2.first;
-                auto &ev = *(kv2.second);
-                handle_new_keys (s, r);
-                auto res_evals = (*m_ssys_map[s])[r];
-                res_evals->merge (ev);
-            }
-        }
-    }
-
-    void resrc_types (const subsystem_t &s, std::vector<std::string> &v)
-    {
-        handle_new_subsystem (s);
-        for (auto &kv : *(m_ssys_map[s]))
-            v.push_back (kv.first);
-    }
-
-    // overall_score and avail are temporary space such that
-    // a child vertex visitor can pass the info to the parent vertex
-    int64_t overall_score ()
-    {
-        return m_overall_score;
-    }
-
-    void set_overall_score (int64_t overall)
-    {
-        m_overall_score = overall;
-    }
-
-    unsigned int avail ()
-    {
-        return m_avail;
-    }
-
-    void set_avail (unsigned int avail)
-    {
-        m_avail = avail;
-    }
-
 private:
-    void handle_new_keys (const subsystem_t &s, const std::string &r)
-    {
-        handle_new_subsystem (s);
-        handle_new_resrc_type (s, r);
-    }
-
-    void handle_new_subsystem (const subsystem_t &s)
-    {
-        if (m_ssys_map.find (s) == m_ssys_map.end ()) {
-            auto o = new std::map<const std::string, detail::evals_t *>();
-            m_ssys_map.insert (std::make_pair (s, o));
-        }
-    }
-
-    void handle_new_resrc_type (const subsystem_t &s, const std::string &r)
-    {
-        if (m_ssys_map[s]->find (r) == m_ssys_map[s]->end ()) {
-            auto e = new detail::evals_t (r);
-            m_ssys_map[s]->insert (std::make_pair (r, e));
-        }
-    }
+    void handle_new_keys (const subsystem_t &s, const std::string &r);
+    void handle_new_subsystem (const subsystem_t &s);
+    void handle_new_resrc_type (const subsystem_t &s, const std::string &r);
 
     std::map<const subsystem_t,
              std::map<const std::string, detail::evals_t *> *> m_ssys_map;


### PR DESCRIPTION
This PR addresses https://github.com/flux-framework/flux-sched/issues/322.

Refactor Scoring API, Resource Data and Color code.

Now use "using" instead of typedef as we are at C++11. 
