### PR TITLE
Condensing core id list in R_lite

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,7 @@ AX_BOOST_FILESYSTEM
 AX_BOOST_GRAPH
 AX_BOOST_REGEX
 PKG_CHECK_MODULES([JOBSPEC], [flux-jobspec], [], [])
+PKG_CHECK_MODULES([IDSET], [flux-idset], [], [])
 AC_CHECK_LIB([readline], [readline],
              [AC_SUBST([READLINE_LIBS], ["-lreadline"])
               AC_DEFINE([HAVE_LIBREADLINE], [1],

--- a/resrc/Makefile.am
+++ b/resrc/Makefile.am
@@ -12,10 +12,10 @@ noinst_HEADERS = resrc_api.h resrc_api_internal.h \
                  resrc.h resrc_tree.h resrc_flow.h resrc_reqst.h
 
 libflux_resrc_la_SOURCES = resrc.c resrc_tree.c resrc_flow.c resrc_reqst.c
-libflux_resrc_la_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/rdl
+libflux_resrc_la_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/rdl $(IDSET_CFLAGS)
 libflux_resrc_la_LIBADD = $(top_builddir)/rdl/libflux-rdl.la \
     $(top_builddir)/src/common/libutil/libutil.la \
-    $(DL_LIBS) $(HWLOC_LIBS) $(UUID_LIBS) $(JANSSON_LIBS) $(CZMQ_LIBS)
+    $(DL_LIBS) $(HWLOC_LIBS) $(UUID_LIBS) $(JANSSON_LIBS) $(CZMQ_LIBS) $(IDSET_LIBS)
 libflux_resrc_la_LDFLAGS = $(AM_LDFLAGS) $(fluxlib_ldflags) \
     -Wl,--version-script=$(srcdir)/resrc_version.map
 

--- a/resrc/resrc_reqst.c
+++ b/resrc/resrc_reqst.c
@@ -566,18 +566,22 @@ int64_t resrc_tree_search (resrc_api_ctx_t *ctx,
          * and omit the intervening socket.
          */
 
-        if (*found_tree)
-            new_tree = resrc_tree_new (*found_tree, resrc_in);
-        else {
-            new_tree = resrc_tree_new (NULL, resrc_in);
-            *found_tree = new_tree;
-        }
+        new_tree = resrc_tree_new (NULL, resrc_in);
         children = resrc_tree_children (resrc_phys_tree (resrc_in));
         child_tree = resrc_tree_list_first (children);
         while (child_tree) {
             nfound += resrc_tree_search (ctx, resrc_tree_resrc (child_tree),
                                          resrc_reqst, &new_tree, available);
             child_tree = resrc_tree_list_next (children);
+        }
+
+        if (nfound) {
+            if (*found_tree)
+                resrc_tree_add_child (*found_tree, new_tree);
+            else
+                *found_tree = new_tree;
+        } else {
+            resrc_tree_destroy (ctx, new_tree, false, false);
         }
     }
 ret:

--- a/resrc/resrc_tree.h
+++ b/resrc/resrc_tree.h
@@ -88,11 +88,11 @@ int resrc_tree_serialize (json_t *o, resrc_tree_t *resrc_tree);
  * \param reduce[out]   json object used for reducing resources whose type
  *                      is contained within reduce_m.
  * \param resrc_tree    resrc_tree object to serialize.
- * \param gather_m      map that contains resoures types to serialize
+ * \param gather_m      map that contains resoure type(s) to serialize
  *                      in the gather form. If the value of the type is
  *                      REDUCE_UNDER_ME, the first offspring resource type
  *                      under it will be serialized in the reduce form.
- * \param reduce_m      map that contains resoures types to serialize
+ * \param reduce_m      map that contains resource type(s) to serialize
  *                      in the reduce form.
  *
  */

--- a/sched/sched.c
+++ b/sched/sched.c
@@ -1381,7 +1381,7 @@ static int req_tpexec_allocate (ssrvctx_t *ctx, flux_lwj_t *job)
     resrc_api_map_put (gmap, "node", (void *)(intptr_t)REDUCE_UNDER_ME);
     resrc_api_map_put (rmap, "core", (void *)(intptr_t)NONE_UNDER_ME);
     if (resrc_tree_serialize_lite (gat, red, job->resrc_tree, gmap, rmap)) {
-        flux_log (h, LOG_ERR, "%"PRId64" resource serialization failed: %s",
+        flux_log (h, LOG_ERR, "job (%"PRId64") resource serialization failed: %s",
                   job->lwj_id, strerror (errno));
         goto done;
     } else if (resolve_rank (ctx, gat)) {

--- a/sched/sched.c
+++ b/sched/sched.c
@@ -721,8 +721,7 @@ static int load_resources (ssrvctx_t *ctx)
             goto done;
         } else if (build_hwloc_rs2rank (ctx, r_mode) != 0) {
             flux_log (ctx->h, LOG_ERR, "failed to build rs2rank");
-            if (errno != 0)
-                errno = EINVAL;
+            errno = EINVAL;
             goto done;
         } else if (rsreader_force_link2rank (ctx->rsapi, ctx->machs) != 0) {
             flux_log (ctx->h, LOG_ERR, "failed to force a link to a rank");

--- a/sched/sched.c
+++ b/sched/sched.c
@@ -1378,11 +1378,17 @@ static int req_tpexec_allocate (ssrvctx_t *ctx, flux_lwj_t *job)
     resrc_api_map_t *gmap = resrc_api_map_new ();
     resrc_api_map_t *rmap = resrc_api_map_new ();
 
+    if (ctx->arg.verbosity > 0) {
+        flux_log (h, LOG_DEBUG, "job(%"PRId64"): selected resource tree",
+                  job->lwj_id);
+        dump_resrc_state (ctx->h, job->resrc_tree);
+    }
+
     resrc_api_map_put (gmap, "node", (void *)(intptr_t)REDUCE_UNDER_ME);
     resrc_api_map_put (rmap, "core", (void *)(intptr_t)NONE_UNDER_ME);
     if (resrc_tree_serialize_lite (gat, red, job->resrc_tree, gmap, rmap)) {
-        flux_log (h, LOG_ERR, "job (%"PRId64") resource serialization failed: %s",
-                  job->lwj_id, strerror (errno));
+        flux_log (h, LOG_ERR, "job (%"PRId64") resource serialization failed",
+                  job->lwj_id);
         goto done;
     } else if (resolve_rank (ctx, gat)) {
         flux_log (ctx->h, LOG_ERR, "resolving a hostname to rank failed");


### PR DESCRIPTION
Add the newly added `idset` support and incorporate `idset` in the `R_lite` generator in resrc_tree.c to condense the core list.