### PR TITLE
travis: change email notifications to go to the flux-sched-dev listserv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,3 +125,10 @@ deploy:
     condition: $TRAVIS_JOB_NUMBER = $TRAVIS_BUILD_NUMBER.1
     tags: true
     repo: flux-framework/flux-sched
+
+notifications:
+  email:
+    recipients:
+      - flux-sched-dev@listserv.llnl.gov
+    on_success: change
+    on_failure: always


### PR DESCRIPTION
This should make the cron failure notifications more visible to the flux-sched devs (and generally anyone interested in being notified of flux-sched build changes).

Does anyone know who the owner of flux-sched-dev is?  I went to make my own list and noticed this one already existed.  I requested to subscribe.  Maybe @garlick or @grondo is the owner?

I marked it as "in progress" until we know at least 1 person has successfully subscribed to the list.