### PR TITLE
experimental: add valgrind test to flux-sched, fix some leaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ addons:
       - libyaml-cpp-dev
       - libboost-all-dev
       - libreadline6
+      - valgrind
 
 before_install:
   - wget https://raw.githubusercontent.com/flux-framework/flux-core/master/src/test/travis-dep-builder.sh

--- a/rdl/rdl.c
+++ b/rdl/rdl.c
@@ -572,9 +572,11 @@ struct rdl * rdl_find (struct rdl *rdl, json_t *args)
      *  stack: [ Method, object, args-table ]
      */
     if (lua_pcall (rdl->L, 2, LUA_MULTRET, 0) || lua_isnoneornil (rdl->L, 1)) {
+        char *s = Jtostr (args);
         VERR (rdl->rl, "find(%s): %s\n",
-                Jtostr (args),
+                s,
                 lua_tostring (rdl->L, -1));
+        free (s);
         return (NULL);
     }
 

--- a/resrc/resrc.c
+++ b/resrc/resrc.c
@@ -123,6 +123,7 @@ void resrc_api_fini (resrc_api_ctx_t *ctx)
     if (ctx->flow_names)
         zlist_destroy (&(ctx->flow_names));
     /* tree_root_resrc should already have been destroyed */
+    free (ctx);
 }
 
 resrc_api_map_t *resrc_api_map_new ()

--- a/resrc/resrc.c
+++ b/resrc/resrc.c
@@ -1149,12 +1149,13 @@ int resrc_to_json_lite (json_t *o, resrc_t *resrc, bool reduce)
             Jadd_str (o, "digest", resrc_digest (resrc));
     } else {
         const char *val = NULL;
+        char *s = NULL;
         if (Jget_str (o, resrc_type (resrc), &val))
-            Jadd_str (o, resrc_type (resrc), xasprintf ("%s,%"PRId64"",
-                                                        val, resrc_id (resrc)));
+            s = xasprintf ("%s,%"PRId64"", val, resrc_id (resrc));
         else
-            Jadd_str (o, resrc_type (resrc), xasprintf ("%"PRId64"",
-                                                        resrc_id (resrc)));
+            s = xasprintf ("%"PRId64"", resrc_id (resrc));
+        Jadd_str (o, resrc_type (resrc), s);
+        free (s);
     }
     return 0;
 }

--- a/resrc/resrc_tree.c
+++ b/resrc/resrc_tree.c
@@ -226,7 +226,7 @@ int resrc_tree_serialize_lite (json_t *gather, json_t *reduce,
     }
 
     if (m_o)
-        json_array_append (gather, m_o);
+        json_array_append_new (gather, m_o);
 
     return rc;
 }

--- a/sched/rs2rank.c
+++ b/sched/rs2rank.c
@@ -96,8 +96,20 @@ static void partition_tab_freefn (void *data)
 static void partition_freefn (void *data)
 {
     partition_t *o = (partition_t *)data;
-    free (o->sig->digest);
-    zlist_destroy (&(o->ranks));
+    if (o) {
+        if (o->sig) {
+            if (o->sig->digest) {
+                free (o->sig->digest);
+                o->sig->digest = NULL;
+            }
+            free (o->sig);
+            o->sig = NULL;
+        }
+        if (o->ranks)
+            zlist_destroy (&(o->ranks));
+        free (o);
+        o = NULL;
+    }
 }
 
 static inline void partition_tab_new (zhash_t *tab, const char *hn)

--- a/sched/sched.c
+++ b/sched/sched.c
@@ -1419,6 +1419,8 @@ done:
         Jput (jcb);
     if (red)
         Jput (red);
+    resrc_api_map_destroy (&gmap);
+    resrc_api_map_destroy (&rmap);
     return rc;
 }
 

