### PR TITLE
travis-ci: use docker for test builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,98 +1,66 @@
+sudo: required
+services: docker
+dist: trusty
 language: c
-
-sudo: false
 
 matrix:
   include:
-    - compiler: gcc
-      env: LUA_VERSION=5.1
-    - compiler: clang
-      env: LUA_VERSION=5.1
-    - compiler: gcc
-      env: LUA_VERSION=5.1 COVERAGE=t
-    - compiler: gcc
-      env: LUA_VERSION=5.2 TEST_INSTALL=t
-    - compiler: clang
-      env: LUA_VERSION=5.2 CC=clang-3.8 CXX=clang++-3.8
-    - compiler: clang
-      env: LUA_VERSION=5.1 CPPCHECK=t
+    - name: "Ubuntu: gcc-8, distcheck"
+      compiler: gcc-8
+      env:
+       - CC=gcc-8
+       - CXX=g++-8
+       - DISTCHECK=t
+    - name: "Ubuntu: clang-6.0 chain-lint"
+      compiler: clang-6.0
+      env:
+       - CC=clang-6.0
+       - CXX=clang++-6.0
+       - chain_lint=t
+    - name: "Ubuntu: COVERAGE=t"
+      compiler: gcc
+      env:
+       - COVERAGE=t
+    - name: "Ubuntu: TEST_INSTALL docker-deploy"
+      compiler: gcc
+      env:
+       - TEST_INSTALL=t
+       - DOCKER_TAG=t
+    - name: "Centos 7: docker-deploy"
+      compiler: gcc
+      env:
+       - IMG=centos7
+       - DOCKER_TAG=t
+
+env:
+  global:
+  - TAP_DRIVER_QUIET=1
+  - DOCKERREPO=fluxrm/flux-sched
+  - DOCKER_USERNAME=travisflux
+
 cache:
   directories:
-    - $HOME/local
     - $HOME/.ccache
-    - $HOME/.local
-
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-      - llvm-toolchain-precise-3.8
-      - george-edison55-precise-backports # CMake 3.0
-    packages:
-      - cmake
-      - cmake-data
-      - clang-3.8
-      - gcc-8
-      - g++-8
-      - uuid-dev
-      - aspell
-      - libopenmpi-dev
-      - ccache
-      - apport # for coredumps
-      - gdb
-      - libmunge-dev
-      - munge
-      - lcov
-      - libyaml-cpp-dev
-      - libboost-all-dev
-      - libreadline6
-      - valgrind
-      - libevent-dev
 
 before_install:
-  - rm -rf $HOME/.luarocks
-  - wget https://raw.githubusercontent.com/flux-framework/flux-core/master/src/test/travis-dep-builder.sh
-  - $(bash ./travis-dep-builder.sh --printenv)
-  - export PKG_CONFIG_PATH=$HOME/local2/lib/pkgconfig:${PKG_CONFIG_PATH}
-  - test "$TRAVIS_PULL_REQUEST" == "false" || export CCACHE_READONLY=1
-  - if test "$CC" = "clang"; then export CCACHE_CPP2=1; fi
-  - depbuilder=$(pwd)/travis-dep-builder.sh
-  - (mkdir -p ../depbuild && cd ../depbuild && bash ${depbuilder} --cachedir=$HOME/local/.cache)
-
   # coveralls-lcov required only for coveralls.io upload:
   - if test "$COVERAGE" = "t"; then gem install coveralls-lcov; fi
-
-script:
- - ulimit -c unlimited
- - export CC="ccache $CC"
- - export MAKECMDS="make distcheck"
- - export FLUX_TESTS_LOGFILE=t
-
- - git clone https://github.com/flux-framework/flux-core.git $HOME/flux-core
- - (cd $HOME/flux-core && ./autogen.sh && ./configure --prefix=$HOME/local2 && make -j 2 && make install)
- - (rm -fr $HOME/flux-core)
- - (find $HOME/local2/lib -name \*.la | xargs rm -f)
- - ($HOME/local2/bin/flux keygen)
-
- # Set LD_LIBRARY_PATH so that flux-core libs can be found
- - export LD_LIBRARY_PATH=$HOME/local2/lib:${LD_LIBRARY_PATH}
-
- # Enable coverage for $CC+coverage build
- - if test "$COVERAGE" = "t" ; then ARGS=--enable-code-coverage; MAKECMDS="make && make check-code-coverage && lcov -l flux-*coverage.info" ; fi
- 
- # Use "make install" and set FLUX_SCHED_TEST_INSTALLED in environment for installed testing:
- - if test "$TEST_INSTALL" = "t"; then ARGS=--prefix=$HOME/local2; MAKECMDS="make && make install && FLUX_SCHED_TEST_INSTALLED=t make check"; fi
-
- # cppcheck instead of make
- - >
-   if test "$CPPCHECK" = "t"; then
-     MAKECMDS="cppcheck --force --inline-suppr -j 2 --std=c99 --std=c++11 --quiet
-             --error-exitcode=1
-             -i src/common/libtap
-              .";
+  - if test -z "$IMG"; then IMG=bionic; fi
+  #  Tag image if this build is on master or result of a tag:
+  - |
+   if test "$DOCKER_TAG" = "t" \
+     -a "$TRAVIS_REPO_SLUG" = "flux-framework/flux-sched" \
+     -a "$TRAVIS_PULL_REQUEST" = "false" \
+     -a \( "$TRAVIS_BRANCH" = "master" -o -n "$TRAVIS_TAG" \); then
+      export TAGNAME="${DOCKERREPO}:${IMG}-${TRAVIS_TAG:-latest}"
+      echo "Tagging new image $TAGNAME"
    fi
 
