### PR TITLE
Add support for resource matching service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,7 @@ after_success:
  - ccache -s
  - if test "$COVERAGE" = "t"; then coveralls-lcov flux*-coverage.info;  bash <(curl -s https://codecov.io/bash); fi
 after_failure:
+ - find . -name test-suite.log | xargs -i sh -c 'printf "===XXX {} XXX===";cat {}'
  - find . -name t[0-9]*.output -print0 | xargs -0 -I'{}' sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'
  - find . -name *.broker.log -print0 | xargs -0 -I'{}' sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'
  - src/test/backtrace-all.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ addons:
 before_install:
   - rm -rf $HOME/.luarocks
   - wget https://raw.githubusercontent.com/flux-framework/flux-core/master/src/test/travis-dep-builder.sh
-  - eval $(bash ./travis-dep-builder.sh --printenv)
+  - $(bash ./travis-dep-builder.sh --printenv)
   - export PKG_CONFIG_PATH=$HOME/local2/lib/pkgconfig:${PKG_CONFIG_PATH}
   - test "$TRAVIS_PULL_REQUEST" == "false" || export CCACHE_READONLY=1
   - if test "$CC" = "clang"; then export CCACHE_CPP2=1; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ addons:
       - cmake
       - cmake-data
       - clang-3.8
-      - gcc-4.9
-      - g++-4.9
+      - gcc-8
+      - g++-8
       - uuid-dev
       - aspell
       - libopenmpi-dev

--- a/configure.ac
+++ b/configure.ac
@@ -147,6 +147,7 @@ AC_CONFIG_FILES([Makefile
   resource/Makefile
   resource/planner/Makefile
   resource/planner/test/Makefile
+  resource/modules/Makefile
   sched/Makefile
   sched/priority/Makefile
   sched/priority/modified_fair_tree/Makefile

--- a/resource/Makefile.am
+++ b/resource/Makefile.am
@@ -43,6 +43,7 @@ utilities_resource_query_SOURCES = \
     policies/dfu_match_high_id_first.cpp \
     policies/dfu_match_low_id_first.cpp \
     policies/dfu_match_locality.cpp \
+    jobinfo/jobinfo.cpp \
     schema/resource_data.cpp \
     schema/infra_data.cpp \
     schema/sched_data.cpp \
@@ -59,6 +60,7 @@ utilities_resource_query_SOURCES = \
     policies/dfu_match_high_id_first.hpp \
     policies/dfu_match_low_id_first.hpp \
     policies/dfu_match_locality.hpp \
+    jobinfo/jobinfo.hpp \
     schema/resource_graph.hpp \
     schema/data_std.hpp \
     schema/infra_data.hpp \

--- a/resource/Makefile.am
+++ b/resource/Makefile.am
@@ -12,37 +12,20 @@ AM_LDFLAGS = $(CODE_COVERAGE_LDFLAGS) \
 AM_CPPFLAGS = -I$(top_srcdir) $(CZMQ_CFLAGS) $(FLUX_CORE_CFLAGS) \
 	      $(BOOST_CPPFLAGS)
 
-SUBDIRS = planner .
+SUBDIRS = planner . modules
+
+noinst_LTLIBRARIES = libresource.la
 
 noinst_PROGRAMS = utilities/grug2dot utilities/resource-query
 
 EXTRA_DIST= \
     utilities/conf
 
-#
-# grug2dot
-#
-utilities_grug2dot_SOURCES = \
-    utilities/grug2dot.cpp \
-    generators/spec.cpp \
-    generators/spec.hpp
-utilities_grug2dot_CXXFLAGS = \
-    $(AM_CXXFLAGS)
-utilities_grug2dot_LDADD = \
-    $(BOOST_SYSTEM_LIB) \
-    $(BOOST_FILESYSTEM_LIB) \
-    $(BOOST_GRAPH_LIB) \
-    $(BOOST_REGEX_LIB)
-
-#.
-# resource-query
-#
-utilities_resource_query_SOURCES = \
-    utilities/resource-query.cpp \
-    utilities/command.cpp \
+libresource_la_SOURCES = \
     policies/dfu_match_high_id_first.cpp \
     policies/dfu_match_low_id_first.cpp \
     policies/dfu_match_locality.cpp \
+    policies/dfu_match_policy_factory.cpp \
     jobinfo/jobinfo.cpp \
     schema/resource_data.cpp \
     schema/infra_data.cpp \
@@ -60,6 +43,7 @@ utilities_resource_query_SOURCES = \
     policies/dfu_match_high_id_first.hpp \
     policies/dfu_match_low_id_first.hpp \
     policies/dfu_match_locality.hpp \
+    policies/dfu_match_policy_factory.hpp \
     jobinfo/jobinfo.hpp \
     schema/resource_graph.hpp \
     schema/data_std.hpp \
@@ -78,15 +62,46 @@ utilities_resource_query_SOURCES = \
     evaluators/fold.hpp \
     config/system_defaults.hpp \
     planner/planner.h
-utilities_resource_query_CXXFLAGS = \
+
+libresource_la_CXXFLAGS = \
+    $(WARNING_CXXFLAGS) \
+    $(CODE_COVERAGE_CFLAGS) \
     $(AM_CXXFLAGS) \
     $(JOBSPEC_CFLAGS)
-utilities_resource_query_LDADD = \
+
+libresource_la_LIBADD = \
     $(top_builddir)/resource/planner/libplanner.la \
     $(JOBSPEC_LIBS) \
-    $(READLINE_LIBS) \
     $(BOOST_SYSTEM_LIB) \
     $(BOOST_FILESYSTEM_LIB) \
     $(BOOST_GRAPH_LIB) \
     $(BOOST_REGEX_LIB)
+
+#
+# grug2dot
+#
+utilities_grug2dot_SOURCES = \
+    utilities/grug2dot.cpp \
+    generators/spec.cpp \
+    generators/spec.hpp
+utilities_grug2dot_CXXFLAGS = \
+    $(AM_CXXFLAGS)
+utilities_grug2dot_LDADD = \
+    $(BOOST_SYSTEM_LIB) \
+    $(BOOST_FILESYSTEM_LIB) \
+    $(BOOST_GRAPH_LIB) \
+    $(BOOST_REGEX_LIB)
+
+#
+# resource-query
+#
+utilities_resource_query_SOURCES = \
+    utilities/resource-query.cpp \
+    utilities/command.cpp
+utilities_resource_query_CXXFLAGS = \
+    $(AM_CXXFLAGS) \
+    $(JOBSPEC_CFLAGS) \
+    $(READLINE_LIBS)
+utilities_resource_query_LDADD = \
+    libresource.la
 

--- a/resource/evaluators/edge_eval_api.cpp
+++ b/resource/evaluators/edge_eval_api.cpp
@@ -22,7 +22,7 @@
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 
-#include "evaluators/edge_eval_api.hpp"
+#include "resource/evaluators/edge_eval_api.hpp"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/evaluators/edge_eval_api.hpp
+++ b/resource/evaluators/edge_eval_api.hpp
@@ -27,7 +27,7 @@
 
 #include <vector>
 #include <string>
-#include "schema/resource_graph.hpp"
+#include "resource/schema/resource_graph.hpp"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/evaluators/fold.hpp
+++ b/resource/evaluators/fold.hpp
@@ -27,7 +27,7 @@
 
 #include <boost/icl/interval.hpp>
 #include <boost/icl/interval_set.hpp>
-#include "evaluators/edge_eval_api.hpp"
+#include "resource/evaluators/edge_eval_api.hpp"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/evaluators/scoring_api.cpp
+++ b/resource/evaluators/scoring_api.cpp
@@ -22,7 +22,7 @@
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 
-#include "evaluators/scoring_api.hpp"
+#include "resource/evaluators/scoring_api.hpp"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/evaluators/scoring_api.hpp
+++ b/resource/evaluators/scoring_api.hpp
@@ -32,9 +32,9 @@
 #include <numeric>
 #include <functional>
 #include <algorithm>
-#include "schema/resource_graph.hpp"
-#include "evaluators/edge_eval_api.hpp"
-#include "evaluators/fold.hpp"
+#include "resource/schema/resource_graph.hpp"
+#include "resource/evaluators/edge_eval_api.hpp"
+#include "resource/evaluators/fold.hpp"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/generators/gen.cpp
+++ b/resource/generators/gen.cpp
@@ -27,8 +27,8 @@
 #include <vector>
 #include <cstdint>
 #include <boost/algorithm/string.hpp>
-#include "generators/gen.hpp"
-#include "planner/planner.h"
+#include "resource/generators/gen.hpp"
+#include "resource/planner/planner.h"
 
 extern "C" {
 #if HAVE_CONFIG_H

--- a/resource/generators/gen.cpp
+++ b/resource/generators/gen.cpp
@@ -431,7 +431,7 @@ const std::string &resource_generator_t::err_message () const
 /*
  * Read a subsystem spec graphml file and generate resource database
  *
- * \param sfile  generator spec file in graphml
+ * \param sn     generator spec file in graphml
  * \param db     graph database consisting of resource graph and various indices
  * \return       0 on success; non-zero integer on an error
  */

--- a/resource/generators/gen.hpp
+++ b/resource/generators/gen.hpp
@@ -27,8 +27,8 @@
 
 #include <string>
 #include <boost/graph/depth_first_search.hpp>
-#include "schema/resource_graph.hpp"
-#include "generators/spec.hpp"
+#include "resource/schema/resource_graph.hpp"
+#include "resource/generators/spec.hpp"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/generators/spec.cpp
+++ b/resource/generators/spec.cpp
@@ -27,7 +27,7 @@
 #include <boost/graph/graphviz.hpp>
 #include <boost/graph/graphml.hpp>
 #include <boost/filesystem.hpp>
-#include "generators/spec.hpp"
+#include "resource/generators/spec.hpp"
 
 extern "C" {
 #if HAVE_CONFIG_H

--- a/resource/jobinfo/jobinfo.cpp
+++ b/resource/jobinfo/jobinfo.cpp
@@ -1,0 +1,75 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include <string>
+#include "resource/jobinfo/jobinfo.hpp"
+
+namespace Flux {
+namespace resource_model {
+
+job_info_t::job_info_t (uint64_t j, job_lifecycle_t s, int64_t at, const std::string &fn,
+                        const std::string &jstr, const std::string &R_str,  double o)
+    : jobid (j), state (s), scheduled_at (at), jobspec_fn (fn), jobspec_str (jstr),
+      R (R_str), overhead (o)
+{
+
+}
+
+job_info_t::job_info_t (uint64_t j, job_lifecycle_t s, int64_t at, const std::string &fn,
+                        const std::string &jstr, double o)
+    : jobid (j), state (s), scheduled_at (at), jobspec_fn (fn), jobspec_str (jstr),
+      overhead (o)
+{
+
+}
+
+void get_jobstate_str (job_lifecycle_t state, std::string &status)
+{
+    switch (state) {
+    case job_lifecycle_t::ALLOCATED:
+        status = "ALLOCATED";
+        break;
+    case job_lifecycle_t::RESERVED:
+        status = "RESERVED";
+        break;
+    case job_lifecycle_t::CANCELLED:
+        status = "CANCELLED";
+        break;
+    case job_lifecycle_t::ERROR:
+        status = "ERROR";
+        break;
+    case job_lifecycle_t::INIT:
+    default:
+        status = "INIT";
+        break;
+    }
+    return;
+}
+
+}
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/jobinfo/jobinfo.hpp
+++ b/resource/jobinfo/jobinfo.hpp
@@ -1,0 +1,61 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef JOBINFO_HPP
+#define JOBINFO_HPP
+
+#include <string>
+
+namespace Flux {
+namespace resource_model {
+
+enum class job_lifecycle_t { INIT, ALLOCATED, RESERVED, CANCELLED, ERROR };
+
+struct job_info_t {
+    job_info_t (uint64_t j, job_lifecycle_t s, int64_t at,
+                const std::string &j_fn, const std::string &jstr,
+                const std::string &R_str,  double o);
+
+    job_info_t (uint64_t j, job_lifecycle_t s, int64_t at,
+                const std::string &j_fn, const std::string &jstr, double o);
+
+    uint64_t jobid = UINT64_MAX;
+    job_lifecycle_t state = job_lifecycle_t::INIT;
+    int64_t scheduled_at = -1;
+    std::string jobspec_fn;
+    std::string jobspec_str;
+    std::string R;
+    double overhead = 0.0f;
+};
+
+void get_jobstate_str (job_lifecycle_t state, std::string &status);
+
+} // namespace resource_model
+} // namespace Flux
+
+#endif // JOBINFO_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/modules/Makefile.am
+++ b/resource/modules/Makefile.am
@@ -14,8 +14,6 @@ AM_CPPFLAGS = -I$(top_srcdir) $(CZMQ_CFLAGS) $(FLUX_CORE_CFLAGS) \
 
 fluxmod_LTLIBRARIES = resource.la
 
-dist_fluxcmd_SCRIPTS = flux-resource
-
 #
 # resource service module
 #

--- a/resource/modules/Makefile.am
+++ b/resource/modules/Makefile.am
@@ -1,0 +1,40 @@
+AM_CXXFLAGS = \
+    $(WARNING_CXXFLAGS) \
+    -Wno-unused-local-typedefs \
+    -Wno-deprecated-declarations \
+    -Wno-unused-variable \
+    -Wno-error \
+    $(CODE_COVERAGE_CXXFLAGS)
+
+AM_LDFLAGS = $(CODE_COVERAGE_LDFLAGS) \
+             $(BOOST_LDFLAGS)
+
+AM_CPPFLAGS = -I$(top_srcdir) $(CZMQ_CFLAGS) $(FLUX_CORE_CFLAGS) \
+          $(BOOST_CPPFLAGS)
+
+fluxmod_LTLIBRARIES = resource.la
+
+dist_fluxcmd_SCRIPTS = flux-resource
+
+#
+# resource service module
+#
+resource_la_SOURCES = \
+    resource_match.cpp
+resource_la_CXXFLAGS = \
+    $(AM_CXXFLAGS) \
+    $(JOBSPEC_CFLAGS) \
+    $(FLUX_CORE_CFLAGS)
+resource_la_LIBADD = \
+    ../libresource.la \
+    $(JOBSPEC_LIBS) \
+    $(FLUX_CORE_LIBS) \
+    $(DL_LIBS) \
+    $(HWLOC_LIBS) \
+    $(UUID_LIBS) \
+    $(JANSSON_LIBS) \
+    $(CZMQ_LIBS)
+resource_la_LDFLAGS = \
+    $(AM_LDFLAGS) \
+    $(fluxmod_ldflags) -module
+

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -1,0 +1,656 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include <cstdint>
+#include <sstream>
+#include <cerrno>
+#include <map>
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+}
+
+#include "resource/schema/resource_graph.hpp"
+#include "resource/generators/gen.hpp"
+#include "resource/traversers/dfu.hpp"
+#include "resource/jobinfo/jobinfo.hpp"
+#include "resource/policies/dfu_match_policy_factory.hpp"
+
+using namespace std;
+using namespace Flux::resource_model;
+
+/******************************************************************************
+ *                                                                            *
+ *                Resource Matching Service Module Context                    *
+ *                                                                            *
+ ******************************************************************************/
+
+struct resource_args_t {
+    string grug;
+    string match_subsystems;
+    string match_policy;
+    string prune_filters;
+    string R_format;
+};
+
+struct resource_ctx_t {
+    flux_t *h;                     /* Flux handle */
+    flux_msg_handler_t **handlers; /* Message handlers */
+    resource_args_t args;          /* Module load options */
+    dfu_match_cb_t *matcher;       /* Match callback object */
+    dfu_traverser_t *traverser;    /* Graph traverser object */
+    resource_graph_db_t db;        /* Resource graph data store */
+    f_resource_graph_t *fgraph;    /* Graph filtered by subsystems to use */
+    map<uint64_t, job_info_t *> jobs;     /* Jobs table */
+    map<uint64_t, uint64_t> allocations;  /* Allocation table */
+    map<uint64_t, uint64_t> reservations; /* Reservation table */
+};
+
+
+/******************************************************************************
+ *                                                                            *
+ *                          Request Handler Prototypes                        *
+ *                                                                            *
+ ******************************************************************************/
+
+static void match_request_cb (flux_t *h, flux_msg_handler_t *w,
+                              const flux_msg_t *msg, void *arg);
+
+static void cancel_request_cb (flux_t *h, flux_msg_handler_t *w,
+                               const flux_msg_t *msg, void *arg);
+
+static void info_request_cb (flux_t *h, flux_msg_handler_t *w,
+                             const flux_msg_t *msg, void *arg);
+
+static void next_jobid_request_cb (flux_t *h, flux_msg_handler_t *w,
+                                   const flux_msg_t *msg, void *arg);
+
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST, "resource.match", match_request_cb, 0},
+    { FLUX_MSGTYPE_REQUEST, "resource.cancel", cancel_request_cb, 0},
+    { FLUX_MSGTYPE_REQUEST, "resource.info", info_request_cb, 0},
+    { FLUX_MSGTYPE_REQUEST, "resource.next_jobid", next_jobid_request_cb, 0},
+    FLUX_MSGHANDLER_TABLE_END
+};
+
+/******************************************************************************
+ *                                                                            *
+ *                   Module Initialization Routines                           *
+ *                                                                            *
+ ******************************************************************************/
+
+static void freectx (void *arg)
+{
+    resource_ctx_t *ctx = (resource_ctx_t *)arg;
+    if (ctx) {
+        flux_msg_handler_delvec (ctx->handlers);
+        delete ctx->matcher;
+        delete ctx->traverser;
+        delete ctx->fgraph;
+        for (auto &kv : ctx->jobs) {
+            delete kv.second;    /* job_info_t* type */
+            ctx->jobs.erase (kv.first);
+        }
+        ctx->jobs.clear ();
+        ctx->allocations.clear ();
+        ctx->reservations.clear ();
+        delete ctx;
+    }
+}
+
+static void set_default_args (resource_args_t &args)
+{
+    args.grug = "none";
+    args.match_subsystems = "containment";
+    args.match_policy = "high";
+    args.prune_filters = "core";
+    args.R_format = "R_NATIVE";
+}
+
+static resource_ctx_t *getctx (flux_t *h)
+{
+    resource_ctx_t *ctx = (resource_ctx_t *)flux_aux_get (h, "resource");
+    if (!ctx) {
+        ctx = new (nothrow)resource_ctx_t;
+        if (!ctx) {
+            errno = ENOMEM;
+            goto done;
+        }
+        ctx->h = h;
+        ctx->handlers = NULL;
+        set_default_args (ctx->args);
+        ctx->matcher = create_match_cb (ctx->args.match_policy);
+        ctx->traverser = new (nothrow)dfu_traverser_t ();
+        if (!ctx->traverser) {
+            errno = ENOMEM;
+            goto done;
+        }
+        ctx->fgraph = NULL; /* Cannot be allocated at this point */
+        flux_aux_set (h, "resource", ctx, freectx);
+    }
+
+done:
+    return ctx;
+}
+
+static int process_args (resource_ctx_t *ctx, int argc, char **argv)
+{
+    int rc = 0;
+    resource_args_t &args = ctx->args;
+    string dflt = "";
+
+    for (int i = 0; i < argc; i++) {
+        if (!strncmp ("grug-conf=", argv[i], sizeof ("grug-conf"))) {
+            args.grug = strstr (argv[i], "=") + 1;
+        } else if (!strncmp ("subsystems=", argv[i], sizeof ("subsystems"))) {
+            dflt = args.match_subsystems;
+            args.match_subsystems = strstr (argv[i], "=") + 1;
+        } else if (!strncmp ("policy=", argv[i], sizeof ("policy"))) {
+            dflt = args.match_policy;
+            args.match_policy = strstr (argv[i], "=") + 1;
+            if (!known_match_policy (args.match_policy)) {
+                flux_log (ctx->h, LOG_ERR,
+                          "Unknown match policy (%s)! Use default (%s).",
+                           args.match_policy.c_str (), dflt.c_str ());
+                args.match_policy = dflt;
+            }
+        } else if (!strncmp ("filters=", argv[i], sizeof ("fileters"))) {
+            dflt = args.prune_filters;
+            args.prune_filters = strstr (argv[i], "=") + 1;
+        } else if (!strncmp ("R-format=", argv[i], sizeof ("R-format"))) {
+            dflt = args.R_format;
+            args.R_format = strstr (argv[i], "=") + 1;
+            if (!known_R_format (args.R_format)) {
+                flux_log (ctx->h, LOG_ERR,
+                          "Unknown R format (%s)! Use default (%s).",
+                           args.R_format.c_str (), dflt.c_str ());
+                args.R_format = dflt;
+            }
+        } else {
+            rc = -1;
+            errno = EINVAL;
+            goto done;
+        }
+    }
+
+done:
+    return rc;
+}
+
+static resource_ctx_t *init_module (flux_t *h, int argc, char **argv)
+{
+    resource_ctx_t *ctx = NULL;
+    uint32_t rank = 1;
+
+    if (!(ctx = getctx (h))) {
+        flux_log (h, LOG_ERR, "can't allocate the context");
+        goto done;
+    }
+    if (flux_get_rank (h, &rank) < 0) {
+        flux_log (h, LOG_ERR, "can't determine rank");
+        goto done;
+    }
+    if (rank) {
+        flux_log (h, LOG_ERR, "resource module must only run on rank 0");
+        goto done;
+    }
+    if (process_args (ctx, argc, argv) != 0) {
+        flux_log (h, LOG_ERR, "can't process module args");
+        goto done;
+    }
+    if (flux_msg_handler_addvec (h, htab, (void *)h, &ctx->handlers) < 0) {
+        flux_log (h, LOG_ERR, "error registering resource event handler");
+        goto done;
+    }
+
+done:
+    return ctx;
+}
+
+
+/******************************************************************************
+ *                                                                            *
+ *              Resource Graph and Traverser Initialization                   *
+ *                                                                            *
+ ******************************************************************************/
+
+static int populate_resource_db (resource_ctx_t *ctx)
+{
+    int rc = 0;
+    resource_generator_t rgen;
+    if (ctx->args.grug != "none") {
+        if ((rc = rgen.read_graphml (ctx->args.grug, ctx->db)) != 0) {
+            errno = EINVAL;
+            rc = -1;
+            flux_log (ctx->h, LOG_ERR, "error in generating resources");
+            goto done;
+        }
+    } else {
+        errno = ENOTSUP;
+        rc = -1;
+        flux_log (ctx->h, LOG_ERR, "hwloc reader not implemented");
+        goto done;
+    }
+
+done:
+    return rc;
+}
+
+static int select_subsystems (resource_ctx_t *ctx)
+{
+    /*
+     * Format of match_subsystems
+     * subsystem1[:relation1[:relation2...]],subsystem2[...
+     */
+    int rc = 0;
+    stringstream ss (ctx->args.match_subsystems);
+    subsystem_t subsystem;
+    string token;
+
+    while (getline (ss, token, ',')) {
+        size_t found = token.find_first_of (":");
+        if (found == std::string::npos) {
+            subsystem = token;
+            if (!ctx->db.known_subsystem (subsystem)) {
+                rc = -1;
+                errno = EINVAL;
+                goto done;
+            }
+            ctx->matcher->add_subsystem (subsystem, "*");
+        } else {
+            subsystem = token.substr (0, found);
+            if (!ctx->db.known_subsystem (subsystem)) {
+                rc = -1;
+                errno = EINVAL;
+                goto done;
+            }
+            stringstream relations (token.substr (found+1, std::string::npos));
+            string relation;
+            while (getline (relations, relation, ':'))
+                ctx->matcher->add_subsystem (subsystem, relation);
+        }
+    }
+
+done:
+    return rc;
+}
+
+static int init_resource_graph (resource_ctx_t *ctx)
+{
+    int rc = 0;
+
+    if ((rc = populate_resource_db (ctx)) != 0) {
+        flux_log (ctx->h, LOG_ERR, "can't populate graph resource database");
+        return rc;
+    }
+    if ((rc = select_subsystems (ctx)) != 0) {
+        flux_log (ctx->h, LOG_ERR, "error processing subsystems %s",
+                  ctx->args.match_subsystems.c_str ());
+        return rc;
+    }
+
+    resource_graph_t &g = ctx->db.resource_graph;
+
+    // Set vertex and edge maps
+    vtx_infra_map_t vmap = get (&resource_pool_t::idata, g);
+    edg_infra_map_t emap = get (&resource_relation_t::idata, g);
+
+    // Set vertex and edge filters based on subsystems to use
+    const multi_subsystemsS &filter = ctx->matcher->subsystemsS ();
+    subsystem_selector_t<vtx_t, f_vtx_infra_map_t> vtxsel (vmap, filter);
+    subsystem_selector_t<edg_t, f_edg_infra_map_t> edgsel (emap, filter);
+
+    // Create a filtered graph based on the filters
+    ctx->fgraph = new (nothrow)f_resource_graph_t (g, edgsel, vtxsel);
+    if (!ctx->fgraph) {
+        errno = ENOMEM;
+        return -1;
+     }
+
+    // Set pruning filter type for scheduler driven aggregate update
+    const string &dom = ctx->matcher->dom_subsystem ();
+    // TODO: Hook this with ctx.args.prune_filters
+    ctx->matcher->set_pruning_type (dom, ANY_RESOURCE_TYPE, "core");
+
+    // Initialize the DFU traverser
+    ctx->traverser->initialize (ctx->fgraph, &(ctx->db.roots), ctx->matcher);
+
+    return rc;
+}
+
+
+/******************************************************************************
+ *                                                                            *
+ *                        Request Handler Routines                            *
+ *                                                                            *
+ ******************************************************************************/
+
+static double get_elapse_time (timeval &st, timeval &et)
+{
+    double ts1 = (double)st.tv_sec + (double)st.tv_usec/1000000.0f;
+    double ts2 = (double)et.tv_sec + (double)et.tv_usec/1000000.0f;
+    return ts2 - ts1;
+}
+
+static inline string get_status_string (int64_t at)
+{
+    return (at == 0)? "ALLOCATED" : "RESERVED";
+}
+
+static int track_schedule_info (resource_ctx_t *ctx, int64_t id, int64_t at,
+                                string &jspec, stringstream &R, double elapse)
+{
+    job_lifecycle_t state = job_lifecycle_t::INIT;
+
+    if (id < 0 || at < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    state = (at == 0)? job_lifecycle_t::ALLOCATED : job_lifecycle_t::RESERVED;
+    ctx->jobs[id] = new job_info_t (id, state, at, "", jspec, R.str (), elapse);
+    if (at == 0)
+        ctx->allocations[id] = id;
+    else
+        ctx->reservations[id] = id;
+
+    return 0;
+}
+
+static int run_match (resource_ctx_t *ctx, int64_t jobid, const char *cmd,
+                      string jstr, int64_t *at, double *ov, stringstream &R)
+{
+    int rc = 0;
+    double elapse = 0.0f;
+    struct timeval start;
+    struct timeval end;
+    dfu_traverser_t &tr = *(ctx->traverser);
+
+    gettimeofday (&start, NULL);
+    if (string ("allocate") == cmd) {
+        Flux::Jobspec::Jobspec j {jstr};
+        rc = tr.run (j, match_op_t::MATCH_ALLOCATE, jobid, at, R);
+        if (rc != 0) {
+            flux_log (ctx->h, LOG_INFO,
+                      "%s can't find resources for %ld.", cmd, (intmax_t)jobid);
+            goto done;
+        }
+    } else if (string ("allocate_orelse_reserve") == cmd) {
+        Flux::Jobspec::Jobspec j {jstr};
+        rc = tr.run (j, match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE,jobid, at, R);
+        if (rc != 0) {
+            flux_log (ctx->h, LOG_INFO,
+                      "%s can't find resources for %ld.", cmd, (intmax_t)jobid);
+            goto done;
+        }
+    } else {
+        rc = -1;
+        errno = EINVAL;
+        goto done;
+    }
+    gettimeofday (&end, NULL);
+    *ov = get_elapse_time (start, end);
+
+    if ((rc = track_schedule_info (ctx, jobid, *at, jstr, R, *ov)) != 0) {
+        flux_log (ctx->h, LOG_ERR, "can't add info for %ld.", (intmax_t)jobid);
+        goto done;
+    }
+
+done:
+    return rc;
+}
+
+static inline bool is_existent_jobid (const resource_ctx_t *ctx, uint64_t jobid)
+{
+    return (ctx->jobs.find (jobid) != ctx->jobs.end ())? true : false;
+}
+
+static int run_remove (resource_ctx_t *ctx, int64_t jobid)
+{
+    int rc = 0;
+    dfu_traverser_t &tr = *(ctx->traverser);
+    if ((rc = tr.remove (jobid)) == 0) {
+        if (is_existent_jobid (ctx, jobid)) {
+           job_info_t *info = ctx->jobs[jobid];
+           info->state = job_lifecycle_t::CANCELLED;
+        }
+    } else {
+        if (is_existent_jobid (ctx, jobid)) {
+           job_info_t *info = ctx->jobs[jobid];
+           info->state = job_lifecycle_t::ERROR;
+           flux_log (ctx->h, LOG_INFO, "can't remove %ld.", (intmax_t)jobid);
+        }
+    }
+    return rc;
+}
+
+static void match_request_cb (flux_t *h, flux_msg_handler_t *w,
+                              const flux_msg_t *msg, void *arg)
+{
+    int64_t at = 0;
+    uint32_t userid = 0;
+    int64_t jobid = -1;
+    double ov = 0.0f;
+    string status = "";
+    const char *cmd = NULL;
+    const char *js_str = NULL;
+    stringstream R;
+    resource_ctx_t *ctx = getctx ((flux_t *)arg);
+
+    if (flux_msg_get_userid (msg, &userid) < 0)
+        goto error;
+
+    flux_log (h, LOG_INFO, "match requested by user (%u).", userid);
+
+    if (flux_request_unpack (msg, NULL, "{s:s s:I s:s}", "cmd", &cmd,
+                             "jobid", &jobid, "jobspec", &js_str) < 0)
+        goto error;
+
+    if (is_existent_jobid (ctx, jobid)) {
+        flux_log (h, LOG_INFO, "invalid jobid (%ld).", (intmax_t)jobid);
+        errno = EINVAL;
+        goto error;
+    }
+
+    if (run_match (ctx, jobid, cmd, js_str, &at, &ov, R) < 0) {
+        flux_log (h, LOG_INFO, "could not resolve match %s for jobid (%ld).",
+                  cmd, (intmax_t)jobid);
+        flux_log (h, LOG_INFO, "error string: %s.", strerror (errno));
+        goto error;
+    }
+
+    status = get_status_string (at);
+    if (flux_respond_pack (h, msg, "{s:I s:s s:f s:s s:I}",
+                                   "jobid", jobid,
+                                   "status", status.c_str (),
+                                   "overhead", ov,
+                                   "R", R.str ().c_str (),
+                                   "at", at) < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+
+    flux_log (h, LOG_INFO, "match request succeeded.");
+    return;
+
+error:
+    if (flux_respond (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+}
+
+static void cancel_request_cb (flux_t *h, flux_msg_handler_t *w,
+                               const flux_msg_t *msg, void *arg)
+{
+    resource_ctx_t *ctx = getctx ((flux_t *)arg);
+    uint32_t userid = 0;
+    int64_t jobid = -1;
+
+    if (flux_msg_get_userid (msg, &userid) < 0)
+        goto error;
+
+    flux_log (h, LOG_INFO, "cancel requested by user (%u).", userid);
+
+    if (flux_request_unpack (msg, NULL, "{s:I}", "jobid", &jobid) < 0)
+        goto error;
+
+    if (ctx->allocations.find (jobid) != ctx->allocations.end ()) {
+        run_remove (ctx, jobid);
+        ctx->allocations.erase (jobid);
+    } else if (ctx->reservations.find (jobid) != ctx->reservations.end ()) {
+        run_remove (ctx, jobid);
+        ctx->reservations.erase (jobid);
+    } else {
+        errno = ENOENT;
+        flux_log (h, LOG_ERR, "cannot find jobid (%ld)", (intmax_t)jobid);
+        goto error;
+    }
+    if (flux_respond_pack (h, msg, "{}") < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+
+    flux_log (h, LOG_INFO, "cancel request succeeded.");
+    return;
+
+error:
+    if (flux_respond (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+}
+
+static void info_request_cb (flux_t *h, flux_msg_handler_t *w,
+                             const flux_msg_t *msg, void *arg)
+{
+    resource_ctx_t *ctx = getctx ((flux_t *)arg);
+    uint32_t userid = 0;
+    int64_t jobid = -1;
+    job_info_t *info = NULL;
+    string status = "";
+
+    if (flux_msg_get_userid (msg, &userid) < 0)
+        goto error;
+
+    flux_log (h, LOG_INFO, "info requested by user (%u).", userid);
+
+    if (flux_request_unpack (msg, NULL, "{s:I}", "jobid", &jobid) < 0)
+        goto error;
+    if (!is_existent_jobid (ctx, jobid)) {
+        errno = ENOENT;
+        flux_log (h, LOG_ERR, "cannot find jobid (%ld)", (intmax_t)jobid);
+        goto error;
+    }
+
+    info = ctx->jobs[jobid];
+    get_jobstate_str (info->state, status);
+    if (flux_respond_pack (h, msg, "{s:I s:s s:I s:f}",
+                                   "jobid", jobid,
+                                   "status", status.c_str (),
+                                   "at", info->scheduled_at,
+                                   "overhead", info->overhead) < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+
+    flux_log (h, LOG_INFO, "info request succeeded.");
+    return;
+
+error:
+    if (flux_respond (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+}
+
+static inline int64_t next_jobid (const std::map<uint64_t, job_info_t *> &m)
+{
+    int64_t jobid = -1;
+    if (m.empty ())
+        jobid = 0;
+    else if (m.rbegin ()->first < INT64_MAX)
+        jobid = m.rbegin ()->first + 1;
+    return jobid;
+}
+
+/* Needed for testing only */
+static void next_jobid_request_cb (flux_t *h, flux_msg_handler_t *w,
+                                   const flux_msg_t *msg, void *arg)
+{
+    resource_ctx_t *ctx = getctx ((flux_t *)arg);
+    uint32_t userid = 0;
+    int64_t jobid = -1;
+
+    if (flux_msg_get_userid (msg, &userid) < 0)
+        goto error;
+
+    flux_log (h, LOG_INFO, "next jobid requested by user (%u).", userid);
+
+    if ((jobid = next_jobid (ctx->jobs)) < 0) {
+        errno = ERANGE;
+        goto error;
+    }
+
+    if (flux_respond_pack (h, msg, "{s:I}", "jobid", jobid) < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+
+    flux_log (h, LOG_INFO, "next_jobid request succeeded.");
+    return;
+
+error:
+    if (flux_respond (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s", __FUNCTION__);
+}
+
+
+/******************************************************************************
+ *                                                                            *
+ *                               Module Main                                  *
+ *                                                                            *
+ ******************************************************************************/
+
+extern "C" int mod_main (flux_t *h, int argc, char **argv)
+{
+    int rc = -1;
+    resource_ctx_t *ctx = NULL;
+    uint32_t rank = 1;
+
+    if (!(ctx = init_module (h, argc, argv))) {
+        flux_log (h, LOG_ERR, "can't initialize resource module");
+        goto done;
+    }
+    flux_log (h, LOG_INFO, "resource module starting...");
+
+    if ((rc = init_resource_graph (ctx)) != 0) {
+        flux_log (h, LOG_ERR, "can't initialize resource graph database");
+        goto done;
+    }
+    flux_log (h, LOG_INFO, "resource graph database loaded");
+
+    if ((rc = flux_reactor_run (flux_get_reactor (h), 0)) < 0) {
+        flux_log (h, LOG_ERR, "flux_reactor_run: %s", strerror (errno));
+        goto done;
+    }
+
+done:
+    return rc;
+}
+
+MOD_NAME ("resource");
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/policies/base/dfu_match_cb.hpp
+++ b/resource/policies/base/dfu_match_cb.hpp
@@ -31,10 +31,10 @@
 #include <cstdint>
 #include <iostream>
 #include <flux/jobspec.hpp>
-#include "schema/resource_graph.hpp"
-#include "evaluators/scoring_api.hpp"
-#include "policies/base/matcher.hpp"
-#include "planner/planner.h"
+#include "resource/schema/resource_graph.hpp"
+#include "resource/evaluators/scoring_api.hpp"
+#include "resource/policies/base/matcher.hpp"
+#include "resource/planner/planner.h"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/policies/base/matcher.hpp
+++ b/resource/policies/base/matcher.hpp
@@ -31,8 +31,8 @@
 #include <set>
 #include <map>
 #include <flux/jobspec.hpp>
-#include "schema/data_std.hpp"
-#include "planner/planner.h"
+#include "resource/schema/data_std.hpp"
+#include "resource/planner/planner.h"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/policies/dfu_match_high_id_first.cpp
+++ b/resource/policies/dfu_match_high_id_first.cpp
@@ -22,7 +22,7 @@
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 
-#include "policies/dfu_match_high_id_first.hpp"
+#include "resource/policies/dfu_match_high_id_first.hpp"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/policies/dfu_match_high_id_first.hpp
+++ b/resource/policies/dfu_match_high_id_first.hpp
@@ -29,7 +29,7 @@
 #include <vector>
 #include <numeric>
 #include <map>
-#include "policies/base/dfu_match_cb.hpp"
+#include "resource/policies/base/dfu_match_cb.hpp"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/policies/dfu_match_locality.cpp
+++ b/resource/policies/dfu_match_locality.cpp
@@ -22,7 +22,7 @@
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 
-#include "policies/dfu_match_locality.hpp"
+#include "resource/policies/dfu_match_locality.hpp"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/policies/dfu_match_locality.hpp
+++ b/resource/policies/dfu_match_locality.hpp
@@ -31,7 +31,7 @@
 #include <map>
 #include <boost/icl/interval.hpp>
 #include <boost/icl/interval_set.hpp>
-#include "policies/base/dfu_match_cb.hpp"
+#include "resource/policies/base/dfu_match_cb.hpp"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/policies/dfu_match_low_id_first.cpp
+++ b/resource/policies/dfu_match_low_id_first.cpp
@@ -22,7 +22,7 @@
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 
-#include "policies/dfu_match_low_id_first.hpp"
+#include "resource/policies/dfu_match_low_id_first.hpp"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/policies/dfu_match_low_id_first.hpp
+++ b/resource/policies/dfu_match_low_id_first.hpp
@@ -29,7 +29,7 @@
 #include <vector>
 #include <numeric>
 #include <map>
-#include "policies/base/dfu_match_cb.hpp"
+#include "resource/policies/base/dfu_match_cb.hpp"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/policies/dfu_match_policy_factory.cpp
+++ b/resource/policies/dfu_match_policy_factory.cpp
@@ -1,0 +1,58 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include <string>
+#include "resource/policies/dfu_match_policy_factory.hpp"
+
+namespace Flux {
+namespace resource_model {
+
+bool known_match_policy (const std::string &policy)
+{
+    bool rc = true;
+    if (policy != HIGH_ID_FIRST && policy != LOW_ID_FIRST
+        && policy != LOCALITY_AWARE)
+        rc = false;
+
+    return rc;
+}
+
+dfu_match_cb_t *create_match_cb (const std::string &policy)
+{
+    dfu_match_cb_t *matcher = NULL;
+    if (policy == HIGH_ID_FIRST)
+        matcher = (dfu_match_cb_t *)new high_first_t ();
+    else if (policy == LOW_ID_FIRST)
+        matcher = (dfu_match_cb_t *)new low_first_t ();
+    else if (policy == LOCALITY_AWARE)
+        matcher = (dfu_match_cb_t *)new greater_interval_first_t ();
+    return matcher;
+}
+
+} // resource_model
+} // Flux
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/policies/dfu_match_policy_factory.hpp
+++ b/resource/policies/dfu_match_policy_factory.hpp
@@ -1,0 +1,55 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef DFU_MATCH_POLICY_FACTORY_HPP
+#define DFU_MATCH_POLICY_FACTORY_HPP
+
+#include <string>
+#include "resource/policies/base/dfu_match_cb.hpp"
+#include "resource/policies/dfu_match_high_id_first.hpp"
+#include "resource/policies/dfu_match_low_id_first.hpp"
+#include "resource/policies/dfu_match_locality.hpp"
+
+namespace Flux {
+namespace resource_model {
+
+const std::string HIGH_ID_FIRST = "high";
+const std::string LOW_ID_FIRST = "low";
+const std::string LOCALITY_AWARE = "locality";
+
+bool known_match_policy (const std::string &policy);
+
+/*! Factory method for creating a matching callback
+ *  object, representing a matching policy.
+ */
+dfu_match_cb_t *create_match_cb (const std::string &policy);
+
+} // resource_model
+} // Flux
+
+#endif // DFU_MATCH_POLICY_FACTORY_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/schema/color.cpp
+++ b/resource/schema/color.cpp
@@ -20,7 +20,7 @@
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 
-#include "schema/color.hpp"
+#include "resource/schema/color.hpp"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/schema/infra_data.cpp
+++ b/resource/schema/infra_data.cpp
@@ -20,7 +20,7 @@
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 
-#include "schema/infra_data.hpp"
+#include "resource/schema/infra_data.hpp"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/schema/infra_data.hpp
+++ b/resource/schema/infra_data.hpp
@@ -25,8 +25,8 @@
 
 #include <map>
 #include <cstdint>
-#include "schema/data_std.hpp"
-#include "planner/planner_multi.h"
+#include "resource/schema/data_std.hpp"
+#include "resource/planner/planner_multi.h"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/schema/resource_data.cpp
+++ b/resource/schema/resource_data.cpp
@@ -20,7 +20,7 @@
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 
-#include "schema/resource_data.hpp"
+#include "resource/schema/resource_data.hpp"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/schema/resource_data.hpp
+++ b/resource/schema/resource_data.hpp
@@ -28,11 +28,11 @@
 #include <cstring>
 #include <map>
 #include <set>
-#include "schema/color.hpp"
-#include "schema/data_std.hpp"
-#include "schema/sched_data.hpp"
-#include "schema/infra_data.hpp"
-#include "planner/planner.h"
+#include "resource/schema/color.hpp"
+#include "resource/schema/data_std.hpp"
+#include "resource/schema/sched_data.hpp"
+#include "resource/schema/infra_data.hpp"
+#include "resource/planner/planner.h"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/schema/resource_graph.hpp
+++ b/resource/schema/resource_graph.hpp
@@ -118,6 +118,11 @@ struct resource_graph_db_t {
     std::map<std::string, std::vector <vtx_t>> by_type;
     std::map<std::string, std::vector <vtx_t>> by_name;
     std::map<std::string, std::vector <vtx_t>> by_path;
+
+    bool known_subsystem (const std::string &s)
+    {
+        return (roots.find (s) != roots.end ())? true : false;
+    }
 };
 
 template<class name_map, class graph_entity>

--- a/resource/schema/resource_graph.hpp
+++ b/resource/schema/resource_graph.hpp
@@ -30,7 +30,7 @@
 #include <boost/graph/filtered_graph.hpp>
 #include <boost/graph/graphviz.hpp>
 #include <boost/graph/graphml.hpp>
-#include "schema/resource_data.hpp"
+#include "resource/schema/resource_data.hpp"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/schema/sched_data.cpp
+++ b/resource/schema/sched_data.cpp
@@ -20,7 +20,7 @@
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 
-#include "schema/sched_data.hpp"
+#include "resource/schema/sched_data.hpp"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/schema/sched_data.hpp
+++ b/resource/schema/sched_data.hpp
@@ -25,7 +25,7 @@
 
 #include <map>
 #include <cstdint>
-#include "planner/planner.h"
+#include "resource/planner/planner.h"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/traversers/dfu.cpp
+++ b/resource/traversers/dfu.cpp
@@ -24,7 +24,7 @@
 
 #include <iostream>
 #include <cstdlib>
-#include "traversers/dfu.hpp"
+#include "resource/traversers/dfu.hpp"
 
 extern "C" {
 #if HAVE_CONFIG_H

--- a/resource/traversers/dfu.cpp
+++ b/resource/traversers/dfu.cpp
@@ -221,6 +221,19 @@ int dfu_traverser_t::remove (int64_t jobid)
     return detail::dfu_impl_t::remove (root, jobid);
 }
 
+namespace Flux {
+namespace resource_model {
+
+bool known_R_format (const string &f)
+{
+    bool rc = true;
+    if (f != R_FORMAT || f != R_LITE_FORMAT || f != R_NATIVE_FORMAT)
+        rc = false;
+    return rc;
+}
+}
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/resource/traversers/dfu.cpp
+++ b/resource/traversers/dfu.cpp
@@ -24,6 +24,7 @@
 
 #include <iostream>
 #include <cstdlib>
+#include <cerrno>
 #include "resource/traversers/dfu.hpp"
 
 extern "C" {
@@ -70,6 +71,10 @@ int dfu_traverser_t::schedule (Jobspec::Jobspec &jobspec,
             rc = detail::dfu_impl_t::select (jobspec, root, meta, x, needs);
         }
     }
+
+    if ((rc != 0) && (errno == 0))
+        errno = EBUSY;
+
     return rc;
 }
 

--- a/resource/traversers/dfu.hpp
+++ b/resource/traversers/dfu.hpp
@@ -27,10 +27,16 @@
 
 #include <iostream>
 #include <cstdlib>
-#include "traversers/dfu_impl.hpp"
+#include "resource/traversers/dfu_impl.hpp"
 
 namespace Flux {
 namespace resource_model {
+
+enum class R_format { R, R_LITE, R_NATIVE };
+
+const char R_FORMAT[] = "R";
+const char R_LITE_FORMAT[] = "R_LITE";
+const char R_NATIVE_FORMAT[] = "R_NATIVE";
 
 /*! Depth-First-and-Up traverser. Perform depth-first visit on the dominant
  *  subsystem and upwalk on each and all of the auxiliary subsystems selected
@@ -128,6 +134,8 @@ private:
                   vtx_t root, unsigned int *needs,
                   std::unordered_map<std::string, int64_t> &dfv);
 };
+
+bool known_R_format (const std::string &f);
 
 } // namespace resource_model
 } // namespace Flux

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -22,7 +22,7 @@
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 
-#include "traversers/dfu_impl.hpp"
+#include "resource/traversers/dfu_impl.hpp"
 
 extern "C" {
 #if HAVE_CONFIG_H

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -29,12 +29,12 @@
 #include <sstream>
 #include <cstdlib>
 #include <flux/jobspec.hpp>
-#include "config/system_defaults.hpp"
-#include "schema/resource_data.hpp"
-#include "schema/resource_graph.hpp"
-#include "policies/base/dfu_match_cb.hpp"
-#include "evaluators/scoring_api.hpp"
-#include "planner/planner.h"
+#include "resource/config/system_defaults.hpp"
+#include "resource/schema/resource_data.hpp"
+#include "resource/schema/resource_graph.hpp"
+#include "resource/policies/base/dfu_match_cb.hpp"
+#include "resource/evaluators/scoring_api.hpp"
+#include "resource/planner/planner.h"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/utilities/command.cpp
+++ b/resource/utilities/command.cpp
@@ -64,33 +64,13 @@ static double get_elapse_time (timeval &st, timeval &et)
     return ts2 - ts1;
 }
 
-static void get_jobstate_str (job_state_t state, string &mode)
-{
-    switch (state) {
-    case job_state_t::ALLOCATED:
-        mode = "ALLOCATED";
-        break;
-    case job_state_t::RESERVED:
-        mode = "RESERVED";
-        break;
-    case job_state_t::CANCELLED:
-        mode = "CANCELLED";
-        break;
-    case job_state_t::INIT:
-    default:
-        mode = "INIT";
-        break;
-    }
-    return;
-}
-
 static int do_remove (resource_context_t *ctx, int64_t jobid)
 {
     int rc = -1;
     if ((rc = ctx->traverser.remove ((int64_t)jobid)) == 0) {
         if (ctx->jobs.find (jobid) != ctx->jobs.end ()) {
            job_info_t *info = ctx->jobs[jobid];
-           info->state = job_state_t::CANCELLED;
+           info->state = job_lifecycle_t::CANCELLED;
         }
     } else {
         cout << ctx->traverser.err_message ();
@@ -105,7 +85,7 @@ static void print_schedule_info (resource_context_t *ctx, ostream &out,
                                  double elapse)
 {
     if (matched) {
-        job_state_t st;
+        job_lifecycle_t st;
         string mode = (at == 0)? "ALLOCATED" : "RESERVED";
         string scheduled_at = (at == 0)? "Now" : to_string (at);
         out << "INFO:" << " =============================" << endl;
@@ -116,8 +96,9 @@ static void print_schedule_info (resource_context_t *ctx, ostream &out,
             out << "INFO:" << " ELAPSE=" << to_string (elapse) << endl;
 
         out << "INFO:" << " =============================" << endl;
-        st = (at == 0)? job_state_t::ALLOCATED : job_state_t::RESERVED;
-        ctx->jobs[jobid] = new job_info_t (jobid, st, at, jobspec_fn, elapse);
+        st = (at == 0)? job_lifecycle_t::ALLOCATED : job_lifecycle_t::RESERVED;
+        ctx->jobs[jobid] = new job_info_t (jobid, st,
+                                           at, jobspec_fn, "", elapse);
         if (at == 0)
             ctx->allocations[jobid] = jobid;
         else

--- a/resource/utilities/command.hpp
+++ b/resource/utilities/command.hpp
@@ -28,25 +28,13 @@
 #include "resource/schema/resource_graph.hpp"
 #include "resource/generators/gen.hpp"
 #include "resource/traversers/dfu.hpp"
+#include "resource/jobinfo/jobinfo.hpp"
 #include <cerrno>
 #include <vector>
 #include <map>
 
 namespace Flux {
 namespace resource_model {
-
-enum class job_state_t { INIT, ALLOCATED, RESERVED, CANCELLED };
-
-struct job_info_t {
-    job_info_t (uint64_t j, job_state_t s, int64_t at, std::string fn, double o)
-        : jobid (j), state (s), scheduled_at (at), jobspec_fn (fn),
-          overhead (o) { }
-    uint64_t jobid = UINT64_MAX;
-    job_state_t state = job_state_t::INIT;
-    int64_t scheduled_at = -1;
-    std::string jobspec_fn;
-    double overhead = 0.0f;
-};
 
 struct test_params_t {
     std::string grug;           /* GRUG file name */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -64,6 +64,7 @@ TESTS = \
     t3008-resource-cancel.t \
     t3009-resource-minmax.t \
     t3010-resource-power.t \
+    t4001-match-allocate.t \
     t5000-valgrind.t
 
 check_SCRIPTS = $(TESTS)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -65,6 +65,7 @@ TESTS = \
     t3009-resource-minmax.t \
     t3010-resource-power.t \
     t4001-match-allocate.t \
+    t4002-match-reserve.t \
     t5000-valgrind.t
 
 check_SCRIPTS = $(TESTS)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -66,6 +66,7 @@ TESTS = \
     t3010-resource-power.t \
     t4001-match-allocate.t \
     t4002-match-reserve.t \
+    t4003-cancel-info.t \
     t5000-valgrind.t
 
 check_SCRIPTS = $(TESTS)

--- a/t/data/resource/jobspecs/basics/bad.yaml
+++ b/t/data/resource/jobspecs/basics/bad.yaml
@@ -1,0 +1,30 @@
+version: 1
+resources:
+    - type: cluster
+`      count: 1
+      with:
+        - type: rack
+          count: 1
+          with:
+            - type: node
+              count: 1
+              with:
+                  - type: slot
+                    count: 1
+                    label: default
+                    with:
+                      - type: socket
+                        count: 1
+                        with:
+                          - type: core
+                            count: 1
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: app
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/scripts/flux-resource
+++ b/t/scripts/flux-resource
@@ -1,0 +1,189 @@
+#!/usr/bin/env python
+
+import argparse
+import errno
+import yaml
+import flux
+
+def heading ():
+    return '{:20} {:20} {:20} {:20}'.format ('JOBID', 'STATUS',
+                                             'AT', 'OVERHEAD (Secs)')
+
+def body (jobid, status, at, overhead):
+    t = "Now" if at == 0 else str (at)
+    o = str (overhead)
+    return '{:20} {:20} {:20} {:20}'.format (str (jobid), status, t, o)
+
+def width ():
+    return 20 + 20 + 20 + 20
+
+"""
+    Class to interface with the resource module with RPC
+"""
+class ResourceModuleInterface:
+    def __init__ (self):
+        self.f = flux.Flux ()
+
+    def rpc_next_jobid (self):
+        resp = self.f.rpc_send ("resource.next_jobid")
+        return resp['jobid']
+
+    def rpc_allocate (self, jobid, jobspec_str):
+        payload = {'cmd' : 'allocate', 'jobid' : jobid, 'jobspec' : jobspec_str}
+        return self.f.rpc_send ("resource.match", payload)
+
+    def rpc_reserve (self, jobid, jobspec_str):
+        payload = {'cmd' : 'allocate_orelse_reserve',
+                   'jobid' : jobid, 'jobspec' : jobspec_str}
+        return self.f.rpc_send ("resource.match", payload)
+
+    def rpc_info (self, jobid):
+        payload = {'jobid' : jobid}
+        return self.f.rpc_send ("resource.info", payload)
+
+    def rpc_cancel (self, jobid):
+        payload = {'jobid' : jobid}
+        return self.f.rpc_send ("resource.cancel", payload)
+
+"""
+    Action for match allocate sub-command
+"""
+def match_alloc_action (args):
+    with open (args.jobspec, 'r') as stream:
+        jobspec_str = yaml.dump (yaml.load (stream))
+        r = ResourceModuleInterface ()
+        resp = r.rpc_allocate (r.rpc_next_jobid (), jobspec_str)
+        print heading ()
+        print body (resp['jobid'], resp['status'], resp['at'], resp['overhead'])
+        print ("=" * width ())
+        print "MATCHED RESOURCES:"
+        print resp['R']
+
+"""
+    Action for match allocate_orelse_reserve sub-command
+"""
+def match_reserve_action (args):
+    with open (args.jobspec, 'r') as stream:
+        jobspec_str = yaml.dump (yaml.load (stream))
+        r = ResourceModuleInterface ()
+        resp = r.rpc_reserve (r.rpc_next_jobid (), jobspec_str)
+        print heading ()
+        print body (resp['jobid'], resp['status'], resp['at'], resp['overhead'])
+        print ("=" * width ())
+        print "MATCHED RESOURCES:"
+        print resp['R']
+
+"""
+    Action for cancel sub-command
+"""
+def cancel_action (args):
+    r = ResourceModuleInterface ()
+    jobid = args.jobid
+    resp = r.rpc_cancel (jobid)
+
+"""
+    Action for info sub-command
+"""
+def info_action (args):
+    r = ResourceModuleInterface ()
+    jobid = args.jobid
+    resp = r.rpc_info (jobid)
+    print heading ()
+    print body (resp['jobid'], resp['status'], resp['at'], resp['overhead'])
+
+
+"""
+    Main entry point
+"""
+def main ():
+    #
+    # Main command arguments/options
+    #
+    desc = 'Front-end command for resource '\
+           'module for testing. Provide 4 sub-commands. '\
+           'For sub-command usage, '\
+           '%(prog)s <sub-command> --help'
+    parser = argparse.ArgumentParser (description=desc)
+    parser.add_argument ('-v', '--verbose', action='store_true',
+                         help='be verbose')
+
+    #
+    # Add subparser for the top-level sub-commands
+    #
+    subpar = parser.add_subparsers (title='Available Commands',
+                                    description='Valid commands',
+                                    help='Additional help')
+    mstr = "Find the best matching resources for a jobspec"
+    istr = "Print info on a single job"
+    cstr = "Cancel an allocated or reserved job"
+    parser_m = subpar.add_parser ('match', help=mstr, description=mstr)
+    parser_i = subpar.add_parser ('info', help=istr, description=istr)
+    parser_c = subpar.add_parser ('cancel', help=cstr, description=cstr)
+
+    #
+    # Add subparser for the match sub-command
+    #
+    subparsers_m = parser_m.add_subparsers (title='Available Commands',
+                                           description='Valid commands',
+                                           help='Additional help')
+
+    mastr = "Allocate the best matching resources if found"
+    mrstr = "Allocate the best matching resources if found. "\
+            "If not found, reserve them instead at earliest time"
+    parser_ma = subparsers_m.add_parser ('allocate', help=mastr)
+    parser_mr = subparsers_m.add_parser ('allocate_orelse_reserve', help=mrstr)
+
+    #
+    # Positional argument for info sub-command
+    #
+    parser_i.add_argument ('jobid', metavar='Jobid', type=int, help='Jobid')
+    parser_i.set_defaults (func=info_action)
+
+    #
+    # Positional argument for cancel sub-command
+    #
+    parser_c.add_argument ('jobid', metavar='Jobid', type=int, help='Jobid')
+    parser_c.set_defaults (func=cancel_action)
+
+    #
+    # Positional argument for match allocate sub-command
+    #
+    parser_ma.add_argument ('jobspec', metavar='Jobspec', type=str,
+                            help='Jobspec file name')
+    parser_ma.set_defaults (func=match_alloc_action)
+
+    #
+    # Positional argument for match allocate_orelse_reserve sub-command
+    #
+    parser_mr.add_argument ('jobspec', metavar='Jobspec', type=str,
+                            help='Jobspec file name')
+    parser_mr.set_defaults (func=match_reserve_action)
+
+    #
+    # Parse the args and call an action routine as part of that
+    #
+    try:
+        args = parser.parse_args ()
+        args.func (args)
+
+    except IOError as e:
+        print "I/O error({0}): {1}".format (e.errno, e.strerror)
+        exit (3)
+
+    except EnvironmentError as e:
+        print "Environment error({0}): {1}".format (e.errno, e.strerror)
+        if e.errno == errno.EBUSY:
+            exit (16)
+        else:
+            exit (1)
+
+    except yaml.YAMLError as e:
+        print "Parsing error: ", e
+        exit (2)
+
+if __name__ == "__main__":
+    main ()
+
+#
+# vi:tabstop=4 shiftwidth=4 expandtab
+#

--- a/t/sharness.d/sched-sharness.sh
+++ b/t/sharness.d/sched-sharness.sh
@@ -10,13 +10,14 @@ if test -n "$FLUX_SCHED_TEST_INSTALLED"; then
   # (We also support testing this when sched is installed
   # another location, but only via make check)
   FLUX_MODULE_PATH_PREPEND=$(which flux | sed -s 's|/bin/flux|/lib/flux/modules/sched|'):${FLUX_MODULE_PATH_PREPEND}
+  FLUX_EXEC_PATH_PREPEND=${SHARNESS_TEST_SRCDIR}/scripts:${FLUX_EXEC_PATH_PREPEND}
 else
   # Set up environment so that we find flux-sched modules,
   #  commands, and Lua libs from the build directories:
   FLUX_LUA_PATH_PREPEND="${SHARNESS_TEST_SRCDIR}/../rdl/?.lua"
   FLUX_LUA_CPATH_PREPEND="${SHARNESS_BUILD_DIRECTORY}/rdl/?.so"
-  FLUX_MODULE_PATH_PREPEND="${SHARNESS_BUILD_DIRECTORY}/sched/.libs"
-  FLUX_EXEC_PATH_PREPEND="${SHARNESS_BUILD_DIRECTORY}/sched"
+  FLUX_MODULE_PATH_PREPEND="${SHARNESS_BUILD_DIRECTORY}/sched/.libs:${SHARNESS_BUILD_DIRECTORY}/resource/modules/.libs"
+  FLUX_EXEC_PATH_PREPEND="${SHARNESS_BUILD_DIRECTORY}/sched:${SHARNESS_TEST_SRCDIR}/scripts"
 fi
 
 ## Set up environment using flux(1) in PATH

--- a/t/t4001-match-allocate.t
+++ b/t/t4001-match-allocate.t
@@ -1,0 +1,68 @@
+#!/bin/sh
+#set -x
+
+test_description='Test the basic functionality of resource-match-allocate
+
+Ensure that the match (allocate) handler within the resource module works
+'
+
+ORIG_HOME=${HOME}
+
+. `dirname $0`/sharness.sh
+
+#
+# sharness modifies $HOME environment variable, but this interferes
+# with python's package search path, in particular its user site package.
+#
+HOME=${ORIG_HOME}
+
+grug="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/tiny.graphml"
+jobspec="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/basics/test001.yaml"
+malform="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/basics/bad.yaml"
+
+#
+# test_under_flux is under sharness.d/
+#
+test_under_flux 1
+
+#
+# print only with --debug
+#
+test_debug '
+    echo ${grug} &&
+    echo ${jobspec} &&
+    echo ${malform}
+'
+
+test_expect_success 'loading resource module with a tiny machine config works' '
+    flux module load resource grug-conf=${grug} \
+subsystems=containment policy=high
+'
+
+test_expect_success 'match-allocate works with a 1-node, 1-socket jobspec' '
+    flux resource match allocate ${jobspec} &&
+    flux resource match allocate ${jobspec} &&
+    flux resource match allocate ${jobspec} &&
+    flux resource match allocate ${jobspec}
+'
+
+test_expect_success 'match-allocate fails when all resources are allocated' '
+    test_expect_code 16 flux resource match allocate ${jobspec} &&
+    test_expect_code 16 flux resource match allocate ${jobspec} &&
+    test_expect_code 16 flux resource match allocate ${jobspec} &&
+    test_expect_code 16 flux resource match allocate ${jobspec}
+'
+
+test_expect_success 'detecting of a non-existent jobspec file works' '
+    test_expect_code 3 flux resource match allocate foo
+'
+
+test_expect_success 'handling of a malformed jobspec works' '
+    test_expect_code 2 flux resource match allocate ${malform}
+'
+
+test_expect_success 'removing resource works' '
+    flux module remove resource
+'
+
+test_done

--- a/t/t4002-match-reserve.t
+++ b/t/t4002-match-reserve.t
@@ -1,0 +1,66 @@
+#!/bin/sh
+#set -x
+
+test_description='Test the basic functionality of allocate_orelse_reserve
+
+Ensure that the match (allocate_orelse_reserve) handler within resource works
+'
+
+ORIG_HOME=${HOME}
+
+. `dirname $0`/sharness.sh
+
+#
+# sharness modifies $HOME environment variable, but this interferes
+# with python's package search path, in particular its user site package.
+#
+HOME=${ORIG_HOME}
+
+grug="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/tiny.graphml"
+jobspec="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/basics/test001.yaml"
+malform="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/basics/bad.yaml"
+
+#
+# test_under_flux is under sharness.d/
+#
+test_under_flux 1
+
+#
+# print only with --debug
+#
+test_debug '
+    echo ${grug} &&
+    echo ${jobspec} &&
+    echo ${malform}
+'
+
+test_expect_success 'loading resource module with a tiny machine config works' '
+    flux module load resource grug-conf=${grug} \
+subsystems=containment policy=low
+'
+
+test_expect_success 'After all resources are allocated, reserve still works' '
+    flux resource match allocate ${jobspec} &&
+    flux resource match allocate ${jobspec} &&
+    flux resource match allocate ${jobspec} &&
+    flux resource match allocate ${jobspec} &&
+    test_expect_code 16 flux resource match allocate ${jobspec} &&
+    flux resource match allocate_orelse_reserve ${jobspec} &&
+    flux resource match allocate_orelse_reserve ${jobspec} &&
+    flux resource match allocate_orelse_reserve ${jobspec} &&
+    flux resource match allocate_orelse_reserve ${jobspec}
+'
+
+test_expect_success 'detecting of a non-existent jobspec file works' '
+    test_expect_code 3 flux resource match allocate_orelse_reserve foo
+'
+
+test_expect_success 'handling of a malformed jobspec works' '
+    test_expect_code 2 flux resource match allocate_orelse_reserve ${malform}
+'
+
+test_expect_success 'removing resource works' '
+    flux module remove resource
+'
+
+test_done

--- a/t/t4003-cancel-info.t
+++ b/t/t4003-cancel-info.t
@@ -1,0 +1,88 @@
+#!/bin/sh
+#set -x
+
+test_description='Test the basic functionality of cancel and info within resource
+
+Ensure that the cancel and info handlers within the resource module works
+'
+
+ORIG_HOME=${HOME}
+
+. `dirname $0`/sharness.sh
+
+#
+# sharness modifies $HOME environment variable, but this interferes
+# with python's package search path, in particular its user site package.
+#
+HOME=${ORIG_HOME}
+
+grug="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/tiny.graphml"
+jobspec="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/basics/test001.yaml"
+
+#
+# test_under_flux is under sharness.d/
+#
+test_under_flux 1
+
+#
+# print only with --debug
+#
+test_debug '
+    echo ${grug} &&
+    echo ${jobspec}
+'
+
+test_expect_success 'loading resource module with a tiny machine config works' '
+    flux module load resource grug-conf=${grug} \
+subsystems=containment policy=high
+'
+
+test_expect_success 'resource-cancel works' '
+    flux resource match allocate ${jobspec} &&
+    flux resource cancel 0 &&
+    flux resource match allocate ${jobspec} &&
+    flux resource cancel 1 &&
+    flux resource match allocate ${jobspec} &&
+    flux resource cancel 2 &&
+    flux resource match allocate ${jobspec} &&
+    flux resource cancel 3
+'
+
+test_expect_success 'resource-info on cancelled jobs works' '
+    flux resource info 0 > info.0 &&
+    flux resource info 1 > info.1 &&
+    flux resource info 2 > info.2 &&
+    flux resource info 3 > info.3 &&
+    grep CANCELLED info.0 &&
+    grep CANCELLED info.1 &&
+    grep CANCELLED info.2 &&
+    grep CANCELLED info.3
+'
+
+test_expect_success 'allocate works with 1-node/1-socket after cancels' '
+    flux resource match allocate ${jobspec} &&
+    flux resource match allocate ${jobspec} &&
+    flux resource match allocate ${jobspec} &&
+    flux resource match allocate ${jobspec}
+'
+
+test_expect_success 'resource-info on allocated jobs works' '
+    flux resource info 4 > info.4 &&
+    flux resource info 5 > info.5 &&
+    flux resource info 6 > info.6 &&
+    flux resource info 7 > info.7 &&
+    grep ALLOCATED info.4 &&
+    grep ALLOCATED info.5 &&
+    grep ALLOCATED info.6 &&
+    grep ALLOCATED info.7
+'
+
+test_expect_success 'cancel on nonexistent jobid is handled gracefully' '
+    test_expect_code 1 flux resource cancel 100000
+'
+
+test_expect_success 'removing resource works' '
+    flux module remove resource
+'
+
+test_done


### PR DESCRIPTION
This PR addresses all of the comments I had received on the posting of the previous experimental PR. 

- Refactor, augment, modify the resource scheduling infrastructure used by both the `resource` module and `resource-query` utility.

- Add the `resource` matching service module that uses this infrastructure to populate the resource graph data store and expose four request handlers (`match`, `cancel`, `info`, and `next_jobid`) `next_jobid` is only needed for testing.

- Add `flux-resource.py` as the front-end command that can interact with `resource` module. This is essential to drive our tests when we don't have the upcoming schedule loop service.

Don't merge this yet as we have a few more steps before landing this. The proposed remaining steps are:

1. Add tests. They will focus on testing the handler and RPC logic as I prefer using `resource-query` for the general correctness and performance tests for the resource scheduling infrastructure (which I already have a bunch).

2. Squash bugs we found during adding tests

3. Land this

4. Merge in @SteVwonder's PR #385 so that `resource` module can be populated with `hwloc` data.

5. Add rc1 and rc3 support with the hwloc mode being default. (Another PR).


If you want to play with this:

copy `t/data/resource/jobspecs/basics/test001.yaml` and `t/data/resource/grugs/tiny.graphml` into a directory first.

```
% flux start -s 1 -o,-S,log-filename=out
% flux module load resource grug-conf=tiny.graphml subsystems=containment policy=high
% flux resource match allocate test001.yaml
JOBID                STATUS               AT                   OVERHEAD (Secs)
0                    ALLOCATED            Now                  0.00181102752686
================================================================================
MATCHED RESOURCES:
      ---------------core35[1:x]
      ------------socket1[1:x]
      ---------node1[1:s]
      ------rack0[1:s]
      ---tiny0[1:s]

% flux resource match allocate test001.yaml
JOBID                STATUS               AT                   OVERHEAD (Secs)
1                    ALLOCATED            Now                  0.000900983810425
================================================================================
MATCHED RESOURCES:
      ---------------core17[1:x]
      ------------socket0[1:x]
      ---------node1[1:s]
      ------rack0[1:s]
      ---tiny0[1:s]

% flux resource match allocate test001.yaml
JOBID                STATUS               AT                   OVERHEAD (Secs)
2                    ALLOCATED            Now                  0.000859975814819
================================================================================
MATCHED RESOURCES:
      ---------------core35[1:x]
      ------------socket1[1:x]
      ---------node0[1:s]
      ------rack0[1:s]
      ---tiny0[1:s]

% flux resource match allocate test001.yaml
JOBID                STATUS               AT                   OVERHEAD (Secs)
3                    ALLOCATED            Now                  0.000686883926392
================================================================================
MATCHED RESOURCES:
      ---------------core17[1:x]
      ------------socket0[1:x]
      ---------node0[1:s]
      ------rack0[1:s]
      ---tiny0[1:s]

% flux resource match allocate test001.yaml
MATCHED RESOURCES: Not found

% flux resource info 3
JOBID                STATUS               AT                   OVERHEAD (Secs)
3                    ALLOCATED            Now                  0.000686883926392

% flux resource match allocate_orelse_reserve test001.yaml
JOBID                STATUS               AT                   OVERHEAD (Secs)
4                    RESERVED             3600                 0.00125002861023
================================================================================
MATCHED RESOURCES:
      ---------------core35[1:x]
      ------------socket1[1:x]
      ---------node1[1:s]
      ------rack0[1:s]
      ---tiny0[1:s]

```
 