### PR TITLE
resource-query as resource matching comms module

### DIFF
--- a/resource/generators/gen.cpp
+++ b/resource/generators/gen.cpp
@@ -431,7 +431,7 @@ const std::string &resource_generator_t::err_message () const
 /*
  * Read a subsystem spec graphml file and generate resource database
  *
- * \param sfile  generator spec file in graphml
+ * \param sn     generator spec file in graphml
  * \param db     graph database consisting of resource graph and various indices
  * \return       0 on success; non-zero integer on an error
  */

--- a/resource/jobinfo/jobinfo.hpp
+++ b/resource/jobinfo/jobinfo.hpp
@@ -1,0 +1,77 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef JOBINFO_HPP
+#define JOBINFO_HPP
+
+#include <string>
+
+namespace Flux {
+namespace resource_model {
+
+enum class job_state_t { INIT, ALLOCATED, RESERVED, CANCELLED, ERROR };
+
+struct job_info_t {
+    job_info_t (uint64_t j, job_state_t s, int64_t at, std::string fn, double o)
+        : jobid (j), state (s), scheduled_at (at), jobspec_fn (fn),
+          jobspec_str (jstr), overhead (o) { }
+    uint64_t jobid = UINT64_MAX;
+    job_state_t state = job_state_t::INIT;
+    int64_t scheduled_at = -1;
+    std::string jobspec_fn;
+    std::string jobspec_str;
+    double overhead = 0.0f;
+};
+
+void get_jobstate_str (job_state_t state, string &mode)
+{
+    switch (state) {
+    case job_state_t::ALLOCATED:
+        mode = "ALLOCATED";
+        break;
+    case job_state_t::RESERVED:
+        mode = "RESERVED";
+        break;
+    case job_state_t::CANCELLED:
+        mode = "CANCELLED";
+        break;
+    case job_state_t::ERROR:
+        mode = "ERROR";
+        break;
+    case job_state_t::INIT:
+    default:
+        mode = "INIT";
+        break;
+    }
+    return;
+}
+
+} // namespace resource_model
+} // namespace Flux
+
+#endif // JOBINFO_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/modules/rquery.cpp
+++ b/resource/modules/rquery.cpp
@@ -1,0 +1,573 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <algorithm>
+#include <iterator>
+#include <cstdint>
+#include <cerrno>
+#include <vector>
+#include <map>
+#include <boost/algorithm/string.hpp>
+#include "resource/schema/resource_graph.hpp"
+#include "resource/generators/gen.hpp"
+#include "resource/traversers/dfu.hpp"
+#include "resource/jobinfo/jobinfo.hpp"
+#include "resource/policies/dfu_match_policy_factory.hpp"
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+}
+
+using namespace std;
+using namespace Flux::resource_model;
+
+/******************************************************************************
+ *                                                                            *
+ *                Resource Matching Service Module Context                    *
+ *                                                                            *
+ ******************************************************************************/
+
+struct rmatch_args_t {
+    string grug;
+    string match_subsystems;
+    string match_policy;
+    string prune_filters;
+    string R_format;
+};
+
+struct rmatch_ctx_t {
+    rmatch_args_t args;          /* Module load options */
+    dfu_match_cb_t *matcher;     /* Match callback object */
+    dfu_traverser_t *traverser;  /* Graph traverser object */
+    resource_graph_db_t db;      /* Resource graph data store */
+    f_resource_graph_t *fgraph;  /* Graph filtered by subsystems to use */
+    map<uint64_t, job_info_t *> jobs;     /* Jobs table */
+    map<uint64_t, uint64_t> allocations;  /* Allocation table */
+    map<uint64_t, uint64_t> reservations; /* Reservation table */
+};
+
+
+/******************************************************************************
+ *                                                                            *
+ *                          Request Handler Prototypes                        *
+ *                                                                            *
+ ******************************************************************************/
+
+static void match_request_cb (flux_t *h, flux_msg_handler_t *w,
+                              const flux_msg_t *msg, void *arg);
+
+
+/******************************************************************************
+ *                                                                            *
+ *                   Module Initialization Routines                           *
+ *                                                                            *
+ ******************************************************************************/
+
+static void freectx (void *arg)
+{
+    if (ctx) {
+        delete ctx->matcher;
+        delete ctx->traverser;
+        delete ctx->fgraph;
+        for (auto &kv : ctx->jobs) {
+            delete kv.second;    /* job_info_t* type */
+            ctx->jobs.erase (kv.first);
+        }
+        ctx->jobs.clear ();
+        ctx->allocations.clear ();
+        ctx->reservations.clear ();
+        delete ctx;
+    }
+}
+
+static void set_default_args (rmatch_args_t &args)
+{
+    args.grug = "none";
+    args.match_subsystems = "CA";
+    args.match_policy = "high";
+    args.prune_filters = "core";
+    args.R_format = "R_lite";
+}
+
+static rmatch_ctx_t *getctx (flux_t *h)
+{
+    rmatch_ctx_t *ctx = (rmatch_ctx_t *)flux_aux_get (h, "resource-query");
+    if (!ctx) {
+        ctx = new rmatch_ctx_t (sizeof (*ctx));
+        set_default_args (ctx->args);
+        ctx->matcher = create_match_cb (ctx->args.match_policy);
+        ctx->traverser = new dfu_traverser_t ();
+        ctx->fgraph = NULL; /* Cannot be allocated at this point */
+    }
+    return ctx;
+}
+
+static int process_args (int argc, char **argv, const rmatch_args_t &args)
+{
+    int rc = 0;
+    string dflt = "";
+
+    for (int i = 0; i < argc; i++) {
+        if (!strncmp ("grug-conf=", argv[i], sizeof ("grug-conf"))) {
+            opts.grug = strstr (argv[i], "=") + 1;
+        } else if (!strncmp ("subsystems=", argv[i], sizeof ("subsystems"))) {
+            dflt = opts.match_subsystems;
+            opts.match_subsystems = strstr (argv[i], "=") + 1;
+        } else if (!strncmp ("policy=", argv[i], sizeof ("policy"))) {
+            dflt = opts.match_policy;
+            opts.match_policy = strstr (argv[i], "=") + 1;
+            if (!known_match_policy (opts.match_policy)) {
+                flux_log (h, LOG_ERR,
+                          "Unknown match policy (%s)! Use default (%s).",
+                           opts.match_policy, dflt);
+                opts.match_policy = dflt;
+            }
+        } else if (!strncmp ("filters=", argv[i], sizeof ("fileters"))) {
+            dflt = opts.prune_filters;
+            opts.prune_filters = strstr (argv[i], "=") + 1;
+        } else if (!strncmp ("R-format=", argv[i], sizeof ("R-format"))) {
+            dflt = opts.R_format;
+            opts.R_format = strstr (argv[i], "=") + 1;
+            if (!known_R_format (opts.R_format)) {
+                flux_log (h, LOG_ERR,
+                          "Unknown R format (%s)! Use default (%s).",
+                           opts.R_format, dflt);
+                opts.R_format = dflt;
+            }
+        } else {
+            rc = -1;
+            errno = EINVAL;
+            goto done;
+        }
+    }
+
+done:
+    return rc;
+}
+
+static rmatch_ctx_t *init_module (flux_t *h, int argc, char **argv)
+{
+    rmatch_ctx_t *ctx = NULL;
+    uint32_t rank = 1;
+
+    if (!(ctx = getctx (h))) {
+        flux_log (h, LOG_ERR, "can't allocate the context");
+        goto done;
+    }
+    if (flux_get_rank (h, &rank)) {
+        flux_log (h, LOG_ERR, "can't determine rank");
+        goto done;
+    }
+    if (rank) {
+        flux_log (h, LOG_ERR, "resource-query module must only run on rank 0");
+        goto done;
+    }
+    if (process_args (argc, argv, &(ctx->args)) != 0) {
+        flux_log (h, LOG_ERR, "can't process module args");
+        goto done;
+    }
+
+done:
+    return ctx;
+}
+
+
+/******************************************************************************
+ *                                                                            *
+ *              Resource Graph and Traverser Initialization                   *
+ *                                                                            *
+ ******************************************************************************/
+
+static int populate_resource_db (rmatch_ctx_t &ctx)
+{
+    int rc = 0;
+    resource_generator_t rgen;
+    if (ctx->args.grug != "none") {
+        if ((rc = rgen.read_graphml (ctx->args.grug, ctx->db)) != 0) {
+            errno = EINVAL;
+            rc = -1;
+            flux_log (h, LOG_ERR, "error in generating resources");
+            goto done;
+        }
+    } else {
+        errno = ENOTSUP;
+        rc = -1;
+        flux_log (h, LOG_ERR, "hwloc reader not implemented");
+        goto done;
+    }
+
+done:
+    return rc;
+}
+
+static int select_subsystems (rmatch_ctx_t *ctx)
+{
+    /*
+     * Format of match_subsystems
+     * subsystem1[:relation1[:relation2...]],subsystem2[...
+     */
+    int rc = 0;
+    stringstream ss (ctx->args.match_subsystems);
+    subsystem_t subsystem;
+    string token;
+
+    while (getline (ss, token, ',')) {
+
+        size_t found = token.find_first_of (":");
+
+        if (found != std::string::npos) {
+            subsystem = token;
+            if (!ctx->resource_graph_db.known_subsystem (subsystem)) {
+                rc = -1;
+                errno = EINVAL;
+                goto done;
+            }
+            ctx->matcher->add_subsystem (subsystem, "*");
+        } else {
+            subsystem = token.substr (0, found);
+            if (!ctx->resource_graph_db.known_subsystem (subsystem)) {
+                rc = -1;
+                errno = EINVAL;
+                goto done;
+            }
+            stringstream relations (token.substr (found+1, std::string::npos));
+            string relation;
+            while (getline (relations, relation, ':'))
+                ctx->matcher->add_subsystem (subsystem, relation);
+        }
+    }
+
+done:
+    return rc;
+}
+
+static int init_resource_graph (rmatch_ctx_t *ctx)
+{
+    int rc = 0;
+    if ((rc = populate_resource_db (ctx)) != 0) {
+        flux_log (h, LOG_ERR, "can't populate graph resource database");
+        goto done;
+    }
+    if ((rc = select_subsystems (ctx)) != 0) {
+        flux_log (h, LOG_ERR, "error processing subsystems %s",
+                  ctx->args.match_subsystems);
+        goto done;
+    }
+
+    resource_graph_t &g = ctx->db.resource_graph;
+
+    // Set vertex and edge maps
+    vtx_infra_map_t vmap = get (&resource_pool_t::idata, g);
+    edg_infra_map_t emap = get (&resource_relation_t::idata, g);
+
+    // Set vertex and edge filters based on subsystems to use
+    const multi_subsystemsS &filter = ctx->matcher->subsystemsS ();
+    subsystem_selector_t<vtx_t, f_vtx_infra_map_t> vtxsel (vmap, filter);
+    subsystem_selector_t<edg_t, f_edg_infra_map_t> edgsel (emap, filter);
+
+    // Create a filtered graph based on the filters
+    ctx->fgraph = new f_resource_graph_t (g, edgsel, vtxsel);
+
+    // Set pruning filter type for scheduler driven aggregate update
+    const string &dom = ctx->matcher->dom_subsystem ();
+    // TODO: Hook this with ctx->args.prune_filters
+    ctx->matcher->set_pruning_type (dom, ANY_RESOURCE_TYPE, "core");
+
+    // Initialize the DFU traverser
+    ctx->traverser->initialize (ctx->fgraph, &(ctx->db.roots), ctx->matcher);
+
+done:
+    return rc;
+}
+
+
+/******************************************************************************
+ *                                                                            *
+ *                        Request Handler Routines                            *
+ *                                                                            *
+ ******************************************************************************/
+
+static double get_elapse_time (timeval &st, timeval &et)
+{
+    double ts1 = (double)st.tv_sec + (double)st.tv_usec/1000000.0f;
+    double ts2 = (double)et.tv_sec + (double)et.tv_usec/1000000.0f;
+    return ts2 - ts1;
+}
+
+static int track_schedule_info (rmatch_ctx_t *ctx, int64_t id, int64_t at,
+                                stringstream &R, double elapse)
+{
+    job_state_t st = job_state_t::INIT;
+
+    if (id < 0 || at < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    st = (at == 0)? job_state_t::ALLOCATED : job_state_t::RESERVED;
+    ctx->jobs[id] = new job_info_t (id, st, at, "", jobspect_str, elapse);
+    if (at == 0)
+        ctx->allocations[id] = id;
+    else
+        ctx->reservations[id] = id;
+
+    return 0;
+}
+
+static int run_match (rmatch_ctx_t *ctx, int64_t jobid, const char *cmd,
+                      string jobspec_str, int64_t *at, stringstream &R)
+{
+    int rc = 0;
+    double elapse = 0.0f;
+    struct timeval start, end;
+
+    gettimeofday (&start, NULL);
+
+    if (strcmp ("allocate", cmd) == 0) {
+        Flux::Jobspec::Jobspec spec {jobspec_str};
+        if ((rc = ctx->traverser->run (job,
+                                       match_op_t::MATCH_ALLOCATE,
+                                       jobid,
+                                       at,
+                                       R)) != 0) {
+            flux_log (h, LOG_INFO,
+                      "allocate could not find matching resources for %lld",
+                      (intmax_t)jobid);
+            goto done;
+        }
+    } else if (strcmp ("allocate_orelse_reserve", cmd) == 0) {
+        Flux::Jobspec::Jobspec spec {jobspec_str};
+        if ((rc = ctx->traverser.run (job,
+                                      match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE,
+                                      jobid,
+                                      at,
+                                      R)) != 0) {
+            flux_log (h, LOG_INFO,
+                      "allocate_orelse_reserve could not find matching "
+                      "resources for jobid (%lld)", (intmax_t)jobid);
+            goto done;
+        }
+    } else {
+        rc = -1;
+        errno = EINVAL;
+        goto done;
+    }
+
+    gettimeofday (&end, NULL);
+    elapse = get_elapse_time (start, end);
+
+    if ((rc = track_schedule_info (ctx, jobid, at, R, elapse)) != 0) {
+        flux_log (h, LOG_ERR, "failed to track the schedule for %lld",
+                  (intmax_t)jobid);
+        goto done;
+    }
+
+done:
+    return rc;
+}
+
+static int run_remove (rmatch_ctx_t *ctx, int64_t jobid)
+{
+    int rc = 0;
+    if ((rc = ctx->traverser.remove (jobid)) == 0) {
+        if (ctx->jobs.find (jobid) != ctx->jobs.end ()) {
+           job_info_t *info = ctx->jobs[jobid];
+           info->state = job_state_t::CANCELLED;
+        }
+    } else {
+        if (ctx->jobs.find (jobid) != ctx->jobs.end ()) {
+           job_info_t *info = ctx->jobs[jobid];
+           info->state = job_state_t::ERROR;
+           flux_log (h, LOG_INFO, "could not remove jobid (%lld).",
+                    (intmax_t)jobid);
+        }
+    }
+    return rc;
+}
+
+static void match_request_cb (flux_t *h, flux_msg_handler_t *w,
+                              const flux_msg_t *msg, void *arg)
+{
+    int64_t at = 0;
+    uint32_t userid = 0;
+    int64_t jobid = -1;
+    const char *cmd = NULL;
+    const char *js_str = NULL;
+    stringstream R;
+    rmatch_ctx_t *ctx = getctx ((flux_t *)arg);
+
+    if (flux_msg_get_userid (msg, &userid) < 0)
+        goto error;
+
+    flux_log (h, LOG_INFO, "match requested by user (%u).", userid);
+
+    if (flux_request_unpack (msg, NULL, "{s:s}", "cmd", &cmd) < 0)
+        goto error;
+    if (flux_request_unpack (msg, NULL, "{s:I}", "jobid", &jobid) < 0)
+        goto error;
+    if (flux_request_unpack (msg, NULL, "{s:s}", "jobspec", &js_str) < 0)
+        goto error;
+    if (run_match (ctx, jobid, cmd, js_str, &at, R) < 0) {
+        flux_log (h, LOG_INFO, "could not resolve match %s for jobid (%lld).",
+                  cmd, (intmax_t)jobid);
+        goto error;
+    }
+    if (flux_repond_pack (h, msg, "{s:s}", "R", R.str ().c_str ()) < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+
+    flux_log (h, LOG_INFO, "match request succeeded.");
+    return;
+
+error:
+    if (flux_respond (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+}
+
+static void cancel_request_cb (flux_t *h, flux_msg_handler_t *w,
+                               const flux_msg_t *msg, void *arg)
+{
+    rmatch_ctx_t *ctx = getctx ((flux_t *)arg);
+    uint32_t userid = 0;
+    int64_t jobid = -1;
+
+    if (flux_msg_get_userid (msg, &userid) < 0)
+        goto error;
+
+    flux_log (h, LOG_INFO, "cancel requested by user (%u).", userid);
+
+    if (flux_request_unpack (msg, NULL, "{s:I}", "jobid", &jobid) < 0)
+        goto error;
+
+    if (ctx->allocations.find (jobid) != ctx->allocations.end ()) {
+        run_remove (ctx, jobid);
+        ctx->allocations.erase (jobid);
+    } else if (ctx->reservations.find (jobid) != ctx->reservations.end ()) {
+        run_remove (ctx, jobid);
+        ctx->reservations.erase (jobid);
+    } else {
+        errno = ENOENT;
+        flux_log (h, LOG_ERR, "cannot find jobid (%lld)", (intmax_t)jobid);
+        goto error;
+    }
+    if (flux_repond_pack (h, msg, "{}") < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+
+    flux_log (h, LOG_INFO, "cancel request succeeded.");
+    return;
+
+error:
+    if (flux_respond (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+}
+
+static void info_request_cb (flux_t *h, flux_msg_handler_t *w,
+                             const flux_msg_t *msg, void *arg)
+{
+    rmatch_ctx_t *ctx = getctx ((flux_t *)arg);
+    uint32_t userid = 0;
+    int64_t jobid == -1;
+
+    if (flux_msg_get_userid (msg, &userid) < 0)
+        goto error;
+
+    flux_log (h, LOG_INFO, "info requested by user (%u).", userid);
+
+    if (flux_request_unpack (msg, NULL, "{s:I}", "jobid", &jobid) < 0)
+        goto error;
+    if (ctx->jobs.find (jobid) == ctx->jobs.end ()) {
+        errno = ENOENT;
+        flux_log (h, LOG_ERR, "cannot find jobid (%lld)", (intmax_t)jobid);
+        goto error;
+    }
+
+    string mode;
+    job_info_t *info = ctx->jobs[jobid];
+    get_jobstate_str (info->state, mode);
+    if (flux_repond_pack (h, msg, "{s:I s:s s:I s:f}",
+                          "jobid", jobid, "mode", mode.c_str (),
+                          "scheduled_at", info->scheduled_at,
+                          "schedule_overhead", info->overhead) < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+
+    flux_log (h, LOG_INFO, "info request succeeded.");
+    return;
+
+error:
+    if (flux_respond (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+}
+
+
+/******************************************************************************
+ *                                                                            *
+ *                               Module Main                                  *
+ *                                                                            *
+ ******************************************************************************/
+
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST, "resource-query.match",  match_request_cb, 0},
+    { FLUX_MSGTYPE_REQUEST, "resource-query.cancel", cancel_request_cb, 0},
+    { FLUX_MSGTYPE_REQUEST, "resource-query.info",   info_request_cb, 0},
+    FLUX_MSGHANDLER_TABLE_END
+};
+
+extern "C" int mod_main (flux_t *h, int argc, char **argv)
+{
+    int rc = -1;
+    rmatch_ctx_t *ctx = NULL;
+    uint32_t rank = 1;
+
+    if (!(ctx = init_module (h, argc, argv))) {
+        flux_log (h, LOG_ERR, "can't initialize resource-query module");
+        goto done;
+    }
+    flux_log (h, LOG_INFO, "resource-query module starting...")
+
+    if ((rc = init_resource_graph (ctx)) != 0) {
+        flux_log (h, LOG_ERR, "can't initialize resource graph database");
+        goto done;
+    }
+    flux_log (h, LOG_INFO, "resource graph database loaded");
+
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
+        flux_log (h, LOG_ERR, "flux_reactor_run: %s", strerror (errno));
+        goto done;
+    }
+
+done:
+    free (ctx);
+    return rc;
+}
+
+MOD_NAME ("resource-query")
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/policies/dfu_match_policy_factory.cpp
+++ b/resource/policies/dfu_match_policy_factory.cpp
@@ -1,0 +1,60 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef DFU_MATCH_POLICY_FACTORY_HPP
+#define DFU_MATCH_POLICY_FACTORY_HPP
+
+#include "resource/policies/dfu_match_policy_factory.hpp"
+
+namespace Flux {
+namespace resource_model {
+
+bool known_match_policy (const string &policy)
+{
+    bool rc = true;
+    if (policy != HIGH_ID_FIRST && policy != LOW_ID_FIRST && policy != LOCALITY)
+        rc = false;
+    return rc;
+}
+
+dfu_match_cb_t *create_match_cb (const string &policy)
+{
+    dfu_match_cb_t *matcher = NULL;
+    if (policy == HIGH_ID_FIRST)
+        matcher = (dfu_match_cb_t *)new high_first_t ();
+    else if (policy == LOW_ID_FIRST)
+        matcher = (dfu_match_cb_t *)new low_first_t ();
+    else if (policy == LOCALITY)
+        matcher = (dfu_match_cb_t *)new greater_interval_first_t ();
+    return matcher;
+}
+
+} // resource_model
+} // Flux
+
+#endif // DFU_MATCH_POLICY_FACTORY_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/policies/dfu_match_policy_factory.hpp
+++ b/resource/policies/dfu_match_policy_factory.hpp
@@ -1,0 +1,50 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef DFU_MATCH_POLICY_FACTORY_HPP
+#define DFU_MATCH_POLICY_FACTORY_HPP
+
+#include "resource/policies/base/dfu_match_cb.hpp"
+#include "resource/policies/dfu_match_high_id_first.hpp"
+#include "resource/policies/dfu_match_low_id_first.hpp"
+#include "resource/policies/dfu_match_locality.hpp"
+
+namespace Flux {
+namespace resource_model {
+
+static const string HIGH_ID_FIRST = "high";
+static const string LOW_ID_FIRST = "low";
+static const string LOCALITY_AWARE = "locality";
+
+bool known_match_policy (const string &policy);
+
+/*! Factory method for creating a matching callback
+ *  object, representing a matching policy.
+ */
+dfu_match_cb_t *create_match_cb (const string &policy);
+
+} // resource_model
+} // Flux
+
+#endif // DFU_MATCH_POLICY_FACTORY_HPP

--- a/resource/schema/resource_graph.hpp
+++ b/resource/schema/resource_graph.hpp
@@ -118,6 +118,11 @@ struct resource_graph_db_t {
     std::map<std::string, std::vector <vtx_t>> by_type;
     std::map<std::string, std::vector <vtx_t>> by_name;
     std::map<std::string, std::vector <vtx_t>> by_path;
+
+    bool known_subsystem (const std::string &s)
+    {
+        return (roots.find (s) == roots.end ())? true : false;
+    }
 };
 
 template<class name_map, class graph_entity>

--- a/resource/traversers/dfu.cpp
+++ b/resource/traversers/dfu.cpp
@@ -80,6 +80,14 @@ int dfu_traverser_t::schedule (Jobspec::Jobspec &jobspec,
  *                                                                          *
  ****************************************************************************/
 
+bool known_R_format (const string &f)
+{
+    bool rc = true;
+    if (f != R_FORMAT || f != R_LITE || f != R_NATIVE)
+        rc = false;
+    return rc;
+}
+
 dfu_traverser_t::dfu_traverser_t ()
 {
 

--- a/resource/traversers/dfu.hpp
+++ b/resource/traversers/dfu.hpp
@@ -32,6 +32,12 @@
 namespace Flux {
 namespace resource_model {
 
+enum class R_format { R, R_LITE, R_NATIVE }
+
+const char *R_FORMAT = "R";
+const char *R_LITE_FORMAT = "R_LITE";
+const char *R_NATIVE_FORMAT = "R_NATIVE";
+
 /*! Depth-First-and-Up traverser. Perform depth-first visit on the dominant
  *  subsystem and upwalk on each and all of the auxiliary subsystems selected
  *  by the matcher callback object (dfu_match_cb_t). Corresponding match
@@ -128,6 +134,8 @@ private:
                   vtx_t root, unsigned int *needs,
                   std::unordered_map<std::string, int64_t> &dfv);
 };
+
+bool known_R_format (const string &f);
 
 } // namespace resource_model
 } // namespace Flux

--- a/resource/utilities/command.cpp
+++ b/resource/utilities/command.cpp
@@ -64,26 +64,6 @@ static double get_elapse_time (timeval &st, timeval &et)
     return ts2 - ts1;
 }
 
-static void get_jobstate_str (job_state_t state, string &mode)
-{
-    switch (state) {
-    case job_state_t::ALLOCATED:
-        mode = "ALLOCATED";
-        break;
-    case job_state_t::RESERVED:
-        mode = "RESERVED";
-        break;
-    case job_state_t::CANCELLED:
-        mode = "CANCELLED";
-        break;
-    case job_state_t::INIT:
-    default:
-        mode = "INIT";
-        break;
-    }
-    return;
-}
-
 static int do_remove (resource_context_t *ctx, int64_t jobid)
 {
     int rc = -1;
@@ -117,7 +97,8 @@ static void print_schedule_info (resource_context_t *ctx, ostream &out,
 
         out << "INFO:" << " =============================" << endl;
         st = (at == 0)? job_state_t::ALLOCATED : job_state_t::RESERVED;
-        ctx->jobs[jobid] = new job_info_t (jobid, st, at, jobspec_fn, elapse);
+        ctx->jobs[jobid] = new job_info_t (jobid, st,
+                                           at, jobspec_fn, "", elapse);
         if (at == 0)
             ctx->allocations[jobid] = jobid;
         else

--- a/resource/utilities/command.hpp
+++ b/resource/utilities/command.hpp
@@ -28,25 +28,13 @@
 #include "resource/schema/resource_graph.hpp"
 #include "resource/generators/gen.hpp"
 #include "resource/traversers/dfu.hpp"
+#include "resource/jobinfo/jobinfo.hpp"
 #include <cerrno>
 #include <vector>
 #include <map>
 
 namespace Flux {
 namespace resource_model {
-
-enum class job_state_t { INIT, ALLOCATED, RESERVED, CANCELLED };
-
-struct job_info_t {
-    job_info_t (uint64_t j, job_state_t s, int64_t at, std::string fn, double o)
-        : jobid (j), state (s), scheduled_at (at), jobspec_fn (fn),
-          overhead (o) { }
-    uint64_t jobid = UINT64_MAX;
-    job_state_t state = job_state_t::INIT;
-    int64_t scheduled_at = -1;
-    std::string jobspec_fn;
-    double overhead = 0.0f;
-};
 
 struct test_params_t {
     std::string grug;           /* GRUG file name */


### PR DESCRIPTION
@SteVwonder and @tpatki: this is just for your two just to show you where I'm headed -- since you are also working on this layer. I don't even have Makefiles for these changes.

`rquery.cpp` is the main file to implement the resource matching service. 

It populates the resource graph database and then handles `match` operations in the request handlers. For now, the `match` request handler will get the serialized jobspec encoded in the message. But in a near future, it will probably get the jobspec from KVS according to the job schema. 

Since we don't have the corresponding scheduling control loop comms module, this handler just returns the `R` in its own native format with the response. Once we have the control loop service around it, and determine what `R` should be and our KVS job schema should be, the `R` format and where it is sent/dumped will change. Changing formats shouldn't be difficult going forward as I plan to make "emitter" as programmable as possible.

Other than this, initially, I probably only want to support a minimal set of other requests -- for now I have `cancel` and `info` requests.

@SteVwonder: I believe your `hwloc` work (Issue #355) should be directly transferrable to this service pattern. 

@tpatki: I believe your locality aware scheduling policy enhancement should also be orthogonal.

If not, let me know.

Any early feedback welcome.

Since this PR won't even compile, feedback related architecture choices and relevance to your other work will be most useful at this point. I know there are lots of typos...