- - autoreconf -i && ./configure ${ARGS} && echo $MAKECMDS && eval ${MAKECMDS}
+script:
+  - |
+   src/test/docker/docker-run-checks.sh -j2 \
+     --image=${IMG} \
+     ${TAGNAME:+--tag=${TAGNAME}}
 
 after_success:
  - ccache -s

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,10 +11,11 @@ EXTRA_DIST= \
 
 CODE_COVERAGE_IGNORE_PATTERN = \
     "$(abs_top_builddir)/t/*" \
-    "/test/*.c" \
-    "/tests/*.c" \
-    "common/libtap/*" \
-    "common/liblsd/*" \
-    "/usr/*"
+    "*/test/*.c" \
+    "*/tests/*.c" \
+    "*/common/libtap/*" \
+    "*/common/liblsd/*" \
+    "/usr/include/*" \
+    "/usr/lib/*"
 CODE_COVERAGE_LCOV_OPTIONS =
 @CODE_COVERAGE_RULES@

--- a/src/test/cppcheck.sh
+++ b/src/test/cppcheck.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cppcheck --force --inline-suppr -j 2 --std=c99 --quiet \
+    --error-exitcode=1 \
+    -i src/common/libtap \
+    src

--- a/src/test/docker/bionic/Dockerfile
+++ b/src/test/docker/bionic/Dockerfile
@@ -1,0 +1,28 @@
+FROM fluxrm/flux-core:bionic-base-latest
+
+ARG USER=flux
+ARG UID=1000
+
+# Install extra buildrequires for flux-sched:
+RUN sudo apt-get update
+RUN sudo apt-get -qq install -y --no-install-recommends \
+	libboost-graph-dev \
+	libboost-system-dev \
+	libboost-filesystem-dev \
+	libboost-regex-dev \
+        libxml2-dev \
+	python-yaml
+
+# Add configured user to image with sudo access:
+#
+RUN \
+ if test "$USER" != "flux"; then  \
+      sudo groupadd -g $UID $USER \
+   && sudo useradd -g $USER -u $UID -d /home/$USER -m $USER \
+   && sudo sh -c "printf \"$USER ALL= NOPASSWD: ALL\\n\" >> /etc/sudoers" \
+   && sudo adduser $USER sudo ; \
+ fi
+
+USER $USER
+WORKDIR /home/$USER
+RUN flux keygen

--- a/src/test/docker/centos7/Dockerfile
+++ b/src/test/docker/centos7/Dockerfile
@@ -1,0 +1,28 @@
+FROM fluxrm/flux-core:centos7-base-latest
+
+ARG USER=flux
+ARG UID=1000
+
+# Install extra buildrequires for flux-sched:
+RUN sudo yum -y install  \
+	libboost-graph-devel \
+	libboost-system-devel \
+	libboost-filesystem-devel \
+	libboost-regex-devel \
+        libxml2-devel \
+	readline-devel \
+	python-yaml
+
+# Add configured user to image with sudo access:
+#
+RUN \
+ if test "$USER" != "flux"; then  \
+      sudo groupadd -g $UID $USER \
+   && sudo useradd -g $USER -u $UID -d /home/$USER -m $USER \
+   && sudo sh -c "printf \"$USER ALL= NOPASSWD: ALL\\n\" >> /etc/sudoers" \
+   && sudo usermod -G wheel $USER; \
+ fi
+
+USER $USER
+WORKDIR /home/$USER
+RUN flux keygen

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -117,6 +117,7 @@ docker run --rm \
     -e USER \
     -e TRAVIS \
     -e TAP_DRIVER_QUIET \
