### PR TITLE
Add hwloc-based GPU scheduling support

### DIFF
--- a/resrc/resrc.c
+++ b/resrc/resrc.c
@@ -910,18 +910,10 @@ static resrc_t *resrc_new_from_hwloc_obj (resrc_api_ctx_t *ctx, hwloc_obj_t obj,
     } else if (!hwloc_compare_types (obj->type, HWLOC_OBJ_GROUP)) {
         type = xstrdup ("group");
         name = xasprintf ("%s%"PRId64"", type, id);
-#if HWLOC_API_VERSION < 0x00010b00
-    } else if (!hwloc_compare_types (obj->type, HWLOC_OBJ_NODE)) {
-#else
     } else if (!hwloc_compare_types (obj->type, HWLOC_OBJ_NUMANODE)) {
-#endif
         type = xstrdup ("numanode");
         name = xasprintf ("%s%"PRId64"", type, id);
-#if HWLOC_API_VERSION < 0x00010b00
-    } else if (!hwloc_compare_types (obj->type, HWLOC_OBJ_SOCKET)) {
-#else
     } else if (!hwloc_compare_types (obj->type, HWLOC_OBJ_PACKAGE)) {
-#endif
         type = xstrdup ("socket");
         name = xasprintf ("%s%"PRId64"", type, id);
 #if HWLOC_API_VERSION < 0x00020000

--- a/sched/rsreader.c
+++ b/sched/rsreader.c
@@ -267,6 +267,8 @@ int rsreader_hwloc_load (resrc_api_ctx_t *rsapi, const char *buf, size_t len,
 
     if (hwloc_topology_init (&topo) != 0)
         goto done;
+    if (hwloc_topology_set_flags (topo, HWLOC_TOPOLOGY_FLAG_IO_DEVICES) != 0)
+        goto err;
     if (hwloc_topology_set_xmlbuffer (topo, buf, len) != 0)
         goto err;
     if (hwloc_topology_load (topo) != 0)

--- a/sched/sched.c
+++ b/sched/sched.c
@@ -662,7 +662,7 @@ static int build_hwloc_rs2rank (ssrvctx_t *ctx, rsreader_t r_mode)
         if (rsreader_hwloc_load (ctx->rsapi, s, len, rank, r_mode, ctx->machs,
                                  &err_str)) {
             Jput (o);
-            flux_log_error (ctx->h, "can't load hwloc data: %s", err_str);
+            flux_log (ctx->h, LOG_ERR, "can't load hwloc data: %s", err_str);
             free (err_str);
             goto done;
         }

--- a/t/data/hwloc-data/004N/exclusive/04-brokers-sierra2/0.xml
+++ b/t/data/hwloc-data/004N/exclusive/04-brokers-sierra2/0.xml
@@ -1,0 +1,721 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0xf0000000,,,,,,,0x00000101" complete_nodeset="0xf0000000,,,,,,,0x00000101" allowed_nodeset="0xf0000000,,,,,,,0x00000101">
+    <page_type size="65536" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <page_type size="1073741824" count="0"/>
+    <info name="PlatformName" value="PowerNV"/>
+    <info name="PlatformModel" value="PowerNV 8335-GTW"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/allocation_54106"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="4.14.0-49.6.1.el7a.ppc64le"/>
+    <info name="OSVersion" value="#1 SMP Wed May 16 21:05:05 UTC 2018"/>
+    <info name="HostName" value="sierra3682"/>
+    <info name="Architecture" value="ppc64le"/>
+    <info name="hwlocVersion" value="1.11.10"/>
+    <info name="ProcessName" value="hwloc_xml"/>
+    <distances nbobjs="6" relative_depth="2" latency_base="10.000000">
+      <latency value="1.000000"/>
+      <latency value="4.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="4.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+    </distances>
+    <object type="Group" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0x00000101" complete_nodeset="0x00000101" allowed_nodeset="0x00000101" depth="0">
+      <object type="NUMANode" os_index="0" cpuset="0x00ffffff,0xffffffff,0xffffffff" complete_cpuset="0x00ffffff,0xffffffff,0xffffffff" online_cpuset="0x00ffffff,0xffffffff,0xffffffff" allowed_cpuset="0x00ffffff,0xffffffff,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="137132310528">
+        <page_type size="65536" count="2092473"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Package" os_index="0" cpuset="0x00ffffff,0xffffffff,0xffffffff" complete_cpuset="0x00ffffff,0xffffffff,0xffffffff" online_cpuset="0x00ffffff,0xffffffff,0xffffffff" allowed_cpuset="0x00ffffff,0xffffffff,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <info name="CPUModel" value="POWER9, altivec supported"/>
+          <info name="CPURevision" value="2.1 (pvr 004e 1201)"/>
+          <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="8" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="12" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="16" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="20" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000" complete_cpuset="0x00ff0000" online_cpuset="0x00ff0000" allowed_cpuset="0x00ff0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000" complete_cpuset="0x00ff0000" online_cpuset="0x00ff0000" allowed_cpuset="0x00ff0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="24" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="28" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000" complete_cpuset="0xff000000" online_cpuset="0xff000000" allowed_cpuset="0xff000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000" complete_cpuset="0xff000000" online_cpuset="0xff000000" allowed_cpuset="0xff000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="32" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="36" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,0x0" complete_cpuset="0x000000ff,0x0" online_cpuset="0x000000ff,0x0" allowed_cpuset="0x000000ff,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,0x0" complete_cpuset="0x000000ff,0x0" online_cpuset="0x000000ff,0x0" allowed_cpuset="0x000000ff,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="40" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="44" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,0x0" complete_cpuset="0x0000ff00,0x0" online_cpuset="0x0000ff00,0x0" allowed_cpuset="0x0000ff00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,0x0" complete_cpuset="0x0000ff00,0x0" online_cpuset="0x0000ff00,0x0" allowed_cpuset="0x0000ff00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="48" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="52" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,0x0" complete_cpuset="0x00ff0000,0x0" online_cpuset="0x00ff0000,0x0" allowed_cpuset="0x00ff0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,0x0" complete_cpuset="0x00ff0000,0x0" online_cpuset="0x00ff0000,0x0" allowed_cpuset="0x00ff0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="56" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="60" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000,0x0" complete_cpuset="0xff000000,0x0" online_cpuset="0xff000000,0x0" allowed_cpuset="0xff000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,0x0" complete_cpuset="0xff000000,0x0" online_cpuset="0xff000000,0x0" allowed_cpuset="0xff000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="64" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="68" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,0x0" complete_cpuset="0x000000ff,,0x0" online_cpuset="0x000000ff,,0x0" allowed_cpuset="0x000000ff,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,0x0" complete_cpuset="0x000000ff,,0x0" online_cpuset="0x000000ff,,0x0" allowed_cpuset="0x000000ff,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="72" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="76" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,,0x0" complete_cpuset="0x0000ff00,,0x0" online_cpuset="0x0000ff00,,0x0" allowed_cpuset="0x0000ff00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,,0x0" complete_cpuset="0x0000ff00,,0x0" online_cpuset="0x0000ff00,,0x0" allowed_cpuset="0x0000ff00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="80" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="84" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,0x0" online_cpuset="0x00ff0000,,0x0" allowed_cpuset="0x00ff0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,0x0" online_cpuset="0x00ff0000,,0x0" allowed_cpuset="0x00ff0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="88" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="92" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-01]">
+          <object type="PCIDev" os_index="4096" name="Samsung Electronics Co Ltd NVMe SSD Controller 172Xa" pci_busid="0000:01:00.0" pci_type="0108 [144d:a822] [1014:0621] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Samsung Electronics Co Ltd"/>
+            <info name="PCIDevice" value="NVMe SSD Controller 172Xa"/>
+            <object type="OSDev" name="nvme0n1" osdev_type="0">
+              <info name="LinuxDeviceID" value="259:0"/>
+              <info name="SerialNumber" value="S3RVNA0J802449"/>
+              <info name="Type" value="Disk"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0002:[00-02]">
+          <object type="PCIDev" os_index="2105344" name="ASPEED Technology, Inc. ASPEED Graphics Family" pci_busid="0002:02:00.0" pci_type="0300 [1a03:2000] [1a03:2000] 41" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+            <info name="PCIDevice" value="ASPEED Graphics Family"/>
+            <object type="OSDev" name="card4" osdev_type="1"/>
+            <object type="OSDev" name="controlD68" osdev_type="1"/>
+          </object>
+        </object>
+        <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0003:[00-01]">
+          <object type="PCIDev" os_index="3149824" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0003:01:00.0" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Mellanox Technologies"/>
+            <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+            <object type="OSDev" name="hsi0" osdev_type="2">
+              <info name="Address" value="00:00:10:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:49:a2:12"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx5_0" osdev_type="3">
+              <info name="NodeGUID" value="ec0d:9a03:0049:a212"/>
+              <info name="SysImageGUID" value="ec0d:9a03:0049:a212"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x2dbf"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:0049:a212"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="3149825" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0003:01:00.1" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Mellanox Technologies"/>
+            <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+            <object type="OSDev" name="hsi1" osdev_type="2">
+              <info name="Address" value="00:00:18:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:49:a2:13"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx5_1" osdev_type="3">
+              <info name="NodeGUID" value="ec0d:9a03:0049:a213"/>
+              <info name="SysImageGUID" value="ec0d:9a03:0049:a212"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x2dc0"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:0049:a213"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="4" bridge_type="0-1" depth="0" bridge_pci="0004:[00-0a]">
+          <object type="PCIDev" os_index="4206592" name="Marvell Technology Group Ltd. 88SE9235 PCIe 2.0 x2 4-port SATA 6 Gb/s Controller" pci_busid="0004:03:00.0" pci_type="0106 [1b4b:9235] [1014:0612] 11" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Marvell Technology Group Ltd."/>
+            <info name="PCIDevice" value="88SE9235 PCIe 2.0 x2 4-port SATA 6 Gb/s Controller"/>
+          </object>
+          <object type="PCIDev" os_index="4210688" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0004:04:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="NVIDIA Corporation"/>
+            <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+            <object type="OSDev" name="renderD128" osdev_type="1"/>
+            <object type="OSDev" name="card0" osdev_type="1"/>
+            <object type="OSDev" name="cuda0" osdev_type="5">
+              <info name="CoProcType" value="CUDA"/>
+              <info name="Backend" value="CUDA"/>
+              <info name="GPUVendor" value="NVIDIA Corporation"/>
+              <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+              <info name="CUDAGlobalMemorySize" value="16515072"/>
+              <info name="CUDAL2CacheSize" value="6144"/>
+              <info name="CUDAMultiProcessors" value="80"/>
+              <info name="CUDACoresPerMP" value="64"/>
+              <info name="CUDASharedMemorySizePerMP" value="48"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="4214784" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0004:05:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="NVIDIA Corporation"/>
+            <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+            <object type="OSDev" name="card1" osdev_type="1"/>
+            <object type="OSDev" name="renderD129" osdev_type="1"/>
+            <object type="OSDev" name="cuda1" osdev_type="5">
+              <info name="CoProcType" value="CUDA"/>
+              <info name="Backend" value="CUDA"/>
+              <info name="GPUVendor" value="NVIDIA Corporation"/>
+              <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+              <info name="CUDAGlobalMemorySize" value="16515072"/>
+              <info name="CUDAL2CacheSize" value="6144"/>
+              <info name="CUDAMultiProcessors" value="80"/>
+              <info name="CUDACoresPerMP" value="64"/>
+              <info name="CUDASharedMemorySizePerMP" value="48"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="5" bridge_type="0-1" depth="0" bridge_pci="0005:[00-01]">
+          <object type="PCIDev" os_index="5246976" name="Broadcom Limited NetXtreme BCM5719 Gigabit Ethernet PCIe" pci_busid="0005:01:00.0" pci_type="0200 [14e4:1657] [14e4:1981] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Broadcom Limited"/>
+            <info name="PCIDevice" value="NetXtreme BCM5719 Gigabit Ethernet PCIe"/>
+            <object type="OSDev" name="enP5p1s0f0" osdev_type="2">
+              <info name="Address" value="70:e2:84:14:6c:1c"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="5246977" name="Broadcom Limited NetXtreme BCM5719 Gigabit Ethernet PCIe" pci_busid="0005:01:00.1" pci_type="0200 [14e4:1657] [14e4:1657] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Broadcom Limited"/>
+            <info name="PCIDevice" value="NetXtreme BCM5719 Gigabit Ethernet PCIe"/>
+            <object type="OSDev" name="enP5p1s0f1" osdev_type="2">
+              <info name="Address" value="70:e2:84:14:6c:1d"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="8" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" local_memory="137166979072">
+        <page_type size="65536" count="2093002"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Package" os_index="8" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+          <info name="CPUModel" value="POWER9, altivec supported"/>
+          <info name="CPURevision" value="2.1 (pvr 004e 1201)"/>
+          <object type="Cache" cpuset="0xff000000,,0x0" complete_cpuset="0xff000000,,0x0" online_cpuset="0xff000000,,0x0" allowed_cpuset="0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,,0x0" complete_cpuset="0xff000000,,0x0" online_cpuset="0xff000000,,0x0" allowed_cpuset="0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2048" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2052" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,,0x0" complete_cpuset="0x000000ff,,,0x0" online_cpuset="0x000000ff,,,0x0" allowed_cpuset="0x000000ff,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,,0x0" complete_cpuset="0x000000ff,,,0x0" online_cpuset="0x000000ff,,,0x0" allowed_cpuset="0x000000ff,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2056" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="96" cpuset="0x00000001,,,0x0" complete_cpuset="0x00000001,,,0x0" online_cpuset="0x00000001,,,0x0" allowed_cpuset="0x00000001,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="97" cpuset="0x00000002,,,0x0" complete_cpuset="0x00000002,,,0x0" online_cpuset="0x00000002,,,0x0" allowed_cpuset="0x00000002,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="98" cpuset="0x00000004,,,0x0" complete_cpuset="0x00000004,,,0x0" online_cpuset="0x00000004,,,0x0" allowed_cpuset="0x00000004,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="99" cpuset="0x00000008,,,0x0" complete_cpuset="0x00000008,,,0x0" online_cpuset="0x00000008,,,0x0" allowed_cpuset="0x00000008,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2060" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="100" cpuset="0x00000010,,,0x0" complete_cpuset="0x00000010,,,0x0" online_cpuset="0x00000010,,,0x0" allowed_cpuset="0x00000010,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="101" cpuset="0x00000020,,,0x0" complete_cpuset="0x00000020,,,0x0" online_cpuset="0x00000020,,,0x0" allowed_cpuset="0x00000020,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="102" cpuset="0x00000040,,,0x0" complete_cpuset="0x00000040,,,0x0" online_cpuset="0x00000040,,,0x0" allowed_cpuset="0x00000040,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="103" cpuset="0x00000080,,,0x0" complete_cpuset="0x00000080,,,0x0" online_cpuset="0x00000080,,,0x0" allowed_cpuset="0x00000080,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2068" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="104" cpuset="0x00000100,,,0x0" complete_cpuset="0x00000100,,,0x0" online_cpuset="0x00000100,,,0x0" allowed_cpuset="0x00000100,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="105" cpuset="0x00000200,,,0x0" complete_cpuset="0x00000200,,,0x0" online_cpuset="0x00000200,,,0x0" allowed_cpuset="0x00000200,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="106" cpuset="0x00000400,,,0x0" complete_cpuset="0x00000400,,,0x0" online_cpuset="0x00000400,,,0x0" allowed_cpuset="0x00000400,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="107" cpuset="0x00000800,,,0x0" complete_cpuset="0x00000800,,,0x0" online_cpuset="0x00000800,,,0x0" allowed_cpuset="0x00000800,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000ff000,,,0x0" complete_cpuset="0x000ff000,,,0x0" online_cpuset="0x000ff000,,,0x0" allowed_cpuset="0x000ff000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000ff000,,,0x0" complete_cpuset="0x000ff000,,,0x0" online_cpuset="0x000ff000,,,0x0" allowed_cpuset="0x000ff000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2072" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="108" cpuset="0x00001000,,,0x0" complete_cpuset="0x00001000,,,0x0" online_cpuset="0x00001000,,,0x0" allowed_cpuset="0x00001000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="109" cpuset="0x00002000,,,0x0" complete_cpuset="0x00002000,,,0x0" online_cpuset="0x00002000,,,0x0" allowed_cpuset="0x00002000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="110" cpuset="0x00004000,,,0x0" complete_cpuset="0x00004000,,,0x0" online_cpuset="0x00004000,,,0x0" allowed_cpuset="0x00004000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="111" cpuset="0x00008000,,,0x0" complete_cpuset="0x00008000,,,0x0" online_cpuset="0x00008000,,,0x0" allowed_cpuset="0x00008000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2076" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="112" cpuset="0x00010000,,,0x0" complete_cpuset="0x00010000,,,0x0" online_cpuset="0x00010000,,,0x0" allowed_cpuset="0x00010000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="113" cpuset="0x00020000,,,0x0" complete_cpuset="0x00020000,,,0x0" online_cpuset="0x00020000,,,0x0" allowed_cpuset="0x00020000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="114" cpuset="0x00040000,,,0x0" complete_cpuset="0x00040000,,,0x0" online_cpuset="0x00040000,,,0x0" allowed_cpuset="0x00040000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="115" cpuset="0x00080000,,,0x0" complete_cpuset="0x00080000,,,0x0" online_cpuset="0x00080000,,,0x0" allowed_cpuset="0x00080000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0ff00000,,,0x0" complete_cpuset="0x0ff00000,,,0x0" online_cpuset="0x0ff00000,,,0x0" allowed_cpuset="0x0ff00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0ff00000,,,0x0" complete_cpuset="0x0ff00000,,,0x0" online_cpuset="0x0ff00000,,,0x0" allowed_cpuset="0x0ff00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2080" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="116" cpuset="0x00100000,,,0x0" complete_cpuset="0x00100000,,,0x0" online_cpuset="0x00100000,,,0x0" allowed_cpuset="0x00100000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="117" cpuset="0x00200000,,,0x0" complete_cpuset="0x00200000,,,0x0" online_cpuset="0x00200000,,,0x0" allowed_cpuset="0x00200000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="118" cpuset="0x00400000,,,0x0" complete_cpuset="0x00400000,,,0x0" online_cpuset="0x00400000,,,0x0" allowed_cpuset="0x00400000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="119" cpuset="0x00800000,,,0x0" complete_cpuset="0x00800000,,,0x0" online_cpuset="0x00800000,,,0x0" allowed_cpuset="0x00800000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2084" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="120" cpuset="0x01000000,,,0x0" complete_cpuset="0x01000000,,,0x0" online_cpuset="0x01000000,,,0x0" allowed_cpuset="0x01000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="121" cpuset="0x02000000,,,0x0" complete_cpuset="0x02000000,,,0x0" online_cpuset="0x02000000,,,0x0" allowed_cpuset="0x02000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="122" cpuset="0x04000000,,,0x0" complete_cpuset="0x04000000,,,0x0" online_cpuset="0x04000000,,,0x0" allowed_cpuset="0x04000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="123" cpuset="0x08000000,,,0x0" complete_cpuset="0x08000000,,,0x0" online_cpuset="0x08000000,,,0x0" allowed_cpuset="0x08000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000000f,0xf0000000,,,0x0" complete_cpuset="0x0000000f,0xf0000000,,,0x0" online_cpuset="0x0000000f,0xf0000000,,,0x0" allowed_cpuset="0x0000000f,0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000000f,0xf0000000,,,0x0" complete_cpuset="0x0000000f,0xf0000000,,,0x0" online_cpuset="0x0000000f,0xf0000000,,,0x0" allowed_cpuset="0x0000000f,0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2088" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="124" cpuset="0x10000000,,,0x0" complete_cpuset="0x10000000,,,0x0" online_cpuset="0x10000000,,,0x0" allowed_cpuset="0x10000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="125" cpuset="0x20000000,,,0x0" complete_cpuset="0x20000000,,,0x0" online_cpuset="0x20000000,,,0x0" allowed_cpuset="0x20000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="126" cpuset="0x40000000,,,0x0" complete_cpuset="0x40000000,,,0x0" online_cpuset="0x40000000,,,0x0" allowed_cpuset="0x40000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="127" cpuset="0x80000000,,,0x0" complete_cpuset="0x80000000,,,0x0" online_cpuset="0x80000000,,,0x0" allowed_cpuset="0x80000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000000f,,,,0x0" complete_cpuset="0x0000000f,,,,0x0" online_cpuset="0x0000000f,,,,0x0" allowed_cpuset="0x0000000f,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2092" cpuset="0x0000000f,,,,0x0" complete_cpuset="0x0000000f,,,,0x0" online_cpuset="0x0000000f,,,,0x0" allowed_cpuset="0x0000000f,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="128" cpuset="0x00000001,,,,0x0" complete_cpuset="0x00000001,,,,0x0" online_cpuset="0x00000001,,,,0x0" allowed_cpuset="0x00000001,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="129" cpuset="0x00000002,,,,0x0" complete_cpuset="0x00000002,,,,0x0" online_cpuset="0x00000002,,,,0x0" allowed_cpuset="0x00000002,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="130" cpuset="0x00000004,,,,0x0" complete_cpuset="0x00000004,,,,0x0" online_cpuset="0x00000004,,,,0x0" allowed_cpuset="0x00000004,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="131" cpuset="0x00000008,,,,0x0" complete_cpuset="0x00000008,,,,0x0" online_cpuset="0x00000008,,,,0x0" allowed_cpuset="0x00000008,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000ff0,,,,0x0" complete_cpuset="0x00000ff0,,,,0x0" online_cpuset="0x00000ff0,,,,0x0" allowed_cpuset="0x00000ff0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00000ff0,,,,0x0" complete_cpuset="0x00000ff0,,,,0x0" online_cpuset="0x00000ff0,,,,0x0" allowed_cpuset="0x00000ff0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000000f0,,,,0x0" complete_cpuset="0x000000f0,,,,0x0" online_cpuset="0x000000f0,,,,0x0" allowed_cpuset="0x000000f0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2096" cpuset="0x000000f0,,,,0x0" complete_cpuset="0x000000f0,,,,0x0" online_cpuset="0x000000f0,,,,0x0" allowed_cpuset="0x000000f0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="132" cpuset="0x00000010,,,,0x0" complete_cpuset="0x00000010,,,,0x0" online_cpuset="0x00000010,,,,0x0" allowed_cpuset="0x00000010,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="133" cpuset="0x00000020,,,,0x0" complete_cpuset="0x00000020,,,,0x0" online_cpuset="0x00000020,,,,0x0" allowed_cpuset="0x00000020,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="134" cpuset="0x00000040,,,,0x0" complete_cpuset="0x00000040,,,,0x0" online_cpuset="0x00000040,,,,0x0" allowed_cpuset="0x00000040,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="135" cpuset="0x00000080,,,,0x0" complete_cpuset="0x00000080,,,,0x0" online_cpuset="0x00000080,,,,0x0" allowed_cpuset="0x00000080,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2100" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="136" cpuset="0x00000100,,,,0x0" complete_cpuset="0x00000100,,,,0x0" online_cpuset="0x00000100,,,,0x0" allowed_cpuset="0x00000100,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="137" cpuset="0x00000200,,,,0x0" complete_cpuset="0x00000200,,,,0x0" online_cpuset="0x00000200,,,,0x0" allowed_cpuset="0x00000200,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="138" cpuset="0x00000400,,,,0x0" complete_cpuset="0x00000400,,,,0x0" online_cpuset="0x00000400,,,,0x0" allowed_cpuset="0x00000400,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="139" cpuset="0x00000800,,,,0x0" complete_cpuset="0x00000800,,,,0x0" online_cpuset="0x00000800,,,,0x0" allowed_cpuset="0x00000800,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000f000,,,,0x0" complete_cpuset="0x0000f000,,,,0x0" online_cpuset="0x0000f000,,,,0x0" allowed_cpuset="0x0000f000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000f000,,,,0x0" complete_cpuset="0x0000f000,,,,0x0" online_cpuset="0x0000f000,,,,0x0" allowed_cpuset="0x0000f000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000f000,,,,0x0" complete_cpuset="0x0000f000,,,,0x0" online_cpuset="0x0000f000,,,,0x0" allowed_cpuset="0x0000f000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2104" cpuset="0x0000f000,,,,0x0" complete_cpuset="0x0000f000,,,,0x0" online_cpuset="0x0000f000,,,,0x0" allowed_cpuset="0x0000f000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="140" cpuset="0x00001000,,,,0x0" complete_cpuset="0x00001000,,,,0x0" online_cpuset="0x00001000,,,,0x0" allowed_cpuset="0x00001000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="141" cpuset="0x00002000,,,,0x0" complete_cpuset="0x00002000,,,,0x0" online_cpuset="0x00002000,,,,0x0" allowed_cpuset="0x00002000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="142" cpuset="0x00004000,,,,0x0" complete_cpuset="0x00004000,,,,0x0" online_cpuset="0x00004000,,,,0x0" allowed_cpuset="0x00004000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="143" cpuset="0x00008000,,,,0x0" complete_cpuset="0x00008000,,,,0x0" online_cpuset="0x00008000,,,,0x0" allowed_cpuset="0x00008000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,,,,0x0" complete_cpuset="0x00ff0000,,,,0x0" online_cpuset="0x00ff0000,,,,0x0" allowed_cpuset="0x00ff0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,,,,0x0" complete_cpuset="0x00ff0000,,,,0x0" online_cpuset="0x00ff0000,,,,0x0" allowed_cpuset="0x00ff0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,,,,0x0" complete_cpuset="0x000f0000,,,,0x0" online_cpuset="0x000f0000,,,,0x0" allowed_cpuset="0x000f0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2112" cpuset="0x000f0000,,,,0x0" complete_cpuset="0x000f0000,,,,0x0" online_cpuset="0x000f0000,,,,0x0" allowed_cpuset="0x000f0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="144" cpuset="0x00010000,,,,0x0" complete_cpuset="0x00010000,,,,0x0" online_cpuset="0x00010000,,,,0x0" allowed_cpuset="0x00010000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="145" cpuset="0x00020000,,,,0x0" complete_cpuset="0x00020000,,,,0x0" online_cpuset="0x00020000,,,,0x0" allowed_cpuset="0x00020000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="146" cpuset="0x00040000,,,,0x0" complete_cpuset="0x00040000,,,,0x0" online_cpuset="0x00040000,,,,0x0" allowed_cpuset="0x00040000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="147" cpuset="0x00080000,,,,0x0" complete_cpuset="0x00080000,,,,0x0" online_cpuset="0x00080000,,,,0x0" allowed_cpuset="0x00080000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2116" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="148" cpuset="0x00100000,,,,0x0" complete_cpuset="0x00100000,,,,0x0" online_cpuset="0x00100000,,,,0x0" allowed_cpuset="0x00100000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="149" cpuset="0x00200000,,,,0x0" complete_cpuset="0x00200000,,,,0x0" online_cpuset="0x00200000,,,,0x0" allowed_cpuset="0x00200000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="150" cpuset="0x00400000,,,,0x0" complete_cpuset="0x00400000,,,,0x0" online_cpuset="0x00400000,,,,0x0" allowed_cpuset="0x00400000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="151" cpuset="0x00800000,,,,0x0" complete_cpuset="0x00800000,,,,0x0" online_cpuset="0x00800000,,,,0x0" allowed_cpuset="0x00800000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000,,,,0x0" complete_cpuset="0xff000000,,,,0x0" online_cpuset="0xff000000,,,,0x0" allowed_cpuset="0xff000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,,,,0x0" complete_cpuset="0xff000000,,,,0x0" online_cpuset="0xff000000,,,,0x0" allowed_cpuset="0xff000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,,,,0x0" complete_cpuset="0x0f000000,,,,0x0" online_cpuset="0x0f000000,,,,0x0" allowed_cpuset="0x0f000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2120" cpuset="0x0f000000,,,,0x0" complete_cpuset="0x0f000000,,,,0x0" online_cpuset="0x0f000000,,,,0x0" allowed_cpuset="0x0f000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="152" cpuset="0x01000000,,,,0x0" complete_cpuset="0x01000000,,,,0x0" online_cpuset="0x01000000,,,,0x0" allowed_cpuset="0x01000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="153" cpuset="0x02000000,,,,0x0" complete_cpuset="0x02000000,,,,0x0" online_cpuset="0x02000000,,,,0x0" allowed_cpuset="0x02000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="154" cpuset="0x04000000,,,,0x0" complete_cpuset="0x04000000,,,,0x0" online_cpuset="0x04000000,,,,0x0" allowed_cpuset="0x04000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="155" cpuset="0x08000000,,,,0x0" complete_cpuset="0x08000000,,,,0x0" online_cpuset="0x08000000,,,,0x0" allowed_cpuset="0x08000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,,,,0x0" complete_cpuset="0xf0000000,,,,0x0" online_cpuset="0xf0000000,,,,0x0" allowed_cpuset="0xf0000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2124" cpuset="0xf0000000,,,,0x0" complete_cpuset="0xf0000000,,,,0x0" online_cpuset="0xf0000000,,,,0x0" allowed_cpuset="0xf0000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="156" cpuset="0x10000000,,,,0x0" complete_cpuset="0x10000000,,,,0x0" online_cpuset="0x10000000,,,,0x0" allowed_cpuset="0x10000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="157" cpuset="0x20000000,,,,0x0" complete_cpuset="0x20000000,,,,0x0" online_cpuset="0x20000000,,,,0x0" allowed_cpuset="0x20000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="158" cpuset="0x40000000,,,,0x0" complete_cpuset="0x40000000,,,,0x0" online_cpuset="0x40000000,,,,0x0" allowed_cpuset="0x40000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="159" cpuset="0x80000000,,,,0x0" complete_cpuset="0x80000000,,,,0x0" online_cpuset="0x80000000,,,,0x0" allowed_cpuset="0x80000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,,,,0x0" complete_cpuset="0x000000ff,,,,,0x0" online_cpuset="0x000000ff,,,,,0x0" allowed_cpuset="0x000000ff,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,,,,0x0" complete_cpuset="0x000000ff,,,,,0x0" online_cpuset="0x000000ff,,,,,0x0" allowed_cpuset="0x000000ff,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,,,,0x0" complete_cpuset="0x0000000f,,,,,0x0" online_cpuset="0x0000000f,,,,,0x0" allowed_cpuset="0x0000000f,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2128" cpuset="0x0000000f,,,,,0x0" complete_cpuset="0x0000000f,,,,,0x0" online_cpuset="0x0000000f,,,,,0x0" allowed_cpuset="0x0000000f,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="160" cpuset="0x00000001,,,,,0x0" complete_cpuset="0x00000001,,,,,0x0" online_cpuset="0x00000001,,,,,0x0" allowed_cpuset="0x00000001,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="161" cpuset="0x00000002,,,,,0x0" complete_cpuset="0x00000002,,,,,0x0" online_cpuset="0x00000002,,,,,0x0" allowed_cpuset="0x00000002,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="162" cpuset="0x00000004,,,,,0x0" complete_cpuset="0x00000004,,,,,0x0" online_cpuset="0x00000004,,,,,0x0" allowed_cpuset="0x00000004,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="163" cpuset="0x00000008,,,,,0x0" complete_cpuset="0x00000008,,,,,0x0" online_cpuset="0x00000008,,,,,0x0" allowed_cpuset="0x00000008,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,,,,0x0" complete_cpuset="0x000000f0,,,,,0x0" online_cpuset="0x000000f0,,,,,0x0" allowed_cpuset="0x000000f0,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2132" cpuset="0x000000f0,,,,,0x0" complete_cpuset="0x000000f0,,,,,0x0" online_cpuset="0x000000f0,,,,,0x0" allowed_cpuset="0x000000f0,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="164" cpuset="0x00000010,,,,,0x0" complete_cpuset="0x00000010,,,,,0x0" online_cpuset="0x00000010,,,,,0x0" allowed_cpuset="0x00000010,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="165" cpuset="0x00000020,,,,,0x0" complete_cpuset="0x00000020,,,,,0x0" online_cpuset="0x00000020,,,,,0x0" allowed_cpuset="0x00000020,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="166" cpuset="0x00000040,,,,,0x0" complete_cpuset="0x00000040,,,,,0x0" online_cpuset="0x00000040,,,,,0x0" allowed_cpuset="0x00000040,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="167" cpuset="0x00000080,,,,,0x0" complete_cpuset="0x00000080,,,,,0x0" online_cpuset="0x00000080,,,,,0x0" allowed_cpuset="0x00000080,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,,,,,0x0" complete_cpuset="0x0000ff00,,,,,0x0" online_cpuset="0x0000ff00,,,,,0x0" allowed_cpuset="0x0000ff00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,,,,,0x0" complete_cpuset="0x0000ff00,,,,,0x0" online_cpuset="0x0000ff00,,,,,0x0" allowed_cpuset="0x0000ff00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,,,,0x0" complete_cpuset="0x00000f00,,,,,0x0" online_cpuset="0x00000f00,,,,,0x0" allowed_cpuset="0x00000f00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2136" cpuset="0x00000f00,,,,,0x0" complete_cpuset="0x00000f00,,,,,0x0" online_cpuset="0x00000f00,,,,,0x0" allowed_cpuset="0x00000f00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="168" cpuset="0x00000100,,,,,0x0" complete_cpuset="0x00000100,,,,,0x0" online_cpuset="0x00000100,,,,,0x0" allowed_cpuset="0x00000100,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="169" cpuset="0x00000200,,,,,0x0" complete_cpuset="0x00000200,,,,,0x0" online_cpuset="0x00000200,,,,,0x0" allowed_cpuset="0x00000200,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="170" cpuset="0x00000400,,,,,0x0" complete_cpuset="0x00000400,,,,,0x0" online_cpuset="0x00000400,,,,,0x0" allowed_cpuset="0x00000400,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="171" cpuset="0x00000800,,,,,0x0" complete_cpuset="0x00000800,,,,,0x0" online_cpuset="0x00000800,,,,,0x0" allowed_cpuset="0x00000800,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,,,,,0x0" complete_cpuset="0x0000f000,,,,,0x0" online_cpuset="0x0000f000,,,,,0x0" allowed_cpuset="0x0000f000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2140" cpuset="0x0000f000,,,,,0x0" complete_cpuset="0x0000f000,,,,,0x0" online_cpuset="0x0000f000,,,,,0x0" allowed_cpuset="0x0000f000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="172" cpuset="0x00001000,,,,,0x0" complete_cpuset="0x00001000,,,,,0x0" online_cpuset="0x00001000,,,,,0x0" allowed_cpuset="0x00001000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="173" cpuset="0x00002000,,,,,0x0" complete_cpuset="0x00002000,,,,,0x0" online_cpuset="0x00002000,,,,,0x0" allowed_cpuset="0x00002000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="174" cpuset="0x00004000,,,,,0x0" complete_cpuset="0x00004000,,,,,0x0" online_cpuset="0x00004000,,,,,0x0" allowed_cpuset="0x00004000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="175" cpuset="0x00008000,,,,,0x0" complete_cpuset="0x00008000,,,,,0x0" online_cpuset="0x00008000,,,,,0x0" allowed_cpuset="0x00008000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="9" bridge_type="0-1" depth="0" bridge_pci="0033:[00-01]">
+          <object type="PCIDev" os_index="53481472" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0033:01:00.0" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Mellanox Technologies"/>
+            <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+            <object type="OSDev" name="hsi2" osdev_type="2">
+              <info name="Address" value="00:00:14:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:49:a2:14"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx5_2" osdev_type="3">
+              <info name="NodeGUID" value="ec0d:9a03:0049:a214"/>
+              <info name="SysImageGUID" value="ec0d:9a03:0049:a212"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x2e21"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:0049:a214"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="53481473" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0033:01:00.1" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Mellanox Technologies"/>
+            <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+            <object type="OSDev" name="hsi3" osdev_type="2">
+              <info name="Address" value="00:00:1c:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:49:a2:15"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx5_3" osdev_type="3">
+              <info name="NodeGUID" value="ec0d:9a03:0049:a215"/>
+              <info name="SysImageGUID" value="ec0d:9a03:0049:a212"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x2e1f"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:0049:a215"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="11" bridge_type="0-1" depth="0" bridge_pci="0035:[00-09]">
+          <object type="PCIDev" os_index="55586816" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0035:03:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="NVIDIA Corporation"/>
+            <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+            <object type="OSDev" name="card2" osdev_type="1"/>
+            <object type="OSDev" name="renderD130" osdev_type="1"/>
+            <object type="OSDev" name="cuda2" osdev_type="5">
+              <info name="CoProcType" value="CUDA"/>
+              <info name="Backend" value="CUDA"/>
+              <info name="GPUVendor" value="NVIDIA Corporation"/>
+              <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+              <info name="CUDAGlobalMemorySize" value="16515072"/>
+              <info name="CUDAL2CacheSize" value="6144"/>
+              <info name="CUDAMultiProcessors" value="80"/>
+              <info name="CUDACoresPerMP" value="64"/>
+              <info name="CUDASharedMemorySizePerMP" value="48"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="55590912" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0035:04:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="NVIDIA Corporation"/>
+            <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+            <object type="OSDev" name="card3" osdev_type="1"/>
+            <object type="OSDev" name="renderD131" osdev_type="1"/>
+            <object type="OSDev" name="cuda3" osdev_type="5">
+              <info name="CoProcType" value="CUDA"/>
+              <info name="Backend" value="CUDA"/>
+              <info name="GPUVendor" value="NVIDIA Corporation"/>
+              <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+              <info name="CUDAGlobalMemorySize" value="16515072"/>
+              <info name="CUDAL2CacheSize" value="6144"/>
+              <info name="CUDAMultiProcessors" value="80"/>
+              <info name="CUDACoresPerMP" value="64"/>
+              <info name="CUDASharedMemorySizePerMP" value="48"/>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="NUMANode" os_index="252" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x10000000,,,,,,,0x0" complete_nodeset="0x10000000,,,,,,,0x0" allowed_nodeset="0x10000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="253" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x20000000,,,,,,,0x0" complete_nodeset="0x20000000,,,,,,,0x0" allowed_nodeset="0x20000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="254" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x40000000,,,,,,,0x0" complete_nodeset="0x40000000,,,,,,,0x0" allowed_nodeset="0x40000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="255" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x80000000,,,,,,,0x0" complete_nodeset="0x80000000,,,,,,,0x0" allowed_nodeset="0x80000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+  </object>
+</topology>

--- a/t/data/hwloc-data/004N/exclusive/04-brokers-sierra2/1.xml
+++ b/t/data/hwloc-data/004N/exclusive/04-brokers-sierra2/1.xml
@@ -1,0 +1,721 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0xf0000000,,,,,,,0x00000101" complete_nodeset="0xf0000000,,,,,,,0x00000101" allowed_nodeset="0xf0000000,,,,,,,0x00000101">
+    <page_type size="65536" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <page_type size="1073741824" count="0"/>
+    <info name="PlatformName" value="PowerNV"/>
+    <info name="PlatformModel" value="PowerNV 8335-GTW"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/allocation_54106"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="4.14.0-49.6.1.el7a.ppc64le"/>
+    <info name="OSVersion" value="#1 SMP Wed May 16 21:05:05 UTC 2018"/>
+    <info name="HostName" value="sierra3179"/>
+    <info name="Architecture" value="ppc64le"/>
+    <info name="hwlocVersion" value="1.11.10"/>
+    <info name="ProcessName" value="hwloc_xml"/>
+    <distances nbobjs="6" relative_depth="2" latency_base="10.000000">
+      <latency value="1.000000"/>
+      <latency value="4.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="4.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+    </distances>
+    <object type="Group" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0x00000101" complete_nodeset="0x00000101" allowed_nodeset="0x00000101" depth="0">
+      <object type="NUMANode" os_index="0" cpuset="0x00ffffff,0xffffffff,0xffffffff" complete_cpuset="0x00ffffff,0xffffffff,0xffffffff" online_cpuset="0x00ffffff,0xffffffff,0xffffffff" allowed_cpuset="0x00ffffff,0xffffffff,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="137132310528">
+        <page_type size="65536" count="2092473"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Package" os_index="0" cpuset="0x00ffffff,0xffffffff,0xffffffff" complete_cpuset="0x00ffffff,0xffffffff,0xffffffff" online_cpuset="0x00ffffff,0xffffffff,0xffffffff" allowed_cpuset="0x00ffffff,0xffffffff,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <info name="CPUModel" value="POWER9, altivec supported"/>
+          <info name="CPURevision" value="2.1 (pvr 004e 1201)"/>
+          <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="8" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="12" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="16" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="20" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000" complete_cpuset="0x00ff0000" online_cpuset="0x00ff0000" allowed_cpuset="0x00ff0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000" complete_cpuset="0x00ff0000" online_cpuset="0x00ff0000" allowed_cpuset="0x00ff0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="24" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="28" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000" complete_cpuset="0xff000000" online_cpuset="0xff000000" allowed_cpuset="0xff000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000" complete_cpuset="0xff000000" online_cpuset="0xff000000" allowed_cpuset="0xff000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="32" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="36" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,0x0" complete_cpuset="0x000000ff,0x0" online_cpuset="0x000000ff,0x0" allowed_cpuset="0x000000ff,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,0x0" complete_cpuset="0x000000ff,0x0" online_cpuset="0x000000ff,0x0" allowed_cpuset="0x000000ff,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="40" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="44" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,0x0" complete_cpuset="0x0000ff00,0x0" online_cpuset="0x0000ff00,0x0" allowed_cpuset="0x0000ff00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,0x0" complete_cpuset="0x0000ff00,0x0" online_cpuset="0x0000ff00,0x0" allowed_cpuset="0x0000ff00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="48" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="52" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,0x0" complete_cpuset="0x00ff0000,0x0" online_cpuset="0x00ff0000,0x0" allowed_cpuset="0x00ff0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,0x0" complete_cpuset="0x00ff0000,0x0" online_cpuset="0x00ff0000,0x0" allowed_cpuset="0x00ff0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="56" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="60" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000,0x0" complete_cpuset="0xff000000,0x0" online_cpuset="0xff000000,0x0" allowed_cpuset="0xff000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,0x0" complete_cpuset="0xff000000,0x0" online_cpuset="0xff000000,0x0" allowed_cpuset="0xff000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="64" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="68" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,0x0" complete_cpuset="0x000000ff,,0x0" online_cpuset="0x000000ff,,0x0" allowed_cpuset="0x000000ff,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,0x0" complete_cpuset="0x000000ff,,0x0" online_cpuset="0x000000ff,,0x0" allowed_cpuset="0x000000ff,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="72" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="76" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,,0x0" complete_cpuset="0x0000ff00,,0x0" online_cpuset="0x0000ff00,,0x0" allowed_cpuset="0x0000ff00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,,0x0" complete_cpuset="0x0000ff00,,0x0" online_cpuset="0x0000ff00,,0x0" allowed_cpuset="0x0000ff00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="80" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="84" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,0x0" online_cpuset="0x00ff0000,,0x0" allowed_cpuset="0x00ff0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,0x0" online_cpuset="0x00ff0000,,0x0" allowed_cpuset="0x00ff0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="88" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="92" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-01]">
+          <object type="PCIDev" os_index="4096" name="Samsung Electronics Co Ltd NVMe SSD Controller 172Xa" pci_busid="0000:01:00.0" pci_type="0108 [144d:a822] [1014:0621] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Samsung Electronics Co Ltd"/>
+            <info name="PCIDevice" value="NVMe SSD Controller 172Xa"/>
+            <object type="OSDev" name="nvme0n1" osdev_type="0">
+              <info name="LinuxDeviceID" value="259:0"/>
+              <info name="SerialNumber" value="S3RVNA0JA01484"/>
+              <info name="Type" value="Disk"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0002:[00-02]">
+          <object type="PCIDev" os_index="2105344" name="ASPEED Technology, Inc. ASPEED Graphics Family" pci_busid="0002:02:00.0" pci_type="0300 [1a03:2000] [1a03:2000] 41" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+            <info name="PCIDevice" value="ASPEED Graphics Family"/>
+            <object type="OSDev" name="card4" osdev_type="1"/>
+            <object type="OSDev" name="controlD68" osdev_type="1"/>
+          </object>
+        </object>
+        <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0003:[00-01]">
+          <object type="PCIDev" os_index="3149824" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0003:01:00.0" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Mellanox Technologies"/>
+            <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+            <object type="OSDev" name="hsi0" osdev_type="2">
+              <info name="Address" value="00:00:10:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:ca:a4:18"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx5_0" osdev_type="3">
+              <info name="NodeGUID" value="ec0d:9a03:00ca:a418"/>
+              <info name="SysImageGUID" value="ec0d:9a03:00ca:a418"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x32ed"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:00ca:a418"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="3149825" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0003:01:00.1" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Mellanox Technologies"/>
+            <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+            <object type="OSDev" name="hsi1" osdev_type="2">
+              <info name="Address" value="00:00:18:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:ca:a4:19"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx5_1" osdev_type="3">
+              <info name="NodeGUID" value="ec0d:9a03:00ca:a419"/>
+              <info name="SysImageGUID" value="ec0d:9a03:00ca:a418"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x32ee"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:00ca:a419"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="4" bridge_type="0-1" depth="0" bridge_pci="0004:[00-0a]">
+          <object type="PCIDev" os_index="4206592" name="Marvell Technology Group Ltd. 88SE9235 PCIe 2.0 x2 4-port SATA 6 Gb/s Controller" pci_busid="0004:03:00.0" pci_type="0106 [1b4b:9235] [1014:0612] 11" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Marvell Technology Group Ltd."/>
+            <info name="PCIDevice" value="88SE9235 PCIe 2.0 x2 4-port SATA 6 Gb/s Controller"/>
+          </object>
+          <object type="PCIDev" os_index="4210688" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0004:04:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="NVIDIA Corporation"/>
+            <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+            <object type="OSDev" name="renderD128" osdev_type="1"/>
+            <object type="OSDev" name="card0" osdev_type="1"/>
+            <object type="OSDev" name="cuda0" osdev_type="5">
+              <info name="CoProcType" value="CUDA"/>
+              <info name="Backend" value="CUDA"/>
+              <info name="GPUVendor" value="NVIDIA Corporation"/>
+              <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+              <info name="CUDAGlobalMemorySize" value="16515072"/>
+              <info name="CUDAL2CacheSize" value="6144"/>
+              <info name="CUDAMultiProcessors" value="80"/>
+              <info name="CUDACoresPerMP" value="64"/>
+              <info name="CUDASharedMemorySizePerMP" value="48"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="4214784" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0004:05:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="NVIDIA Corporation"/>
+            <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+            <object type="OSDev" name="card1" osdev_type="1"/>
+            <object type="OSDev" name="renderD129" osdev_type="1"/>
+            <object type="OSDev" name="cuda1" osdev_type="5">
+              <info name="CoProcType" value="CUDA"/>
+              <info name="Backend" value="CUDA"/>
+              <info name="GPUVendor" value="NVIDIA Corporation"/>
+              <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+              <info name="CUDAGlobalMemorySize" value="16515072"/>
+              <info name="CUDAL2CacheSize" value="6144"/>
+              <info name="CUDAMultiProcessors" value="80"/>
+              <info name="CUDACoresPerMP" value="64"/>
+              <info name="CUDASharedMemorySizePerMP" value="48"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="5" bridge_type="0-1" depth="0" bridge_pci="0005:[00-01]">
+          <object type="PCIDev" os_index="5246976" name="Broadcom Limited NetXtreme BCM5719 Gigabit Ethernet PCIe" pci_busid="0005:01:00.0" pci_type="0200 [14e4:1657] [14e4:1981] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Broadcom Limited"/>
+            <info name="PCIDevice" value="NetXtreme BCM5719 Gigabit Ethernet PCIe"/>
+            <object type="OSDev" name="enP5p1s0f0" osdev_type="2">
+              <info name="Address" value="70:e2:84:14:9d:1f"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="5246977" name="Broadcom Limited NetXtreme BCM5719 Gigabit Ethernet PCIe" pci_busid="0005:01:00.1" pci_type="0200 [14e4:1657] [14e4:1657] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Broadcom Limited"/>
+            <info name="PCIDevice" value="NetXtreme BCM5719 Gigabit Ethernet PCIe"/>
+            <object type="OSDev" name="enP5p1s0f1" osdev_type="2">
+              <info name="Address" value="70:e2:84:14:9d:20"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="8" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" local_memory="137166979072">
+        <page_type size="65536" count="2093002"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Package" os_index="8" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+          <info name="CPUModel" value="POWER9, altivec supported"/>
+          <info name="CPURevision" value="2.1 (pvr 004e 1201)"/>
+          <object type="Cache" cpuset="0xff000000,,0x0" complete_cpuset="0xff000000,,0x0" online_cpuset="0xff000000,,0x0" allowed_cpuset="0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,,0x0" complete_cpuset="0xff000000,,0x0" online_cpuset="0xff000000,,0x0" allowed_cpuset="0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2048" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2052" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,,0x0" complete_cpuset="0x000000ff,,,0x0" online_cpuset="0x000000ff,,,0x0" allowed_cpuset="0x000000ff,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,,0x0" complete_cpuset="0x000000ff,,,0x0" online_cpuset="0x000000ff,,,0x0" allowed_cpuset="0x000000ff,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2056" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="96" cpuset="0x00000001,,,0x0" complete_cpuset="0x00000001,,,0x0" online_cpuset="0x00000001,,,0x0" allowed_cpuset="0x00000001,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="97" cpuset="0x00000002,,,0x0" complete_cpuset="0x00000002,,,0x0" online_cpuset="0x00000002,,,0x0" allowed_cpuset="0x00000002,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="98" cpuset="0x00000004,,,0x0" complete_cpuset="0x00000004,,,0x0" online_cpuset="0x00000004,,,0x0" allowed_cpuset="0x00000004,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="99" cpuset="0x00000008,,,0x0" complete_cpuset="0x00000008,,,0x0" online_cpuset="0x00000008,,,0x0" allowed_cpuset="0x00000008,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2060" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="100" cpuset="0x00000010,,,0x0" complete_cpuset="0x00000010,,,0x0" online_cpuset="0x00000010,,,0x0" allowed_cpuset="0x00000010,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="101" cpuset="0x00000020,,,0x0" complete_cpuset="0x00000020,,,0x0" online_cpuset="0x00000020,,,0x0" allowed_cpuset="0x00000020,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="102" cpuset="0x00000040,,,0x0" complete_cpuset="0x00000040,,,0x0" online_cpuset="0x00000040,,,0x0" allowed_cpuset="0x00000040,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="103" cpuset="0x00000080,,,0x0" complete_cpuset="0x00000080,,,0x0" online_cpuset="0x00000080,,,0x0" allowed_cpuset="0x00000080,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,,,0x0" complete_cpuset="0x0000ff00,,,0x0" online_cpuset="0x0000ff00,,,0x0" allowed_cpuset="0x0000ff00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,,,0x0" complete_cpuset="0x0000ff00,,,0x0" online_cpuset="0x0000ff00,,,0x0" allowed_cpuset="0x0000ff00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2064" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="104" cpuset="0x00000100,,,0x0" complete_cpuset="0x00000100,,,0x0" online_cpuset="0x00000100,,,0x0" allowed_cpuset="0x00000100,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="105" cpuset="0x00000200,,,0x0" complete_cpuset="0x00000200,,,0x0" online_cpuset="0x00000200,,,0x0" allowed_cpuset="0x00000200,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="106" cpuset="0x00000400,,,0x0" complete_cpuset="0x00000400,,,0x0" online_cpuset="0x00000400,,,0x0" allowed_cpuset="0x00000400,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="107" cpuset="0x00000800,,,0x0" complete_cpuset="0x00000800,,,0x0" online_cpuset="0x00000800,,,0x0" allowed_cpuset="0x00000800,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2068" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="108" cpuset="0x00001000,,,0x0" complete_cpuset="0x00001000,,,0x0" online_cpuset="0x00001000,,,0x0" allowed_cpuset="0x00001000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="109" cpuset="0x00002000,,,0x0" complete_cpuset="0x00002000,,,0x0" online_cpuset="0x00002000,,,0x0" allowed_cpuset="0x00002000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="110" cpuset="0x00004000,,,0x0" complete_cpuset="0x00004000,,,0x0" online_cpuset="0x00004000,,,0x0" allowed_cpuset="0x00004000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="111" cpuset="0x00008000,,,0x0" complete_cpuset="0x00008000,,,0x0" online_cpuset="0x00008000,,,0x0" allowed_cpuset="0x00008000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,,,0x0" complete_cpuset="0x00ff0000,,,0x0" online_cpuset="0x00ff0000,,,0x0" allowed_cpuset="0x00ff0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,,,0x0" complete_cpuset="0x00ff0000,,,0x0" online_cpuset="0x00ff0000,,,0x0" allowed_cpuset="0x00ff0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2072" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="112" cpuset="0x00010000,,,0x0" complete_cpuset="0x00010000,,,0x0" online_cpuset="0x00010000,,,0x0" allowed_cpuset="0x00010000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="113" cpuset="0x00020000,,,0x0" complete_cpuset="0x00020000,,,0x0" online_cpuset="0x00020000,,,0x0" allowed_cpuset="0x00020000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="114" cpuset="0x00040000,,,0x0" complete_cpuset="0x00040000,,,0x0" online_cpuset="0x00040000,,,0x0" allowed_cpuset="0x00040000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="115" cpuset="0x00080000,,,0x0" complete_cpuset="0x00080000,,,0x0" online_cpuset="0x00080000,,,0x0" allowed_cpuset="0x00080000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2076" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="116" cpuset="0x00100000,,,0x0" complete_cpuset="0x00100000,,,0x0" online_cpuset="0x00100000,,,0x0" allowed_cpuset="0x00100000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="117" cpuset="0x00200000,,,0x0" complete_cpuset="0x00200000,,,0x0" online_cpuset="0x00200000,,,0x0" allowed_cpuset="0x00200000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="118" cpuset="0x00400000,,,0x0" complete_cpuset="0x00400000,,,0x0" online_cpuset="0x00400000,,,0x0" allowed_cpuset="0x00400000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="119" cpuset="0x00800000,,,0x0" complete_cpuset="0x00800000,,,0x0" online_cpuset="0x00800000,,,0x0" allowed_cpuset="0x00800000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000,,,0x0" complete_cpuset="0xff000000,,,0x0" online_cpuset="0xff000000,,,0x0" allowed_cpuset="0xff000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,,,0x0" complete_cpuset="0xff000000,,,0x0" online_cpuset="0xff000000,,,0x0" allowed_cpuset="0xff000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2080" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="120" cpuset="0x01000000,,,0x0" complete_cpuset="0x01000000,,,0x0" online_cpuset="0x01000000,,,0x0" allowed_cpuset="0x01000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="121" cpuset="0x02000000,,,0x0" complete_cpuset="0x02000000,,,0x0" online_cpuset="0x02000000,,,0x0" allowed_cpuset="0x02000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="122" cpuset="0x04000000,,,0x0" complete_cpuset="0x04000000,,,0x0" online_cpuset="0x04000000,,,0x0" allowed_cpuset="0x04000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="123" cpuset="0x08000000,,,0x0" complete_cpuset="0x08000000,,,0x0" online_cpuset="0x08000000,,,0x0" allowed_cpuset="0x08000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2084" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="124" cpuset="0x10000000,,,0x0" complete_cpuset="0x10000000,,,0x0" online_cpuset="0x10000000,,,0x0" allowed_cpuset="0x10000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="125" cpuset="0x20000000,,,0x0" complete_cpuset="0x20000000,,,0x0" online_cpuset="0x20000000,,,0x0" allowed_cpuset="0x20000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="126" cpuset="0x40000000,,,0x0" complete_cpuset="0x40000000,,,0x0" online_cpuset="0x40000000,,,0x0" allowed_cpuset="0x40000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="127" cpuset="0x80000000,,,0x0" complete_cpuset="0x80000000,,,0x0" online_cpuset="0x80000000,,,0x0" allowed_cpuset="0x80000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,,,0x0" complete_cpuset="0x000000ff,,,,0x0" online_cpuset="0x000000ff,,,,0x0" allowed_cpuset="0x000000ff,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,,,0x0" complete_cpuset="0x000000ff,,,,0x0" online_cpuset="0x000000ff,,,,0x0" allowed_cpuset="0x000000ff,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,,,0x0" complete_cpuset="0x0000000f,,,,0x0" online_cpuset="0x0000000f,,,,0x0" allowed_cpuset="0x0000000f,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2088" cpuset="0x0000000f,,,,0x0" complete_cpuset="0x0000000f,,,,0x0" online_cpuset="0x0000000f,,,,0x0" allowed_cpuset="0x0000000f,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="128" cpuset="0x00000001,,,,0x0" complete_cpuset="0x00000001,,,,0x0" online_cpuset="0x00000001,,,,0x0" allowed_cpuset="0x00000001,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="129" cpuset="0x00000002,,,,0x0" complete_cpuset="0x00000002,,,,0x0" online_cpuset="0x00000002,,,,0x0" allowed_cpuset="0x00000002,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="130" cpuset="0x00000004,,,,0x0" complete_cpuset="0x00000004,,,,0x0" online_cpuset="0x00000004,,,,0x0" allowed_cpuset="0x00000004,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="131" cpuset="0x00000008,,,,0x0" complete_cpuset="0x00000008,,,,0x0" online_cpuset="0x00000008,,,,0x0" allowed_cpuset="0x00000008,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,,,0x0" complete_cpuset="0x000000f0,,,,0x0" online_cpuset="0x000000f0,,,,0x0" allowed_cpuset="0x000000f0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2092" cpuset="0x000000f0,,,,0x0" complete_cpuset="0x000000f0,,,,0x0" online_cpuset="0x000000f0,,,,0x0" allowed_cpuset="0x000000f0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="132" cpuset="0x00000010,,,,0x0" complete_cpuset="0x00000010,,,,0x0" online_cpuset="0x00000010,,,,0x0" allowed_cpuset="0x00000010,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="133" cpuset="0x00000020,,,,0x0" complete_cpuset="0x00000020,,,,0x0" online_cpuset="0x00000020,,,,0x0" allowed_cpuset="0x00000020,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="134" cpuset="0x00000040,,,,0x0" complete_cpuset="0x00000040,,,,0x0" online_cpuset="0x00000040,,,,0x0" allowed_cpuset="0x00000040,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="135" cpuset="0x00000080,,,,0x0" complete_cpuset="0x00000080,,,,0x0" online_cpuset="0x00000080,,,,0x0" allowed_cpuset="0x00000080,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2100" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="136" cpuset="0x00000100,,,,0x0" complete_cpuset="0x00000100,,,,0x0" online_cpuset="0x00000100,,,,0x0" allowed_cpuset="0x00000100,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="137" cpuset="0x00000200,,,,0x0" complete_cpuset="0x00000200,,,,0x0" online_cpuset="0x00000200,,,,0x0" allowed_cpuset="0x00000200,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="138" cpuset="0x00000400,,,,0x0" complete_cpuset="0x00000400,,,,0x0" online_cpuset="0x00000400,,,,0x0" allowed_cpuset="0x00000400,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="139" cpuset="0x00000800,,,,0x0" complete_cpuset="0x00000800,,,,0x0" online_cpuset="0x00000800,,,,0x0" allowed_cpuset="0x00000800,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000ff000,,,,0x0" complete_cpuset="0x000ff000,,,,0x0" online_cpuset="0x000ff000,,,,0x0" allowed_cpuset="0x000ff000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000ff000,,,,0x0" complete_cpuset="0x000ff000,,,,0x0" online_cpuset="0x000ff000,,,,0x0" allowed_cpuset="0x000ff000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000f000,,,,0x0" complete_cpuset="0x0000f000,,,,0x0" online_cpuset="0x0000f000,,,,0x0" allowed_cpuset="0x0000f000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2104" cpuset="0x0000f000,,,,0x0" complete_cpuset="0x0000f000,,,,0x0" online_cpuset="0x0000f000,,,,0x0" allowed_cpuset="0x0000f000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="140" cpuset="0x00001000,,,,0x0" complete_cpuset="0x00001000,,,,0x0" online_cpuset="0x00001000,,,,0x0" allowed_cpuset="0x00001000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="141" cpuset="0x00002000,,,,0x0" complete_cpuset="0x00002000,,,,0x0" online_cpuset="0x00002000,,,,0x0" allowed_cpuset="0x00002000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="142" cpuset="0x00004000,,,,0x0" complete_cpuset="0x00004000,,,,0x0" online_cpuset="0x00004000,,,,0x0" allowed_cpuset="0x00004000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="143" cpuset="0x00008000,,,,0x0" complete_cpuset="0x00008000,,,,0x0" online_cpuset="0x00008000,,,,0x0" allowed_cpuset="0x00008000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000f0000,,,,0x0" complete_cpuset="0x000f0000,,,,0x0" online_cpuset="0x000f0000,,,,0x0" allowed_cpuset="0x000f0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2108" cpuset="0x000f0000,,,,0x0" complete_cpuset="0x000f0000,,,,0x0" online_cpuset="0x000f0000,,,,0x0" allowed_cpuset="0x000f0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="144" cpuset="0x00010000,,,,0x0" complete_cpuset="0x00010000,,,,0x0" online_cpuset="0x00010000,,,,0x0" allowed_cpuset="0x00010000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="145" cpuset="0x00020000,,,,0x0" complete_cpuset="0x00020000,,,,0x0" online_cpuset="0x00020000,,,,0x0" allowed_cpuset="0x00020000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="146" cpuset="0x00040000,,,,0x0" complete_cpuset="0x00040000,,,,0x0" online_cpuset="0x00040000,,,,0x0" allowed_cpuset="0x00040000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="147" cpuset="0x00080000,,,,0x0" complete_cpuset="0x00080000,,,,0x0" online_cpuset="0x00080000,,,,0x0" allowed_cpuset="0x00080000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2112" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="148" cpuset="0x00100000,,,,0x0" complete_cpuset="0x00100000,,,,0x0" online_cpuset="0x00100000,,,,0x0" allowed_cpuset="0x00100000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="149" cpuset="0x00200000,,,,0x0" complete_cpuset="0x00200000,,,,0x0" online_cpuset="0x00200000,,,,0x0" allowed_cpuset="0x00200000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="150" cpuset="0x00400000,,,,0x0" complete_cpuset="0x00400000,,,,0x0" online_cpuset="0x00400000,,,,0x0" allowed_cpuset="0x00400000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="151" cpuset="0x00800000,,,,0x0" complete_cpuset="0x00800000,,,,0x0" online_cpuset="0x00800000,,,,0x0" allowed_cpuset="0x00800000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000,,,,0x0" complete_cpuset="0xff000000,,,,0x0" online_cpuset="0xff000000,,,,0x0" allowed_cpuset="0xff000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,,,,0x0" complete_cpuset="0xff000000,,,,0x0" online_cpuset="0xff000000,,,,0x0" allowed_cpuset="0xff000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,,,,0x0" complete_cpuset="0x0f000000,,,,0x0" online_cpuset="0x0f000000,,,,0x0" allowed_cpuset="0x0f000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2120" cpuset="0x0f000000,,,,0x0" complete_cpuset="0x0f000000,,,,0x0" online_cpuset="0x0f000000,,,,0x0" allowed_cpuset="0x0f000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="152" cpuset="0x01000000,,,,0x0" complete_cpuset="0x01000000,,,,0x0" online_cpuset="0x01000000,,,,0x0" allowed_cpuset="0x01000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="153" cpuset="0x02000000,,,,0x0" complete_cpuset="0x02000000,,,,0x0" online_cpuset="0x02000000,,,,0x0" allowed_cpuset="0x02000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="154" cpuset="0x04000000,,,,0x0" complete_cpuset="0x04000000,,,,0x0" online_cpuset="0x04000000,,,,0x0" allowed_cpuset="0x04000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="155" cpuset="0x08000000,,,,0x0" complete_cpuset="0x08000000,,,,0x0" online_cpuset="0x08000000,,,,0x0" allowed_cpuset="0x08000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,,,,0x0" complete_cpuset="0xf0000000,,,,0x0" online_cpuset="0xf0000000,,,,0x0" allowed_cpuset="0xf0000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2124" cpuset="0xf0000000,,,,0x0" complete_cpuset="0xf0000000,,,,0x0" online_cpuset="0xf0000000,,,,0x0" allowed_cpuset="0xf0000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="156" cpuset="0x10000000,,,,0x0" complete_cpuset="0x10000000,,,,0x0" online_cpuset="0x10000000,,,,0x0" allowed_cpuset="0x10000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="157" cpuset="0x20000000,,,,0x0" complete_cpuset="0x20000000,,,,0x0" online_cpuset="0x20000000,,,,0x0" allowed_cpuset="0x20000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="158" cpuset="0x40000000,,,,0x0" complete_cpuset="0x40000000,,,,0x0" online_cpuset="0x40000000,,,,0x0" allowed_cpuset="0x40000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="159" cpuset="0x80000000,,,,0x0" complete_cpuset="0x80000000,,,,0x0" online_cpuset="0x80000000,,,,0x0" allowed_cpuset="0x80000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,,,,0x0" complete_cpuset="0x000000ff,,,,,0x0" online_cpuset="0x000000ff,,,,,0x0" allowed_cpuset="0x000000ff,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,,,,0x0" complete_cpuset="0x000000ff,,,,,0x0" online_cpuset="0x000000ff,,,,,0x0" allowed_cpuset="0x000000ff,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,,,,0x0" complete_cpuset="0x0000000f,,,,,0x0" online_cpuset="0x0000000f,,,,,0x0" allowed_cpuset="0x0000000f,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2128" cpuset="0x0000000f,,,,,0x0" complete_cpuset="0x0000000f,,,,,0x0" online_cpuset="0x0000000f,,,,,0x0" allowed_cpuset="0x0000000f,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="160" cpuset="0x00000001,,,,,0x0" complete_cpuset="0x00000001,,,,,0x0" online_cpuset="0x00000001,,,,,0x0" allowed_cpuset="0x00000001,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="161" cpuset="0x00000002,,,,,0x0" complete_cpuset="0x00000002,,,,,0x0" online_cpuset="0x00000002,,,,,0x0" allowed_cpuset="0x00000002,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="162" cpuset="0x00000004,,,,,0x0" complete_cpuset="0x00000004,,,,,0x0" online_cpuset="0x00000004,,,,,0x0" allowed_cpuset="0x00000004,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="163" cpuset="0x00000008,,,,,0x0" complete_cpuset="0x00000008,,,,,0x0" online_cpuset="0x00000008,,,,,0x0" allowed_cpuset="0x00000008,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,,,,0x0" complete_cpuset="0x000000f0,,,,,0x0" online_cpuset="0x000000f0,,,,,0x0" allowed_cpuset="0x000000f0,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2132" cpuset="0x000000f0,,,,,0x0" complete_cpuset="0x000000f0,,,,,0x0" online_cpuset="0x000000f0,,,,,0x0" allowed_cpuset="0x000000f0,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="164" cpuset="0x00000010,,,,,0x0" complete_cpuset="0x00000010,,,,,0x0" online_cpuset="0x00000010,,,,,0x0" allowed_cpuset="0x00000010,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="165" cpuset="0x00000020,,,,,0x0" complete_cpuset="0x00000020,,,,,0x0" online_cpuset="0x00000020,,,,,0x0" allowed_cpuset="0x00000020,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="166" cpuset="0x00000040,,,,,0x0" complete_cpuset="0x00000040,,,,,0x0" online_cpuset="0x00000040,,,,,0x0" allowed_cpuset="0x00000040,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="167" cpuset="0x00000080,,,,,0x0" complete_cpuset="0x00000080,,,,,0x0" online_cpuset="0x00000080,,,,,0x0" allowed_cpuset="0x00000080,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,,,,,0x0" complete_cpuset="0x0000ff00,,,,,0x0" online_cpuset="0x0000ff00,,,,,0x0" allowed_cpuset="0x0000ff00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,,,,,0x0" complete_cpuset="0x0000ff00,,,,,0x0" online_cpuset="0x0000ff00,,,,,0x0" allowed_cpuset="0x0000ff00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,,,,0x0" complete_cpuset="0x00000f00,,,,,0x0" online_cpuset="0x00000f00,,,,,0x0" allowed_cpuset="0x00000f00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2136" cpuset="0x00000f00,,,,,0x0" complete_cpuset="0x00000f00,,,,,0x0" online_cpuset="0x00000f00,,,,,0x0" allowed_cpuset="0x00000f00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="168" cpuset="0x00000100,,,,,0x0" complete_cpuset="0x00000100,,,,,0x0" online_cpuset="0x00000100,,,,,0x0" allowed_cpuset="0x00000100,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="169" cpuset="0x00000200,,,,,0x0" complete_cpuset="0x00000200,,,,,0x0" online_cpuset="0x00000200,,,,,0x0" allowed_cpuset="0x00000200,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="170" cpuset="0x00000400,,,,,0x0" complete_cpuset="0x00000400,,,,,0x0" online_cpuset="0x00000400,,,,,0x0" allowed_cpuset="0x00000400,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="171" cpuset="0x00000800,,,,,0x0" complete_cpuset="0x00000800,,,,,0x0" online_cpuset="0x00000800,,,,,0x0" allowed_cpuset="0x00000800,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,,,,,0x0" complete_cpuset="0x0000f000,,,,,0x0" online_cpuset="0x0000f000,,,,,0x0" allowed_cpuset="0x0000f000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2140" cpuset="0x0000f000,,,,,0x0" complete_cpuset="0x0000f000,,,,,0x0" online_cpuset="0x0000f000,,,,,0x0" allowed_cpuset="0x0000f000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="172" cpuset="0x00001000,,,,,0x0" complete_cpuset="0x00001000,,,,,0x0" online_cpuset="0x00001000,,,,,0x0" allowed_cpuset="0x00001000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="173" cpuset="0x00002000,,,,,0x0" complete_cpuset="0x00002000,,,,,0x0" online_cpuset="0x00002000,,,,,0x0" allowed_cpuset="0x00002000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="174" cpuset="0x00004000,,,,,0x0" complete_cpuset="0x00004000,,,,,0x0" online_cpuset="0x00004000,,,,,0x0" allowed_cpuset="0x00004000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="175" cpuset="0x00008000,,,,,0x0" complete_cpuset="0x00008000,,,,,0x0" online_cpuset="0x00008000,,,,,0x0" allowed_cpuset="0x00008000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="9" bridge_type="0-1" depth="0" bridge_pci="0033:[00-01]">
+          <object type="PCIDev" os_index="53481472" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0033:01:00.0" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Mellanox Technologies"/>
+            <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+            <object type="OSDev" name="hsi2" osdev_type="2">
+              <info name="Address" value="00:00:14:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:ca:a4:1a"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx5_2" osdev_type="3">
+              <info name="NodeGUID" value="ec0d:9a03:00ca:a41a"/>
+              <info name="SysImageGUID" value="ec0d:9a03:00ca:a418"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x335d"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:00ca:a41a"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="53481473" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0033:01:00.1" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Mellanox Technologies"/>
+            <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+            <object type="OSDev" name="hsi3" osdev_type="2">
+              <info name="Address" value="00:00:1c:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:ca:a4:1b"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx5_3" osdev_type="3">
+              <info name="NodeGUID" value="ec0d:9a03:00ca:a41b"/>
+              <info name="SysImageGUID" value="ec0d:9a03:00ca:a418"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x3333"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:00ca:a41b"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="11" bridge_type="0-1" depth="0" bridge_pci="0035:[00-09]">
+          <object type="PCIDev" os_index="55586816" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0035:03:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="NVIDIA Corporation"/>
+            <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+            <object type="OSDev" name="card2" osdev_type="1"/>
+            <object type="OSDev" name="renderD130" osdev_type="1"/>
+            <object type="OSDev" name="cuda2" osdev_type="5">
+              <info name="CoProcType" value="CUDA"/>
+              <info name="Backend" value="CUDA"/>
+              <info name="GPUVendor" value="NVIDIA Corporation"/>
+              <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+              <info name="CUDAGlobalMemorySize" value="16515072"/>
+              <info name="CUDAL2CacheSize" value="6144"/>
+              <info name="CUDAMultiProcessors" value="80"/>
+              <info name="CUDACoresPerMP" value="64"/>
+              <info name="CUDASharedMemorySizePerMP" value="48"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="55590912" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0035:04:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="NVIDIA Corporation"/>
+            <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+            <object type="OSDev" name="card3" osdev_type="1"/>
+            <object type="OSDev" name="renderD131" osdev_type="1"/>
+            <object type="OSDev" name="cuda3" osdev_type="5">
+              <info name="CoProcType" value="CUDA"/>
+              <info name="Backend" value="CUDA"/>
+              <info name="GPUVendor" value="NVIDIA Corporation"/>
+              <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+              <info name="CUDAGlobalMemorySize" value="16515072"/>
+              <info name="CUDAL2CacheSize" value="6144"/>
+              <info name="CUDAMultiProcessors" value="80"/>
+              <info name="CUDACoresPerMP" value="64"/>
+              <info name="CUDASharedMemorySizePerMP" value="48"/>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="NUMANode" os_index="252" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x10000000,,,,,,,0x0" complete_nodeset="0x10000000,,,,,,,0x0" allowed_nodeset="0x10000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="253" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x20000000,,,,,,,0x0" complete_nodeset="0x20000000,,,,,,,0x0" allowed_nodeset="0x20000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="254" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x40000000,,,,,,,0x0" complete_nodeset="0x40000000,,,,,,,0x0" allowed_nodeset="0x40000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="255" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x80000000,,,,,,,0x0" complete_nodeset="0x80000000,,,,,,,0x0" allowed_nodeset="0x80000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+  </object>
+</topology>