--- a/sched/sched.c
+++ b/sched/sched.c
@@ -2155,7 +2155,7 @@ static int timer_event_cb (flux_t *h, void *arg)
 
 static int job_status_cb (const char *jcbstr, void *arg, int errnum)
 {
-    int rc = 0;
+    int rc = -1;
     json_t *jcb = NULL;
     ssrvctx_t *ctx = getctx ((flux_t *)arg);
     flux_lwj_t *j = NULL;
@@ -2163,21 +2163,22 @@ static int job_status_cb (const char *jcbstr, void *arg, int errnum)
 
     if (errnum > 0) {
         flux_log (ctx->h, LOG_ERR, "%s: errnum passed in", __FUNCTION__);
-        return -1;
+        goto out;
     }
     if (!(jcb = Jfromstr (jcbstr))) {
         flux_log (ctx->h, LOG_ERR, "%s: error parsing JSON string",
                   __FUNCTION__);
-        return -1;
+        goto out;
     }
     if (is_newjob (jcb))
         q_enqueue_into_pqueue (ctx, jcb);
     if ((j = fetch_job_and_event (ctx, jcb, &ns)) == NULL) {
         flux_log (ctx->h, LOG_INFO, "%s: nonexistent job", __FUNCTION__);
         flux_log (ctx->h, LOG_INFO, "%s: directly launched job?", __FUNCTION__);
-        return -1;
+        goto out;
     }
     rc = action (ctx, j, ns, jcb);
+out:
     Jput (jcb);
     return rc;
 }

--- a/sched/sched.c
+++ b/sched/sched.c
@@ -457,7 +457,7 @@ done:
 
 static int update_state (flux_t *h, uint64_t jid, job_state_t os, job_state_t ns)
 {
-    const char *jcbstr = NULL;
+    char *jcbstr = NULL;
     int rc = -1;
     json_t *jcb = Jnew ();
     json_t *o = Jnew ();
@@ -468,6 +468,7 @@ static int update_state (flux_t *h, uint64_t jid, job_state_t os, job_state_t ns
     jcbstr = Jtostr (jcb);
     rc = jsc_update_jcb (h, jid, JSC_STATE_PAIR, jcbstr);
     Jput (jcb);
+    free (jcbstr);
     return rc;
 }
 
@@ -852,16 +853,17 @@ static void handle_jsc_queue (ssrvctx_t *ctx)
     jsc_event_t *jsc_event = NULL;
 
     while (zlist_size (ctx->sctx.jsc_queue) > 0) {
+        char *jcbstr;
         jsc_event = (jsc_event_t *)zlist_pop (ctx->sctx.jsc_queue);
+        jcbstr = Jtostr (jsc_event->jcb);
         flux_log (ctx->h,
                   LOG_DEBUG,
                   "JscEvent being handled - JSON: %s, errnum: %d",
-                  Jtostr (jsc_event->jcb),
-                  jsc_event->errnum);
-        job_status_cb (Jtostr (jsc_event->jcb), jsc_event->arg,
-                       jsc_event->errnum);
+                  jcbstr, jsc_event->errnum);
+        job_status_cb (jcbstr, jsc_event->arg, jsc_event->errnum);
         Jput (jsc_event->jcb);
         free (jsc_event);
+        free (jcbstr);
     }
 }
 
@@ -908,6 +910,7 @@ static void start_cb (flux_t *h,
 
 static int sim_job_status_cb (const char *jcbstr, void *arg, int errnum)
 {
+    char *s;
     json_t *jcb = NULL;
     ssrvctx_t *ctx = getctx ((flux_t *)arg);
     jsc_event_t *event = (jsc_event_t*) xzmalloc (sizeof (jsc_event_t));
@@ -927,13 +930,13 @@ static int sim_job_status_cb (const char *jcbstr, void *arg, int errnum)
     event->arg = arg;
     event->errnum = errnum;
 
+    s = Jtostr (event->jcb);
     flux_log (ctx->h,
               LOG_DEBUG,
               "JscEvent being queued - JSON: %s, errnum: %d",
-              Jtostr (event->jcb),
-              event->errnum);
+              s, event->errnum);
+    free (s);
     zlist_append (ctx->sctx.jsc_queue, event);
-
     return 0;
 }
 
