### PR TITLE
sched: fix request handler type mismatch on i386

### DIFF
--- a/sched/sched.c
+++ b/sched/sched.c
@@ -1943,7 +1943,7 @@ static void exclude_request_cb (flux_t *h, flux_msg_handler_t *w,
 {
     ssrvctx_t *ctx = getctx ((flux_t *)arg);
     const char *hostname = NULL;
-    bool kill = false;
+    int kill = false;
     uint32_t userid = 0;
     char *topic = NULL;
     resrc_t *node = NULL;


### PR DESCRIPTION
Problem: exclude_request_cb() unpacks a 'b' boolean
JSON value to a bool, but unpack expects an int.
This caused a segfault on i386 (32-bit).

Change bool to an int.

Fixes #345