### PR TITLE
Add valgrind wrap specification for dlclose in sched/plugin.c

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,7 @@ AC_CHECK_LIB([dl], [dlerror],
 PKG_CHECK_MODULES([HWLOC], [hwloc >= 1.11.1], [], [])
 PKG_CHECK_MODULES([JANSSON], [jansson >= 2.6], [], [])
 PKG_CHECK_MODULES([XML2], [libxml-2.0])
+AX_VALGRIND_H
 AX_PROG_LUA([5.1],[5.3])
 AX_LUA_HEADERS
 AX_LUA_LIBS
@@ -63,7 +64,17 @@ AC_CHECK_LIB([readline], [readline],
              [AC_MSG_ERROR([Please install GNU readline])])
 
 # Checks for header files.
-AC_CHECK_HEADERS([inttypes.h limits.h stdint.h stdlib.h string.h sys/time.h unistd.h readline/readline.h readline/history.h])
+AC_CHECK_HEADERS([\
+  inttypes.h \
+  limits.h \
+  stdint.h \
+  stdlib.h \
+  string.h \
+  sys/time.h \
+  unistd.h \
+  readline/readline.h \
+  readline/history.h \
+])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_HEADER_STDBOOL # in newer ac version:  AC_CHECK_HEADER_STDBOOL

--- a/m4/ax_valgrind.m4
+++ b/m4/ax_valgrind.m4
@@ -1,0 +1,59 @@
+# ===========================================================================
+#      https://github.com/flux-framework/flux-sched/
+# ===========================================================================
+# SYNOPSIS
+#
+#   AX_VALGRIND_H
+#
+# DESCRIPTION
+#
+#   Find valgrind.h first trying pkg-config, fallback to valgrind.h
+#    or valgrind/valgrind.h
+#
+#  This macro will set
+#  HAVE_VALGRIND if valgrind.h support was found
+#  HAVE_VALGRIND_H if #include <valgrind.h> works
+#  HAVE_VALGRIND_VALGRIND_H if #include <valgrind/valgrind.h> works
+#
+# LICENSE
+#
+#   Copyright (c) 2016 Lawrence Livermore National Security, LLC.  Produced at
+#   the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+#   LLNL-CODE-658032 All rights reserved.
+#
+#   This file is part of the Flux resource manager framework.
+#   For details, see https://github.com/flux-framework.
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the Free
+#   Software Foundation; either version 2 of the license, or (at your option)
+#   any later version.
+#
+#   Flux is distributed in the hope that it will be useful, but WITHOUT
+#   ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+#   FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program; if not, write to the Free Software Foundation, Inc.,
+#   59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+#   See also:  http://www.gnu.org/licenses/
+#
+
+AC_DEFUN([AX_VALGRIND_H], [
+  PKG_CHECK_MODULES([VALGRIND], [valgrind],
+      [AC_DEFINE([HAVE_VALGRIND], [1], [Define if you have valgrind.h])
+       ax_valgrind_saved_CFLAGS=$CFLAGS
+       ax_valgrind_saved_CPPFLAGS=$CPPFLAGS
+       CFLAGS="$CFLAGS $VALGRIND_CFLAGS"
+       CPPFLAGS="$CFLAGS"
+       AC_CHECK_HEADERS([valgrind.h valgrind/valgrind.h])
+       CFLAGS="$ax_valgrind_saved_CFLAGS"
+       CPPFLAGS="$ax_valgrind_saved_CPPFLAGS"
+      ],
+      [AC_CHECK_HEADERS([valgrind.h valgrind/valgrind.h],
+                        [AC_DEFINE([HAVE_VALGRIND], [1],
+                                   [Define if you have valgrind.h])])
+      ])
+  ]
+)

--- a/sched/Makefile.am
+++ b/sched/Makefile.am
@@ -23,7 +23,7 @@ schedplugin_LTLIBRARIES = \
 noinst_HEADERS = scheduler.h rs2rank.h rsreader.h plugin.h
 
 sched_la_SOURCES = sched.c rs2rank.c rsreader.c plugin.c
-sched_la_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/resrc
+sched_la_CFLAGS = $(AM_CFLAGS) $(VALGRIND_CFLAGS) -I$(top_srcdir)/resrc
 sched_la_LIBADD = $(top_builddir)/resrc/libflux-resrc.la \
     $(FLUX_CORE_LIBS) $(DL_LIBS) $(HWLOC_LIBS) $(UUID_LIBS) \
     $(JANSSON_LIBS) $(CZMQ_LIBS) \

--- a/sched/plugin.c
+++ b/sched/plugin.c
@@ -29,6 +29,14 @@
 #include <flux/core.h>
 #include <czmq.h>
 
+#if HAVE_VALGRIND
+# if HAVE_VALGRIND_H
+#  include <valgrind.h>
+# elif HAVE_VALGRIND_VALGRIND_H
+#  include <valgrind/valgrind.h>
+# endif
+#endif
+
 #include "src/common/libutil/shortjansson.h"
 #include "scheduler.h"
 #include "plugin.h"
@@ -432,6 +440,12 @@ void sched_plugin_loader_destroy (struct sched_plugin_loader *sploader)
         free (sploader);
     }
 }
+
+#if HAVE_VALGRIND
+/* Disable dlclose() during valgrind operation
+ */
+void I_WRAP_SONAME_FNNAME_ZZ(Za,dlclose)(void *dso) {}
+#endif
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab


### PR DESCRIPTION
@dongahn, can you try these two commits and see if they have any effect on the results you are seeing with `t5000-valgrind.t`?

IIUC, this should allow flux-sched valgrind test to work with even a flux-core that was not configured with `valgrind/valgrind.h`. Once `sched.so` is dlopened by `flux-broker`, the valgrind spec added to `sched/plugin.c` should become active and reroute future calls to `dlclose()` to the noop wrapped version.

You will have to apply these two commits and rerun `./autogen` and `./configure`. Then ensure that valgrind/valgrind.h was found with 
```
$ grep VALGRIND config.h
#define HAVE_VALGRIND_VALGRIND_H 1
```
Then retry the valgrind tests and ensure there are no false positives/missing symbols.

Thanks!