+    --cap-add SYS_PTRACE \
     --tty \
     ${INTERACTIVE:+--interactive} \
     travis-builder:${IMAGE} \

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -118,6 +118,7 @@ docker run --rm \
     -e TRAVIS \
     -e TAP_DRIVER_QUIET \
     --tty \
+    ${INTERACTIVE:+--interactive} \
     travis-builder:${IMAGE} \
     ${INTERACTIVE:-./src/test/travis_run.sh ${CONFIGURE_ARGS}} \
     || die "docker run failed"

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+#
+#  Build flux-sched docker image and run tests, exporting
+#   important environment variables to the docker environment.
+#
+#  Arguments here are passed directly to ./configure
+#
+#
+# option Defaults:
+IMAGE=bionic
+JOBS=2
+MOUNT_HOME_ARGS="--volume=$HOME:/home/$USER -e HOME"
+
+#
+declare -r prog=${0##*/}
+die() { echo -e "$prog: $@"; exit 1; }
+
+#
+declare -r long_opts="help,quiet,interactive,image:,jobs:,no-cache,no-home,distcheck,tag:"
+declare -r short_opts="hqIdi:j:t:"
+declare -r usage="
+Usage: $prog [OPTIONS] -- [CONFIGURE_ARGS...]\n\
+Build docker image for travis builds, then run tests inside the new\n\
+container as the current user and group.\n\
+\n\
+Uses the current git repo for the build.\n\
+\n\
+Options:\n\
+ -h, --help                    Display this message\n\
+     --no-cache                Disable docker caching\n\
+     --no-home                 Skip mounting the host home directory\n\
+ -q, --quiet                   Add --quiet to docker-build\n\
+ -t, --tag=TAG                 If checks succeed, tag image as NAME\n\
+ -i, --image=NAME              Use base docker image NAME (default=$IMAGE)\n\
+ -j, --jobs=N                  Value for make -j (default=$JOBS)\n
+ -d, --distcheck               Run 'make distcheck' instead of 'make check'\n\
+ -I, --interactive             Instead of running travis build, run docker\n\
+                                image with interactive shell.\n\
+"
+
+# check if running in OSX
+if [[ "$(uname)" == "Darwin" ]]; then
+    # BSD getopt
+    GETOPTS=`/usr/bin/getopt $short_opts -- $*`
+else
+    # GNU getopt
+    GETOPTS=`/usr/bin/getopt -u -o $short_opts -l $long_opts -n $prog -- $@`
+    if [[ $? != 0 ]]; then
+        die "$usage"
+    fi
+    eval set -- "$GETOPTS"
+fi
+while true; do
+    case "$1" in
+      -h|--help)                   echo -ne "$usage";          exit 0  ;;
+      -q|--quiet)                  QUIET="--quiet";            shift   ;;
+      -i|--image)                  IMAGE="$2";                 shift 2 ;;
+      -j|--jobs)                   JOBS="$2";                  shift 2 ;;
+      -I|--interactive)            INTERACTIVE="/bin/bash";    shift   ;;
+      -d|--distcheck)              DISTCHECK=t;                shift   ;;
+      --no-cache)                  NO_CACHE="--no-cache";      shift   ;;
+      --no-home)                   MOUNT_HOME_ARGS="";         shift   ;;
+      -t|--tag)                    TAG="$2";                   shift 2 ;;
+      --)                          shift; break;                       ;;
+      *)                           die "Invalid option '$1'\n$usage"   ;;
+    esac
+done
+
+
+TOP=$(git rev-parse --show-toplevel 2>&1) \
+    || die "not inside flux-sched git repository!"
+which docker >/dev/null \
+    || die "unable to find a docker binary"
+
+CONFIGURE_ARGS="$@"
+
+. ${TOP}/src/test/travis-lib.sh
+
+travis_fold "docker_build" \
+  "Building image $IMAGE for user $USER $(id -u) group=$(id -g)" \
+  docker build \
+    ${NO_CACHE} \
+    ${QUIET} \
+    --build-arg USER=$USER \
+    --build-arg UID=$(id -u) \
+    -t travis-builder:${IMAGE} \
+    $TOP/src/test/docker/${IMAGE} \
+    || die "docker build failed"
+
+if [[ -n "$MOUNT_HOME_ARGS" ]]; then
+    echo "mounting $HOME as /home/$USER"
+fi
+echo "mounting $TOP as /usr/src"
+
+export JOBS
+export DISTCHECK
+export chain_lint
+
+docker run --rm \
+    --workdir=/usr/src \
+    --volume=$TOP:/usr/src \
+    $MOUNT_HOME_ARGS \
+    -e CC \
+    -e CXX \
+    -e LDFLAGS \
+    -e CFLAGS \
+    -e CPPFLAGS \
+    -e GCOV \
+    -e CCACHE_CPP2 \
+    -e CCACHE_READONLY \
+    -e COVERAGE \
+    -e TEST_INSTALL \
+    -e CPPCHECK \
+    -e DISTCHECK \
+    -e chain_lint \
+    -e JOBS \
+    -e USER \
+    -e TRAVIS \
+    -e TAP_DRIVER_QUIET \
+    --tty \
+    travis-builder:${IMAGE} \
+    ${INTERACTIVE:-./src/test/travis_run.sh ${CONFIGURE_ARGS}} \
+    || die "docker run failed"
+
+if test -n "$TAG"; then
+    # Re-run 'make install' in fresh image, otherwise we get all
+    # the context from the build above
+    docker run --name=tmp.$$ \
+	--workdir=/usr/src \
+        --volume=$TOP:/usr/src \
+        --user="root" \
+	travis-builder:${IMAGE} \
+	sh -c "make install && \
+               userdel $USER" \
+	|| (docker rm tmp.$$; die "docker run of 'make install' failed")
+    docker commit \
+	--change 'CMD "/usr/bin/flux"' \
+	--change 'USER flux' \
+	--change 'WORKDIR /home/flux' \
+	tmp.$$ $TAG \
+	|| die "docker commit failed"
+    docker rm tmp.$$
+    echo "Tagged image $TAG"
+fi

