### PR TITLE
Introduce planner_multi_t 

### DIFF
--- a/resource/generators/gen.cpp
+++ b/resource/generators/gen.cpp
@@ -206,16 +206,12 @@ vtx_t dfs_emitter_t::emit_vertex (ggv_t u, gge_t e, const gg_t &recipe,
     db.resource_graph[v].type = recipe[u].type;
     db.resource_graph[v].basename = recipe[u].basename;
     db.resource_graph[v].size = recipe[u].size;
-    const char *res_types[1] = {NULL};
-    res_types[0] = recipe[u].type.c_str ();
-    const uint64_t avail = recipe[u].size;
-    planner_t *plans = planner_new (0, INT64_MAX, &avail, res_types, 1);
-    db.resource_graph[v].schedule.plans = plans;
-
-    const char *jobs = X_CHECKER_JOBS_STR;
-    const uint64_t njobs = X_CHECKER_NJOBS;
-    planner_t *x_checker = planner_new (0, INT64_MAX, &njobs, &jobs, 1);
-    db.resource_graph[v].schedule.x_checker = x_checker;
+    db.resource_graph[v].schedule.plans = planner_new (0, INT64_MAX,
+                                                       recipe[u].size,
+                                                       recipe[u].type.c_str ());
+    db.resource_graph[v].schedule.x_checker = planner_new (0, INT64_MAX,
+                                                           X_CHECKER_NJOBS,
+                                                           X_CHECKER_JOBS_STR);
     db.resource_graph[v].id = id;
     db.resource_graph[v].name = recipe[u].basename + istr;
     db.resource_graph[v].paths[ssys] = pref + "/" + db.resource_graph[v].name;

--- a/resource/planner/Makefile.am
+++ b/resource/planner/Makefile.am
@@ -12,9 +12,9 @@ AM_LDFLAGS = \
 SUBDIRS = . test
 
 noinst_LTLIBRARIES = libplanner.la
-noinst_HEADERS = planner.h
+noinst_HEADERS = planner.h planner_multi.h
 
-libplanner_la_SOURCES = planner.c
+libplanner_la_SOURCES = planner.c planner_multi.c
 libplanner_la_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/resource/planner
 libplanner_la_LIBADD = \
 	$(top_builddir)/src/common/libutil/libutil.la \

--- a/resource/planner/planner.h
+++ b/resource/planner/planner.h
@@ -32,8 +32,6 @@
 extern "C" {
 #endif
 
-#define PLANNER_NUM_TYPES 5
-
 typedef struct planner planner_t;
 
 /*! Construct a planner.
@@ -42,26 +40,19 @@ typedef struct planner planner_t;
  *                      (i.e., the base time of the planner to be constructed).
  *  \param duration     time span of this planner (i.e., all planned spans
  *                      must end before base_time + duration).
- *  \param resource_totals
- *                      64-bit unsigned integer array of size len where each
- *                      element contains the total count of available resources
- *                      of a single resource type. Up to PLANNER_NUM_TYPES types
- *                      are supported.
- *  \param resource_types
- *                      string array of size len where each element contains
- *                      the resource type corresponding to each corresponding
- *                      element in the resource_totals array.
- *  \param len          length of the resource_totals and resource_types arrays;
- *                      must not exceed PLANNER_NUM_TYPES.
+ *  \param resource_total
+ *                      the total count of available resources.
+ *  \param resource_type
+ *                      the resource type string
  *  \return             new planner context; NULL on an error with errno set
  *                      as follows:
- *                      0 on success; -1 on an error with errno set:
+ *                      pointer to a planner_t object on success; -1 on
+ *                      an error with errno set:
  *                          EINVAL: invalid argument.
- *                          ERANGE: resource_totals contains an out-of-range value.
+ *                          ERANGE: resource_total is an out-of-range value.
  */
 planner_t *planner_new (int64_t base_time, uint64_t duration,
-                        const uint64_t *resource_totals,
-                        const char **resource_types, size_t len);
+                        uint64_t resource_total, const char *resource_type);
 
 /*! Reset the planner with a new time bound. Destroy all existing planned spans.
  *
@@ -89,15 +80,8 @@ void planner_destroy (planner_t **ctx_p);
  */
 int64_t planner_base_time (planner_t *ctx);
 int64_t planner_duration (planner_t *ctx);
-size_t planner_resources_len (planner_t *ctx);
-int64_t planner_resource_total_at (planner_t *ctx, unsigned int i);
-int64_t planner_resource_total_by_type (planner_t *ctx,
-                                        const char *resource_type);
-const uint64_t *planner_resource_totals (planner_t *ctx);
-const char **planner_resource_types (planner_t *ctx);
-int planner_resource_index_of_type (planner_t *ctx,
-                                    const char *resource_type);
-const char *planner_resource_type_at (planner_t *ctx, unsigned int i);
+int64_t planner_resource_total (planner_t *ctx);
+const char *planner_resource_type (planner_t *ctx);
 
 /*! Find and return the earliest point in integer time when the request can be
  *  satisfied.
@@ -111,19 +95,15 @@ const char *planner_resource_type_at (planner_t *ctx, unsigned int i);
  *  \param ctx          opaque planner context returned from planner_new.
  *  \param on_or_after  available on or after the specified time.
  *  \param duration     requested duration; must be greater than or equal to 1.
- *  \param resource_counts
- *                      64-bit unsigned integer array of size len specifying
- *                      the requested resource counts.
- *  \param len          length of resource_counts and resource_types arrays;
- *                      must not exceed PLANNER_NUM_TYPES.
+ *  \param request      resource count request.
  *  \return             earliest time at which the request can be satisfied;
  *                      -1 on an error with errno set as follows:
  *                          EINVAL: invalid argument.
- *                          ERANGE: resource_counts contain an out-of-range value.
+ *                          ERANGE: request is an out-of-range value.
+ *                          ENOENT: no scheduleable point
  */
 int64_t planner_avail_time_first (planner_t *ctx, int64_t on_or_after,
-                                  uint64_t duration,
-                                  const uint64_t *resource_counts, size_t len);
+                                  uint64_t duration, uint64_t request);
 
 /*! Find and return the next earliest point in time at which the same request
  *  queried before via either planner_avail_time_first or
@@ -132,10 +112,13 @@ int64_t planner_avail_time_first (planner_t *ctx, int64_t on_or_after,
  *
  *  \param ctx          opaque planner context returned from planner_new.
  *  \return             earliest time at which the request can be satisfied;
- *                      -1 on an error with errno set as follows:
+ *                      -1 on error with errno set as follows:
  *                          EINVAL: invalid argument.
+ *                          ERANGE: request is out of range
+ *                          ENOENT: no scheduleable point
  */
 int64_t planner_avail_time_next (planner_t *ctx);
+
 
 /*! Test if the given request can be satisfied at the start time.
  *  Note on semantics: Unlike planner_avail_time* functions, this function
@@ -145,107 +128,37 @@ int64_t planner_avail_time_next (planner_t *ctx);
  *  \param at           start time from which the requested resources must
  *                      be available for duration.
  *  \param duration     requested duration; must be greater than or equal to 1.
- *  \param resource_counts
- *                      64-bit unsigned integer array of size len specifying
- *                      the requested resource counts.
- *  \param len          length of resource_counts and resource_types arrays.
- *                      must not exceed PLANNER_NUM_TYPES.
+ *  \param request      resource count request.
  *  \return             0 if the request can be satisfied; -1 if it cannot
  *                      be satisfied or an error encountered (errno as follows):
  *                          EINVAL: invalid argument.
- *                          ERANGE: resource_counts contain an out-of-range value.
+ *                          ERANGE: request is an out-of-range value.
  *                          ENOTSUP: internal error encountered.
  */
 int planner_avail_during (planner_t *ctx, int64_t at, uint64_t duration,
-                          const uint64_t *resource_counts, size_t len);
+                          uint64_t request);
 
-/*! Return how many ith resources are available for the duration starting from at.
+/*! Return how resources are available for the duration starting from at.
  *
  *  \param ctx          opaque planner context returned from planner_new.
  *  \param at           instant time for which this query is made.
  *  \param duration     requested duration; must be greater than or equal to 1.
- *  \param i            index of the resource type to queried; must be less than
- *                      PLANNER_NUM_TYPES.
  *  \return             available resource count; -1 on an error with errno set
  *                      as follows:
  *                          EINVAL: invalid argument.
  */
 int64_t planner_avail_resources_during (planner_t *ctx, int64_t at,
-                                        uint64_t duration, unsigned int i);
+                                        uint64_t duration);
 
-/*! Return how many resources of resource_type are available for the duration
- *  starting from at.
- *
+/*! Return how many resources are available at the given time.
  *
  *  \param ctx          opaque planner context returned from planner_new.
  *  \param at           instant time for which this query is made.
- *  \param duration     requested duration; must be greater than or equal to 1.
- *  \param resource_type
- *                      the resource type to queried.
  *  \return             available resource count; -1 on an error with errno set
  *                      as follows:
  *                          EINVAL: invalid argument.
  */
