### PR TITLE
simulator: track a flux-core API change

### DIFF
--- a/simulator/sim_execsrv.c
+++ b/simulator/sim_execsrv.c
@@ -598,7 +598,7 @@ static void trigger_cb (flux_t *h,
     zhash_t *job_hash = NULL;
     ctx_t *ctx = (ctx_t *)arg;
 
-    if (flux_msg_get_json (msg, &json_str) < 0 || json_str == NULL
+    if (flux_msg_get_string (msg, &json_str) < 0 || json_str == NULL
         || !(o = Jfromstr (json_str))) {
         flux_log (h, LOG_ERR, "%s: bad message", __FUNCTION__);
         return;

--- a/simulator/simsrv.c
+++ b/simulator/simsrv.c
@@ -220,7 +220,7 @@ static void join_cb (flux_t *h,
     sim_state_t *sim_state = ctx->sim_state;
     uint32_t size;
 
-    if (flux_msg_get_json (msg, &json_str) < 0 || json_str == NULL
+    if (flux_msg_get_string (msg, &json_str) < 0 || json_str == NULL
         || !(request = Jfromstr (json_str))
         || !Jget_str (request, "mod_name", &mod_name)
         || !Jget_int (request, "rank", &mod_rank)
@@ -353,7 +353,7 @@ static void rdl_update_cb (flux_t *h,
     const char *json_str = NULL, *rdl_str = NULL;
     ctx_t *ctx = (ctx_t *)arg;
 
-    if (flux_msg_get_json (msg, &json_str) < 0 || json_str == NULL
+    if (flux_msg_get_string (msg, &json_str) < 0 || json_str == NULL
         || !(o = Jfromstr (json_str))) {
         flux_log (h, LOG_ERR, "%s: bad message", __FUNCTION__);
         Jput (o);
@@ -382,7 +382,7 @@ static void reply_cb (flux_t *h,
     sim_state_t *curr_sim_state = ctx->sim_state;
     sim_state_t *reply_sim_state;
 
-    if (flux_msg_get_json (msg, &json_str) < 0 || json_str == NULL
+    if (flux_msg_get_string (msg, &json_str) < 0 || json_str == NULL
         || !(request = Jfromstr (json_str))) {
         flux_log (h, LOG_ERR, "%s: bad reply message", __FUNCTION__);
         Jput (request);
@@ -413,7 +413,7 @@ static void alive_cb (flux_t *h,
 {
     const char *json_str;
 
-    if (flux_msg_get_json (msg, &json_str) < 0 || json_str == NULL) {
+    if (flux_msg_get_string (msg, &json_str) < 0 || json_str == NULL) {
         flux_log (h, LOG_ERR, "%s: bad reply message", __FUNCTION__);
         return;
     }

--- a/simulator/submitsrv.c
+++ b/simulator/submitsrv.c
@@ -358,7 +358,7 @@ static void trigger_cb (flux_t *h,
     const char *json_str = NULL;
     sim_state_t *sim_state = NULL;
 
-    if (flux_msg_get_json (msg, &json_str) < 0 || json_str == NULL
+    if (flux_msg_get_string (msg, &json_str) < 0 || json_str == NULL
         || !(o = Jfromstr (json_str))) {
         flux_log (h, LOG_ERR, "%s: bad message", __FUNCTION__);
         Jput (o);


### PR DESCRIPTION
Use flux_msg_get_string () instead of flux_msg_get_json ().

Resolve Issue #350. 