@@ -1365,7 +1368,7 @@ done:
  */
 static int req_tpexec_allocate (ssrvctx_t *ctx, flux_lwj_t *job)
 {
-    const char *jcbstr = NULL;
+    char *jcbstr = NULL;
     int rc = -1;
     flux_t *h = ctx->h;
     json_t *jcb = Jnew ();
@@ -1391,8 +1394,10 @@ static int req_tpexec_allocate (ssrvctx_t *ctx, flux_lwj_t *job)
     if (jsc_update_jcb (h, job->lwj_id, JSC_R_LITE, jcbstr) != 0) {
         flux_log (h, LOG_ERR, "error jsc udpate: %"PRId64" (%s)", job->lwj_id,
                   strerror (errno));
+        free (jcbstr);
         goto done;
     }
+    free (jcbstr);
     Jput (jcb);
 
     jcb = Jnew ();
@@ -1404,8 +1409,10 @@ static int req_tpexec_allocate (ssrvctx_t *ctx, flux_lwj_t *job)
     jcbstr = Jtostr (jcb);
     if (jsc_update_jcb (h, job->lwj_id, JSC_RDL_ALLOC, jcbstr) != 0) {
         flux_log (h, LOG_ERR, "error updating jcb");
+        free (jcbstr);
         goto done;
     }
+    free (jcbstr);
 
     if ((update_state (h, job->lwj_id, job->state, J_ALLOCATED)) != 0) {
         flux_log (h, LOG_ERR, "failed to update the state of job %"PRId64"",

--- a/src/common/libutil/shortjansson.h
+++ b/src/common/libutil/shortjansson.h
@@ -237,9 +237,9 @@ Jget_ar_str (json_t *o, int n, const char **sp)
     return true;
 }
 
-/* Encode JSON to string (owned by JSON, do not free)
+/* Encode JSON to string
  */
-static __inline__ const char *
+static __inline__ char *
 Jtostr (json_t *o)
 {
     return o ? json_dumps (o, 0) : NULL;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -63,7 +63,8 @@ TESTS = \
     t3007-resource-iobw.t \
     t3008-resource-cancel.t \
     t3009-resource-minmax.t \
-    t3010-resource-power.t
+    t3010-resource-power.t \
+    t5000-valgrind.t
 
 check_SCRIPTS = $(TESTS)
 
@@ -73,7 +74,8 @@ EXTRA_DIST= \
     data/resource/jobspecs/basics \
 	scripts \
 	sharness.sh \
-	sharness.d
+	sharness.d \
+	valgrind
 
 clean-local:
 	rm -rf *.o test-results trash-directory*

--- a/t/t5000-valgrind.t
+++ b/t/t5000-valgrind.t
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+test_description='Run broker under valgrind with a small workload'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. `dirname $0`/sharness.sh
+
+if ! which valgrind >/dev/null; then
+    skip_all='skipping valgrind tests since no valgrind executable found'
+    test_done
+fi
+export FLUX_PMI_SINGLETON=1 # avoid finding leaks in slurm libpmi.so
+
+VALGRIND=`which valgrind`
+VALGRIND_SUPPRESSIONS=${SHARNESS_TEST_SRCDIR}/valgrind/valgrind.supp
+VALGRIND_WORKLOAD=${SHARNESS_TEST_SRCDIR}/valgrind/valgrind-workload.sh
+
+# broker run under valgrind may need extra retries in flux_open():
+FLUX_LOCAL_CONNECTOR_RETRY_COUNT=10
+
+# Broker under last component of FLUX_EXEC_PATH:
+BROKER=$(PATH=${FLUX_EXEC_PATH} /usr/bin/which flux-broker)
+test_expect_success 'found executable flux-broker' '
+	echo "found broker at ${BROKER}" >&2 &&
+	test -x "$BROKER"
+'
+# Do not run test by default unless valgrind wrapped dlclose is found in
+#  flux-broker, since this has been known to introduce false positives
+#  (flux-framework/flux-core#1097). However, allow run to be forced on
+#  the cmdline with -d, --debug.
+#
+have_valgrind_h() {
+    nm --defined-only ${BROKER} | grep -q ZZ_Za_dlclose
+}
+if ! have_valgrind_h && test "$debug" = ""; then
+    skip_all='Skipping valgrind test because flux-broker does not wrap dlclose. Use -d to force.'
+    test_done
+fi
+
+
+test_expect_success 'valgrind reports no new errors on single broker run' '
+	flux ${VALGRIND} \
+		--tool=memcheck \
+		--leak-check=full \
+		--gen-suppressions=all \
+		--trace-children=no \
+		--child-silent-after-fork=yes \
+		--num-callers=30 \
+		--leak-resolution=med \
+		--error-exitcode=1 \
+		--suppressions=$VALGRIND_SUPPRESSIONS \
+		${BROKER} --shutdown-grace=4 ${VALGRIND_WORKLOAD} 10
+'
+test_done

--- a/t/valgrind/valgrind-workload.sh
+++ b/t/valgrind/valgrind-workload.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+flux module load sched
+
+size=$(flux getattr size)
+NJOBS=$1
+echo FLUX_URI=$FLUX_URI
+
+for i in `seq 1 $NJOBS`; do
+    flux wreckrun --ntasks $size /bin/true
+done
+
+flux module remove sched

--- a/t/valgrind/valgrind.supp
+++ b/t/valgrind/valgrind.supp
@@ -1,0 +1,62 @@
+{
+   <socketcall_sendto>
+   Memcheck:Param
+   socketcall.sendto(msg)
+   fun:send
+   ...
+}
+{
+   <socketcall_sendto>
+   Memcheck:Param
+   socketcall.send(msg)
+   fun:send
+   ...
+}
+{
+   <libev_io_start_realloc>
+   Memcheck:Leak
+   fun:malloc
+   fun:realloc
+   fun:ev_realloc
+   fun:fd_change
+   fun:ev_io_start
+   fun:ev_invoke_pending
+   fun:ev_run
+   ...
+}
+{
+   <libltdl_known_leak>
+   Memcheck:Leak
+   fun:malloc
+   fun:lt__malloc
+   fun:lt__zalloc
+   obj:*/libltdl.so.7.3.1
+   fun:lt_dlopenadvise
+   ...
+}
+{
+   <list_node_alloc>
+   Memcheck:Leak
+   fun:malloc
+   fun:list_alloc_aux
+   ...
+   fun:list_node_create
+   ...
+}
+{
+   <ipaddr_getprimary>
+   Memcheck:Leak
+   fun:malloc
+   ...
+   fun:gaih_inet.constprop.5
+   fun:getaddrinfo
+   fun:ipaddr_getprimary
+   ...
+}
+{
+   <libdl_lookup_symbol_x>
+   Memcheck:Addr8
+   fun:do_lookup_x
+   obj:*
+   fun:_dl_lookup_symbol_x
+}


### PR DESCRIPTION
This somewhat experimental PR adds the `t5000-valgrind.t` to flux-sched, and fixes some of the leaks found. The valgrind test has the following differences from flux-core:
 * runs with `test_expect_failure` because there are still many leaks. Once all detected leaks are fixed the test can be updated.
 * A hacky attempt to determine if flux-broker was built with the `dlclose` valgrind wrapper is added, and the test is skipped if the symbol `ZZ_Za_dlclose` isn't found.
 * The path to `flux-broker` is determined via `$(PATH=${FLUX_EXEC_PATH} /usr/bin/which flux-broker)`. This should be the flux-broker for the version of flux-core under which flux-sched was configured.
 * An extra test is added to ensure the found path to `flux-broker` is executable.

The `valgrind-workload.sh` is also just a copy from flux-core, this could be extended for flux-sched.

The leaks fixed here were all fairly obvious given valgrind output in #327 . One thing that happened was when shortjson.h was switched to shortjansson.h, the fact that `Jtostr()` now required its argument to be freed was missed. I would actually suggest that the functions in shortjansson.h should be avoided on future development in flux-sched.

This isn't ready for merge yet. I may need to iterate on the valgrind test implementation.