-int64_t planner_avail_resources_during_by_type (planner_t *ctx, int64_t at,
-                                                uint64_t duration,
-                                                const char *resource_type);
-
-/*! Return how many resources are available for the duration starting from at.
- *
- *
- *  \param ctx          opaque planner context returned from planner_new.
- *  \param at           instant time for which this query is made.
- *  \param duration     requested duration; must be greater than or equal to 1.
- *  \param resources    resources array buffer to copy and return available counts
- *                      into.
- *  \return             available resource count; -1 on an error with errno set
- *                      as follows:
- *                          EINVAL: invalid argument.
- */
-int planner_avail_resources_array_during (planner_t *ctx, int64_t at,
-                                          uint64_t duration, int64_t *resources,
-                                          size_t len);
-
-/*! Return how many resources of ith type is available at the given time.
- *
- *  \param ctx          opaque planner context returned from planner_new.
- *  \param at           instant time for which this query is made.
- *  \param i            index of the resource type to queried; must be less than
- *                      PLANNER_NUM_TYPES.
- *  \return             available resource count; -1 on an error with errno set
- *                      as follows:
- *                          EINVAL: invalid argument.
- */
-int64_t planner_avail_resources_at (planner_t *ctx, int64_t at, unsigned int i);
-
-
-/*! Return how many resources of resource_type are available at the given instant
- *  time.
- *
- *  \param ctx          opaque planner context returned from planner_new.
- *  \param at           instant time for which this query is made.
- *  \param resource_type
- *                      the resource type to be queried.
- *  \return             available resource count; -1 on an error with errno set
- *                      as follows:
- *                          EINVAL: invalid argument.
- */
-int64_t planner_avail_resources_at_by_type (planner_t *ctx, int64_t at,
-                                            const char *resource_type);
-
-
-/*! Return how many resources are available at the given instant time.
- *
- *  \param ctx          opaque planner context returned from planner_new.
- *  \param at           instant time for which this query is made.
- *  \param resources    resources array buffer to copy and return available
- *                      counts into.
- *  \param len          length of resources array.
- *  \return             0 on success; -1 on an error with errno set as follows:
- *                          EINVAL: invalid argument.
- */
-int planner_avail_resources_array_at (planner_t *ctx, int64_t at,
-                                      int64_t *resources, size_t len);
+int64_t planner_avail_resources_at (planner_t *ctx, int64_t at);
 
 
 /*! Add a new span to the planner and update the planner's resource/time state.
@@ -256,11 +169,7 @@ int planner_avail_resources_array_at (planner_t *ctx, int64_t at,
  *  \param start_time   start time from which the resource request must
  *                      be available for duration.
  *  \param duration     requested duration; must be greater than or equal to 1.
- *  \param resource_counts
- *                      64-bit unsigned integer array of size len specifying
- *                      the requested resource counts.
- *  \param len          length of resource_counts and resource_types array;
- *                      must not exceed PLANNER_NUM_TYPES.
+ *  \param request      resource count request.
  *
  *  \return             span id on success; -1 on an error with errno set as follows:
  *                          EINVAL: invalid argument.
@@ -269,7 +178,7 @@ int planner_avail_resources_array_at (planner_t *ctx, int64_t at,
  *                                  e.g., reserving more than available.
  */
 int64_t planner_add_span (planner_t *ctx, int64_t start_time, uint64_t duration,
-                          const uint64_t *resource_counts, size_t len);
+                          uint64_t request);
 
 /*! Remove the existing span from the planner and update its resource/time state.
  *  Reset the planner's iterator such that planner_avail_time_next will be made
@@ -297,10 +206,7 @@ bool planner_is_active_span (planner_t *ctx, int64_t span_id);
 int64_t planner_span_start_time (planner_t *ctx, int64_t span_id);
 int64_t planner_span_duration (planner_t *ctx, int64_t span_id);
 int64_t planner_span_id (planner_t *ctx, int64_t span_id);
-int64_t planner_span_resource_count_at (planner_t *ctx, int64_t span_id,
-                                        unsigned int at);
-int64_t planner_span_resource_count_by_type (planner_t *ctx, int64_t span_id,
-                                             const char *resource_type);
+int64_t planner_span_resource_count (planner_t *ctx, int64_t span_id);
 
 #ifdef __cplusplus
 }

--- a/resource/planner/planner_multi.c
+++ b/resource/planner/planner_multi.c
@@ -1,0 +1,469 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include <stdlib.h>
+#include <string.h>
+#include <czmq.h>
+#include <errno.h>
+
+#include "src/common/libutil/xzmalloc.h"
+#include "planner_multi.h"
+
+struct request {
+    int64_t on_or_after;
+    uint64_t duration;
+    int64_t *counts;
+};
+
+struct planner_multi {
+    planner_t **planners;
+    uint64_t *resource_totals;
+    char **resource_types;
+    size_t size;
+    struct request iter;
+    zhashx_t *span_lookup;
+    uint64_t span_counter;
+};
+
+void fill_iter_request (planner_multi_t *ctx, struct request *iter,
+                        int64_t at, uint64_t duration,
+                        const uint64_t *resources, size_t len)
+{
+    iter->on_or_after = at;
+    iter->duration = duration;
+    memcpy (iter->counts, resources, len * sizeof (*resources));
+}
+
+planner_multi_t *planner_multi_new (int64_t base_time, uint64_t duration,
+                                    const uint64_t *resource_totals,
+                                    const char **resource_types, size_t len)
+{
+    int i = 0;
+    planner_multi_t *ctx = NULL;
+
+    if (duration < 1 || !resource_totals || !resource_types) {
+        errno = EINVAL;
+        goto done;
+    } else {
+        for (i = 0; i < len; ++i) {
+            if (resource_totals[i] > INT64_MAX) {
+                errno = ERANGE;
+                goto done;
+            }
+        }
+    }
+
+    ctx = xzmalloc (sizeof (*ctx));
+    ctx->resource_totals = xzmalloc (len * sizeof (*(ctx->resource_totals)));
+    ctx->resource_types = xzmalloc (len * sizeof (*(ctx->resource_types)));
+    ctx->planners = xzmalloc (len * sizeof (*(ctx->planners)));
+    ctx->size = len;
+    ctx->iter.on_or_after = 0;
+    ctx->iter.duration = 0;
+    ctx->iter.counts = xzmalloc (len * sizeof (*(ctx->iter.counts)));
+    for (i = 0; i < len; ++i) {
+        ctx->resource_totals[i] = resource_totals[i];
+        ctx->resource_types[i] = xstrdup (resource_types[i]);
+        ctx->planners[i] = planner_new (base_time, duration,
+                                        resource_totals[i], resource_types[i]);
+    }
+    ctx->span_lookup = zhashx_new ();
+    ctx->span_counter = 0;
+done:
+    return ctx;
+}
+
+int64_t planner_multi_base_time (planner_multi_t *ctx)
+{
+    if (!ctx) {
+        errno = EINVAL;
+        return -1;
+    }
+    return planner_base_time (ctx->planners[0]);
+}
+
+int64_t planner_multi_duration (planner_multi_t *ctx)
+{
+    if (!ctx) {
+        errno = EINVAL;
+        return -1;
+    }
+    return planner_duration (ctx->planners[0]);
+}
+
+size_t planner_multi_resources_len (planner_multi_t *ctx)
+{
+    if (!ctx) {
+        errno = EINVAL;
+        return 0;
+    }
+    return ctx->size;
+}
+
+const char **planner_multi_resource_types (planner_multi_t *ctx)
+{
+    if (!ctx) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return (const char **)ctx->resource_types;
+}
+
+const uint64_t *planner_multi_resource_totals (planner_multi_t *ctx)
+{
+    if (!ctx) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return (const uint64_t *)ctx->resource_totals;
+}
+
+int64_t planner_multi_resource_total_at (planner_multi_t *ctx, unsigned int i)
+{
+    int64_t rc = -1;
+    if (ctx) {
+        if (i >= ctx->size) {
+            errno = EINVAL;
+            goto done;
+        }
+        rc = planner_resource_total (ctx->planners[i]);
+    }
+done:
+    return rc;
+}
+
+int64_t planner_multi_resource_total_by_type (planner_multi_t *ctx,
+                                              const char *resource_type)
+{
+    int i = 0;
+    int64_t rc = -1;
+    if (!ctx || !resource_type)
+        goto done;
+    for (i = 0; i < ctx->size; i++) {
+        if (!strcmp (ctx->resource_types[i], resource_type)) {
+            rc = planner_resource_total (ctx->planners[i]);
+            break;
+        }
+    }
+    if (i == ctx->size)
+        errno = EINVAL;
+done:
+    return rc;
+}
+
+int planner_multi_reset (planner_multi_t *ctx, int64_t base_time, uint64_t duration)
+{
+    int i = 0;
+    int rc = -1;
+    if (!ctx || duration < 1) {
+        errno = EINVAL;
+        goto done;
+    }
+
+    for (i = 0; i < ctx->size; ++i)
+        if (planner_reset (ctx->planners[i], base_time, duration) == -1)
+            goto done;
+
+    rc = 0;
+done:
+    return rc;
+}
+
+void planner_multi_destroy (planner_multi_t **ctx_p)
+{
+    int i = 0;
+    if (ctx_p && *ctx_p) {
+        for (i = 0; i < (*ctx_p)->size; ++i)
+            planner_destroy (&((*ctx_p)->planners[i]));
+
+        free ((*ctx_p)->resource_totals);
+        free ((*ctx_p)->resource_types);
+        free ((*ctx_p)->iter.counts);
+        free (*ctx_p);
+        *ctx_p = NULL;
+    }
+}
+
+planner_t *planner_multi_planner_at (planner_multi_t *ctx, unsigned int i)
+{
+    planner_t *planner = NULL;
+    if (!ctx || i >= ctx->size) {
+        errno = EINVAL;
+        goto done;
+    }
+    planner = ctx->planners[i];
+done:
+    return planner;
+}
+
+int64_t planner_multi_avail_time_first (planner_multi_t *ctx,
+                                        int64_t on_or_after, uint64_t duration,
+                                        const uint64_t *resource_requests,
+                                        size_t len)
+{
+    int i = 0;
+    int unmet = 0;
+    int64_t t = -1;
+
+    if (!ctx || !resource_requests || ctx->size < 1
+         || ctx->size != len) {
+        errno = EINVAL;
+        goto done;
+    }
+
+    fill_iter_request (ctx, &(ctx->iter),
+                       on_or_after, duration, resource_requests, len);
+
+    if ((t = planner_avail_time_first (ctx->planners[0], on_or_after,
+                                       duration, resource_requests[0])) == -1)
+        goto done;
+
+    do {
+        unmet = 0;
+        for (i = 1; i < ctx->size; ++i) {
+            if ((unmet = planner_avail_during (ctx->planners[i],
+                                               t, duration,
+                                               resource_requests[i])) == -1)
+                break;
+        }
+    } while (unmet && (t = planner_avail_time_next (ctx->planners[0])) != -1);
+
+done:
+    return t;
+}
+
+int64_t planner_multi_avail_time_next (planner_multi_t *ctx)
+{
+    int i = 0;
+    int unmet = 0;
+    int64_t t = -1;
+
+    if (!ctx) {
+        errno = EINVAL;
+        goto done;
+    }
+
+    do {
+        unmet = 0;
+        if ((t = planner_avail_time_next (ctx->planners[0])) == -1)
+            break;
+        for (i = 1; i < ctx->size; ++i) {
+            if ((unmet = planner_avail_during (ctx->planners[i], t,
+                                               ctx->iter.duration,
+                                               ctx->iter.counts[i])) == -1)
+                break;
+        }
+    } while (unmet);
+
+done:
+    return t;
+}
+
+int64_t planner_multi_avail_resources_at (planner_multi_t *ctx, int64_t at,
+                                          unsigned int i)
+{
+    if (!ctx || i >= ctx->size) {
+        errno = EINVAL;
+        return -1;
+    }
+    return planner_avail_resources_at (ctx->planners[i], at);
+}
+
+int planner_multi_avail_resources_array_at (planner_multi_t *ctx, int64_t at,
+                                            int64_t *resource_counts,
+                                            size_t len)
+{
+    int i = 0;
+    int64_t rc = 0;
+    if (!ctx || !resource_counts || ctx->size != len) {
+        errno = EINVAL;
+        return -1;
+    }
+    for (i = 0; i < ctx->size; ++i) {
+        rc = planner_avail_resources_at (ctx->planners[i], at);
+        if (rc == -1)
+            break;
+        resource_counts[i] = rc;
+    }
+    return (rc == -1)? -1 : 0;
+}
+
+int planner_multi_avail_during (planner_multi_t *ctx, int64_t at, uint64_t duration,
+                                const uint64_t *resource_requests, size_t len)
+{
+    int i = 0;
+    int rc = 0;
+    if (!ctx || !resource_requests || ctx->size != len) {
+        errno = EINVAL;
+        return -1;
+    }
+    for (i = 0; i < ctx->size; ++i) {
+        rc = planner_avail_during (ctx->planners[i], at, duration,
+                                   resource_requests[i]);
+        if (rc == -1)
+            break;
+    }
+    return rc;
+}
+
+int planner_multi_avail_resources_array_during (planner_multi_t *ctx, int64_t at,
+                                                uint64_t duration,
+                                                int64_t *resource_counts,
+                                                size_t len)
+{
+    int i = 0;
+    int64_t rc = 0;
+    if (!ctx || !resource_counts || ctx->size < 1 || ctx->size != len) {
+        errno = EINVAL;
+        return -1;
+    }
+    for (i = 0; i < ctx->size; ++i) {
+        rc = planner_avail_resources_during (ctx->planners[i], at, duration);
+        if (rc == -1)
+            break;
+        resource_counts[i] = rc;
+    }
+    return (rc == -1)? -1 : 0;
+}
+
+static void zlist_free_wrap (void *o)
+{
+    zlist_t *list = (zlist_t *)o;
+    if (list)
+        zlist_destroy (&list);
+}
+
+int64_t planner_multi_add_span (planner_multi_t *ctx, int64_t start_time,
+                                uint64_t duration,
+                                const uint64_t *resource_requests,
+                                size_t len)
+{
+    char key[32];
+    int i = 0;
+    zlist_t *list = NULL;
+    int64_t span = -1;
+    int64_t mspan = -1;
+
+    if (!ctx || !resource_requests || len != ctx->size)
+        return -1;
+
+    list = zlist_new ();
+    mspan = ctx->span_counter;
+    ctx->span_counter++;
+    sprintf (key, "%jd", (intmax_t)mspan);
+
+    for (i = 0; i < len; ++i) {
+        if ((span = planner_add_span (ctx->planners[i],
+                                      start_time, duration,
+                                      resource_requests[i])) == -1)
+            goto error;
+
+        zlist_append (list, (void *)(intptr_t)span);
+    }
+
+    zhashx_insert (ctx->span_lookup, key, list);
+    zhashx_freefn (ctx->span_lookup, key, zlist_free_wrap);
+    return mspan;
+
+error:
+    zlist_destroy (&list);
+    return -1;
+}
+
+int planner_multi_rem_span (planner_multi_t *ctx, int64_t span_id)
+{
+    int i = 0;
+    int rc = -1;
+    char key[32];
+    void *s = NULL;
+    zlist_t *list = NULL;
+
+    if (!ctx || span_id < 0) {
+        errno = EINVAL;
+        goto done;
+    }
+
+    sprintf (key, "%jd", (intmax_t)span_id);
+    if (!(list = zhashx_lookup (ctx->span_lookup, key))) {
+        errno = EINVAL;
+        goto done;
+    }
+
+    for (i = 0, s = zlist_first (list); s; i++, s = zlist_next (list))
+        if (planner_rem_span (ctx->planners[i], (int64_t)s) == -1)
+            goto done;
+
+    zhashx_delete (ctx->span_lookup, key);
+    rc  = 0;
+done:
+    return rc;
+}
+
+int64_t planner_multi_span_first (planner_multi_t *ctx)
+{
+    int64_t rc = -1;
+    void *span = NULL;
+    if (!ctx) {
+        errno = EINVAL;
+        goto done;
+    }
+    if ( !(span = zhashx_first (ctx->span_lookup))) {
+        errno = ENOENT;
+        goto done;
+
+    }
+    rc = (int64_t)span;
+done:
+    return rc;
+}
+
+int64_t planner_multi_span_next (planner_multi_t *ctx)
+{
+    int64_t rc = -1;
+    void *span = NULL;
+    if (!ctx) {
+        errno = EINVAL;
+        goto done;
+    }
+    if ( !(span = zhashx_next (ctx->span_lookup))) {
+        errno = ENOENT;
+        goto done;
+    }
+    rc = (int64_t)span;
+done:
+    return rc;
+}
+
+size_t planner_multi_span_size (planner_multi_t *ctx)
+{
+   if (!ctx) {
+        errno = EINVAL;
+        return 0;
+    }
+    return zhashx_size (ctx->span_lookup);
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/resource/planner/planner_multi.h
+++ b/resource/planner/planner_multi.h
@@ -1,0 +1,283 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef PLANNER_MULTI_H
+#define PLANNER_MULTI_H
+
+#include "planner.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct planner_multi planner_multi_t;
+
+/*! Construct a planner_multi_t contex that creates and manages len number of
+ *  planner_t objects. Individual planner_t context can be accessed via
+ *  planner_multi_at (i). Index i corresponds to the resource type of
+ *  i^th element of resource_types array.
+ *
+ *  \param base_time    earliest schedulable point expressed in integer time
+ *                      (i.e., the base time of the planner to be constructed).
+ *  \param duration     time span of this planner_multi (i.e., all planned spans
+ *                      must end before base_time + duration).
+ *  \param resource_totals
+ *                      64-bit unsigned integer array of size len where each
+ *                      element contains the total count of available resources
+ *                      of a single resource type.
+ *  \param resource_types
+ *                      string array of size len where each element contains
+ *                      the resource type corresponding to each corresponding
+ *                      element in the resource_totals array.
+ *  \param len          length of the resource_totals and resource_types arrays.
+ *
+ *  \return             a new planner_multi context; NULL on error with errno
+ *                      set as follows:
+ *                          EINVAL: invalid argument.
+ *                          ERANGE: resource_totals contains an out-of-range
+ *                                  value.
+ */
+planner_multi_t *planner_multi_new (int64_t base_time, uint64_t duration,
+                                    const uint64_t *resource_totals,
+                                    const char **resource_types, size_t len);
+
+/*! Getters:
+ *  \return             -1 or NULL on an error with errno set as follows:
+ *                         EINVAL: invalid argument.
+ */
+int64_t planner_multi_base_time (planner_multi_t *ctx);
+int64_t planner_multi_duration (planner_multi_t *ctx);
+size_t planner_multi_resources_len (planner_multi_t *ctx);
+const char **planner_multi_resource_types (planner_multi_t *ctx);
+const uint64_t *planner_multi_resource_totals (planner_multi_t *ctx);
+int64_t planner_multi_resource_total_at (planner_multi_t *ctx, unsigned int i);
+int64_t planner_multi_resource_total_by_type (planner_multi_t *ctx,
+                                              const char *resource_type);
+
+/*! Reset the planner_multi_t context with a new time bound.
+ *  Destroy all existing planned spans in its managed planner_t objects.
+ *
+ *  \param ctx          an opaque planner_multi_t context returned from
+ *                      planner_multi_new.
+ *  \param base_time    the earliest schedulable point expressed in integer time
+ *                      (i.e., the base time of the planner to be constructed).
+ *  \param duration     the time span of this planner (i.e., all planned spans
+ *                      must end before base_time + duration).
+ *  \return             0 on success; -1 on error with errno set as follows:
+ *                          EINVAL: invalid argument.
+ */
+int planner_multi_reset (planner_multi_t *ctx, int64_t base_time,
+                         uint64_t duration);
+
+/*! Destroy the planner_multi.
+ *
+ *  \param ctx_p        a pointer to a planner_multi_t context pointer returned
+ *                      from planner_new
+ *
+ */
+void planner_multi_destroy (planner_multi_t **ctx_p);
+
+/*! Return the i^th planner object managed by the planner_multi_t ctx.
+ *  Index i corresponds to the resource type of i^th element of
+ *  resource_types array passed in via planner_multi_new ().
+ *
+ *  \param ctx          an opaque planner_multi_t context returned from
+ *                      planner_multi_new.
+ *  \param i            planner array index
+ *  \return             a planner_t context pointer on success; NULL on error
+ *                      with errno set as follows:
+ *                          EINVAL: invalid argument.
+ */
+planner_t *planner_multi_planner_at (planner_multi_t *ctx, unsigned int i);
+
+/*! Find and return the earliest point in integer time when the request can be
+ *  satisfied.
+ *
+ *  Note on semantics: this function returns a time point where the resource state
+ *  changes. If the number of available resources change at time point t1 and
+ *  t2 (assuming t2 is greater than t1+2), the possible schedule points that this
+ *  function can return is either t1 or t2, but not t1+1 nor t1+2 even if these
+ *  points also satisfy the request.
+ *
+ *  \param ctx          an opaque planner_multi_t context returned from
+ *                      planner_multi_new.
+ *  \param on_or_after  available on or after the specified time.
+ *  \param duration     requested duration; must be greater than or equal to 1.
+ *  \param resource_requests
+ *                      64-bit unsigned integer array of size len specifying
+ *                      the requested resource counts.
+ *  \param len          length of resource_counts and resource_types arrays.
+ *  \return             the earliest time at which the resource request
+ *                      can be satisfied;
+ *                      -1 on error with errno set as follows:
+ *                          EINVAL: invalid argument.
+ *                          ERANGE: resource_counts contain an out-of-range value.
+ *                          ENOENT: no scheduleable point
+ */
+int64_t planner_multi_avail_time_first (planner_multi_t *ctx,
+                                        int64_t on_or_after, uint64_t duration,
+                                        const uint64_t *resource_requests, size_t len);
+
+/*! Find and return the next earliest point in time at which the same request
+ *  queried before via either planner_avail_time_first or
+ *  planner_multi_avail_time_next can be satisfied.  Same semantics as
+ *  planner_multi_avail_time_first.
+ *
+ *  \param ctx          an opaque planner_multi_t context returned from
+ *                      planner_multi_new.
+ *  \return             the next earliest time at which the resource request
+ *                      can be satisfied;
+ *                      -1 on error with errno set as follows:
+ *                          EINVAL: invalid argument.
+ *                          ERANGE: request out of range
+ *                          ENOENT: no scheduleable point
+ */
+int64_t planner_multi_avail_time_next (planner_multi_t *ctx);
+
+
+/*! Return how many resources of ith type is available at the given time.
+ *
+ *  \param ctx          opaque planner context returned from planner_multi_new.
+ *  \param at           instant time for which this query is made.
+ *  \param i            index of the resource type to queried
+ *  \return             available resource count; -1 on an error with errno set
+ *                      as follows:
+ *                          EINVAL: invalid argument.
+ */
+int64_t planner_multi_avail_resources_at (planner_multi_t *ctx, int64_t at,
+                                          unsigned int i);
+
+/*! Return how many resources are available at the given instant time (at).
+ *
+ *  \param ctx          an opaque planner_multi_t context returned from
+ *                      planner_multi_new.
+ *  \param at           instant time for which this query is made.
+ *  \param resource_counts
+ *                      resources array buffer to copy and return available
+ *                      counts into.
+ *  \param len          length of resources array.
+ *  \return             0 on success; -1 on error with errno set as follows:
+ *                          EINVAL: invalid argument.
+ */
+int planner_multi_avail_resources_array_at (planner_multi_t *ctx, int64_t at,
+                                            int64_t *resource_counts, size_t len);
+
+/*! Test if the given resource request can be satisfied at the start time.
+ *  Note on semantics: Unlike planner_multi_avail_time* functions, this function
+ *  can be used to test an arbitrary time span.
+ *
+ *  \param ctx          an opaque planner_multi_t context returned from
+ *                      planner_multi_new.
+ *  \param at           start time from which the requested resources must
+ *                      be available for duration.
+ *  \param duration     requested duration; must be greater than or equal to 1.
+ *  \param resource_requests
+ *                      64-bit unsigned integer array of size len specifying
+ *                      the requested resource counts.
+ *  \param len          length of resource_counts and resource_types arrays.
+ *  \return             0 if the request can be satisfied; -1 if it cannot
+ *                      be satisfied or an error encountered (errno as follows):
+ *                          EINVAL: invalid argument.
+ *                          ERANGE: resource_counts contain an out-of-range value.
+ *                          ENOTSUP: internal error encountered.
+ */
+int planner_multi_avail_during (planner_multi_t *ctx, int64_t at,
+                                uint64_t duration,
+                                const uint64_t *resource_requests, size_t len);
+
+/*! Return how many resources are available for the duration starting from at.
+ *
+ *  \param ctx          an opaque planner_multi_t context returned from
+ *                      planner_multi_new.
+ *  \param at           instant time for which this query is made.
+ *  \param duration     requested duration; must be greater than or equal to 1.
+ *  \param resource_counts
+ *                      resources array buffer to copy and return available counts
+ *                      into.
+ *  \param len          length of resource_counts and resource_types arrays.
+ *  \return             0 on success; -1 on an error with errno set as follows:
+ *                          EINVAL: invalid argument.
+ */
+
+int planner_multi_avail_resources_array_during (planner_multi_t *ctx,
+                                                int64_t at, uint64_t duration,
+                                                int64_t *resource_counts, size_t len);
+
+/*! Add a new span to the multi-planner and update the planner's resource/time
+ *  state. Reset the multi-planner's iterator so that
+ *  planner_multi_avail_time_next will be made to return the earliest
+ *  schedulable point.
+ *
+ *  \param ctx          opaque planner_multi_t context returned
+ *                      from planner_multi_new.
+ *  \param start_time   start time from which the resource request must
+ *                      be available for duration.
+ *  \param duration     requested duration; must be greater than or equal to 1.
+ *  \param resource_requests
+ *                      resource counts request.
+ *  \param len          length of requests.
+ *
+ *  \return             span id on success; -1 on error with errno set
+ *                      as follows:
+ *                          EINVAL: invalid argument.
+ *                          EKEYREJECTED: can't update planner's internal data.
+ *                          ERANGE: a resource state became out of a valid
+ *                                  range, e.g., reserving more than available.
+ */
+int64_t planner_multi_add_span (planner_multi_t *ctx, int64_t start_time,
+                                uint64_t duration, const uint64_t *resource_requests,
+                                size_t len);
+
+/*! Remove the existing span from multi-planner and update resource/time state.
+ *  Reset the planner's iterator such that planner_avail_time_next will be made
+ *  to return the earliest schedulable point.
+ *
+ *  \param ctx          opaque multi-planner context returned
+ *                      from planner_multi_new.
+ *  \param span_id      span_id returned from planner_multi_add_span.
+ *  \return             0 on success; -1 on error with errno set as follows:
+ *                          EINVAL: invalid argument.
+ *                          EKEYREJECTED: span could not be removed from
+ *                                        the planner's internal data structures.
+ *                          ERANGE: a resource state became out of a valid range.
+ */
+int planner_multi_rem_span (planner_multi_t *ctx, int64_t span_id);
+
+//! Span iterators -- there is no specific iteration order
+//  return -1 when you no longer can iterate: EINVAL when ctx is NULL.
+//  ENOENT when you reached the end of the spans
+int64_t planner_multi_span_first (planner_multi_t *ctx);
+int64_t planner_multi_span_next (planner_multi_t *ctx);
+
+size_t planner_multi_span_size (planner_multi_t *ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PLANNER_MULTI_H */
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/resource/planner/test/Makefile.am
+++ b/resource/planner/test/Makefile.am
@@ -11,7 +11,7 @@ TESTS_ENVIRONMENT = \
     LUA_PATH="$(abs_top_srcdir)/rdl/?.lua;$(FLUX_PREFIX)/share/lua/5.1/?.lua;$(LUA_PATH);;" \
     LUA_CPATH="$(abs_top_builddir)/rdl/?.so;$(abs_top_builddir)/rdl/test/.libs/?.so;$(FLUX_PREFIX)/lib64/lua/5.1/?.so;$(FLUX_PREFIX)/lib/lua/5.1/?.so;$(LUA_CPATH);;"
 
-TESTS = planner_test01
+TESTS = planner_test01 planner_test02
 
 check_PROGRAMS = $(TESTS)
 planner_test01_SOURCES = planner_test01.cpp
@@ -22,3 +22,13 @@ planner_test01_LDADD = \
 	$(top_builddir)/src/common/librbtree/librbtree.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(CZMQ_LIBS)
+
+planner_test02_SOURCES = planner_test02.cpp
+planner_test02_CXXFLAGS = $(AM_CXXFLAGS) -I$(top_srcdir)/resource/planner
+planner_test02_LDADD = \
+	$(top_builddir)/resource/planner/libplanner.la \
+	$(top_builddir)/src/common/libutil/libutil.la \
+	$(top_builddir)/src/common/librbtree/librbtree.la \
+	$(top_builddir)/src/common/libtap/libtap.la \
+	$(CZMQ_LIBS)
+

--- a/resource/planner/test/planner_test02.cpp
+++ b/resource/planner/test/planner_test02.cpp
@@ -1,0 +1,584 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+# include <config.h>
+#endif
+#include <cstdlib>
+#include <sstream>
+#include <string>
+#include <cstring>
+#include <cstdint>
+#include <cerrno>
+#include <vector>
+#include <map>
+#include "planner_multi.h"
+#include "src/common/libtap/tap.h"
+
+static void to_stream (int64_t base_time, uint64_t duration, const uint64_t *cnts,
+                      const char **types, size_t len, std::stringstream &ss)
+{
+    if (base_time != -1)
+        ss << "B(" << base_time << "):";
+
+    ss << "D(" << duration << "):" << "R(<";
+    for (unsigned int i = 0; i < len; ++i)
+        ss << types[i] << "(" << cnts[i] << ")";
+
+    ss << ">)";
+}
+
+static int test_multi_basics ()
+{
+    int rc;
+    bool bo = false;
+    size_t len = 5;
+    int64_t t = -1, avail = -1, tmax = INT64_MAX;
+    int64_t span1 = -1, span2 = -1, span3 = -1;
+    const uint64_t resource_totals[] = {10, 20, 30, 20, 100};
+    const char *resource_types[] = {"A", "B", "C", "D", "E"};
+    const uint64_t counts1[] = {1, 2, 3, 2, 10};
+    const uint64_t counts5[] = {5, 10, 15, 10, 50};
+    const uint64_t counts_many_E[] = {1, 1, 1, 1, 50};
+    const uint64_t counts_only_C[] = {0, 0, 15, 0, 0};
+    const uint64_t *counts10 = resource_totals;
+    int64_t avail_resources[] = {0, 0, 0, 0, 0};
+    planner_multi_t *ctx = NULL;
+    std::stringstream ss;
+
+    errno = 0;
+    to_stream (0, tmax, resource_totals, (const char **)resource_types, len, ss);
+    ctx = planner_multi_new (0, INT64_MAX, resource_totals, resource_types, len);
+    ok ((ctx && !errno), "new with (%s)", ss.str ().c_str ());
+
+    ss.str ("");
+    to_stream (-1, 5, counts10, (const char **)resource_types, len, ss);
+    rc = planner_multi_avail_during (ctx, 0, 1, counts10, len);
+    ok ((!rc && !errno), "checking multi avail works (%s)", ss.str ().c_str ());
+
+    ss.str ("");
+    to_stream (-1, 1000, counts5, (const char **)resource_types, len, ss);
+    rc = planner_multi_avail_during (ctx, 1, 1000, counts5, len);
+    ok ((!rc && !errno), "multi-resource avail works (%s)", ss.str ().c_str ());
+
+    span1 = planner_multi_add_span (ctx, 1, 1000, counts5, len);
+    ok ((span1 != -1), "span1 added for (%s)", ss.str ().c_str ());
+
+    ss.str ("");
+    to_stream (-1, 1000, counts10, (const char **)resource_types, len, ss);
+    rc = planner_multi_avail_during (ctx, 2000, 1001, counts10, len);
+    span2 = planner_multi_add_span (ctx, 2000, 1001, counts10, len);
+    ok ((span2 != -1), "span2 added for (%s)", ss.str ().c_str ());
+
+    ss.str ("");
+    to_stream (-1, 2990, counts1, (const char **)resource_types, len, ss);
+    rc = planner_multi_avail_during (ctx, 10, 2991, counts1, len);
+    ok ((rc == -1) && !errno, "over-alloc multi: (%s)", ss.str ().c_str ());
+
+    ss.str ("");
+    to_stream (-1, 1990, counts1, (const char **)resource_types, len, ss);
+    rc = planner_multi_avail_during (ctx, 10, 1990, counts1, len);
+    ok ((!rc && !errno), "overlapped multi resources (%s)", ss.str ().c_str ());
+    span3 = planner_multi_add_span (ctx, 10, 1990, counts1, len);
+    ok ((span3 != -1), "span3 added for (%s)", ss.str ().c_str ());
+
+    ss.str ("");
+
+    avail = planner_multi_avail_resources_at (ctx, 1, 0);
+    bo = (bo || avail != 5);
+    avail = planner_multi_avail_resources_at (ctx, 10, 1);
+    bo = (bo || avail != 8);
+    planner_multi_avail_resources_array_at (ctx, 500, avail_resources, len);
+    bo = (bo || avail_resources[2] != 12);
+    avail = planner_multi_avail_resources_at (ctx, 1500, 0);
+    bo = (bo || avail != 9);
+    avail = planner_multi_avail_resources_at (ctx, 2000, 0);
+    bo = (bo || avail != 0);
+    avail = planner_multi_avail_resources_at (ctx, 2500, 0);
+    bo = (bo || avail != 0);
+    avail = planner_multi_avail_resources_at (ctx, 3000, 4);
+    bo = (bo || avail != 0);
+    avail = planner_multi_avail_resources_at (ctx, 3001, 2);
+    bo = (bo || avail != 30);
+    ok (!bo && !errno, "avail_at_resources_* works");
+
+    bo = false;
+    t = planner_multi_avail_time_first (ctx, 0, 9, counts_only_C, len);
+    bo = (bo || t != 0);
+    t = planner_multi_avail_time_next (ctx);
+    bo = (bo || t != 1);
+    t = planner_multi_avail_time_next (ctx);
+    bo = (bo || t != 1001);
+    t = planner_multi_avail_time_next (ctx);
+    bo = (bo || t != 3001);
+    t = planner_multi_avail_time_next (ctx);
+    bo = (bo || t != -1);
+    ok (!bo && errno == ENOENT, "avail_time_* works");
+
+    errno = 0;
+    bo = false;
+    t = planner_multi_avail_time_first (ctx, 0, 10, counts_many_E, len);
+    bo = (bo || t != 0);
+    t = planner_multi_avail_time_next (ctx);
+    bo = (bo || t != 1001);
+    t = planner_multi_avail_time_next (ctx);
+    bo = (bo || t != 3001);
+    t = planner_multi_avail_time_next (ctx);
+    bo = (bo || t != -1);
+    ok (!bo && errno == ENOENT, "avail_time_* test2 works");
+
+    planner_multi_destroy (&ctx);
+    return 0;
+}
+
+static int test_multi_getters ()
+{
+    bool bo = false;
+    size_t len = 2;
+    int64_t rc = -1;
+    int64_t avail = -1;
+    std::stringstream ss;
+    planner_multi_t *ctx = NULL;
+    uint64_t resource_total[] = {10, 20};
+    const char *resource_types[] = {"1", "2"};
+
+    errno = 0;
+    to_stream (0, 9999, resource_total, (const char **)resource_types, len, ss);
+    ctx = planner_multi_new (0, 9999, resource_total, resource_types, len);
+    ok ((ctx && !errno), "new with (%s)", ss.str ().c_str ());
+
+    rc = planner_multi_base_time (ctx);
+    ok ((rc == 0), "base_time works for (%s)", ss.str ().c_str ());
+
+    rc = planner_multi_duration (ctx);
+    ok ((rc == 9999), "duration works for (%s)", ss.str ().c_str ());
+
+    avail = planner_multi_resource_total_at (ctx, 0);
+    bo = (bo || (avail != 10));
+
+    avail = planner_multi_resource_total_by_type (ctx, "2");
+    bo = (bo || (avail != 20));
+
+    ok ((!bo && !errno), "planner_multi getters work");
+
+    planner_multi_destroy (&ctx);
+    return 0;
+}
+
+static int test_multi_strictly_larger ()
+{
+    size_t len = 5;
+    int rc = -1;
+    int64_t t = -1;
+    int64_t tmax = INT64_MAX;
+    int64_t span = -1;
+    const uint64_t resource_totals[] = {10, 20, 30, 40, 50};
+    const char *resource_types[] = {"A", "B", "C", "D", "E"};
+    const uint64_t request1[] = {1, 0, 0, 0, 0};
+    const uint64_t request2[] = {0, 2, 0, 0, 0};
+    const uint64_t request3[] = {0, 0, 3, 0, 0};
+    const uint64_t request4[] = {0, 0, 0, 4, 0};
+    const uint64_t request5[] = {0, 0, 0, 0, 5};
+    const uint64_t requestA[] = {10, 20, 30, 40, 45};
+    const uint64_t requestB[] = {0, 0, 0, 30, 40};
+    const uint64_t requestC[] = {10, 18, 30, 30, 30};
+    planner_multi_t *ctx = NULL;
+    std::stringstream ss;
+
+    errno = 0;
+    to_stream (0, tmax, resource_totals, (const char **)resource_types, len, ss);
+    ctx = planner_multi_new (0, INT64_MAX, resource_totals, resource_types, len);
+    ok ((ctx && !errno), "new with (%s)", ss.str ().c_str ());
+
+    /* The resource state will become the following after
+       planner_multi_add_span calls:
+
+        0:     9, 18, 27, 36, 45
+        1000: 10, 18, 27, 36, 45
+        2000: 10, 20, 27, 36, 45
+        3000: 10, 20, 30, 36, 45
+        4000: 10, 20, 30, 40, 45
+        5000: 10, 20, 30, 40, 50
+     */
+
+    ss.str ("");
+    to_stream (0, 1000, request1, (const char **)resource_types, len, ss);
+    rc = planner_multi_avail_during (ctx, 0, 1000, request1, len);
+    ok ((!rc && !errno), "multi-resource avail works (%s)", ss.str ().c_str ());
+
+    span = planner_multi_add_span (ctx, 0, 1000, request1, len);
+    ok ((span != -1), "span added for (%s)", ss.str ().c_str ());
+
+    ss.str ("");
+    to_stream (0, 2000, request2, (const char **)resource_types, len, ss);
+    rc = planner_multi_avail_during (ctx, 0, 2000, request2, len);
+    ok ((!rc && !errno), "multi-resource avail works (%s)", ss.str ().c_str ());
+
+    span = planner_multi_add_span (ctx, 0, 2000, request2, len);
+    ok ((span != -1), "span added for (%s)", ss.str ().c_str ());
+
+    ss.str ("");
+    to_stream (0, 3000, request3, (const char **)resource_types, len, ss);
+    rc = planner_multi_avail_during (ctx, 0, 3000, request3, len);
+    ok ((!rc && !errno), "multi-resource avail works (%s)", ss.str ().c_str ());
+
+    span = planner_multi_add_span (ctx, 0, 3000, request3, len);
+    ok ((span != -1), "span added for (%s)", ss.str ().c_str ());
+
+    ss.str ("");
+    to_stream (0, 4000, request4, (const char **)resource_types, len, ss);
+    rc = planner_multi_avail_during (ctx, 0, 4000, request4, len);
+    ok ((!rc && !errno), "multi-resource avail works (%s)", ss.str ().c_str ());
+
+    span = planner_multi_add_span (ctx, 0, 4000, request4, len);
+    ok ((span != -1), "span added for (%s)", ss.str ().c_str ());
+
+    ss.str ("");
+    to_stream (0, 5000, request5, (const char **)resource_types, len, ss);
+    rc = planner_multi_avail_during (ctx, 0, 5000, request5, len);
+    ok ((!rc && !errno), "multi-resource avail works (%s)", ss.str ().c_str ());
+
+    span = planner_multi_add_span (ctx, 0, 5000, request5, len);
+    ok ((span != -1), "span added for (%s)", ss.str ().c_str ());
+
+    ss.str ("");
+    to_stream (0, 1000, requestA, (const char **)resource_types, len, ss);
+    t = planner_multi_avail_time_first (ctx, 0, 1000, requestA, len);
+    ok ((t == 4000), "avail_time_first for (%s)", ss.str ().c_str ());
+    t = planner_multi_avail_time_next (ctx);
+    ok ((t == 5000), "avail_time_next for (%s)", ss.str ().c_str ());
+    t = planner_multi_avail_time_next (ctx);
+    ok ((t == -1 && errno == ENOENT), "avail_time_next for (%s)",
+         ss.str ().c_str ());
+
+    ss.str ("");
+    to_stream (0, 1000, requestB, (const char **)resource_types, len, ss);
+    t = planner_multi_avail_time_first (ctx, 0, 1000, requestB, len);
+    ok ((t == 0), "avail_time_first for (%s)", ss.str ().c_str ());
+    t = planner_multi_avail_time_next (ctx);
+    ok ((t == 1000), "avail_time_first for (%s)", ss.str ().c_str ());
+    t = planner_multi_avail_time_next (ctx);
+    ok ((t == 2000), "avail_time_first for (%s)", ss.str ().c_str ());
+    t = planner_multi_avail_time_next (ctx);
+    ok ((t == 3000), "avail_time_first for (%s)", ss.str ().c_str ());
+    t = planner_multi_avail_time_next (ctx);
+    ok ((t == 4000), "avail_time_next for (%s)", ss.str ().c_str ());
+    t = planner_multi_avail_time_next (ctx);
+    ok ((t == 5000), "avail_time_next for (%s)", ss.str ().c_str ());
+    t = planner_multi_avail_time_next (ctx);
+    ok ((t == -1 && errno == ENOENT), "avail_time_next for (%s)",
+         ss.str ().c_str ());
+
+    t = planner_multi_avail_time_first (ctx, 3500, 1000, requestB, len);
+    ok ((t == 4000), "avail_time_first for (%s)", ss.str ().c_str ());
+    t = planner_multi_avail_time_next (ctx);
+    ok ((t == 5000), "avail_time_next for (%s)", ss.str ().c_str ());
+    t = planner_multi_avail_time_next (ctx);
+    ok ((t == -1 && errno == ENOENT), "avail_time_next for (%s)",
+         ss.str ().c_str ());
+
+    ss.str ("");
+    to_stream (0, 1000, requestC, (const char **)resource_types, len, ss);
+    t = planner_multi_avail_time_first (ctx, 0, 1000, requestC, len);
+    ok ((t == 3000), "avail_time_first for (%s)", ss.str ().c_str ());
+    t = planner_multi_avail_time_next (ctx);
+    ok ((t == 4000), "avail_time_next for (%s)", ss.str ().c_str ());
+    t = planner_multi_avail_time_next (ctx);
+    ok ((t == 5000), "avail_time_next for (%s)", ss.str ().c_str ());
+    t = planner_multi_avail_time_next (ctx);
+    ok ((t == -1 && errno == ENOENT), "avail_time_next for (%s)",
+         ss.str ().c_str ());
+
+    return 0;
+}
+
+static int test_multi_partially_larger ()
+{
+    size_t len = 5;
+    int rc = -1;
+    int64_t t = -1;
+    int64_t tmax = INT64_MAX;
+    int64_t span = -1;
+    const uint64_t resource_totals[] = {10, 20, 30, 40, 50};
+    const char *resource_types[] = {"A", "B", "C", "D", "E"};
+    const uint64_t request1[] = {1, 0, 0, 0, 0};
+    const uint64_t request2[] = {0, 2, 0, 0, 0};
+    const uint64_t request3[] = {0, 0, 3, 0, 0};
+    const uint64_t request4[] = {0, 0, 0, 4, 0};
+    const uint64_t request5[] = {0, 0, 0, 0, 5};
+    const uint64_t requestA[] = {10, 20, 30, 40, 50};
+    const uint64_t requestB[] = {9, 20, 27, 36, 50};
+    const uint64_t requestC[] = {9, 19, 30, 40, 50};
+    planner_multi_t *ctx = NULL;
+    std::stringstream ss;
+
+    errno = 0;
+    to_stream (0, tmax, resource_totals, (const char **)resource_types, len, ss);
+    ctx = planner_multi_new (0, INT64_MAX, resource_totals, resource_types, len);
+    ok ((ctx && !errno), "new with (%s)", ss.str ().c_str ());
+
+    /* The resource state will become the following after
+       planner_multi_add_span calls:
+
+        0:     9, 20, 30, 40, 50
+        1000: 10, 18, 30, 40, 50
+        2000: 10, 20, 27, 40, 50
+        3000: 10, 20, 30, 36, 50
+        4000: 10, 20, 30, 40, 45
+        5000: 10, 20, 30, 40, 50
+     */
+
+    ss.str ("");
+    to_stream (0, 1000, request1, (const char **)resource_types, len, ss);
+    rc = planner_multi_avail_during (ctx, 0, 1000, request1, len);
+    ok ((!rc && !errno), "multi-resource avail works (%s)", ss.str ().c_str ());
+
+    span = planner_multi_add_span (ctx, 0, 1000, request1, len);
+    ok ((span != -1), "span added for (%s)", ss.str ().c_str ());
+
+    ss.str ("");
+    to_stream (1000, 1000, request2, (const char **)resource_types, len, ss);
+    rc = planner_multi_avail_during (ctx, 1000, 1000, request2, len);
+    ok ((!rc && !errno), "multi-resource avail works (%s)", ss.str ().c_str ());
+
+    span = planner_multi_add_span (ctx, 1000, 1000, request2, len);
+    ok ((span != -1), "span added for (%s)", ss.str ().c_str ());
+
+    ss.str ("");
+    to_stream (2000, 1000, request3, (const char **)resource_types, len, ss);
+    rc = planner_multi_avail_during (ctx, 2000, 1000, request3, len);
+    ok ((!rc && !errno), "multi-resource avail works (%s)", ss.str ().c_str ());
+
+    span = planner_multi_add_span (ctx, 2000, 1000, request3, len);
+    ok ((span != -1), "span added for (%s)", ss.str ().c_str ());
+
+    ss.str ("");
+    to_stream (3000, 1000, request4, (const char **)resource_types, len, ss);
+    rc = planner_multi_avail_during (ctx, 3000, 1000, request4, len);
+    ok ((!rc && !errno), "multi-resource avail works (%s)", ss.str ().c_str ());
+
+    span = planner_multi_add_span (ctx, 3000, 1000, request4, len);
+    ok ((span != -1), "span added for (%s)", ss.str ().c_str ());
+
+    ss.str ("");
+    to_stream (4000, 1000, request5, (const char **)resource_types, len, ss);
+    rc = planner_multi_avail_during (ctx, 4000, 1000, request5, len);
+    ok ((!rc && !errno), "multi-resource avail works (%s)", ss.str ().c_str ());
+
+    span = planner_multi_add_span (ctx, 4000, 1000, request5, len);
+    ok ((span != -1), "span added for (%s)", ss.str ().c_str ());
+
+    ss.str ("");
+    to_stream (-1, 1000, requestA, (const char **)resource_types, len, ss);
+    t = planner_multi_avail_time_first (ctx, 0, 1000, requestA, len);
+    ok ((t == 5000), "avail_time_first for (%s)", ss.str ().c_str ());
+    t = planner_multi_avail_time_next (ctx);
+    ok ((t == -1 && errno == ENOENT), "avail_time_next for (%s)",
+         ss.str ().c_str ());
+
+    ss.str ("");
+    to_stream (-1, 1000, requestB, (const char **)resource_types, len, ss);
+    t = planner_multi_avail_time_first (ctx, 0, 1000, requestB, len);
+    ok ((t == 0), "avail_time_first for (%s)", ss.str ().c_str ());
+    t = planner_multi_avail_time_next (ctx);
+    ok ((t == 2000), "avail_time_next for (%s)", ss.str ().c_str ());
+    t = planner_multi_avail_time_next (ctx);
+    ok ((t == 3000), "avail_time_next for (%s)", ss.str ().c_str ());
+    t = planner_multi_avail_time_next (ctx);
+    ok ((t == 5000), "avail_time_next for (%s)", ss.str ().c_str ());
+    t = planner_multi_avail_time_next (ctx);
+    ok ((t == -1 && errno == ENOENT), "avail_time_next for (%s)",
+         ss.str ().c_str ());
+
+    ss.str ("");
+    to_stream (-1, 1000, requestC, (const char **)resource_types, len, ss);
+    t = planner_multi_avail_time_first (ctx, 0, 1000, requestC, len);
+    ok ((t == 0), "avail_time_first for (%s)", ss.str ().c_str ());
+    t = planner_multi_avail_time_next (ctx);
+    ok ((t == 5000), "avail_time_next for (%s)", ss.str ().c_str ());
+    t = planner_multi_avail_time_next (ctx);
+    ok ((t == -1 && errno == ENOENT), "avail_time_next for (%s)",
+         ss.str ().c_str ());
+
+    return 0;
+}
+
+static int test_multi_many_spans ()
+{
+    size_t len = 3;
+    int rc = -1;
+    int64_t t = -1;
+    int64_t tmax = INT64_MAX;
+    int64_t span = -1;
+    bool bo = false;
+    const uint64_t resource_totals[] = {99, 99, 99};
+    const char *resource_types[] = {"A", "B", "C"};
+    const uint64_t requestA[] = {99, 99, 99};
+    const uint64_t requestB[] = {98, 1, 98};
+    const uint64_t requestC[] = {50, 49, 50};
+    planner_multi_t *ctx = NULL;
+    std::stringstream ss;
+
+    errno = 0;
+    to_stream (0, tmax, resource_totals, (const char **)resource_types, len, ss);
+    ctx = planner_multi_new (0, INT64_MAX, resource_totals, resource_types, len);
+    ok ((ctx && !errno), "new with (%s)", ss.str ().c_str ());
+
+    for (int i = 0; i < 1000; i++) {
+        uint64_t request[] = {0, 0, 0};
+        request[0] = i % 100;
+        request[1] = 99 - (i % 100);
+        request[2] = i % 100;
+
+        rc = planner_multi_avail_during (ctx, i*1000, 1000,
+                                         (const uint64_t *)request, len);
+        bo = (bo || rc);
+        span = planner_multi_add_span (ctx, i*1000, 1000,
+                                       (const uint64_t *)request, len);
+        bo = (bo || span == -1);
+    }
+    ok ((!bo && !errno), "many multi_add_spans work");
+
+    ss.str ("");
+    to_stream (-1, 1000, requestA, (const char **)resource_types, len, ss);
+    t = planner_multi_avail_time_first (ctx, 0, 1000, requestA, len);
+    ok ((t == 1000000), "avail_time_first for (%s)", ss.str ().c_str ());
+    t = planner_multi_avail_time_next (ctx);
+    ok ((t == -1) && errno == ENOENT , "avail_time_next for (%s)",
+    ss.str ().c_str ());
+
+    ss.str ("");
+    bo = false;
+    to_stream (-1, 1000, requestB, (const char **)resource_types, len, ss);
+    t = planner_multi_avail_time_first (ctx, 0, 1000, requestB, len);
+    bo = (bo || (t != 1000));
+
+    for (int i = 1; i < 10; i++) {
+        t = planner_multi_avail_time_next (ctx);
+        bo = (bo || (t != (1000 * (100 * i + 1))));
+    }
+    t = planner_multi_avail_time_next (ctx);
+    bo = (bo || (t != 1000000));
+    t = planner_multi_avail_time_next (ctx);
+    bo = (bo || !(t == -1 && errno == ENOENT));
+    ok (!bo, "avail_time_next for (%s)", ss.str ().c_str ());
+
+    ss.str ("");
+    bo = false;
+    to_stream (-1, 1000, requestC, (const char **)resource_types, len, ss);
+    t = planner_multi_avail_time_first (ctx, 0, 1000, requestC, len);
+    bo = (bo || (t != 49000));
+
+    for (int i = 1; i < 10; i++) {
+        t = planner_multi_avail_time_next (ctx);
+        bo = (bo || (t != (1000 * (100 * i + 49))));
+    }
+
+    t = planner_multi_avail_time_next (ctx);
+    bo = (bo || (t != 1000000));
+    t = planner_multi_avail_time_next (ctx);
+    bo = (bo || !(t == -1 && errno == ENOENT));
+    ok (!bo, "avail_time_next for (%s)", ss.str ().c_str ());
+    return 0;
+}
+
+static int test_multi_add_remove ()
+{
+    size_t len = 5;
+    size_t size = 0;
+    int rc = -1;
+    int64_t tmax = INT64_MAX;
+    int64_t span1 = -1, span2 = -1, span3 = -1;
+    const uint64_t resource_totals[] = {10, 20, 30, 40, 50};
+    const char *resource_types[] = {"A", "B", "C", "D", "E"};
+    const uint64_t request1[] = {1, 0, 0, 0, 0};
+    const uint64_t request2[] = {0, 2, 0, 0, 0};
+    const uint64_t request3[] = {0, 0, 3, 0, 0};
+    planner_multi_t *ctx = NULL;
+    std::stringstream ss;
+
+    errno = 0;
+    to_stream (0, tmax, resource_totals, (const char **)resource_types, len, ss);
+    ctx = planner_multi_new (0, INT64_MAX, resource_totals, resource_types, len);
+    ok ((ctx && !errno), "new with (%s)", ss.str ().c_str ());
+
+    ss.str ("");
+    to_stream (0, 1000, request1, (const char **)resource_types, len, ss);
+    rc = planner_multi_avail_during (ctx, 0, 1000, request1, len);
+    ok ((!rc && !errno), "multi-resource avail works (%s)", ss.str ().c_str ());
+
+    span1 = planner_multi_add_span (ctx, 0, 1000, request1, len);
+    ok ((span1 != -1), "span added for (%s)", ss.str ().c_str ());
+
+    ss.str ("");
+    to_stream (1000, 1000, request2, (const char **)resource_types, len, ss);
+    rc = planner_multi_avail_during (ctx, 1000, 1000, request2, len);
+    ok ((!rc && !errno), "multi-resource avail works (%s)", ss.str ().c_str ());
+
+    span2 = planner_multi_add_span (ctx, 1000, 1000, request2, len);
+    ok ((span2 != -1), "span added for (%s)", ss.str ().c_str ());
+
+    ss.str ("");
+    to_stream (2000, 1000, request3, (const char **)resource_types, len, ss);
+    rc = planner_multi_avail_during (ctx, 2000, 1000, request3, len);
+    ok ((!rc && !errno), "multi-resource avail works (%s)", ss.str ().c_str ());
+
+    span3 = planner_multi_add_span (ctx, 2000, 1000, request3, len);
+    ok ((span3 != -1), "span added for (%s)", ss.str ().c_str ());
+
+    rc = planner_multi_rem_span (ctx, span2);
+    ok ((!rc && !errno), "multi_rem_span works");
+
+    size = planner_multi_span_size (ctx);
+    ok ((size == 2), "planner_multi_span_size works");
+
+    return 0;
+
+}
+
+
+int main (int argc, char *argv[])
+{
+    plan (79);
+
+    test_multi_basics ();
+
+    test_multi_getters ();
+
+    test_multi_strictly_larger ();
+
+    test_multi_partially_larger ();
+
+    test_multi_many_spans ();
+
+    test_multi_add_remove ();
+
+    done_testing ();
+
+    return EXIT_SUCCESS;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/resource/schema/infra_data.cpp
+++ b/resource/schema/infra_data.cpp
@@ -67,20 +67,20 @@ pool_infra_t::pool_infra_t ()
 
 pool_infra_t::pool_infra_t (const pool_infra_t &o): infra_base_t (o)
 {
-   // don't copy the content of infrastructure tables and subtree
-   // planner objects.
-   colors = o.colors;
-   for (auto &kv : o.subplans) {
-       planner_t *p = kv.second;
-       if (!p)
-           continue;
-       int64_t base_time = planner_base_time (p);
-       uint64_t duration = planner_duration (p);
-       size_t len = planner_resources_len (p);
-       subplans[kv.first] = planner_new (base_time, duration,
-                                planner_resource_totals (p),
-                                planner_resource_types (p), len);
-   }
+    // don't copy the content of infrastructure tables and subtree
+    // planner objects.
+    colors = o.colors;
+    for (auto &kv : o.subplans) {
+        planner_multi_t *p = kv.second;
+        if (!p)
+            continue;
+        int64_t base_time = planner_multi_base_time (p);
+        uint64_t duration = planner_multi_duration (p);
+        size_t len = planner_multi_resources_len (p);
+        subplans[kv.first] = planner_multi_new (base_time, duration,
+                                 planner_multi_resource_totals (p),
+                                 planner_multi_resource_types (p), len);
+    }
 }
 
 pool_infra_t &pool_infra_t::operator= (const pool_infra_t &o)
@@ -90,15 +90,15 @@ pool_infra_t &pool_infra_t::operator= (const pool_infra_t &o)
     infra_base_t::operator= (o);
     colors = o.colors;
     for (auto &kv : o.subplans) {
-        planner_t *p = kv.second;
+        planner_multi_t *p = kv.second;
         if (!p)
             continue;
-        int64_t base_time = planner_base_time (p);
-        uint64_t duration = planner_duration (p);
-        size_t len = planner_resources_len (p);
-        subplans[kv.first] = planner_new (base_time, duration,
-                                 planner_resource_totals (p),
-                                 planner_resource_types (p), len);
+        int64_t base_time = planner_multi_base_time (p);
+        uint64_t duration = planner_multi_duration (p);
+        size_t len = planner_multi_resources_len (p);
+        subplans[kv.first] = planner_multi_new (base_time, duration,
+                                 planner_multi_resource_totals (p),
+                                 planner_multi_resource_types (p), len);
     }
     return *this;
 }
@@ -106,14 +106,14 @@ pool_infra_t &pool_infra_t::operator= (const pool_infra_t &o)
 pool_infra_t::~pool_infra_t ()
 {
     for (auto &kv : subplans)
-        planner_destroy (&(kv.second));
+        planner_multi_destroy (&(kv.second));
 }
 
 void pool_infra_t::scrub ()
 {
     job2span.clear ();
     for (auto &kv : subplans)
-        planner_destroy (&(kv.second));
+        planner_multi_destroy (&(kv.second));
     colors.clear ();
 }
 

--- a/resource/schema/infra_data.hpp
+++ b/resource/schema/infra_data.hpp
@@ -26,7 +26,7 @@
 #include <map>
 #include <cstdint>
 #include "schema/data_std.hpp"
-#include "planner/planner.h"
+#include "planner/planner_multi.h"
 
 namespace Flux {
 namespace resource_model {
@@ -52,7 +52,7 @@ struct pool_infra_t : public infra_base_t {
     virtual void scrub ();
 
     std::map<int64_t, int64_t> job2span;
-    std::map<subsystem_t, planner_t *> subplans;
+    std::map<subsystem_t, planner_multi_t *> subplans;
     std::map<subsystem_t, uint64_t> colors;
 };
 

--- a/resource/schema/sched_data.cpp
+++ b/resource/schema/sched_data.cpp
@@ -34,25 +34,22 @@ schedule_t::schedule_t (const schedule_t &o)
 {
     int64_t base_time = 0;
     uint64_t duration = 0;
-    size_t len = 0;
 
     // copy constructor does not copy the contents
     // of the schedule tables and of the planner objects.
     if (o.plans) {
         base_time = planner_base_time (o.plans);
         duration = planner_duration (o.plans);
-        len = planner_resources_len (o.plans);
         plans = planner_new (base_time, duration,
-                             planner_resource_totals (o.plans),
-                             planner_resource_types (o.plans), len);
+                             planner_resource_total (o.plans),
+                             planner_resource_type (o.plans));
     }
     if (o.x_checker) {
         base_time = planner_base_time (o.x_checker);
         duration = planner_duration (o.x_checker);
-        len = planner_resources_len (o.x_checker);
         x_checker = planner_new (base_time, duration,
-                                 planner_resource_totals (o.x_checker),
-                                 planner_resource_types (o.x_checker), len);
+                                 planner_resource_total (o.x_checker),
+                                 planner_resource_type (o.x_checker));
     }
 }
 
@@ -67,18 +64,16 @@ schedule_t &schedule_t::operator= (const schedule_t &o)
     if (o.plans) {
         base_time = planner_base_time (o.plans);
         duration = planner_duration (o.plans);
-        len = planner_resources_len (o.plans);
         plans = planner_new (base_time, duration,
-                             planner_resource_totals (o.plans),
-                             planner_resource_types (o.plans), len);
+                             planner_resource_total (o.plans),
+                             planner_resource_type (o.plans));
     }
     if (o.x_checker) {
         base_time = planner_base_time (o.x_checker);
         duration = planner_duration (o.x_checker);
-        len = planner_resources_len (o.x_checker);
         x_checker = planner_new (base_time, duration,
-                                 planner_resource_totals (o.x_checker),
-                                 planner_resource_types (o.x_checker), len);
+                                 planner_resource_total (o.x_checker),
+                                 planner_resource_type (o.x_checker));
     }
     return *this;
 }