--- a/t/data/hwloc-data/004N/exclusive/04-brokers-sierra2/2.xml
+++ b/t/data/hwloc-data/004N/exclusive/04-brokers-sierra2/2.xml
@@ -1,0 +1,725 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0xf0000000,,,,,,,0x00000101" complete_nodeset="0xf0000000,,,,,,,0x00000101" allowed_nodeset="0xf0000000,,,,,,,0x00000101">
+    <page_type size="65536" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <page_type size="1073741824" count="0"/>
+    <info name="PlatformName" value="PowerNV"/>
+    <info name="PlatformModel" value="PowerNV 8335-GTW"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/allocation_54106"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="4.14.0-49.6.1.el7a.ppc64le"/>
+    <info name="OSVersion" value="#1 SMP Wed May 16 21:05:05 UTC 2018"/>
+    <info name="HostName" value="sierra3683"/>
+    <info name="Architecture" value="ppc64le"/>
+    <info name="hwlocVersion" value="1.11.10"/>
+    <info name="ProcessName" value="hwloc_xml"/>
+    <distances nbobjs="6" relative_depth="2" latency_base="10.000000">
+      <latency value="1.000000"/>
+      <latency value="4.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="4.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+    </distances>
+    <object type="Group" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0x00000101" complete_nodeset="0x00000101" allowed_nodeset="0x00000101" depth="0">
+      <object type="NUMANode" os_index="0" cpuset="0x00ffffff,0xffffffff,0xffffffff" complete_cpuset="0x00ffffff,0xffffffff,0xffffffff" online_cpuset="0x00ffffff,0xffffffff,0xffffffff" allowed_cpuset="0x00ffffff,0xffffffff,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="137132376064">
+        <page_type size="65536" count="2092474"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Package" os_index="0" cpuset="0x00ffffff,0xffffffff,0xffffffff" complete_cpuset="0x00ffffff,0xffffffff,0xffffffff" online_cpuset="0x00ffffff,0xffffffff,0xffffffff" allowed_cpuset="0x00ffffff,0xffffffff,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <info name="CPUModel" value="POWER9, altivec supported"/>
+          <info name="CPURevision" value="2.1 (pvr 004e 1201)"/>
+          <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="0" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="4" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="8" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="12" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000" complete_cpuset="0x00ff0000" online_cpuset="0x00ff0000" allowed_cpuset="0x00ff0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000" complete_cpuset="0x00ff0000" online_cpuset="0x00ff0000" allowed_cpuset="0x00ff0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="16" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="20" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000" complete_cpuset="0xff000000" online_cpuset="0xff000000" allowed_cpuset="0xff000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000" complete_cpuset="0xff000000" online_cpuset="0xff000000" allowed_cpuset="0xff000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="24" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="28" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,0x0" complete_cpuset="0x000000ff,0x0" online_cpuset="0x000000ff,0x0" allowed_cpuset="0x000000ff,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,0x0" complete_cpuset="0x000000ff,0x0" online_cpuset="0x000000ff,0x0" allowed_cpuset="0x000000ff,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="32" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="36" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,0x0" complete_cpuset="0x0000ff00,0x0" online_cpuset="0x0000ff00,0x0" allowed_cpuset="0x0000ff00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,0x0" complete_cpuset="0x0000ff00,0x0" online_cpuset="0x0000ff00,0x0" allowed_cpuset="0x0000ff00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="40" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="44" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,0x0" complete_cpuset="0x00ff0000,0x0" online_cpuset="0x00ff0000,0x0" allowed_cpuset="0x00ff0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,0x0" complete_cpuset="0x00ff0000,0x0" online_cpuset="0x00ff0000,0x0" allowed_cpuset="0x00ff0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="48" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="52" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000,0x0" complete_cpuset="0xff000000,0x0" online_cpuset="0xff000000,0x0" allowed_cpuset="0xff000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,0x0" complete_cpuset="0xff000000,0x0" online_cpuset="0xff000000,0x0" allowed_cpuset="0xff000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="56" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="60" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="68" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="72" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,,0x0" complete_cpuset="0x0000ff00,,0x0" online_cpuset="0x0000ff00,,0x0" allowed_cpuset="0x0000ff00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,,0x0" complete_cpuset="0x0000ff00,,0x0" online_cpuset="0x0000ff00,,0x0" allowed_cpuset="0x0000ff00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="80" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="84" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,0x0" online_cpuset="0x00ff0000,,0x0" allowed_cpuset="0x00ff0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,0x0" online_cpuset="0x00ff0000,,0x0" allowed_cpuset="0x00ff0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="88" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="92" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-01]">
+          <object type="PCIDev" os_index="4096" name="Samsung Electronics Co Ltd NVMe SSD Controller 172Xa" pci_busid="0000:01:00.0" pci_type="0108 [144d:a822] [1014:0621] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Samsung Electronics Co Ltd"/>
+            <info name="PCIDevice" value="NVMe SSD Controller 172Xa"/>
+            <object type="OSDev" name="nvme0n1" osdev_type="0">
+              <info name="LinuxDeviceID" value="259:0"/>
+              <info name="SerialNumber" value="S3RVNA0J801421"/>
+              <info name="Type" value="Disk"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0002:[00-02]">
+          <object type="PCIDev" os_index="2105344" name="ASPEED Technology, Inc. ASPEED Graphics Family" pci_busid="0002:02:00.0" pci_type="0300 [1a03:2000] [1a03:2000] 41" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+            <info name="PCIDevice" value="ASPEED Graphics Family"/>
+            <object type="OSDev" name="card4" osdev_type="1"/>
+            <object type="OSDev" name="controlD68" osdev_type="1"/>
+          </object>
+        </object>
+        <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0003:[00-01]">
+          <object type="PCIDev" os_index="3149824" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0003:01:00.0" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Mellanox Technologies"/>
+            <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+            <object type="OSDev" name="hsi0" osdev_type="2">
+              <info name="Address" value="00:00:10:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:8f:f0:80"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx5_0" osdev_type="3">
+              <info name="NodeGUID" value="ec0d:9a03:008f:f080"/>
+              <info name="SysImageGUID" value="ec0d:9a03:008f:f080"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x2e55"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:008f:f080"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="3149825" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0003:01:00.1" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Mellanox Technologies"/>
+            <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+            <object type="OSDev" name="hsi1" osdev_type="2">
+              <info name="Address" value="00:00:18:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:8f:f0:81"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx5_1" osdev_type="3">
+              <info name="NodeGUID" value="ec0d:9a03:008f:f081"/>
+              <info name="SysImageGUID" value="ec0d:9a03:008f:f080"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x2e56"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:008f:f081"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="4" bridge_type="0-1" depth="0" bridge_pci="0004:[00-0a]">
+          <object type="PCIDev" os_index="4206592" name="Marvell Technology Group Ltd. 88SE9235 PCIe 2.0 x2 4-port SATA 6 Gb/s Controller" pci_busid="0004:03:00.0" pci_type="0106 [1b4b:9235] [1014:0612] 11" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Marvell Technology Group Ltd."/>
+            <info name="PCIDevice" value="88SE9235 PCIe 2.0 x2 4-port SATA 6 Gb/s Controller"/>
+          </object>
+          <object type="PCIDev" os_index="4210688" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0004:04:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="NVIDIA Corporation"/>
+            <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+            <object type="OSDev" name="renderD128" osdev_type="1"/>
+            <object type="OSDev" name="card0" osdev_type="1"/>
+            <object type="OSDev" name="cuda0" osdev_type="5">
+              <info name="CoProcType" value="CUDA"/>
+              <info name="Backend" value="CUDA"/>
+              <info name="GPUVendor" value="NVIDIA Corporation"/>
+              <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+              <info name="CUDAGlobalMemorySize" value="16515072"/>
+              <info name="CUDAL2CacheSize" value="6144"/>
+              <info name="CUDAMultiProcessors" value="80"/>
+              <info name="CUDACoresPerMP" value="64"/>
+              <info name="CUDASharedMemorySizePerMP" value="48"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="4214784" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0004:05:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="NVIDIA Corporation"/>
+            <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+            <object type="OSDev" name="card1" osdev_type="1"/>
+            <object type="OSDev" name="renderD129" osdev_type="1"/>
+            <object type="OSDev" name="cuda1" osdev_type="5">
+              <info name="CoProcType" value="CUDA"/>
+              <info name="Backend" value="CUDA"/>
+              <info name="GPUVendor" value="NVIDIA Corporation"/>
+              <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+              <info name="CUDAGlobalMemorySize" value="16515072"/>
+              <info name="CUDAL2CacheSize" value="6144"/>
+              <info name="CUDAMultiProcessors" value="80"/>
+              <info name="CUDACoresPerMP" value="64"/>
+              <info name="CUDASharedMemorySizePerMP" value="48"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="5" bridge_type="0-1" depth="0" bridge_pci="0005:[00-01]">
+          <object type="PCIDev" os_index="5246976" name="Broadcom Limited NetXtreme BCM5719 Gigabit Ethernet PCIe" pci_busid="0005:01:00.0" pci_type="0200 [14e4:1657] [14e4:1981] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Broadcom Limited"/>
+            <info name="PCIDevice" value="NetXtreme BCM5719 Gigabit Ethernet PCIe"/>
+            <object type="OSDev" name="enP5p1s0f0" osdev_type="2">
+              <info name="Address" value="70:e2:84:14:69:f4"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="5246977" name="Broadcom Limited NetXtreme BCM5719 Gigabit Ethernet PCIe" pci_busid="0005:01:00.1" pci_type="0200 [14e4:1657] [14e4:1657] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Broadcom Limited"/>
+            <info name="PCIDevice" value="NetXtreme BCM5719 Gigabit Ethernet PCIe"/>
+            <object type="OSDev" name="enP5p1s0f1" osdev_type="2">
+              <info name="Address" value="70:e2:84:14:69:f5"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="8" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" local_memory="137166979072">
+        <page_type size="65536" count="2093002"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Package" os_index="8" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+          <info name="CPUModel" value="POWER9, altivec supported"/>
+          <info name="CPURevision" value="2.1 (pvr 004e 1201)"/>
+          <object type="Cache" cpuset="0xff000000,,0x0" complete_cpuset="0xff000000,,0x0" online_cpuset="0xff000000,,0x0" allowed_cpuset="0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,,0x0" complete_cpuset="0xff000000,,0x0" online_cpuset="0xff000000,,0x0" allowed_cpuset="0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2048" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2052" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,,0x0" complete_cpuset="0x000000ff,,,0x0" online_cpuset="0x000000ff,,,0x0" allowed_cpuset="0x000000ff,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,,0x0" complete_cpuset="0x000000ff,,,0x0" online_cpuset="0x000000ff,,,0x0" allowed_cpuset="0x000000ff,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2056" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="96" cpuset="0x00000001,,,0x0" complete_cpuset="0x00000001,,,0x0" online_cpuset="0x00000001,,,0x0" allowed_cpuset="0x00000001,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="97" cpuset="0x00000002,,,0x0" complete_cpuset="0x00000002,,,0x0" online_cpuset="0x00000002,,,0x0" allowed_cpuset="0x00000002,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="98" cpuset="0x00000004,,,0x0" complete_cpuset="0x00000004,,,0x0" online_cpuset="0x00000004,,,0x0" allowed_cpuset="0x00000004,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="99" cpuset="0x00000008,,,0x0" complete_cpuset="0x00000008,,,0x0" online_cpuset="0x00000008,,,0x0" allowed_cpuset="0x00000008,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2060" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="100" cpuset="0x00000010,,,0x0" complete_cpuset="0x00000010,,,0x0" online_cpuset="0x00000010,,,0x0" allowed_cpuset="0x00000010,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="101" cpuset="0x00000020,,,0x0" complete_cpuset="0x00000020,,,0x0" online_cpuset="0x00000020,,,0x0" allowed_cpuset="0x00000020,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="102" cpuset="0x00000040,,,0x0" complete_cpuset="0x00000040,,,0x0" online_cpuset="0x00000040,,,0x0" allowed_cpuset="0x00000040,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="103" cpuset="0x00000080,,,0x0" complete_cpuset="0x00000080,,,0x0" online_cpuset="0x00000080,,,0x0" allowed_cpuset="0x00000080,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,,,0x0" complete_cpuset="0x0000ff00,,,0x0" online_cpuset="0x0000ff00,,,0x0" allowed_cpuset="0x0000ff00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,,,0x0" complete_cpuset="0x0000ff00,,,0x0" online_cpuset="0x0000ff00,,,0x0" allowed_cpuset="0x0000ff00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2064" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="104" cpuset="0x00000100,,,0x0" complete_cpuset="0x00000100,,,0x0" online_cpuset="0x00000100,,,0x0" allowed_cpuset="0x00000100,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="105" cpuset="0x00000200,,,0x0" complete_cpuset="0x00000200,,,0x0" online_cpuset="0x00000200,,,0x0" allowed_cpuset="0x00000200,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="106" cpuset="0x00000400,,,0x0" complete_cpuset="0x00000400,,,0x0" online_cpuset="0x00000400,,,0x0" allowed_cpuset="0x00000400,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="107" cpuset="0x00000800,,,0x0" complete_cpuset="0x00000800,,,0x0" online_cpuset="0x00000800,,,0x0" allowed_cpuset="0x00000800,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2068" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="108" cpuset="0x00001000,,,0x0" complete_cpuset="0x00001000,,,0x0" online_cpuset="0x00001000,,,0x0" allowed_cpuset="0x00001000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="109" cpuset="0x00002000,,,0x0" complete_cpuset="0x00002000,,,0x0" online_cpuset="0x00002000,,,0x0" allowed_cpuset="0x00002000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="110" cpuset="0x00004000,,,0x0" complete_cpuset="0x00004000,,,0x0" online_cpuset="0x00004000,,,0x0" allowed_cpuset="0x00004000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="111" cpuset="0x00008000,,,0x0" complete_cpuset="0x00008000,,,0x0" online_cpuset="0x00008000,,,0x0" allowed_cpuset="0x00008000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,,,0x0" complete_cpuset="0x00ff0000,,,0x0" online_cpuset="0x00ff0000,,,0x0" allowed_cpuset="0x00ff0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,,,0x0" complete_cpuset="0x00ff0000,,,0x0" online_cpuset="0x00ff0000,,,0x0" allowed_cpuset="0x00ff0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2072" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="112" cpuset="0x00010000,,,0x0" complete_cpuset="0x00010000,,,0x0" online_cpuset="0x00010000,,,0x0" allowed_cpuset="0x00010000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="113" cpuset="0x00020000,,,0x0" complete_cpuset="0x00020000,,,0x0" online_cpuset="0x00020000,,,0x0" allowed_cpuset="0x00020000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="114" cpuset="0x00040000,,,0x0" complete_cpuset="0x00040000,,,0x0" online_cpuset="0x00040000,,,0x0" allowed_cpuset="0x00040000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="115" cpuset="0x00080000,,,0x0" complete_cpuset="0x00080000,,,0x0" online_cpuset="0x00080000,,,0x0" allowed_cpuset="0x00080000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2076" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="116" cpuset="0x00100000,,,0x0" complete_cpuset="0x00100000,,,0x0" online_cpuset="0x00100000,,,0x0" allowed_cpuset="0x00100000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="117" cpuset="0x00200000,,,0x0" complete_cpuset="0x00200000,,,0x0" online_cpuset="0x00200000,,,0x0" allowed_cpuset="0x00200000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="118" cpuset="0x00400000,,,0x0" complete_cpuset="0x00400000,,,0x0" online_cpuset="0x00400000,,,0x0" allowed_cpuset="0x00400000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="119" cpuset="0x00800000,,,0x0" complete_cpuset="0x00800000,,,0x0" online_cpuset="0x00800000,,,0x0" allowed_cpuset="0x00800000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000,,,0x0" complete_cpuset="0xff000000,,,0x0" online_cpuset="0xff000000,,,0x0" allowed_cpuset="0xff000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,,,0x0" complete_cpuset="0xff000000,,,0x0" online_cpuset="0xff000000,,,0x0" allowed_cpuset="0xff000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2080" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="120" cpuset="0x01000000,,,0x0" complete_cpuset="0x01000000,,,0x0" online_cpuset="0x01000000,,,0x0" allowed_cpuset="0x01000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="121" cpuset="0x02000000,,,0x0" complete_cpuset="0x02000000,,,0x0" online_cpuset="0x02000000,,,0x0" allowed_cpuset="0x02000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="122" cpuset="0x04000000,,,0x0" complete_cpuset="0x04000000,,,0x0" online_cpuset="0x04000000,,,0x0" allowed_cpuset="0x04000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="123" cpuset="0x08000000,,,0x0" complete_cpuset="0x08000000,,,0x0" online_cpuset="0x08000000,,,0x0" allowed_cpuset="0x08000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2084" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="124" cpuset="0x10000000,,,0x0" complete_cpuset="0x10000000,,,0x0" online_cpuset="0x10000000,,,0x0" allowed_cpuset="0x10000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="125" cpuset="0x20000000,,,0x0" complete_cpuset="0x20000000,,,0x0" online_cpuset="0x20000000,,,0x0" allowed_cpuset="0x20000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="126" cpuset="0x40000000,,,0x0" complete_cpuset="0x40000000,,,0x0" online_cpuset="0x40000000,,,0x0" allowed_cpuset="0x40000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="127" cpuset="0x80000000,,,0x0" complete_cpuset="0x80000000,,,0x0" online_cpuset="0x80000000,,,0x0" allowed_cpuset="0x80000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,,,0x0" complete_cpuset="0x000000ff,,,,0x0" online_cpuset="0x000000ff,,,,0x0" allowed_cpuset="0x000000ff,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,,,0x0" complete_cpuset="0x000000ff,,,,0x0" online_cpuset="0x000000ff,,,,0x0" allowed_cpuset="0x000000ff,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,,,0x0" complete_cpuset="0x0000000f,,,,0x0" online_cpuset="0x0000000f,,,,0x0" allowed_cpuset="0x0000000f,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2088" cpuset="0x0000000f,,,,0x0" complete_cpuset="0x0000000f,,,,0x0" online_cpuset="0x0000000f,,,,0x0" allowed_cpuset="0x0000000f,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="128" cpuset="0x00000001,,,,0x0" complete_cpuset="0x00000001,,,,0x0" online_cpuset="0x00000001,,,,0x0" allowed_cpuset="0x00000001,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="129" cpuset="0x00000002,,,,0x0" complete_cpuset="0x00000002,,,,0x0" online_cpuset="0x00000002,,,,0x0" allowed_cpuset="0x00000002,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="130" cpuset="0x00000004,,,,0x0" complete_cpuset="0x00000004,,,,0x0" online_cpuset="0x00000004,,,,0x0" allowed_cpuset="0x00000004,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="131" cpuset="0x00000008,,,,0x0" complete_cpuset="0x00000008,,,,0x0" online_cpuset="0x00000008,,,,0x0" allowed_cpuset="0x00000008,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,,,0x0" complete_cpuset="0x000000f0,,,,0x0" online_cpuset="0x000000f0,,,,0x0" allowed_cpuset="0x000000f0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2092" cpuset="0x000000f0,,,,0x0" complete_cpuset="0x000000f0,,,,0x0" online_cpuset="0x000000f0,,,,0x0" allowed_cpuset="0x000000f0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="132" cpuset="0x00000010,,,,0x0" complete_cpuset="0x00000010,,,,0x0" online_cpuset="0x00000010,,,,0x0" allowed_cpuset="0x00000010,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="133" cpuset="0x00000020,,,,0x0" complete_cpuset="0x00000020,,,,0x0" online_cpuset="0x00000020,,,,0x0" allowed_cpuset="0x00000020,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="134" cpuset="0x00000040,,,,0x0" complete_cpuset="0x00000040,,,,0x0" online_cpuset="0x00000040,,,,0x0" allowed_cpuset="0x00000040,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="135" cpuset="0x00000080,,,,0x0" complete_cpuset="0x00000080,,,,0x0" online_cpuset="0x00000080,,,,0x0" allowed_cpuset="0x00000080,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2100" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="136" cpuset="0x00000100,,,,0x0" complete_cpuset="0x00000100,,,,0x0" online_cpuset="0x00000100,,,,0x0" allowed_cpuset="0x00000100,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="137" cpuset="0x00000200,,,,0x0" complete_cpuset="0x00000200,,,,0x0" online_cpuset="0x00000200,,,,0x0" allowed_cpuset="0x00000200,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="138" cpuset="0x00000400,,,,0x0" complete_cpuset="0x00000400,,,,0x0" online_cpuset="0x00000400,,,,0x0" allowed_cpuset="0x00000400,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="139" cpuset="0x00000800,,,,0x0" complete_cpuset="0x00000800,,,,0x0" online_cpuset="0x00000800,,,,0x0" allowed_cpuset="0x00000800,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000ff000,,,,0x0" complete_cpuset="0x000ff000,,,,0x0" online_cpuset="0x000ff000,,,,0x0" allowed_cpuset="0x000ff000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000ff000,,,,0x0" complete_cpuset="0x000ff000,,,,0x0" online_cpuset="0x000ff000,,,,0x0" allowed_cpuset="0x000ff000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000f000,,,,0x0" complete_cpuset="0x0000f000,,,,0x0" online_cpuset="0x0000f000,,,,0x0" allowed_cpuset="0x0000f000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2104" cpuset="0x0000f000,,,,0x0" complete_cpuset="0x0000f000,,,,0x0" online_cpuset="0x0000f000,,,,0x0" allowed_cpuset="0x0000f000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="140" cpuset="0x00001000,,,,0x0" complete_cpuset="0x00001000,,,,0x0" online_cpuset="0x00001000,,,,0x0" allowed_cpuset="0x00001000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="141" cpuset="0x00002000,,,,0x0" complete_cpuset="0x00002000,,,,0x0" online_cpuset="0x00002000,,,,0x0" allowed_cpuset="0x00002000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="142" cpuset="0x00004000,,,,0x0" complete_cpuset="0x00004000,,,,0x0" online_cpuset="0x00004000,,,,0x0" allowed_cpuset="0x00004000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="143" cpuset="0x00008000,,,,0x0" complete_cpuset="0x00008000,,,,0x0" online_cpuset="0x00008000,,,,0x0" allowed_cpuset="0x00008000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000f0000,,,,0x0" complete_cpuset="0x000f0000,,,,0x0" online_cpuset="0x000f0000,,,,0x0" allowed_cpuset="0x000f0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2108" cpuset="0x000f0000,,,,0x0" complete_cpuset="0x000f0000,,,,0x0" online_cpuset="0x000f0000,,,,0x0" allowed_cpuset="0x000f0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="144" cpuset="0x00010000,,,,0x0" complete_cpuset="0x00010000,,,,0x0" online_cpuset="0x00010000,,,,0x0" allowed_cpuset="0x00010000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="145" cpuset="0x00020000,,,,0x0" complete_cpuset="0x00020000,,,,0x0" online_cpuset="0x00020000,,,,0x0" allowed_cpuset="0x00020000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="146" cpuset="0x00040000,,,,0x0" complete_cpuset="0x00040000,,,,0x0" online_cpuset="0x00040000,,,,0x0" allowed_cpuset="0x00040000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="147" cpuset="0x00080000,,,,0x0" complete_cpuset="0x00080000,,,,0x0" online_cpuset="0x00080000,,,,0x0" allowed_cpuset="0x00080000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0ff00000,,,,0x0" complete_cpuset="0x0ff00000,,,,0x0" online_cpuset="0x0ff00000,,,,0x0" allowed_cpuset="0x0ff00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0ff00000,,,,0x0" complete_cpuset="0x0ff00000,,,,0x0" online_cpuset="0x0ff00000,,,,0x0" allowed_cpuset="0x0ff00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2112" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="148" cpuset="0x00100000,,,,0x0" complete_cpuset="0x00100000,,,,0x0" online_cpuset="0x00100000,,,,0x0" allowed_cpuset="0x00100000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="149" cpuset="0x00200000,,,,0x0" complete_cpuset="0x00200000,,,,0x0" online_cpuset="0x00200000,,,,0x0" allowed_cpuset="0x00200000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="150" cpuset="0x00400000,,,,0x0" complete_cpuset="0x00400000,,,,0x0" online_cpuset="0x00400000,,,,0x0" allowed_cpuset="0x00400000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="151" cpuset="0x00800000,,,,0x0" complete_cpuset="0x00800000,,,,0x0" online_cpuset="0x00800000,,,,0x0" allowed_cpuset="0x00800000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0f000000,,,,0x0" complete_cpuset="0x0f000000,,,,0x0" online_cpuset="0x0f000000,,,,0x0" allowed_cpuset="0x0f000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2116" cpuset="0x0f000000,,,,0x0" complete_cpuset="0x0f000000,,,,0x0" online_cpuset="0x0f000000,,,,0x0" allowed_cpuset="0x0f000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="152" cpuset="0x01000000,,,,0x0" complete_cpuset="0x01000000,,,,0x0" online_cpuset="0x01000000,,,,0x0" allowed_cpuset="0x01000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="153" cpuset="0x02000000,,,,0x0" complete_cpuset="0x02000000,,,,0x0" online_cpuset="0x02000000,,,,0x0" allowed_cpuset="0x02000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="154" cpuset="0x04000000,,,,0x0" complete_cpuset="0x04000000,,,,0x0" online_cpuset="0x04000000,,,,0x0" allowed_cpuset="0x04000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="155" cpuset="0x08000000,,,,0x0" complete_cpuset="0x08000000,,,,0x0" online_cpuset="0x08000000,,,,0x0" allowed_cpuset="0x08000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000000f,0xf0000000,,,,0x0" complete_cpuset="0x0000000f,0xf0000000,,,,0x0" online_cpuset="0x0000000f,0xf0000000,,,,0x0" allowed_cpuset="0x0000000f,0xf0000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000000f,0xf0000000,,,,0x0" complete_cpuset="0x0000000f,0xf0000000,,,,0x0" online_cpuset="0x0000000f,0xf0000000,,,,0x0" allowed_cpuset="0x0000000f,0xf0000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0xf0000000,,,,0x0" complete_cpuset="0xf0000000,,,,0x0" online_cpuset="0xf0000000,,,,0x0" allowed_cpuset="0xf0000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2120" cpuset="0xf0000000,,,,0x0" complete_cpuset="0xf0000000,,,,0x0" online_cpuset="0xf0000000,,,,0x0" allowed_cpuset="0xf0000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="156" cpuset="0x10000000,,,,0x0" complete_cpuset="0x10000000,,,,0x0" online_cpuset="0x10000000,,,,0x0" allowed_cpuset="0x10000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="157" cpuset="0x20000000,,,,0x0" complete_cpuset="0x20000000,,,,0x0" online_cpuset="0x20000000,,,,0x0" allowed_cpuset="0x20000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="158" cpuset="0x40000000,,,,0x0" complete_cpuset="0x40000000,,,,0x0" online_cpuset="0x40000000,,,,0x0" allowed_cpuset="0x40000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="159" cpuset="0x80000000,,,,0x0" complete_cpuset="0x80000000,,,,0x0" online_cpuset="0x80000000,,,,0x0" allowed_cpuset="0x80000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000000f,,,,,0x0" complete_cpuset="0x0000000f,,,,,0x0" online_cpuset="0x0000000f,,,,,0x0" allowed_cpuset="0x0000000f,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2124" cpuset="0x0000000f,,,,,0x0" complete_cpuset="0x0000000f,,,,,0x0" online_cpuset="0x0000000f,,,,,0x0" allowed_cpuset="0x0000000f,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="160" cpuset="0x00000001,,,,,0x0" complete_cpuset="0x00000001,,,,,0x0" online_cpuset="0x00000001,,,,,0x0" allowed_cpuset="0x00000001,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="161" cpuset="0x00000002,,,,,0x0" complete_cpuset="0x00000002,,,,,0x0" online_cpuset="0x00000002,,,,,0x0" allowed_cpuset="0x00000002,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="162" cpuset="0x00000004,,,,,0x0" complete_cpuset="0x00000004,,,,,0x0" online_cpuset="0x00000004,,,,,0x0" allowed_cpuset="0x00000004,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="163" cpuset="0x00000008,,,,,0x0" complete_cpuset="0x00000008,,,,,0x0" online_cpuset="0x00000008,,,,,0x0" allowed_cpuset="0x00000008,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000ff0,,,,,0x0" complete_cpuset="0x00000ff0,,,,,0x0" online_cpuset="0x00000ff0,,,,,0x0" allowed_cpuset="0x00000ff0,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00000ff0,,,,,0x0" complete_cpuset="0x00000ff0,,,,,0x0" online_cpuset="0x00000ff0,,,,,0x0" allowed_cpuset="0x00000ff0,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000000f0,,,,,0x0" complete_cpuset="0x000000f0,,,,,0x0" online_cpuset="0x000000f0,,,,,0x0" allowed_cpuset="0x000000f0,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2128" cpuset="0x000000f0,,,,,0x0" complete_cpuset="0x000000f0,,,,,0x0" online_cpuset="0x000000f0,,,,,0x0" allowed_cpuset="0x000000f0,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="164" cpuset="0x00000010,,,,,0x0" complete_cpuset="0x00000010,,,,,0x0" online_cpuset="0x00000010,,,,,0x0" allowed_cpuset="0x00000010,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="165" cpuset="0x00000020,,,,,0x0" complete_cpuset="0x00000020,,,,,0x0" online_cpuset="0x00000020,,,,,0x0" allowed_cpuset="0x00000020,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="166" cpuset="0x00000040,,,,,0x0" complete_cpuset="0x00000040,,,,,0x0" online_cpuset="0x00000040,,,,,0x0" allowed_cpuset="0x00000040,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="167" cpuset="0x00000080,,,,,0x0" complete_cpuset="0x00000080,,,,,0x0" online_cpuset="0x00000080,,,,,0x0" allowed_cpuset="0x00000080,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00000f00,,,,,0x0" complete_cpuset="0x00000f00,,,,,0x0" online_cpuset="0x00000f00,,,,,0x0" allowed_cpuset="0x00000f00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2132" cpuset="0x00000f00,,,,,0x0" complete_cpuset="0x00000f00,,,,,0x0" online_cpuset="0x00000f00,,,,,0x0" allowed_cpuset="0x00000f00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="168" cpuset="0x00000100,,,,,0x0" complete_cpuset="0x00000100,,,,,0x0" online_cpuset="0x00000100,,,,,0x0" allowed_cpuset="0x00000100,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="169" cpuset="0x00000200,,,,,0x0" complete_cpuset="0x00000200,,,,,0x0" online_cpuset="0x00000200,,,,,0x0" allowed_cpuset="0x00000200,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="170" cpuset="0x00000400,,,,,0x0" complete_cpuset="0x00000400,,,,,0x0" online_cpuset="0x00000400,,,,,0x0" allowed_cpuset="0x00000400,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="171" cpuset="0x00000800,,,,,0x0" complete_cpuset="0x00000800,,,,,0x0" online_cpuset="0x00000800,,,,,0x0" allowed_cpuset="0x00000800,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000f000,,,,,0x0" complete_cpuset="0x0000f000,,,,,0x0" online_cpuset="0x0000f000,,,,,0x0" allowed_cpuset="0x0000f000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000f000,,,,,0x0" complete_cpuset="0x0000f000,,,,,0x0" online_cpuset="0x0000f000,,,,,0x0" allowed_cpuset="0x0000f000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000f000,,,,,0x0" complete_cpuset="0x0000f000,,,,,0x0" online_cpuset="0x0000f000,,,,,0x0" allowed_cpuset="0x0000f000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2136" cpuset="0x0000f000,,,,,0x0" complete_cpuset="0x0000f000,,,,,0x0" online_cpuset="0x0000f000,,,,,0x0" allowed_cpuset="0x0000f000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="172" cpuset="0x00001000,,,,,0x0" complete_cpuset="0x00001000,,,,,0x0" online_cpuset="0x00001000,,,,,0x0" allowed_cpuset="0x00001000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="173" cpuset="0x00002000,,,,,0x0" complete_cpuset="0x00002000,,,,,0x0" online_cpuset="0x00002000,,,,,0x0" allowed_cpuset="0x00002000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="174" cpuset="0x00004000,,,,,0x0" complete_cpuset="0x00004000,,,,,0x0" online_cpuset="0x00004000,,,,,0x0" allowed_cpuset="0x00004000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="175" cpuset="0x00008000,,,,,0x0" complete_cpuset="0x00008000,,,,,0x0" online_cpuset="0x00008000,,,,,0x0" allowed_cpuset="0x00008000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="9" bridge_type="0-1" depth="0" bridge_pci="0033:[00-01]">
+          <object type="PCIDev" os_index="53481472" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0033:01:00.0" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Mellanox Technologies"/>
+            <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+            <object type="OSDev" name="hsi2" osdev_type="2">
+              <info name="Address" value="00:00:14:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:8f:f0:82"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx5_2" osdev_type="3">
+              <info name="NodeGUID" value="ec0d:9a03:008f:f082"/>
+              <info name="SysImageGUID" value="ec0d:9a03:008f:f080"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x2e57"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:008f:f082"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="53481473" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0033:01:00.1" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Mellanox Technologies"/>
+            <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+            <object type="OSDev" name="hsi3" osdev_type="2">
+              <info name="Address" value="00:00:1c:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:8f:f0:83"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx5_3" osdev_type="3">
+              <info name="NodeGUID" value="ec0d:9a03:008f:f083"/>
+              <info name="SysImageGUID" value="ec0d:9a03:008f:f080"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x2e58"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:008f:f083"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="11" bridge_type="0-1" depth="0" bridge_pci="0035:[00-09]">
+          <object type="PCIDev" os_index="55586816" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0035:03:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="NVIDIA Corporation"/>
+            <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+            <object type="OSDev" name="card2" osdev_type="1"/>
+            <object type="OSDev" name="renderD130" osdev_type="1"/>
+            <object type="OSDev" name="cuda2" osdev_type="5">
+              <info name="CoProcType" value="CUDA"/>
+              <info name="Backend" value="CUDA"/>
+              <info name="GPUVendor" value="NVIDIA Corporation"/>
+              <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+              <info name="CUDAGlobalMemorySize" value="16515072"/>
+              <info name="CUDAL2CacheSize" value="6144"/>
+              <info name="CUDAMultiProcessors" value="80"/>
+              <info name="CUDACoresPerMP" value="64"/>
+              <info name="CUDASharedMemorySizePerMP" value="48"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="55590912" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0035:04:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="NVIDIA Corporation"/>
+            <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+            <object type="OSDev" name="card3" osdev_type="1"/>
+            <object type="OSDev" name="renderD131" osdev_type="1"/>
+            <object type="OSDev" name="cuda3" osdev_type="5">
+              <info name="CoProcType" value="CUDA"/>
+              <info name="Backend" value="CUDA"/>
+              <info name="GPUVendor" value="NVIDIA Corporation"/>
+              <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+              <info name="CUDAGlobalMemorySize" value="16515072"/>
+              <info name="CUDAL2CacheSize" value="6144"/>
+              <info name="CUDAMultiProcessors" value="80"/>
+              <info name="CUDACoresPerMP" value="64"/>
+              <info name="CUDASharedMemorySizePerMP" value="48"/>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="NUMANode" os_index="252" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x10000000,,,,,,,0x0" complete_nodeset="0x10000000,,,,,,,0x0" allowed_nodeset="0x10000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="253" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x20000000,,,,,,,0x0" complete_nodeset="0x20000000,,,,,,,0x0" allowed_nodeset="0x20000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="254" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x40000000,,,,,,,0x0" complete_nodeset="0x40000000,,,,,,,0x0" allowed_nodeset="0x40000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="255" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x80000000,,,,,,,0x0" complete_nodeset="0x80000000,,,,,,,0x0" allowed_nodeset="0x80000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+  </object>
+</topology>

