### PR TITLE
Drop rank.N support in favor of R_lite

### DIFF
--- a/resrc/test/tresrc.c
+++ b/resrc/test/tresrc.c
@@ -361,6 +361,7 @@ static int test_a_resrc (resrc_api_ctx_t *rsapi, resrc_t *resrc, bool rdl)
     resrc_api_map_put (gather_map, "node", (void *)(intptr_t)REDUCE_UNDER_ME);
     resrc_api_map_t *reduce_map = resrc_api_map_new ();
     resrc_api_map_put (reduce_map, "core", (void *)(intptr_t)NONE_UNDER_ME);
+    resrc_api_map_put (reduce_map, "gpu", (void *)(intptr_t)NONE_UNDER_ME);
 
     init_time ();
     rc = resrc_tree_serialize_lite (gather, reduce, found_tree,

--- a/sched/sched.c
+++ b/sched/sched.c
@@ -1385,6 +1385,7 @@ static int req_tpexec_allocate (ssrvctx_t *ctx, flux_lwj_t *job)
 
     resrc_api_map_put (gmap, "node", (void *)(intptr_t)REDUCE_UNDER_ME);
     resrc_api_map_put (rmap, "core", (void *)(intptr_t)NONE_UNDER_ME);
+    resrc_api_map_put (rmap, "gpu", (void *)(intptr_t)NONE_UNDER_ME);
     if (resrc_tree_serialize_lite (gat, red, job->resrc_tree, gmap, rmap)) {
         flux_log (h, LOG_ERR, "job (%"PRId64") resource serialization failed",
                   job->lwj_id);

--- a/t/scripts/R_lite.lua
+++ b/t/scripts/R_lite.lua
@@ -1,0 +1,82 @@
+#!/usr/bin/env lua
+
+local cpuset = require 'flux.cpuset'
+local id_to_kvs_path = require 'wreck'.id_to_path
+local f = assert (require 'flux'.new())
+local jobid = tonumber (arg[1])
+local rank = arg[2] or "all"
+local resource_type = arg[3] or "all"
+local format = arg[4] or "all"
+
+local function die (...)
+    io.stderr:write (string.format (...))
+    os.exit (1)
+end
+
+local function usage ()
+    io.stderr:write ('Usage: R_lite Jobid [Rank Resource Format]\n')
+    io.stderr:write ([[
+  Print R_lite information on a job.
+      Jobid       jobid.
+
+  Optional Arguments
+      Rank        a specific rank for which to print resource info;
+                  if "all" is given, print for all ranks.
+      Resource    type of the resource for which to print the info:
+                  all (default), core, or gpu.
+      Format      if "count" is given, print only the count on the resource(s)
+                  if "id", print only the ID of the resource(s)
+                  if omitted, print both the count and ID.
+]]) 
+end
+
+local function r_string (resources, count, id)
+    local s = ""
+
+    for k,v in pairs (resources) do
+        if resource_type == "all" or (resource_type == k and format == "all") then
+            s = s..(count and "count="..#cpuset.new (resources[k]).." " or "")
+            s = s..(id and k.."="..resources[k] or "")
+        elseif resource_type == k then
+            s = s..(count and #cpuset.new (resources[k]) or "")
+            s = s..(id and resources[k] or "")
+        end
+    end
+    return s
+end
+
+local function run (count, id)
+    local key = id_to_kvs_path{ flux = f, jobid = jobid }..".R_lite"
+    local R_lite = assert (f:kvs_get (key))
+    local hit = false
+
+    for _,r in pairs (R_lite) do
+        local rtype = r.children[resource_type]
+        if resource_type ~= "all" and not rtype then
+            die ("No info in R_lite for %s\n", resource_type)
+        end
+
+        if rank == "all" then
+            hit = true;
+            print ("rank"..r.rank..": "..r_string (r.children, count, id))
+        elseif r.rank == tonumber (rank) then
+            hit = true;
+            print (r_string (r.children, count, id))
+        end
+    end
+
+    if hit == false then
+        die ("No info in R_lite for rank %d\n", rank)
+    end
+end
+
+local count = (format == "all" or format == "count")
+local id = (format == "all" or format == "id")
+if not jobid or #arg < 1 or (count == false and id == false) then
+    usage ()
+    os.exit ()
+end
+
+run (count, id)
+
+-- vi: ts=4 sw=4 expandtab

--- a/t/sharness.d/sched-sharness.sh
+++ b/t/sharness.d/sched-sharness.sh
@@ -124,8 +124,8 @@ verify_1N_sleep_jobs () {
     local rank=0
     for i in `seq $sched_start_jobid $sched_end_jobid`
     do
-        flux kvs get $(job_kvs_path $i).rank.$rank.cores \
-            > $sched_test_session.$i.out
+        $SHARNESS_TEST_SRCDIR/scripts/R_lite.lua ${i} ${rank} core count \
+            > ${sched_test_session}.${i}.out
         grep $cores $sched_test_session.$i.out
         if [ $? -ne 0 ]
         then


### PR DESCRIPTION
This PR drops rank.N and introduces GPU support into `R_lite`. If GPUs are involved, `R_lite` will look like:

`[ { "node": "cab1234", "children": { "core": "0-15", "gpu": "0-1" }, "rank": 0 } ]`

@trws and @grondo: will this representation work? I think `wreck` is okay with the introduction of the `gpu` field.

Now, a bunch of scheduler tests will fail with these changes because of this [sharness script code](https://github.com/flux-framework/flux-sched/blob/master/t/sharness.d/sched-sharness.sh#L127).

I will have to adjust this script code to make use of `R_lite` instead of `rank.N.cores`. I can write a simple C wrapper that makes use of jansson and idset for this purpose, but I'm wondering if flux-core already has some utilities that I can use for this purpose. @grondo?