--- a/resource/traversers/dfu.cpp
+++ b/resource/traversers/dfu.cpp
@@ -58,13 +58,14 @@ int dfu_traverser_t::schedule (Jobspec::Jobspec &jobspec,
         meta.allocate = false;
         int64_t t = meta.at + 1;
         vector<uint64_t> agg;
-        planner_t *p = (*get_graph ())[root].idata.subplans.at (dom);
-        size_t len = planner_resources_len (p);
+        planner_multi_t *p = (*get_graph ())[root].idata.subplans.at (dom);
+        size_t len = planner_multi_resources_len (p);
+        uint64_t duration = meta.duration;
         detail::dfu_impl_t::count (p, dfv, agg);
         // TODO: examine correctness when a jobspec doesn't include
         // the subtree plan resource type
-        for (t = planner_avail_time_first (p, t, meta.duration, &agg[0], len);
-             (t != -1 && rc != 0); t = planner_avail_time_next (p)) {
+        for (t = planner_multi_avail_time_first (p, t, duration, &agg[0], len);
+             (t != -1 && rc != 0); t = planner_multi_avail_time_next (p)) {
             meta.at = t;
             rc = detail::dfu_impl_t::select (jobspec, root, meta, x, needs);
         }

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -138,14 +138,14 @@ public:
      *  planner-tracking resource types into resource_counts array, a form that
      *  can be used with Planner API.
      *
-     *  \param plan      planner object.
+     *  \param plan      multi-planner object.
      *  \param lookup    a map type such as std::map or unordered_map.
      *  \param[out] resource_counts
      *                   output array.
      *  \return          0 on success; -1 on error.
      */
     template <class lookup_t>
-    int count (planner_t *plan, const lookup_t &lookup,
+    int count (planner_multi_t *plan, const lookup_t &lookup,
                std::vector<uint64_t> &resource_counts);
 
     /*! Entry point for graph matching and scoring depth-first-and-up (DFU) walk.
@@ -214,8 +214,8 @@ private:
     int prune (const jobmeta_t &meta, bool excl, const std::string &subsystem,
                vtx_t u, const std::vector<Jobspec::Resource> &resources);
 
-    planner_t *subtree_plan (vtx_t u, std::vector<uint64_t> &avail,
-                             std::vector<const char *> &types);
+    planner_multi_t *subtree_plan (vtx_t u, std::vector<uint64_t> &avail,
+                                   std::vector<const char *> &types);
 
     /*! Test various matching conditions between jobspec and graph
      * including slot match
@@ -307,12 +307,12 @@ private:
 }; // the end of class dfu_impl_t
 
 template <class lookup_t>
-int dfu_impl_t::count (planner_t *plan, const lookup_t &lookup,
+int dfu_impl_t::count (planner_multi_t *plan, const lookup_t &lookup,
                        std::vector<uint64_t> &resource_counts)
 {
     int rc = 0;
-    size_t len = planner_resources_len (plan);
-    const char **resource_types = planner_resource_types (plan);
+    size_t len = planner_multi_resources_len (plan);
+    const char **resource_types = planner_multi_resource_types (plan);
     for (unsigned int i = 0; i < len; ++i) {
         if (lookup.find (resource_types[i]) != lookup.end ()) {
             uint64_t n = (uint64_t)lookup.at (resource_types[i]);

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -47,13 +47,14 @@ extern "C" {
 using namespace std;
 using namespace Flux::resource_model;
 
-#define OPTIONS "G:S:P:g:o:t:e:h"
+#define OPTIONS "G:S:P:g:o:p:t:e:h"
 static const struct option longopts[] = {
     {"grug",             required_argument,  0, 'G'},
     {"match-subsystems", required_argument,  0, 'S'},
     {"match-policy",     required_argument,  0, 'P'},
     {"graph-format",     required_argument,  0, 'g'},
     {"graph-output",     required_argument,  0, 'o'},
+    {"prune-filters",    required_argument,  0, 'p'},
     {"test-output",      required_argument,  0, 't'},
     {"elapse",           required_argument,  0, 'e'},
     {"help",             no_argument,        0, 'h'},
@@ -130,6 +131,18 @@ static void usage (int code)
 "                low: Select resources with low ID first\n"
 "                locality: Select contiguous resources first in their ID space\n"
 "            (default=high).\n"
+"\n"
+"    -C, --prune-filters=<[HL-resource1|]:LL-resource1[,[HL-resource2|]:LL-resource2...]...]>\n"
+"            Install a planner-based cache at each HL(High-Level)-resource,\n"
+"                vertex which maintains the state of LL(Low-Level)-resources\n"
+"                in aggregate residing under its subtree. If a spec requests\n"
+"                1 node with 4 cores, and the visiting node vertex has\n"
+"                only a total of 2 available cores in aggreate at its\n"
+"                subtree, traverse will prune the further descent from\n"
+"                this node vertex to speep up the search. Example:\n"
+"                    rack:node,node:core\n"
+"                    :core,cluster:node,rack:node\n"
+"                (default=:core).\n"
 "\n"
 "    -g, --graph-format=<dot|graphml>\n"
 "            Specify the graph format of the output file\n"

--- a/t/data/resource/commands/basics/cmds03.in
+++ b/t/data/resource/commands/basics/cmds03.in
@@ -1,4 +1,4 @@
-# 4x cluster[1]->rack[1]->node[1]->slot[1]->socket[1]->core[1]
+# 10x cluster[1]->rack[1]->node[1]->slot[1]->socket[1]->core[1]
 match allocate_orelse_reserve @TEST_SRCDIR@/data/resource/jobspecs/basics/test001.yaml
 match allocate_orelse_reserve @TEST_SRCDIR@/data/resource/jobspecs/basics/test001.yaml
 match allocate_orelse_reserve @TEST_SRCDIR@/data/resource/jobspecs/basics/test001.yaml


### PR DESCRIPTION
This PR is still experimental: I thought I should post this now as I will be busy with travel for awhile. 

This PR mainly addresses a minimum time resource tree problem within the planner layer. This reverse search tree is designed to satisify a query like "when is the earliest scheduled point at which I can schedule *n* amounts of resources" in `O(lg N)` time. However, this advanced algorithm only works when it deals with a single resource type and doesn't work correctly when it deals with multiple resource types.

In response, this PR limits the planner layer such that that it only manages a single resource type. Instead, it adds `planner_multi_t` layer to handle multiple resources. It also adjusted the rest of the resource code for this change.

Finally a bunch of test cases has also been added.

When I circle back to this, I will do further cleanup and tighten some loosen ends to ensure correctness for a few more corner cases.