--- a/src/test/travis-lib.sh
+++ b/src/test/travis-lib.sh
@@ -1,0 +1,52 @@
+#
+# Fold commands in travis-ci output window with timing
+# https://github.com/travis-ci/travis-ci/issues/2285
+# and
+# https://github.com/travis-ci/travis-build/tree/master/lib/travis/build/bash
+#
+
+
+# Globals for travis_time_start/end:
+TRAVIS_TIME=
+TRAVIS_TIME_ID=
+
+#  Only emit travis_start/end and travis_time blocks if we're actually
+#   running under Travis-CI
+#
+if test "$TRAVIS" = "true"; then
+  travis_time_start() {
+    TRAVIS_TIME=$(date +%s%N)
+    TRAVIS_TIME_ID="$(printf %08x $((RANDOM * RANDOM)))"
+    printf 'travis_time:start:%s\r\033[0K' $TRAVIS_TIME_ID
+  }
+  travis_time_end() {
+    local finish=$(date +%s%N)
+    printf 'travis_time:end:%s:start=%s,finish=%s,duration=%s\r\033[0K' \
+           $TRAVIS_TIME_ID $TRAVIS_TIME $finish $((finish - TRAVIS_TIME))
+  }
+  travis_fold_start() {
+    printf 'travis_fold:start:%s\r\033[0K\033[33;1m%s\033[0m' "$1" "$2"
+  }
+  travis_fold_end() {
+    printf 'travis_fold:end:%s\r\033[0K' "$1"
+  }
+else
+  travis_time_start() { return 0;}
+  travis_time_end()   { return 0;}
+  travis_fold_start() { return 0;}
+  travis_fold_end()   { return 0;}
+fi
+
+travis_fold() {
+    local NAME=$1
+    local DESC=$2
+    shift 2
+    travis_fold_start "$NAME" "$DESC"
+    travis_time_start
+    echo
+    eval "$@"
+    rc=$?
+    travis_time_end
+    travis_fold_end "$NAME"
+    return $rc
+}