--- a/t/data/hwloc-data/004N/exclusive/04-brokers-sierra2/3.xml
+++ b/t/data/hwloc-data/004N/exclusive/04-brokers-sierra2/3.xml
@@ -1,0 +1,725 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0xf0000000,,,,,,,0x00000101" complete_nodeset="0xf0000000,,,,,,,0x00000101" allowed_nodeset="0xf0000000,,,,,,,0x00000101">
+    <page_type size="65536" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <page_type size="1073741824" count="0"/>
+    <info name="PlatformName" value="PowerNV"/>
+    <info name="PlatformModel" value="PowerNV 8335-GTW"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/allocation_54106"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="4.14.0-49.6.1.el7a.ppc64le"/>
+    <info name="OSVersion" value="#1 SMP Wed May 16 21:05:05 UTC 2018"/>
+    <info name="HostName" value="sierra3178"/>
+    <info name="Architecture" value="ppc64le"/>
+    <info name="hwlocVersion" value="1.11.10"/>
+    <info name="ProcessName" value="hwloc_xml"/>
+    <distances nbobjs="6" relative_depth="2" latency_base="10.000000">
+      <latency value="1.000000"/>
+      <latency value="4.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="4.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="8.000000"/>
+      <latency value="1.000000"/>
+    </distances>
+    <object type="Group" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0x00000101" complete_nodeset="0x00000101" allowed_nodeset="0x00000101" depth="0">
+      <object type="NUMANode" os_index="0" cpuset="0x00ffffff,0xffffffff,0xffffffff" complete_cpuset="0x00ffffff,0xffffffff,0xffffffff" online_cpuset="0x00ffffff,0xffffffff,0xffffffff" allowed_cpuset="0x00ffffff,0xffffffff,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="137132310528">
+        <page_type size="65536" count="2092473"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Package" os_index="0" cpuset="0x00ffffff,0xffffffff,0xffffffff" complete_cpuset="0x00ffffff,0xffffffff,0xffffffff" online_cpuset="0x00ffffff,0xffffffff,0xffffffff" allowed_cpuset="0x00ffffff,0xffffffff,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <info name="CPUModel" value="POWER9, altivec supported"/>
+          <info name="CPURevision" value="2.1 (pvr 004e 1201)"/>
+          <object type="Cache" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="4" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000ff0" complete_cpuset="0x00000ff0" online_cpuset="0x00000ff0" allowed_cpuset="0x00000ff0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00000ff0" complete_cpuset="0x00000ff0" online_cpuset="0x00000ff0" allowed_cpuset="0x00000ff0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="8" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="12" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000ff000" complete_cpuset="0x000ff000" online_cpuset="0x000ff000" allowed_cpuset="0x000ff000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000ff000" complete_cpuset="0x000ff000" online_cpuset="0x000ff000" allowed_cpuset="0x000ff000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="16" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="20" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0ff00000" complete_cpuset="0x0ff00000" online_cpuset="0x0ff00000" allowed_cpuset="0x0ff00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0ff00000" complete_cpuset="0x0ff00000" online_cpuset="0x0ff00000" allowed_cpuset="0x0ff00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="24" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="28" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000000f,0xf0000000" complete_cpuset="0x0000000f,0xf0000000" online_cpuset="0x0000000f,0xf0000000" allowed_cpuset="0x0000000f,0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000000f,0xf0000000" complete_cpuset="0x0000000f,0xf0000000" online_cpuset="0x0000000f,0xf0000000" allowed_cpuset="0x0000000f,0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="32" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="36" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000ff0,0x0" complete_cpuset="0x00000ff0,0x0" online_cpuset="0x00000ff0,0x0" allowed_cpuset="0x00000ff0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00000ff0,0x0" complete_cpuset="0x00000ff0,0x0" online_cpuset="0x00000ff0,0x0" allowed_cpuset="0x00000ff0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="40" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="44" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000ff000,0x0" complete_cpuset="0x000ff000,0x0" online_cpuset="0x000ff000,0x0" allowed_cpuset="0x000ff000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000ff000,0x0" complete_cpuset="0x000ff000,0x0" online_cpuset="0x000ff000,0x0" allowed_cpuset="0x000ff000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="48" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="52" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0ff00000,0x0" complete_cpuset="0x0ff00000,0x0" online_cpuset="0x0ff00000,0x0" allowed_cpuset="0x0ff00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0ff00000,0x0" complete_cpuset="0x0ff00000,0x0" online_cpuset="0x0ff00000,0x0" allowed_cpuset="0x0ff00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="56" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="60" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000000f,0xf0000000,0x0" complete_cpuset="0x0000000f,0xf0000000,0x0" online_cpuset="0x0000000f,0xf0000000,0x0" allowed_cpuset="0x0000000f,0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000000f,0xf0000000,0x0" complete_cpuset="0x0000000f,0xf0000000,0x0" online_cpuset="0x0000000f,0xf0000000,0x0" allowed_cpuset="0x0000000f,0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="64" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="68" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000ff0,,0x0" complete_cpuset="0x00000ff0,,0x0" online_cpuset="0x00000ff0,,0x0" allowed_cpuset="0x00000ff0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00000ff0,,0x0" complete_cpuset="0x00000ff0,,0x0" online_cpuset="0x00000ff0,,0x0" allowed_cpuset="0x00000ff0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="72" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="76" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="80" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,0x0" online_cpuset="0x00ff0000,,0x0" allowed_cpuset="0x00ff0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,0x0" online_cpuset="0x00ff0000,,0x0" allowed_cpuset="0x00ff0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="88" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="92" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-01]">
+          <object type="PCIDev" os_index="4096" name="Samsung Electronics Co Ltd NVMe SSD Controller 172Xa" pci_busid="0000:01:00.0" pci_type="0108 [144d:a822] [1014:0621] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Samsung Electronics Co Ltd"/>
+            <info name="PCIDevice" value="NVMe SSD Controller 172Xa"/>
+            <object type="OSDev" name="nvme0n1" osdev_type="0">
+              <info name="LinuxDeviceID" value="259:0"/>
+              <info name="SerialNumber" value="S3RVNA0JA00506"/>
+              <info name="Type" value="Disk"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0002:[00-02]">
+          <object type="PCIDev" os_index="2105344" name="ASPEED Technology, Inc. ASPEED Graphics Family" pci_busid="0002:02:00.0" pci_type="0300 [1a03:2000] [1a03:2000] 41" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+            <info name="PCIDevice" value="ASPEED Graphics Family"/>
+            <object type="OSDev" name="card4" osdev_type="1"/>
+            <object type="OSDev" name="controlD68" osdev_type="1"/>
+          </object>
+        </object>
+        <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0003:[00-01]">
+          <object type="PCIDev" os_index="3149824" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0003:01:00.0" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Mellanox Technologies"/>
+            <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+            <object type="OSDev" name="hsi0" osdev_type="2">
+              <info name="Address" value="00:00:10:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:cc:9a:ba"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx5_0" osdev_type="3">
+              <info name="NodeGUID" value="ec0d:9a03:00cc:9aba"/>
+              <info name="SysImageGUID" value="ec0d:9a03:00cc:9aba"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x330f"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:00cc:9aba"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="3149825" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0003:01:00.1" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Mellanox Technologies"/>
+            <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+            <object type="OSDev" name="hsi1" osdev_type="2">
+              <info name="Address" value="00:00:18:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:cc:9a:bb"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx5_1" osdev_type="3">
+              <info name="NodeGUID" value="ec0d:9a03:00cc:9abb"/>
+              <info name="SysImageGUID" value="ec0d:9a03:00cc:9aba"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x3310"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:00cc:9abb"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="4" bridge_type="0-1" depth="0" bridge_pci="0004:[00-0a]">
+          <object type="PCIDev" os_index="4206592" name="Marvell Technology Group Ltd. 88SE9235 PCIe 2.0 x2 4-port SATA 6 Gb/s Controller" pci_busid="0004:03:00.0" pci_type="0106 [1b4b:9235] [1014:0612] 11" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Marvell Technology Group Ltd."/>
+            <info name="PCIDevice" value="88SE9235 PCIe 2.0 x2 4-port SATA 6 Gb/s Controller"/>
+          </object>
+          <object type="PCIDev" os_index="4210688" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0004:04:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="NVIDIA Corporation"/>
+            <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+            <object type="OSDev" name="renderD128" osdev_type="1"/>
+            <object type="OSDev" name="card0" osdev_type="1"/>
+            <object type="OSDev" name="cuda0" osdev_type="5">
+              <info name="CoProcType" value="CUDA"/>
+              <info name="Backend" value="CUDA"/>
+              <info name="GPUVendor" value="NVIDIA Corporation"/>
+              <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+              <info name="CUDAGlobalMemorySize" value="16515072"/>
+              <info name="CUDAL2CacheSize" value="6144"/>
+              <info name="CUDAMultiProcessors" value="80"/>
+              <info name="CUDACoresPerMP" value="64"/>
+              <info name="CUDASharedMemorySizePerMP" value="48"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="4214784" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0004:05:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="NVIDIA Corporation"/>
+            <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+            <object type="OSDev" name="card1" osdev_type="1"/>
+            <object type="OSDev" name="renderD129" osdev_type="1"/>
+            <object type="OSDev" name="cuda1" osdev_type="5">
+              <info name="CoProcType" value="CUDA"/>
+              <info name="Backend" value="CUDA"/>
+              <info name="GPUVendor" value="NVIDIA Corporation"/>
+              <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+              <info name="CUDAGlobalMemorySize" value="16515072"/>
+              <info name="CUDAL2CacheSize" value="6144"/>
+              <info name="CUDAMultiProcessors" value="80"/>
+              <info name="CUDACoresPerMP" value="64"/>
+              <info name="CUDASharedMemorySizePerMP" value="48"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="5" bridge_type="0-1" depth="0" bridge_pci="0005:[00-01]">
+          <object type="PCIDev" os_index="5246976" name="Broadcom Limited NetXtreme BCM5719 Gigabit Ethernet PCIe" pci_busid="0005:01:00.0" pci_type="0200 [14e4:1657] [14e4:1981] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Broadcom Limited"/>
+            <info name="PCIDevice" value="NetXtreme BCM5719 Gigabit Ethernet PCIe"/>
+            <object type="OSDev" name="enP5p1s0f0" osdev_type="2">
+              <info name="Address" value="70:e2:84:14:9c:b9"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="5246977" name="Broadcom Limited NetXtreme BCM5719 Gigabit Ethernet PCIe" pci_busid="0005:01:00.1" pci_type="0200 [14e4:1657] [14e4:1657] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Broadcom Limited"/>
+            <info name="PCIDevice" value="NetXtreme BCM5719 Gigabit Ethernet PCIe"/>
+            <object type="OSDev" name="enP5p1s0f1" osdev_type="2">
+              <info name="Address" value="70:e2:84:14:9c:ba"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="8" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" local_memory="137166979072">
+        <page_type size="65536" count="2093002"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Package" os_index="8" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+          <info name="CPUModel" value="POWER9, altivec supported"/>
+          <info name="CPURevision" value="2.1 (pvr 004e 1201)"/>
+          <object type="Cache" cpuset="0xff000000,,0x0" complete_cpuset="0xff000000,,0x0" online_cpuset="0xff000000,,0x0" allowed_cpuset="0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,,0x0" complete_cpuset="0xff000000,,0x0" online_cpuset="0xff000000,,0x0" allowed_cpuset="0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2048" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2052" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,,0x0" complete_cpuset="0x000000ff,,,0x0" online_cpuset="0x000000ff,,,0x0" allowed_cpuset="0x000000ff,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,,0x0" complete_cpuset="0x000000ff,,,0x0" online_cpuset="0x000000ff,,,0x0" allowed_cpuset="0x000000ff,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2056" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="96" cpuset="0x00000001,,,0x0" complete_cpuset="0x00000001,,,0x0" online_cpuset="0x00000001,,,0x0" allowed_cpuset="0x00000001,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="97" cpuset="0x00000002,,,0x0" complete_cpuset="0x00000002,,,0x0" online_cpuset="0x00000002,,,0x0" allowed_cpuset="0x00000002,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="98" cpuset="0x00000004,,,0x0" complete_cpuset="0x00000004,,,0x0" online_cpuset="0x00000004,,,0x0" allowed_cpuset="0x00000004,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="99" cpuset="0x00000008,,,0x0" complete_cpuset="0x00000008,,,0x0" online_cpuset="0x00000008,,,0x0" allowed_cpuset="0x00000008,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2060" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="100" cpuset="0x00000010,,,0x0" complete_cpuset="0x00000010,,,0x0" online_cpuset="0x00000010,,,0x0" allowed_cpuset="0x00000010,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="101" cpuset="0x00000020,,,0x0" complete_cpuset="0x00000020,,,0x0" online_cpuset="0x00000020,,,0x0" allowed_cpuset="0x00000020,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="102" cpuset="0x00000040,,,0x0" complete_cpuset="0x00000040,,,0x0" online_cpuset="0x00000040,,,0x0" allowed_cpuset="0x00000040,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="103" cpuset="0x00000080,,,0x0" complete_cpuset="0x00000080,,,0x0" online_cpuset="0x00000080,,,0x0" allowed_cpuset="0x00000080,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,,,0x0" complete_cpuset="0x0000ff00,,,0x0" online_cpuset="0x0000ff00,,,0x0" allowed_cpuset="0x0000ff00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,,,0x0" complete_cpuset="0x0000ff00,,,0x0" online_cpuset="0x0000ff00,,,0x0" allowed_cpuset="0x0000ff00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2064" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="104" cpuset="0x00000100,,,0x0" complete_cpuset="0x00000100,,,0x0" online_cpuset="0x00000100,,,0x0" allowed_cpuset="0x00000100,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="105" cpuset="0x00000200,,,0x0" complete_cpuset="0x00000200,,,0x0" online_cpuset="0x00000200,,,0x0" allowed_cpuset="0x00000200,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="106" cpuset="0x00000400,,,0x0" complete_cpuset="0x00000400,,,0x0" online_cpuset="0x00000400,,,0x0" allowed_cpuset="0x00000400,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="107" cpuset="0x00000800,,,0x0" complete_cpuset="0x00000800,,,0x0" online_cpuset="0x00000800,,,0x0" allowed_cpuset="0x00000800,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2068" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="108" cpuset="0x00001000,,,0x0" complete_cpuset="0x00001000,,,0x0" online_cpuset="0x00001000,,,0x0" allowed_cpuset="0x00001000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="109" cpuset="0x00002000,,,0x0" complete_cpuset="0x00002000,,,0x0" online_cpuset="0x00002000,,,0x0" allowed_cpuset="0x00002000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="110" cpuset="0x00004000,,,0x0" complete_cpuset="0x00004000,,,0x0" online_cpuset="0x00004000,,,0x0" allowed_cpuset="0x00004000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="111" cpuset="0x00008000,,,0x0" complete_cpuset="0x00008000,,,0x0" online_cpuset="0x00008000,,,0x0" allowed_cpuset="0x00008000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00ff0000,,,0x0" complete_cpuset="0x00ff0000,,,0x0" online_cpuset="0x00ff0000,,,0x0" allowed_cpuset="0x00ff0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00ff0000,,,0x0" complete_cpuset="0x00ff0000,,,0x0" online_cpuset="0x00ff0000,,,0x0" allowed_cpuset="0x00ff0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2072" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="112" cpuset="0x00010000,,,0x0" complete_cpuset="0x00010000,,,0x0" online_cpuset="0x00010000,,,0x0" allowed_cpuset="0x00010000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="113" cpuset="0x00020000,,,0x0" complete_cpuset="0x00020000,,,0x0" online_cpuset="0x00020000,,,0x0" allowed_cpuset="0x00020000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="114" cpuset="0x00040000,,,0x0" complete_cpuset="0x00040000,,,0x0" online_cpuset="0x00040000,,,0x0" allowed_cpuset="0x00040000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="115" cpuset="0x00080000,,,0x0" complete_cpuset="0x00080000,,,0x0" online_cpuset="0x00080000,,,0x0" allowed_cpuset="0x00080000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2076" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="116" cpuset="0x00100000,,,0x0" complete_cpuset="0x00100000,,,0x0" online_cpuset="0x00100000,,,0x0" allowed_cpuset="0x00100000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="117" cpuset="0x00200000,,,0x0" complete_cpuset="0x00200000,,,0x0" online_cpuset="0x00200000,,,0x0" allowed_cpuset="0x00200000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="118" cpuset="0x00400000,,,0x0" complete_cpuset="0x00400000,,,0x0" online_cpuset="0x00400000,,,0x0" allowed_cpuset="0x00400000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="119" cpuset="0x00800000,,,0x0" complete_cpuset="0x00800000,,,0x0" online_cpuset="0x00800000,,,0x0" allowed_cpuset="0x00800000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2084" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="120" cpuset="0x01000000,,,0x0" complete_cpuset="0x01000000,,,0x0" online_cpuset="0x01000000,,,0x0" allowed_cpuset="0x01000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="121" cpuset="0x02000000,,,0x0" complete_cpuset="0x02000000,,,0x0" online_cpuset="0x02000000,,,0x0" allowed_cpuset="0x02000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="122" cpuset="0x04000000,,,0x0" complete_cpuset="0x04000000,,,0x0" online_cpuset="0x04000000,,,0x0" allowed_cpuset="0x04000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="123" cpuset="0x08000000,,,0x0" complete_cpuset="0x08000000,,,0x0" online_cpuset="0x08000000,,,0x0" allowed_cpuset="0x08000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000000f,0xf0000000,,,0x0" complete_cpuset="0x0000000f,0xf0000000,,,0x0" online_cpuset="0x0000000f,0xf0000000,,,0x0" allowed_cpuset="0x0000000f,0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000000f,0xf0000000,,,0x0" complete_cpuset="0x0000000f,0xf0000000,,,0x0" online_cpuset="0x0000000f,0xf0000000,,,0x0" allowed_cpuset="0x0000000f,0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2088" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="124" cpuset="0x10000000,,,0x0" complete_cpuset="0x10000000,,,0x0" online_cpuset="0x10000000,,,0x0" allowed_cpuset="0x10000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="125" cpuset="0x20000000,,,0x0" complete_cpuset="0x20000000,,,0x0" online_cpuset="0x20000000,,,0x0" allowed_cpuset="0x20000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="126" cpuset="0x40000000,,,0x0" complete_cpuset="0x40000000,,,0x0" online_cpuset="0x40000000,,,0x0" allowed_cpuset="0x40000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="127" cpuset="0x80000000,,,0x0" complete_cpuset="0x80000000,,,0x0" online_cpuset="0x80000000,,,0x0" allowed_cpuset="0x80000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000000f,,,,0x0" complete_cpuset="0x0000000f,,,,0x0" online_cpuset="0x0000000f,,,,0x0" allowed_cpuset="0x0000000f,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2092" cpuset="0x0000000f,,,,0x0" complete_cpuset="0x0000000f,,,,0x0" online_cpuset="0x0000000f,,,,0x0" allowed_cpuset="0x0000000f,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="128" cpuset="0x00000001,,,,0x0" complete_cpuset="0x00000001,,,,0x0" online_cpuset="0x00000001,,,,0x0" allowed_cpuset="0x00000001,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="129" cpuset="0x00000002,,,,0x0" complete_cpuset="0x00000002,,,,0x0" online_cpuset="0x00000002,,,,0x0" allowed_cpuset="0x00000002,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="130" cpuset="0x00000004,,,,0x0" complete_cpuset="0x00000004,,,,0x0" online_cpuset="0x00000004,,,,0x0" allowed_cpuset="0x00000004,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="131" cpuset="0x00000008,,,,0x0" complete_cpuset="0x00000008,,,,0x0" online_cpuset="0x00000008,,,,0x0" allowed_cpuset="0x00000008,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000ff0,,,,0x0" complete_cpuset="0x00000ff0,,,,0x0" online_cpuset="0x00000ff0,,,,0x0" allowed_cpuset="0x00000ff0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00000ff0,,,,0x0" complete_cpuset="0x00000ff0,,,,0x0" online_cpuset="0x00000ff0,,,,0x0" allowed_cpuset="0x00000ff0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x000000f0,,,,0x0" complete_cpuset="0x000000f0,,,,0x0" online_cpuset="0x000000f0,,,,0x0" allowed_cpuset="0x000000f0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2096" cpuset="0x000000f0,,,,0x0" complete_cpuset="0x000000f0,,,,0x0" online_cpuset="0x000000f0,,,,0x0" allowed_cpuset="0x000000f0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="132" cpuset="0x00000010,,,,0x0" complete_cpuset="0x00000010,,,,0x0" online_cpuset="0x00000010,,,,0x0" allowed_cpuset="0x00000010,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="133" cpuset="0x00000020,,,,0x0" complete_cpuset="0x00000020,,,,0x0" online_cpuset="0x00000020,,,,0x0" allowed_cpuset="0x00000020,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="134" cpuset="0x00000040,,,,0x0" complete_cpuset="0x00000040,,,,0x0" online_cpuset="0x00000040,,,,0x0" allowed_cpuset="0x00000040,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="135" cpuset="0x00000080,,,,0x0" complete_cpuset="0x00000080,,,,0x0" online_cpuset="0x00000080,,,,0x0" allowed_cpuset="0x00000080,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2100" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="136" cpuset="0x00000100,,,,0x0" complete_cpuset="0x00000100,,,,0x0" online_cpuset="0x00000100,,,,0x0" allowed_cpuset="0x00000100,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="137" cpuset="0x00000200,,,,0x0" complete_cpuset="0x00000200,,,,0x0" online_cpuset="0x00000200,,,,0x0" allowed_cpuset="0x00000200,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="138" cpuset="0x00000400,,,,0x0" complete_cpuset="0x00000400,,,,0x0" online_cpuset="0x00000400,,,,0x0" allowed_cpuset="0x00000400,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="139" cpuset="0x00000800,,,,0x0" complete_cpuset="0x00000800,,,,0x0" online_cpuset="0x00000800,,,,0x0" allowed_cpuset="0x00000800,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000ff000,,,,0x0" complete_cpuset="0x000ff000,,,,0x0" online_cpuset="0x000ff000,,,,0x0" allowed_cpuset="0x000ff000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000ff000,,,,0x0" complete_cpuset="0x000ff000,,,,0x0" online_cpuset="0x000ff000,,,,0x0" allowed_cpuset="0x000ff000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000f000,,,,0x0" complete_cpuset="0x0000f000,,,,0x0" online_cpuset="0x0000f000,,,,0x0" allowed_cpuset="0x0000f000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2104" cpuset="0x0000f000,,,,0x0" complete_cpuset="0x0000f000,,,,0x0" online_cpuset="0x0000f000,,,,0x0" allowed_cpuset="0x0000f000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="140" cpuset="0x00001000,,,,0x0" complete_cpuset="0x00001000,,,,0x0" online_cpuset="0x00001000,,,,0x0" allowed_cpuset="0x00001000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="141" cpuset="0x00002000,,,,0x0" complete_cpuset="0x00002000,,,,0x0" online_cpuset="0x00002000,,,,0x0" allowed_cpuset="0x00002000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="142" cpuset="0x00004000,,,,0x0" complete_cpuset="0x00004000,,,,0x0" online_cpuset="0x00004000,,,,0x0" allowed_cpuset="0x00004000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="143" cpuset="0x00008000,,,,0x0" complete_cpuset="0x00008000,,,,0x0" online_cpuset="0x00008000,,,,0x0" allowed_cpuset="0x00008000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000f0000,,,,0x0" complete_cpuset="0x000f0000,,,,0x0" online_cpuset="0x000f0000,,,,0x0" allowed_cpuset="0x000f0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2108" cpuset="0x000f0000,,,,0x0" complete_cpuset="0x000f0000,,,,0x0" online_cpuset="0x000f0000,,,,0x0" allowed_cpuset="0x000f0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="144" cpuset="0x00010000,,,,0x0" complete_cpuset="0x00010000,,,,0x0" online_cpuset="0x00010000,,,,0x0" allowed_cpuset="0x00010000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="145" cpuset="0x00020000,,,,0x0" complete_cpuset="0x00020000,,,,0x0" online_cpuset="0x00020000,,,,0x0" allowed_cpuset="0x00020000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="146" cpuset="0x00040000,,,,0x0" complete_cpuset="0x00040000,,,,0x0" online_cpuset="0x00040000,,,,0x0" allowed_cpuset="0x00040000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="147" cpuset="0x00080000,,,,0x0" complete_cpuset="0x00080000,,,,0x0" online_cpuset="0x00080000,,,,0x0" allowed_cpuset="0x00080000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2112" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="148" cpuset="0x00100000,,,,0x0" complete_cpuset="0x00100000,,,,0x0" online_cpuset="0x00100000,,,,0x0" allowed_cpuset="0x00100000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="149" cpuset="0x00200000,,,,0x0" complete_cpuset="0x00200000,,,,0x0" online_cpuset="0x00200000,,,,0x0" allowed_cpuset="0x00200000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="150" cpuset="0x00400000,,,,0x0" complete_cpuset="0x00400000,,,,0x0" online_cpuset="0x00400000,,,,0x0" allowed_cpuset="0x00400000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="151" cpuset="0x00800000,,,,0x0" complete_cpuset="0x00800000,,,,0x0" online_cpuset="0x00800000,,,,0x0" allowed_cpuset="0x00800000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xff000000,,,,0x0" complete_cpuset="0xff000000,,,,0x0" online_cpuset="0xff000000,,,,0x0" allowed_cpuset="0xff000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0xff000000,,,,0x0" complete_cpuset="0xff000000,,,,0x0" online_cpuset="0xff000000,,,,0x0" allowed_cpuset="0xff000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0f000000,,,,0x0" complete_cpuset="0x0f000000,,,,0x0" online_cpuset="0x0f000000,,,,0x0" allowed_cpuset="0x0f000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2120" cpuset="0x0f000000,,,,0x0" complete_cpuset="0x0f000000,,,,0x0" online_cpuset="0x0f000000,,,,0x0" allowed_cpuset="0x0f000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="152" cpuset="0x01000000,,,,0x0" complete_cpuset="0x01000000,,,,0x0" online_cpuset="0x01000000,,,,0x0" allowed_cpuset="0x01000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="153" cpuset="0x02000000,,,,0x0" complete_cpuset="0x02000000,,,,0x0" online_cpuset="0x02000000,,,,0x0" allowed_cpuset="0x02000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="154" cpuset="0x04000000,,,,0x0" complete_cpuset="0x04000000,,,,0x0" online_cpuset="0x04000000,,,,0x0" allowed_cpuset="0x04000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="155" cpuset="0x08000000,,,,0x0" complete_cpuset="0x08000000,,,,0x0" online_cpuset="0x08000000,,,,0x0" allowed_cpuset="0x08000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0xf0000000,,,,0x0" complete_cpuset="0xf0000000,,,,0x0" online_cpuset="0xf0000000,,,,0x0" allowed_cpuset="0xf0000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2124" cpuset="0xf0000000,,,,0x0" complete_cpuset="0xf0000000,,,,0x0" online_cpuset="0xf0000000,,,,0x0" allowed_cpuset="0xf0000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="156" cpuset="0x10000000,,,,0x0" complete_cpuset="0x10000000,,,,0x0" online_cpuset="0x10000000,,,,0x0" allowed_cpuset="0x10000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="157" cpuset="0x20000000,,,,0x0" complete_cpuset="0x20000000,,,,0x0" online_cpuset="0x20000000,,,,0x0" allowed_cpuset="0x20000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="158" cpuset="0x40000000,,,,0x0" complete_cpuset="0x40000000,,,,0x0" online_cpuset="0x40000000,,,,0x0" allowed_cpuset="0x40000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="159" cpuset="0x80000000,,,,0x0" complete_cpuset="0x80000000,,,,0x0" online_cpuset="0x80000000,,,,0x0" allowed_cpuset="0x80000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000ff,,,,,0x0" complete_cpuset="0x000000ff,,,,,0x0" online_cpuset="0x000000ff,,,,,0x0" allowed_cpuset="0x000000ff,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x000000ff,,,,,0x0" complete_cpuset="0x000000ff,,,,,0x0" online_cpuset="0x000000ff,,,,,0x0" allowed_cpuset="0x000000ff,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x0000000f,,,,,0x0" complete_cpuset="0x0000000f,,,,,0x0" online_cpuset="0x0000000f,,,,,0x0" allowed_cpuset="0x0000000f,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2128" cpuset="0x0000000f,,,,,0x0" complete_cpuset="0x0000000f,,,,,0x0" online_cpuset="0x0000000f,,,,,0x0" allowed_cpuset="0x0000000f,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="160" cpuset="0x00000001,,,,,0x0" complete_cpuset="0x00000001,,,,,0x0" online_cpuset="0x00000001,,,,,0x0" allowed_cpuset="0x00000001,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="161" cpuset="0x00000002,,,,,0x0" complete_cpuset="0x00000002,,,,,0x0" online_cpuset="0x00000002,,,,,0x0" allowed_cpuset="0x00000002,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="162" cpuset="0x00000004,,,,,0x0" complete_cpuset="0x00000004,,,,,0x0" online_cpuset="0x00000004,,,,,0x0" allowed_cpuset="0x00000004,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="163" cpuset="0x00000008,,,,,0x0" complete_cpuset="0x00000008,,,,,0x0" online_cpuset="0x00000008,,,,,0x0" allowed_cpuset="0x00000008,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x000000f0,,,,,0x0" complete_cpuset="0x000000f0,,,,,0x0" online_cpuset="0x000000f0,,,,,0x0" allowed_cpuset="0x000000f0,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2132" cpuset="0x000000f0,,,,,0x0" complete_cpuset="0x000000f0,,,,,0x0" online_cpuset="0x000000f0,,,,,0x0" allowed_cpuset="0x000000f0,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="164" cpuset="0x00000010,,,,,0x0" complete_cpuset="0x00000010,,,,,0x0" online_cpuset="0x00000010,,,,,0x0" allowed_cpuset="0x00000010,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="165" cpuset="0x00000020,,,,,0x0" complete_cpuset="0x00000020,,,,,0x0" online_cpuset="0x00000020,,,,,0x0" allowed_cpuset="0x00000020,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="166" cpuset="0x00000040,,,,,0x0" complete_cpuset="0x00000040,,,,,0x0" online_cpuset="0x00000040,,,,,0x0" allowed_cpuset="0x00000040,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="167" cpuset="0x00000080,,,,,0x0" complete_cpuset="0x00000080,,,,,0x0" online_cpuset="0x00000080,,,,,0x0" allowed_cpuset="0x00000080,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0000ff00,,,,,0x0" complete_cpuset="0x0000ff00,,,,,0x0" online_cpuset="0x0000ff00,,,,,0x0" allowed_cpuset="0x0000ff00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+            <object type="Cache" cpuset="0x0000ff00,,,,,0x0" complete_cpuset="0x0000ff00,,,,,0x0" online_cpuset="0x0000ff00,,,,,0x0" allowed_cpuset="0x0000ff00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="524288" depth="2" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Cache" cpuset="0x00000f00,,,,,0x0" complete_cpuset="0x00000f00,,,,,0x0" online_cpuset="0x00000f00,,,,,0x0" allowed_cpuset="0x00000f00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2136" cpuset="0x00000f00,,,,,0x0" complete_cpuset="0x00000f00,,,,,0x0" online_cpuset="0x00000f00,,,,,0x0" allowed_cpuset="0x00000f00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="168" cpuset="0x00000100,,,,,0x0" complete_cpuset="0x00000100,,,,,0x0" online_cpuset="0x00000100,,,,,0x0" allowed_cpuset="0x00000100,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="169" cpuset="0x00000200,,,,,0x0" complete_cpuset="0x00000200,,,,,0x0" online_cpuset="0x00000200,,,,,0x0" allowed_cpuset="0x00000200,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="170" cpuset="0x00000400,,,,,0x0" complete_cpuset="0x00000400,,,,,0x0" online_cpuset="0x00000400,,,,,0x0" allowed_cpuset="0x00000400,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="171" cpuset="0x00000800,,,,,0x0" complete_cpuset="0x00000800,,,,,0x0" online_cpuset="0x00000800,,,,,0x0" allowed_cpuset="0x00000800,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+              <object type="Cache" cpuset="0x0000f000,,,,,0x0" complete_cpuset="0x0000f000,,,,,0x0" online_cpuset="0x0000f000,,,,,0x0" allowed_cpuset="0x0000f000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="32768" depth="1" cache_linesize="128" cache_associativity="32" cache_type="1">
+                <object type="Core" os_index="2140" cpuset="0x0000f000,,,,,0x0" complete_cpuset="0x0000f000,,,,,0x0" online_cpuset="0x0000f000,,,,,0x0" allowed_cpuset="0x0000f000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                  <object type="PU" os_index="172" cpuset="0x00001000,,,,,0x0" complete_cpuset="0x00001000,,,,,0x0" online_cpuset="0x00001000,,,,,0x0" allowed_cpuset="0x00001000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="173" cpuset="0x00002000,,,,,0x0" complete_cpuset="0x00002000,,,,,0x0" online_cpuset="0x00002000,,,,,0x0" allowed_cpuset="0x00002000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="174" cpuset="0x00004000,,,,,0x0" complete_cpuset="0x00004000,,,,,0x0" online_cpuset="0x00004000,,,,,0x0" allowed_cpuset="0x00004000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                  <object type="PU" os_index="175" cpuset="0x00008000,,,,,0x0" complete_cpuset="0x00008000,,,,,0x0" online_cpuset="0x00008000,,,,,0x0" allowed_cpuset="0x00008000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="9" bridge_type="0-1" depth="0" bridge_pci="0033:[00-01]">
+          <object type="PCIDev" os_index="53481472" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0033:01:00.0" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Mellanox Technologies"/>
+            <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+            <object type="OSDev" name="hsi2" osdev_type="2">
+              <info name="Address" value="00:00:14:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:cc:9a:bc"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx5_2" osdev_type="3">
+              <info name="NodeGUID" value="ec0d:9a03:00cc:9abc"/>
+              <info name="SysImageGUID" value="ec0d:9a03:00cc:9aba"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x335c"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:00cc:9abc"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="53481473" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0033:01:00.1" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Mellanox Technologies"/>
+            <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+            <object type="OSDev" name="hsi3" osdev_type="2">
+              <info name="Address" value="00:00:1c:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:cc:9a:bd"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="mlx5_3" osdev_type="3">
+              <info name="NodeGUID" value="ec0d:9a03:00cc:9abd"/>
+              <info name="SysImageGUID" value="ec0d:9a03:00cc:9aba"/>
+              <info name="Port1State" value="4"/>
+              <info name="Port1LID" value="0x3332"/>
+              <info name="Port1LMC" value="0"/>
+              <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:00cc:9abd"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="11" bridge_type="0-1" depth="0" bridge_pci="0035:[00-09]">
+          <object type="PCIDev" os_index="55586816" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0035:03:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="NVIDIA Corporation"/>
+            <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+            <object type="OSDev" name="card2" osdev_type="1"/>
+            <object type="OSDev" name="renderD130" osdev_type="1"/>
+            <object type="OSDev" name="cuda2" osdev_type="5">
+              <info name="CoProcType" value="CUDA"/>
+              <info name="Backend" value="CUDA"/>
+              <info name="GPUVendor" value="NVIDIA Corporation"/>
+              <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+              <info name="CUDAGlobalMemorySize" value="16515072"/>
+              <info name="CUDAL2CacheSize" value="6144"/>
+              <info name="CUDAMultiProcessors" value="80"/>
+              <info name="CUDACoresPerMP" value="64"/>
+              <info name="CUDASharedMemorySizePerMP" value="48"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="55590912" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0035:04:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="NVIDIA Corporation"/>
+            <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+            <object type="OSDev" name="card3" osdev_type="1"/>
+            <object type="OSDev" name="renderD131" osdev_type="1"/>
+            <object type="OSDev" name="cuda3" osdev_type="5">
+              <info name="CoProcType" value="CUDA"/>
+              <info name="Backend" value="CUDA"/>
+              <info name="GPUVendor" value="NVIDIA Corporation"/>
+              <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+              <info name="CUDAGlobalMemorySize" value="16515072"/>
+              <info name="CUDAL2CacheSize" value="6144"/>
+              <info name="CUDAMultiProcessors" value="80"/>
+              <info name="CUDACoresPerMP" value="64"/>
+              <info name="CUDASharedMemorySizePerMP" value="48"/>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="NUMANode" os_index="252" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x10000000,,,,,,,0x0" complete_nodeset="0x10000000,,,,,,,0x0" allowed_nodeset="0x10000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="253" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x20000000,,,,,,,0x0" complete_nodeset="0x20000000,,,,,,,0x0" allowed_nodeset="0x20000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="254" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x40000000,,,,,,,0x0" complete_nodeset="0x40000000,,,,,,,0x0" allowed_nodeset="0x40000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+    <object type="NUMANode" os_index="255" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x80000000,,,,,,,0x0" complete_nodeset="0x80000000,,,,,,,0x0" allowed_nodeset="0x80000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+    </object>
+  </object>
+</topology>


### PR DESCRIPTION
This PR requires a flux-core PR, which I will post soon.

- Modify resrc to recognize and use CoProc devices  as gpu resource type. Include CUDA GPU as well as AMD GPU (at least in theory since I couldn't test this on AMD).

- Add a test using hwloc xml data generated from Sierra using a hwloc library configured with CUDA

- Minor cleanups