### PR TITLE
Condense the core id list in R_lite

### DIFF
--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -3,7 +3,7 @@ AM_CFLAGS = \
 	$(CODE_COVERAGE_CFLAGS)
 
 AM_CPPFLAGS = \
-	$(CZMQ_CFLAGS)
+	$(CZMQ_CFLAGS) -I${top_srcdir}/src/common/libutil
 
 AM_LDFLAGS = \
 	$(CODE_COVERAGE_LIBS)
@@ -16,4 +16,12 @@ libutil_la_SOURCES = \
 	log.c \
 	log.h \
 	oom.h \
-	shortjansson.h
+	shortjansson.h \
+	nodeset.c \
+	nodeset.h \
+	veb.c \
+	veb.h \
+	monotime.c \
+	monotime.h
+
+EXTRA_DIST = veb_mach.c

--- a/src/common/libutil/monotime.c
+++ b/src/common/libutil/monotime.c
@@ -1,0 +1,68 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <time.h>
+#include <stdbool.h>
+
+#include "monotime.h"
+
+static struct timespec ts_diff (struct timespec start, struct timespec end)
+{
+        struct timespec temp;
+        if ((end.tv_nsec-start.tv_nsec)<0) {
+                temp.tv_sec = end.tv_sec-start.tv_sec-1;
+                temp.tv_nsec = 1000000000+end.tv_nsec-start.tv_nsec;
+        } else {
+                temp.tv_sec = end.tv_sec-start.tv_sec;
+                temp.tv_nsec = end.tv_nsec-start.tv_nsec;
+        }
+        return temp;
+}
+
+double monotime_since (struct timespec t0)
+{
+    struct timespec ts, d;
+    clock_gettime (CLOCK_MONOTONIC, &ts);
+
+    d = ts_diff (t0, ts);
+
+    return ((double) d.tv_sec * 1000 + (double) d.tv_nsec / 1000000);
+}
+
+void monotime (struct timespec *tp)
+{
+    clock_gettime (CLOCK_MONOTONIC, tp);
+}
+
+bool monotime_isset (struct timespec t)
+{
+    return (t.tv_sec || t.tv_nsec);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/monotime.h
+++ b/src/common/libutil/monotime.h
@@ -1,0 +1,14 @@
+#ifndef _UTIL_MONOTIME_H
+#define _UTIL_MONOTIME_H
+
+#include <time.h>
+#include <stdbool.h>
+
+double monotime_since (struct timespec t0); /* milliseconds */
+void monotime (struct timespec *tp);
+bool monotime_isset (struct timespec t);
+
+#endif /* !_UTIL_MONOTIME_H */
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/nodeset.c
+++ b/src/common/libutil/nodeset.c
@@ -1,0 +1,628 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+/* nodeset.c - set of unsigned integer ranks */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <assert.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <inttypes.h>
+
+#include "veb.h"
+#include "oom.h"
+#include "monotime.h"
+
+#include "nodeset.h"
+
+static const int string_initsize = 4096;
+static const uint32_t veb_minsize = 1<<10;
+
+#undef MIN
+#define MIN(a,b) ((a)<(b)?(a):(b))
+#undef MAX
+#define MAX(a,b) ((a)>(b)?(a):(b))
+
+#define NS_MAGIC 0xfeef0001
+struct nodeset_struct {
+    int magic;
+    int refcount;
+
+    Veb T;      /* Van Emde Boas tree - T.D is data, T.M is size */
+                /*  all ops are O(log m), for key bitsize m: 2^m = T.M */
+    char conf_separator[2];
+    bool conf_ranges;
+    bool conf_brackets;
+    unsigned int conf_padding;
+
+    char *s;    /* cached string representation */
+    int s_size;
+    bool s_valid;
+};
+
+#define NS_ITR_MAGIC 0xf004feef
+struct nodeset_iterator_struct {
+    int magic;
+    nodeset_t *n;
+    uint32_t r;
+    bool started;
+};
+
+static bool nodeset_single (nodeset_t *n);
+
+#define NS_FIRST(n)    vebsucc ((n)->T,0)
+#define NS_NEXT(n,r)   vebsucc ((n)->T,(r)+1)
+#define NS_LAST(n)     vebpred ((n)->T,(n)->T.M-1)
+#define NS_PREV(n,r)   vebpred ((n)->T,(r)-1)
+#define NS_SIZE(n)     ((n)->T.M)
+#define NS_TEST(n,r)   (vebsucc ((n)->T,(r))==(r))
+
+#define ABS_MAX_SIZE   (~(uint32_t)0)
+#define ABS_MAX_RANK   (~(uint32_t)0 - 1)
+
+static Veb vebdup (Veb T)
+{
+    uint32_t size = vebsize (T.M);
+    Veb t;
+
+    t.k = T.k;
+    t.M = T.M;
+    if ((t.D = malloc (size)))
+        memcpy (t.D, T.D, size);
+    return t;
+}
+
+nodeset_t *nodeset_create_size (uint32_t size)
+{
+    nodeset_t *n = malloc (sizeof (*n));
+    if (!n)
+        oom ();
+    n->magic = NS_MAGIC;
+    n->refcount = 1;
+    n->T = vebnew (size, 0);
+    if (!n->T.D)
+        oom ();
+    n->conf_separator[0] = ',';
+    n->conf_separator[1] = '\0';
+    n->conf_ranges = true;
+    n->conf_brackets = true;
+    n->conf_padding = 0;
+    n->s = NULL;
+    n->s_size = 0;
+    n->s_valid = false;
+    return n;
+}
+
+nodeset_t *nodeset_create (void)
+{
+    return nodeset_create_size (veb_minsize);
+}
+
+nodeset_t *nodeset_dup (nodeset_t *n)
+{
+    nodeset_t *cpy = malloc (sizeof (*cpy));
+
+    if (!cpy)
+        oom ();
+    memcpy (cpy, n, sizeof (*cpy));
+    cpy->refcount = 1;
+    cpy->T = vebdup (n->T);
+    if (!cpy->T.D)
+        oom ();
+    if (cpy->s_size > 0) {
+        if (!(cpy->s = malloc (cpy->s_size)))
+            oom ();
+        memcpy (cpy->s, n->s, cpy->s_size);
+    }
+    return cpy;
+}
+
+static void nodeset_incref (nodeset_t *n)
+{
+    n->refcount++;
+}
+
+static void nodeset_decref (nodeset_t *n)
+{
+    if (--n->refcount == 0) {
+        n->magic = ~NS_MAGIC;
+        free (n->T.D);
+        if (n->s)
+            free (n->s);
+        free (n);
+    }
+}
+
+void nodeset_destroy (nodeset_t *n)
+{
+    assert (n->magic == NS_MAGIC);
+    nodeset_decref (n);
+}
+
+nodeset_t *nodeset_create_string (const char *s)
+{
+    nodeset_t *n = nodeset_create ();
+    if (!nodeset_add_string (n, s)) {
+        nodeset_destroy (n);
+        return NULL;
+    }
+    return n;
+}
+
+nodeset_t *nodeset_create_range (uint32_t a, uint32_t b)
+{
+    nodeset_t *n = nodeset_create ();
+    nodeset_add_range (n, a, b);
+    return n;
+}
+
+nodeset_t *nodeset_create_rank (uint32_t r)
+{
+    nodeset_t *n = nodeset_create ();
+    nodeset_add_rank (n, r);
+    return n;
+}
+
+void nodeset_config_separator (nodeset_t *n, char c)
+{
+    assert (n->magic == NS_MAGIC);
+    if (n->conf_separator[0] != c)
+        n->s_valid = false;
+    n->conf_separator[0] = c;
+}
+
+void nodeset_config_ranges (nodeset_t *n, bool enable)
+{
+    assert (n->magic == NS_MAGIC);
+    if (n->conf_ranges != enable)
+        n->s_valid = false;
+    n->conf_ranges = enable;
+}
+
+void nodeset_config_brackets (nodeset_t *n, bool enable)
+{
+    assert (n->magic == NS_MAGIC);
+    if (n->conf_brackets != enable)
+        n->s_valid = false;
+    n->conf_brackets = enable;
+}
+
+void nodeset_config_padding (nodeset_t *n, unsigned int padding)
+{
+    assert (n->magic == NS_MAGIC);
+    if (padding > 10)
+        padding = 10;
+    if (n->conf_padding != padding)
+        n->s_valid = false;
+    n->conf_padding = padding;
+}
+
+bool nodeset_resize (nodeset_t *n, uint32_t size)
+{
+    assert (n->magic == NS_MAGIC);
+
+    uint32_t r;
+    Veb T;
+
+    if (size < veb_minsize)         /* don't allow size below minimum */
+        size = veb_minsize;
+    if (size < NS_SIZE (n)) {       /* If shrinking, bump size up to */
+        r = NS_FIRST (n);           /*   fit highest rank in set. */
+        while (r < NS_SIZE (n)) {
+            if (r >= size)
+                size = r + 1;
+            r = NS_NEXT (n, r);
+        }
+    }
+    if (size != NS_SIZE (n)) {
+        T = vebnew (size, 0);
+        if (!T.D)
+            oom ();
+        r = NS_FIRST (n);
+        while (r < NS_SIZE (n)) {
+            vebput (T, r);
+            r = NS_NEXT (n, r);
+        }
+        free (n->T.D);
+        n->T = T;
+    }
+    return true;
+}
+
+#define CHECK_SIZE(o,n) ((n)>(o)&&(o)<=ABS_MAX_SIZE)
+
+static bool nodeset_expandtofit (nodeset_t *n, uint32_t r)
+{
+    uint32_t size = NS_SIZE (n);
+    while (size <= r && CHECK_SIZE(size, size << 1))
+        size = size << 1;
+    while (size <= r && CHECK_SIZE(size, size + veb_minsize))
+        size += veb_minsize;
+    if (size <= r && CHECK_SIZE(size, r + 1))
+        size = r + 1;
+    if (size <= r)
+        return false;
+    return nodeset_resize (n, size);
+}
+
+void nodeset_minimize (nodeset_t *n)
+{
+    assert (n->magic == NS_MAGIC);
+    nodeset_resize (n, 0);
+    if (n->s) {
+        free (n->s);
+        n->s = NULL;
+        n->s_size = 0;
+        n->s_valid = false;
+    }
+}
+
+nodeset_iterator_t *nodeset_iterator_create (nodeset_t *n)
+{
+    nodeset_iterator_t *itr = malloc (sizeof (*itr));
+    if (!itr)
+        oom ();
+    itr->magic = NS_ITR_MAGIC;
+    itr->n = n;
+    nodeset_incref (itr->n);
+    itr->r = NODESET_EOF;
+    itr->started = false;
+    return itr;
+}
+
+void nodeset_iterator_destroy (nodeset_iterator_t *itr)
+{
+    assert (itr->magic == NS_ITR_MAGIC);
+    nodeset_decref (itr->n);
+    itr->magic = ~NS_ITR_MAGIC;
+    free (itr);
+}
+
+uint32_t nodeset_next (nodeset_iterator_t *itr)
+{
+    if (itr->started)
+        itr->r = NS_NEXT (itr->n, itr->r);
+    else {
+        itr->r = NS_FIRST (itr->n);
+        itr->started = true;
+    }
+    return (itr->r == NS_SIZE (itr->n) ? NODESET_EOF : itr->r);
+}
+
+uint32_t nodeset_next_rank (nodeset_t *n, uint32_t r)
+{
+    uint32_t next = NS_NEXT (n, r);
+    return (next == NS_SIZE (n) ? NODESET_EOF : next);
+}
+
+void nodeset_iterator_rewind (nodeset_iterator_t *itr)
+{
+    itr->started = false;
+}
+
+bool nodeset_add_rank (nodeset_t *n, uint32_t r)
+{
+    assert (n->magic == NS_MAGIC);
+
+    if (NS_SIZE (n) <= r && !nodeset_expandtofit (n, r))
+        return false;
+    vebput (n->T, r);
+    n->s_valid = false;
+    return true;
+}
+
+bool nodeset_add_range (nodeset_t *n, uint32_t a, uint32_t b)
+{
+    assert (n->magic == NS_MAGIC);
+
+    uint32_t r;
+    uint32_t lo = MIN(a,b);
+    uint32_t hi = MAX(a,b);
+
+    if (NS_SIZE (n) <= hi && !nodeset_expandtofit (n, hi))
+        return false;
+    for (r = lo; r <= hi; r++)
+        vebput (n->T, r);
+    n->s_valid = false;
+    return true;
+}
+
+void nodeset_delete_rank (nodeset_t *n, uint32_t r)
+{
+    assert (n->magic == NS_MAGIC);
+    if (r <= ABS_MAX_RANK)
+        vebdel (n->T, r);
+    n->s_valid = false;
+}
+
+void nodeset_delete_range (nodeset_t *n, uint32_t a, uint32_t b)
+{
+    assert (n->magic == NS_MAGIC);
+
+    uint32_t r;
+    uint32_t lo = MIN(a,b);
+    uint32_t hi = MAX(a,b);
+
+    for (r = lo; r <= hi; r++)
+        if (r <= ABS_MAX_RANK)
+            vebdel (n->T, r);
+    n->s_valid = false;
+}
+
+bool nodeset_test_rank (nodeset_t *n, uint32_t r)
+{
+    assert (n->magic == NS_MAGIC);
+    return r < NS_SIZE (n) ? NS_TEST (n, r) : false;
+}
+
+bool nodeset_test_range (nodeset_t *n, uint32_t a, uint32_t b)
+{
+    assert (n->magic == NS_MAGIC);
+
+    uint32_t r;
+    uint32_t lo = MIN(a,b);
+    uint32_t hi = MAX(a,b);
+
+    if (hi >= NS_SIZE (n) || lo >= NS_SIZE (n))
+        return false;
+    for (r = lo; r <= hi; r++)
+        if (!NS_TEST (n, r))
+            return false;
+    return true;
+}
+
+static void
+catstr (char **sp, int *lenp, int *usedp, const char *adds)
+{
+    int l = strlen (adds);
+    int buflen = *lenp;
+
+    while (*usedp + l + 1 > buflen)
+        buflen *= 2;
+    if (buflen > *lenp) {
+        *lenp = buflen;
+        if (!(*sp = realloc (*sp, *lenp)))
+            oom ();
+    }
+    strcpy (*sp + *usedp, adds);
+    *usedp += l;
+}
+
+const char *nodeset_string (nodeset_t *n)
+{
+    assert (n->magic == NS_MAGIC);
+
+    const char *sep = "";
+    int used = 0;
+    uint32_t r, lo = 0, hi = 0;
+    bool inrange = false;
+    char tmp[128];
+
+    if (!n->s_valid) {
+        if (!n->s) {
+            n->s_size = string_initsize;
+            if (!(n->s = malloc (n->s_size)))
+                oom ();
+        }
+        n->s[0] = '\0';
+        if (n->conf_brackets && !nodeset_single (n))
+            catstr (&n->s, &n->s_size, &used, "[");
+        r = NS_FIRST (n);
+        while (r < NS_SIZE (n) || inrange) {
+            if (n->conf_ranges) {
+                if (!inrange) {
+                    lo = hi = r;
+                    inrange = true;
+                } else if (r < NS_SIZE (n) && r == hi + 1) {
+                    hi++;
+                } else if (lo == hi) {
+                    snprintf (tmp, sizeof (tmp), "%s%0*"PRIu32, sep,
+                              n->conf_padding, lo);
+                    catstr (&n->s, &n->s_size, &used, tmp);
+                    sep = n->conf_separator;
+                    inrange = false;
+                    continue;
+                } else {
+                    snprintf (tmp, sizeof (tmp), "%s%0*"PRIu32"-%0*"PRIu32, sep,
+                             n->conf_padding, lo,
+                             n->conf_padding, hi);
+                    catstr (&n->s, &n->s_size, &used, tmp);
+                    sep = n->conf_separator;
+                    inrange = false;
+                    continue;
+                }
+            } else {
+                snprintf (tmp, sizeof (tmp), "%s%0*"PRIu32, sep,
+                          n->conf_padding, r);
+                catstr (&n->s, &n->s_size, &used, tmp);
+                sep = n->conf_separator;
+                inrange = false;
+            }
+            if (r < NS_SIZE (n))
+                r = NS_NEXT (n, r);
+        }
+        if (n->s[0] == '[')
+            catstr (&n->s, &n->s_size, &used, "]");
+        n->s_valid = true;
+    }
+    return n->s;
+}
+
+static bool str2rank (const char *s, uint32_t *rp)
+{
+    char *endptr = NULL;
+    uint32_t r = strtoul (s, &endptr, 10);
+
+    if (endptr == s || *endptr != '\0')
+        return false;
+    *rp = r;
+    return true;
+}
+
+typedef enum { OP_ADD, OP_DEL, OP_TEST } op_t;
+
+static bool nodeset_op_string (nodeset_t *n, op_t op, const char *str)
+{
+    char *cpy;
+    int len;
+    char *p, *s, *saveptr = NULL, *a1;
+    uint32_t lo, hi;
+    int count = 0;
+
+    len = strlen (str);
+    if (str[0] == '[' && str[len - 1] == ']') { /* hostlist compat */
+        if (!(cpy = strdup (str + 1)))
+            oom ();
+        cpy[len - 2] = '\0';
+    } else
+        if (!(cpy = strdup (str)))
+            oom ();
+
+    a1 = cpy;
+    while ((s = strtok_r (a1, ",", &saveptr))) {
+        if ((p = strchr (s, '-'))) {
+            *p = '\0';
+            if (!str2rank (s, &lo) || !str2rank (p + 1, &hi))
+                break;
+            if (op == OP_DEL) {
+                nodeset_delete_range (n, hi, lo);
+            } else if (op == OP_ADD) {
+                if (!nodeset_add_range (n, hi, lo))
+                    break;
+            } else if (op == OP_TEST) {
+                if (!nodeset_test_range (n, hi, lo))
+                    break;
+            }
+        } else {
+            if (!str2rank (s, &lo))
+                break;
+            if (op == OP_DEL) {
+                nodeset_delete_rank (n, lo);
+            } else if (op == OP_ADD) {
+                if (!nodeset_add_rank (n, lo))
+                    break;
+            } else if (op == OP_TEST) {
+                if (!nodeset_test_rank (n, lo))
+                    break;
+            }
+        }
+        a1 = NULL;
+        count++;
+    }
+    free (cpy);
+    if (s || (count == 0 && strlen (str) > 0))
+        return false;
+    return true;
+}
+
+bool nodeset_add_string (nodeset_t *n, const char *str)
+{
+    assert (n->magic == NS_MAGIC);
+    return nodeset_op_string (n, OP_ADD, str);
+}
+
+bool nodeset_delete_string (nodeset_t *n, const char *str)
+{
+    assert (n->magic == NS_MAGIC);
+    return nodeset_op_string (n, OP_DEL, str);
+}
+
+bool nodeset_test_string (nodeset_t *n, const char *str)
+{
+    assert (n->magic == NS_MAGIC);
+    return nodeset_op_string (n, OP_TEST, str);
+}
+
+uint32_t nodeset_count (nodeset_t *n)
+{
+    assert (n->magic == NS_MAGIC);
+
+    uint32_t count = 0;
+    uint32_t r;
+
+    r = NS_FIRST (n);
+    while (r < NS_SIZE (n)) {
+        count++;
+        r = NS_NEXT (n, r);
+    }
+    return count;
+}
+
+uint32_t nodeset_min (nodeset_t *n)
+{
+    assert (n->magic == NS_MAGIC);
+    uint32_t r = NS_FIRST (n);
+    return r == NS_SIZE (n) ? NODESET_EOF : r;
+}
+
+uint32_t nodeset_max (nodeset_t *n)
+{
+    assert (n->magic == NS_MAGIC);
+    uint32_t r = NS_LAST (n);
+    return r == NS_SIZE (n) ? NODESET_EOF : r;
+}
+
+static bool nodeset_single (nodeset_t *n)
+{
+    uint32_t len = 0;
+    uint32_t r;
+
+    r = NS_FIRST (n);
+    while (r < NS_SIZE (n) && len < 2) {
+        len++;
+        r = NS_NEXT (n, r);
+    }
+    return (len < 2);
+}
+
+uint32_t nodeset_getattr (nodeset_t *n, int attr)
+{
+    assert (n->magic == NS_MAGIC);
+    switch (attr) {
+        case NODESET_ATTR_BYTES:
+            return vebsize (n->T.M) + n->s_size + sizeof (*n);
+        case NODESET_ATTR_SIZE:
+            return NS_SIZE (n);
+        case NODESET_ATTR_MINSIZE:
+            return veb_minsize;
+        case NODESET_ATTR_MAXSIZE:
+            return ABS_MAX_SIZE;
+        case NODESET_ATTR_MAXRANK:
+            return ABS_MAX_RANK;
+        default:
+            return 0;
+    }
+}
+
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/nodeset.h
+++ b/src/common/libutil/nodeset.h
@@ -1,0 +1,118 @@
+/* nodeset_t - set of unsigned integer ranks */
+
+#ifndef _UTIL_NODESET_H
+#define _UTIL_NODESET_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef struct nodeset_struct nodeset_t;
+typedef struct nodeset_iterator_struct nodeset_iterator_t;
+
+#define NODESET_EOF (~(uint32_t)0)
+
+/* Create/destroy/dup a nodeset_t.
+ */
+void nodeset_destroy (nodeset_t *n);
+
+nodeset_t *nodeset_create (void);
+nodeset_t *nodeset_create_size (uint32_t size);
+nodeset_t *nodeset_create_range (uint32_t a, uint32_t b);
+nodeset_t *nodeset_create_rank (uint32_t r);
+nodeset_t *nodeset_create_string (const char *s);
+
+nodeset_t *nodeset_dup (nodeset_t *n);
+
+/* Configure separator used in nodeset_string().
+ * Default: ','
+ */
+void nodeset_config_separator (nodeset_t *n, char c);
+
+/* Configure whether nodeset_string() will use hyphenated ranges.
+ * Default: enabled
+ */
+void nodeset_config_ranges (nodeset_t *n, bool enable);
+
+/* Configure whether nodeset_string() will use brackets to distinguish
+ * a set of ranks from a single rank.
+ * Default: enabled
+ */
+void nodeset_config_brackets (nodeset_t *n, bool enable);
+
+/* Configure whether nodeset_string() will pad with leading zeroes (max 10).
+ * Default: disabled (pad = 0)
+ */
+void nodeset_config_padding (nodeset_t *n, unsigned pad);
+
+/* Configure the internal size of the nodeset_t (capacity).
+ * When shrinking, target size will be automatically increased to fit the
+ * higest rank in the nodeset_t, and to be at least the minimum size (1K).
+ * N.B. it is not necessary to make this call before adding a rank >= size.
+ * When that occurs size will be increased automatically, but this call
+ * will save time for expected set size >> default.
+ * Default: 1K (internal size ~133 bytes)
+ */
+bool nodeset_resize (nodeset_t *n, uint32_t size);
+
+/* Drop nodeset_string()'s cache and call nodeset_resize() with size = 0.
+ */
+void nodeset_minimize (nodeset_t *n);
+
+/* Add range/rank/string-nodeset to nodeset_t.
+ */
+bool nodeset_add_range (nodeset_t *n, uint32_t a, uint32_t b);
+bool nodeset_add_rank (nodeset_t *n, uint32_t r);
+bool nodeset_add_string (nodeset_t *n, const char *s);
+
+/* Delete range/rank/string-nodeset from nodeset_t.
+ */
+void nodeset_delete_range (nodeset_t *n, uint32_t a, uint32_t b);
+void nodeset_delete_rank (nodeset_t *n, uint32_t r);
+bool nodeset_delete_string (nodeset_t *n, const char *s);
+
+/* Test (full) list membership of range/rank/string-nodeset_t.
+ */
+bool nodeset_test_range (nodeset_t *n, uint32_t a, uint32_t b);
+bool nodeset_test_rank (nodeset_t *n, uint32_t r);
+bool nodeset_test_string (nodeset_t *n, const char *s);
+
+/* Get string-nodeset from nodeset.  Do not free.
+ */
+const char *nodeset_string (nodeset_t *n);
+
+/* Return the number of nodes in the list.
+ */
+uint32_t nodeset_count (nodeset_t *n);
+
+/* Return the min/max node ranks in the list, or NODESET_EOF if list is empty.
+ */
+uint32_t nodeset_min (nodeset_t *n);
+uint32_t nodeset_max (nodeset_t *n);
+
+/* Return next rank above r in the list, or NODESET_EOF if list is empty
+ */
+uint32_t nodeset_next_rank (nodeset_t *n, uint32_t r);
+
+/* Iteration.  Terminate when NODESET_EOF is returned.
+ */
+nodeset_iterator_t *nodeset_iterator_create (nodeset_t *n);
+void nodeset_iterator_destroy (nodeset_iterator_t *itr);
+uint32_t nodeset_next (nodeset_iterator_t *itr);
+void nodeset_iterator_rewind (nodeset_iterator_t *itr);
+
+/* Query internal nodeset attributes (mainly for testing)
+ */
+enum {
+    NODESET_ATTR_BYTES,     /* current internal size of nodeset in bytes */
+    NODESET_ATTR_SIZE,      /* current veb set size */
+    NODESET_ATTR_MINSIZE,   /* minimum veb set size (a constant) */
+    NODESET_ATTR_MAXSIZE,   /* maximum possible veb set size (a constant) */
+    NODESET_ATTR_MAXRANK,   /* maximum possible rank (a constant ) */
+};
+uint32_t nodeset_getattr (nodeset_t *n, int attr);
+
+#endif /* !_UTIL_NODESET_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/veb.c
+++ b/src/common/libutil/veb.c
@@ -1,0 +1,369 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include "veb.h"
+#include "veb_mach.c"
+
+/*
+Copyright (c) 2010 Jani Lahtinen <jani.lahtinen8@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+static uint
+bytes(uint x)
+{
+	return x/8+(x%8>0);
+}
+
+static uint
+zeros(uint k)
+{
+	return ~0<<k;
+}
+
+static uint
+ones(uint k)
+{
+	return ~zeros(k);
+}
+
+static uint
+ipow(uint k)
+{
+	return 1<<k;
+}
+
+static uint
+lowbits(uint x, uint k)
+{
+	return x&ones(k);
+}
+
+static uint
+highbits(uint x, uint k)
+{
+	return x>>k;
+}
+
+static uint
+decode(uchar D[], uint b)
+{
+	uint x = 0;
+	int i;
+
+	for (i = 0; i < b; ++i)
+		x |= D[i]<<8*i;
+	return x;
+}
+
+static void
+encode(uchar D[], uint b, uint x)
+{
+	int i;
+	for (i = 0; i < b; ++i)
+		D[i] = (x>>8*i)&0xff;
+}
+
+static void
+set(uchar D[], uint x)
+{
+	D[x/8] |= (1<<x%8);
+}
+
+static void
+unset(uchar D[], uint x)
+{
+	D[x/8] &= ~(1<<x%8);
+}
+
+static uint
+low(Veb T)
+{
+	if (T.M <= WORD) {
+		uint x = decode(T.D,bytes(T.M));
+		if (x == 0)
+			return T.M;
+		return ctz(x);
+	}
+	return decode(T.D,bytes(T.k));
+}
+
+static void
+setlow(Veb T, uint x)
+{
+	if (T.M <= WORD)
+		set(T.D,x);
+	else
+		encode(T.D,bytes(T.k),x);
+}
+
+static uint
+high(Veb T)
+{
+	if (T.M <= WORD) {
+		uint x = decode(T.D,bytes(T.M));
+		if (x == 0)
+			return T.M;
+		return fls(x)-1;
+	}
+	return decode(T.D+bytes(T.k),bytes(T.k));
+}
+
+static void
+sethigh(Veb T, uint x)
+{
+	if (T.M <= WORD)
+		set(T.D,x);
+	else
+		encode(T.D+bytes(T.k),bytes(T.k),x);
+}
+
+uint
+vebsize(uint M)
+{
+	if (M <= WORD)
+		return bytes(M);
+	uint k = fls(M-1);
+	uint m = highbits(M-1,k/2)+1;
+	uint n = ipow(k/2);
+	return 2*bytes(k)+vebsize(m)+(m-1)*vebsize(n)+vebsize(M-(m-1)*n);
+}
+
+static Veb
+aux(Veb S)
+{
+	Veb T;
+	T.k = S.k-S.k/2;
+	T.D = S.D+2*bytes(S.k);
+	T.M = highbits(S.M-1,S.k/2)+1;
+	return T;
+}
+
+static Veb
+branch(Veb S, uint i)
+{
+	Veb T;
+	uint k = S.k/2;
+	uint m = highbits(S.M-1,k)+1;
+	uint n = ipow(k);
+	if (i < m-1) {
+		T.M = n;
+		T.k = k;
+	} else {
+		T.M = S.M-(m-1)*n;
+		T.k = fls(T.M-1);
+	}
+	T.D = S.D+2*bytes(S.k)+vebsize(m)+i*vebsize(n);
+	return T;
+}
+
+static int
+empty(Veb T)
+{
+	if (T.M <= WORD)
+		return decode(T.D,bytes(T.M))==0;
+	if (low(T) <= high(T))
+		return 0;
+	return 1;
+}
+
+static void
+mkempty(Veb T)
+{
+	int i;
+	if (T.M <= WORD) {
+		encode(T.D,bytes(T.M),0);
+		return;
+	}
+	setlow(T,1);
+	sethigh(T,0);
+	mkempty(aux(T));
+	uint m = highbits(T.M-1,T.k/2)+1;
+	for (i = 0; i < m; ++i)
+		mkempty(branch(T,i));
+}
+
+Veb
+vebnew(uint M, int full)
+{
+	Veb T;
+	T.M = 0;
+	T.k = fls(M-1);
+	T.D = malloc(vebsize(M));
+	if (T.D) {
+		T.M = M;
+		mkempty(T);
+		if (full) {
+			for (uint m=0; m < T.M; m++)
+				vebput(T,m);
+		}
+	}
+	return T;
+}
+
+void
+vebput(Veb T, uint x)
+{
+	if (x >= T.M)
+		return;
+	if (T.M <= WORD) {
+		set(T.D,x);
+		return;
+	}
+	if (empty(T)) {
+		setlow(T,x);
+		sethigh(T,x);
+		return;
+	}
+	uint lo = low(T);
+	uint hi = high(T);
+	if (x == lo || x == hi)
+		return;
+	if (x < lo) {
+		setlow(T,x);
+		if (lo == hi)
+			return;
+		x = lo;
+	} else if (x > hi) {
+		sethigh(T,x);
+		if (lo == hi)
+			return;
+		x = hi;
+	}
+	uint i = highbits(x,T.k/2);
+	uint j = lowbits(x,T.k/2);
+	Veb B = branch(T,i);
+	vebput(B,j);
+	if (low(B) == high(B))
+		vebput(aux(T),i);
+}
+
+void
+vebdel(Veb T, uint x)
+{
+	if (empty(T) || x >= T.M)
+		return;
+	if (T.M <= WORD) {
+		unset(T.D,x);
+		return;
+	}
+	uint lo = low(T);
+	uint hi = high(T);
+	if (x < lo || x > hi)
+		return;
+	if (lo == hi && x == lo) {
+		sethigh(T,0);
+		setlow(T,1);
+		return;
+	}
+	uint i,j;
+	Veb B, A = aux(T);
+	if (x == lo) {
+		if (empty(A)) {
+			setlow(T,hi);
+			return;
+		} else {
+			i = low(A);
+			B = branch(T,i);
+			j = low(B);
+			setlow(T,i*ipow(T.k/2)+j);
+		}
+	} else if (x == hi) {
+		if (empty(A)) {
+			sethigh(T,lo);
+			return;
+		} else {
+			i = high(A);
+			B = branch(T,i);
+			j = high(B);
+			sethigh(T,i*ipow(T.k/2)+j);
+		}
+	} else {
+		i = highbits(x,T.k/2);
+		j = lowbits(x,T.k/2);
+		B = branch(T,i);
+	}
+	vebdel(B,j);
+	if (empty(B))
+		vebdel(A,i);
+}
+
+uint
+vebsucc(Veb T, uint x)
+{
+	uint hi = high(T);
+	if (empty(T) || x > hi)
+		return T.M;
+	if (T.M <= WORD) {
+		uint y = decode(T.D,bytes(T.M));
+		y &= zeros(x);
+		if (y > 0)
+			return ctz(y);
+		return T.M;
+	}
+	uint lo = low(T);
+	if (x <= lo)
+		return lo;
+	Veb A = aux(T);
+	if (empty(A) || x == hi)
+		return hi;
+	uint i = highbits(x,T.k/2);
+	uint j = lowbits(x,T.k/2);
+	Veb B = branch(T,i);
+	if (!empty(B) && j <= high(B))
+		return i*ipow(T.k/2)+vebsucc(B,j);
+	i = vebsucc(A,i+1);
+	if (i == A.M)
+		return hi;
+	B = branch(T,i);
+	return i*ipow(T.k/2)+low(B);
+}
+
+uint
+vebpred(Veb T, uint x)
+{
+	uint lo = low(T);
+	if (empty(T) || x < lo || x >= T.M)
+		return T.M;
+	if (T.M <= WORD) {
+		uint y = decode(T.D,bytes(T.M));
+		y &= ones(x+1);
+		if (y > 0)
+			return fls(y)-1;
+		return T.M;
+	}
+	uint hi = high(T);
+	if (x >= hi)
+		return hi;
+	Veb A = aux(T);
+	if (empty(A) || x == lo)
+		return lo;
+	uint i = highbits(x,T.k/2);
+	uint j = lowbits(x,T.k/2);
+	Veb B = branch(T,i);
+	if (!empty(B) && j >= low(B))
+		return i*ipow(T.k/2)+vebpred(B,j);
+	i = vebpred(A,i-1);
+	if (i == A.M)
+		return lo;
+	B = branch(T,i);
+	return i*ipow(T.k/2)+high(B);
+}

--- a/src/common/libutil/veb.h
+++ b/src/common/libutil/veb.h
@@ -1,0 +1,43 @@
+#ifndef _UTIL_LIBVEB_H
+#define _UTIL_LIBVEB_H
+/*
+Copyright (c) 2010 Jani Lahtinen <jani.lahtinen8@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+typedef unsigned int uint;
+typedef unsigned char uchar;
+typedef struct Veb Veb;
+
+struct Veb
+{
+	uchar *D;
+	uint k;
+	uint M;
+};
+
+Veb vebnew(uint, int);
+uint vebsize(uint);
+void vebdel(Veb, uint);
+void vebput(Veb, uint);
+uint vebsucc(Veb, uint);
+uint vebpred(Veb, uint);
+
+#endif /* _UTIL_LIBVEB_H */

--- a/src/common/libutil/veb_mach.c
+++ b/src/common/libutil/veb_mach.c
@@ -1,0 +1,21 @@
+
+#define WORD \
+	sizeof(uint)*8
+
+static uint
+clz(uint x)
+{
+	return __builtin_clz(x);
+}
+
+static uint
+ctz(uint x)
+{
+	return __builtin_ctz(x);
+}
+
+static uint
+fls(uint x)
+{
+	return WORD-clz(x);
+}


### PR DESCRIPTION
This is somewhat experimental. I at least wanted to do this to see the valgrind results on Travis. So don't merge yet.

Pull in nodeset class and friends from `flux-core` and add those files to flux-ached's libutil.

Incorporate nodeset to`R_lite` generator in `resrc_tree.c` to condense the list.