--- a/src/test/travis_run.sh
+++ b/src/test/travis_run.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+#
+#  Test runner script meant to be executed inside of a docker container
+#
+#  Usage: travis_run.sh [OPTIONS...]
+#
+#  Where OPTIONS are passed directly to ./configure
+#
+#  The script is otherwise influenced by the following environment variables:
+#
+#  JOBS=N        Argument for make's -j option, default=2
+#  COVERAGE      Run with --enable-code-coverage, `make check-code-coverage`
+#  TEST_INSTALL  Run `make check` against installed flux-core
+#  CPPCHECK      Run cppcheck if set to "t"
+#  DISTCHECK     Run `make distcheck` if set
+#  FAKETIME      Support libfaketime tests
+#  chain_lint    Run sharness with --chain-lint if chain_lint=t
+#
+#  And, obviously, some crucial variables that configure itself cares about:
+#
+#  CC, CXX, LDFLAGS, CFLAGS, etc.
+#
+
+# source travis_fold and travis_time functions:
+. src/test/travis-lib.sh
+
+ARGS="$@"
+JOBS=${JOBS:-2}
+MAKECMDS="make -j ${JOBS} ${DISTCHECK:+dist}check"
+
+ulimit -c unlimited
+
+if test -n "$FAKETIME"; then
+  # Add non-standard path for libfaketime to LD_LIBRARY_PATH:
+  export LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/faketime"
+
+  # Ensure travis builds libev such that libfaketime will work:
+  # (force libev to *not* use syscall interface for clock_gettime())
+  export CPPFLAGS="$CPPFLAGS -DEV_USE_CLOCK_SYSCALL=0 -DEV_USE_MONOTONIC=1"
+fi
+
+# Force git to update the shallow clone and include tags so git-describe works
+travis_fold "git_fetch_tags" "git fetch --unshallow --tags" \
+ git fetch --unshallow --tags || true
+
+# Manually update ccache symlinks (XXX: Is this really necessary?)
+test -x /usr/sbin/update-ccache-symlinks && \
+    sudo /usr/sbin/update-ccache-symlinks
+export PATH=/usr/lib/ccache:$PATH
+
+# Ensure ccache dir exists
+mkdir -p $HOME/.ccache
+
+# clang+ccache requries second cpp pass:
+if echo "$CC" | grep -q "clang"; then
+    CCACHE_CPP=1
+fi
+
+# Enable coverage for $CC-coverage build
+# We can't use distcheck here, it doesn't play well with coverage testing:
+if test "$COVERAGE" = "t"; then
+    ARGS="$ARGS --enable-code-coverage"
+    MAKECMDS="make -j $JOBS && \
+              make -j $JOBS check-code-coverage && \
+              lcov -l flux*-coverage.info"
+
+# Use make install for T_INSTALL:
+elif test "$TEST_INSTALL" = "t"; then
+    ARGS="$ARGS --prefix=/usr --sysconfdir=/etc"
+    MAKECMDS="make -j $JOBS && sudo make install && \
+              /usr/bin/flux keygen --force && \
+              FLUX_TEST_INSTALLED_PATH=/usr/bin make -j $JOBS check"
+fi
+
+# Travis has limited resources, even though number of processors might
+#  might appear to be large. Limit session size for testing to 5 to avoid
+#  spurious timeouts.
+export FLUX_TEST_SIZE_MAX=5
+
+# Invoke MPI tests
+export TEST_MPI=t
+
+# Generate logfiles from sharness tests for extra information:
+export FLUX_TESTS_LOGFILE=t
+export DISTCHECK_CONFIGURE_FLAGS="${ARGS}"
+
+if test "$CPPCHECK" = "t"; then
+    sh -x src/test/cppcheck.sh
+fi
+
+if ! test -d $HOME/.flux/curve; then
+    travis_fold "flux_keygen" "flux keygen ..." flux keygen
+fi
+travis_fold "autogen.sh" "./autogen.sh..." ./autogen.sh
+travis_fold "configure"  "./configure ${ARGS}..." ./configure ${ARGS}
+travis_fold "make_clean" "make clean..." make clean
+
+eval ${MAKECMDS}

--- a/t/t2002-easy.t
+++ b/t/t2002-easy.t
@@ -48,7 +48,7 @@ test_expect_success 'jobs scheduled in correct order' '
 '
 
 test_expect_success 'sim: unloaded' '
-    flux module remove sched
+    flux module remove sched &&
     flux module remove sim_exec &&
     flux module remove submit &&
     flux module remove sim

--- a/t/t5000-valgrind.t
+++ b/t/t5000-valgrind.t
@@ -39,7 +39,7 @@ test_expect_success 'found executable flux-broker' '
 	test -x "$BROKER"
 '
 test_expect_success 'valgrind reports no new errors on single broker run' '
-	flux ${VALGRIND} \
+	run_timeout 120 flux ${VALGRIND} \
 		--tool=memcheck \
 		--leak-check=full \
 		--gen-suppressions=all \


### PR DESCRIPTION
I went ahead and copied over the docker scripts from flux-core to get flux-sched building with docker as well. Unfortunately, I wasn't clever enough to write the scripts so they could be exactly shared between different flux-* projects, so the copies here are modified slightly, but work generally the same.

The other difference is that the flux-sched Dockerfiles pull directly from `fluxrm/flux-core:${IMAGE}-latest`, i.e. from the docker images auto-deployed from the flux-core travis builds. If a branch or PR of flux-sched ever requires a specific version of flux-core, the Dockerfiles could be modified to instead pull for `fluxrm/flux-core:${IMAGE}-vx.y.z` to get the tagged flux-core instead.

I also copied over support for TAP_DRIVER_QUIET in `tap-driver.sh`.