### PR TITLE
Integrate jobspec into resource, etc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,13 +63,13 @@ AC_DEFINE_UNQUOTED([LIBLUA_SO], ["$LIBLUA_SONAME"],
 PKG_CHECK_MODULES([UUID], [uuid], [], [])
 AX_FLUX_CORE
 
+X_AC_YAMLCPP
 AX_BOOST_BASE([1.53.0], [], [AC_MSG_ERROR([Please use boost == 1.53 or > 1.58])])
 AX_CHECK_BUGGY_BOOST
 AX_BOOST_SYSTEM
 AX_BOOST_FILESYSTEM
 AX_BOOST_GRAPH
 AX_BOOST_REGEX
-PKG_CHECK_MODULES([JOBSPEC], [flux-jobspec], [], [])
 PKG_CHECK_MODULES([IDSET], [flux-idset], [], [])
 AC_CHECK_LIB([readline], [readline],
              [AC_SUBST([READLINE_LIBS], ["-lreadline"])
@@ -153,6 +153,8 @@ AC_CONFIG_FILES([Makefile
   resource/Makefile
   resource/planner/Makefile
   resource/planner/test/Makefile
+  resource/libjobspec/Makefile
+  resource/utilities/Makefile
   resource/modules/Makefile
   sched/Makefile
   sched/priority/Makefile

--- a/m4/x_ac_yamlcpp.m4
+++ b/m4/x_ac_yamlcpp.m4
@@ -1,0 +1,32 @@
+AC_DEFUN([X_AC_YAMLCPP], [
+
+    PKG_CHECK_MODULES([YAMLCPP], [yaml-cpp >= 0.5.1], ,
+                      [AC_MSG_ERROR(dnl
+                      [Required yaml-cpp package version not installed.
+                       Set the PKG_CONFIG_PATH env var appropriately.])])
+
+    ac_save_LIBS="$LIBS"
+    LIBS="$LIBS $YAMLCPP_LIBS"
+    ac_save_CFLAGS="$CFLAGS"
+    CFLAGS="$CFLAGS $YAMLCPP_CFLAGS"
+    AC_LANG_PUSH([C++])
+
+    AC_MSG_CHECKING([whether yaml-cpp/yaml.h is usable])
+    AC_PREPROC_IFELSE(
+        [AC_LANG_PROGRAM([#include <yaml-cpp/yaml.h>], [])],
+            [AC_MSG_RESULT([yes])],
+            [AC_MSG_FAILURE([yaml-cpp/yaml.h doesn't appear to be usable.])]
+    )
+
+    # YAML::Node::Mark() is only present in yaml-cpp beginning
+    # with release 0.5.3.
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <yaml-cpp/yaml.h>],
+                                    [YAML::Node node; node.Mark()])],
+                   [AC_DEFINE([HAVE_YAML_MARK], [1],
+                              [Define to 1 if yaml-cpp library has YAML::Node::Mark()])],
+                   [])
+
+    AC_LANG_POP([C++])
+    LIBS="$ac_save_LIBS"
+    CFLAGS="$ac_save_CFLAGS"
+])

--- a/resource/Makefile.am
+++ b/resource/Makefile.am
@@ -12,11 +12,9 @@ AM_LDFLAGS = $(CODE_COVERAGE_LDFLAGS) \
 AM_CPPFLAGS = -I$(top_srcdir) $(CZMQ_CFLAGS) $(FLUX_CORE_CFLAGS) \
 	      $(BOOST_CPPFLAGS)
 
-SUBDIRS = planner . modules
+SUBDIRS = libjobspec planner . utilities modules
 
 noinst_LTLIBRARIES = libresource.la
-
-noinst_PROGRAMS = utilities/grug2dot utilities/resource-query
 
 EXTRA_DIST= \
     utilities/conf
@@ -66,42 +64,13 @@ libresource_la_SOURCES = \
 libresource_la_CXXFLAGS = \
     $(WARNING_CXXFLAGS) \
     $(CODE_COVERAGE_CFLAGS) \
-    $(AM_CXXFLAGS) \
-    $(JOBSPEC_CFLAGS)
+    $(AM_CXXFLAGS)
 
 libresource_la_LIBADD = \
     $(top_builddir)/resource/planner/libplanner.la \
-    $(JOBSPEC_LIBS) \
+    $(top_builddir)/resource/libjobspec/libjobspec_conv.la \
     $(BOOST_SYSTEM_LIB) \
     $(BOOST_FILESYSTEM_LIB) \
     $(BOOST_GRAPH_LIB) \
     $(BOOST_REGEX_LIB)
-
-#
-# grug2dot
-#
-utilities_grug2dot_SOURCES = \
-    utilities/grug2dot.cpp \
-    generators/spec.cpp \
-    generators/spec.hpp
-utilities_grug2dot_CXXFLAGS = \
-    $(AM_CXXFLAGS)
-utilities_grug2dot_LDADD = \
-    $(BOOST_SYSTEM_LIB) \
-    $(BOOST_FILESYSTEM_LIB) \
-    $(BOOST_GRAPH_LIB) \
-    $(BOOST_REGEX_LIB)
-
-#
-# resource-query
-#
-utilities_resource_query_SOURCES = \
-    utilities/resource-query.cpp \
-    utilities/command.cpp
-utilities_resource_query_CXXFLAGS = \
-    $(AM_CXXFLAGS) \
-    $(JOBSPEC_CFLAGS) \
-    $(READLINE_LIBS)
-utilities_resource_query_LDADD = \
-    libresource.la
 

--- a/resource/libjobspec/Makefile.am
+++ b/resource/libjobspec/Makefile.am
@@ -1,4 +1,10 @@
+noinst_PROGRAMS = flux-jobspec-validate
 noinst_LTLIBRARIES = libjobspec_conv.la
+
+flux_jobspec_validate_SOURCES = flux-jobspec-validate.cpp
+flux_jobspec_validate_LDADD = \
+    libjobspec_conv.la \
+    $(YAMLCPP_LIBS)
 
 libjobspec_conv_la_CXXFLAGS = \
 	$(WARNING_CXXFLAGS) \

--- a/resource/libjobspec/Makefile.am
+++ b/resource/libjobspec/Makefile.am
@@ -1,0 +1,9 @@
+noinst_LTLIBRARIES = libjobspec_conv.la
+
+libjobspec_conv_la_CXXFLAGS = \
+	$(WARNING_CXXFLAGS) \
+	$(CODE_COVERAGE_CXXFLAGS) \
+	$(YAMLCPP_CFLAGS)
+libjobspec_conv_la_LIBADD = $(CODE_COVERAGE_LIBS) $(YAMLCPP_LIBS)
+libjobspec_conv_la_SOURCES = jobspec.cpp jobspec.hpp
+

--- a/resource/libjobspec/flux-jobspec-validate.cpp
+++ b/resource/libjobspec/flux-jobspec-validate.cpp
@@ -1,0 +1,84 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include <iostream>
+#include <fstream>
+#include <string>
+
+#include <flux/jobspec.hpp>
+#include <yaml-cpp/yaml.h>
+
+using namespace std;
+using namespace Flux::Jobspec;
+
+void parse_yaml_stream_docs (std::istream& js_stream)
+{
+    bool first = true;
+    for (auto&& rootnode: YAML::LoadAll (js_stream)) {
+        Jobspec js;
+        if (!first)
+            cout << endl;
+        else
+            first = false;
+        js = Jobspec (rootnode);
+        cout << js;
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    try {
+        if (argc == 1) {
+            parse_yaml_stream_docs (cin);
+        } else {
+            for (int i = 1; i < argc; i++) {
+                std::ifstream js_file (argv[i]);
+                if (js_file.fail()) {
+                    cerr << argv[0] << ": Unable to open file \"" << argv[i] << "\"" << endl;
+                    return 1;
+                }
+                parse_yaml_stream_docs (js_file);
+            }
+        }
+    } catch (parse_error& e) {
+        cerr << argv[0] << ": ";
+        if (e.position != -1)
+            cerr << argv[0] << "position " << e.position << ", ";
+        if (e.line != -1)
+            cerr << argv[0] << "line " << e.line << ", ";
+        if (e.column != -1)
+            cerr << "column " << e.column << ", ";
+        cerr << e.what() << endl;
+        return 2;
+    } catch (...) {
+        cerr << argv[0] << ": Unknown non-standard exception" << endl;
+        return 3;
+    }
+
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/libjobspec/jobspec.cpp
+++ b/resource/libjobspec/jobspec.cpp
@@ -1,0 +1,540 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include "jobspec.hpp"
+
+#include <iostream>
+#include <string>
+#include <unordered_map>
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+}
+
+using namespace std;
+using namespace Flux::Jobspec;
+
+parse_error::parse_error(const char *msg)
+    : runtime_error(msg),
+      position(-1),
+      line(-1),
+      column(-1)
+{}
+
+parse_error::parse_error(const YAML::Node &node, const char *msg)
+    : runtime_error(msg),
+#ifdef HAVE_YAML_MARK
+      position(node.Mark().pos),
+      line(node.Mark().line+1),
+      column(node.Mark().column)
+#else
+      position(-1),
+      line(-1),
+      column(-1)
+#endif
+{}
+
+namespace {
+void parse_yaml_count (Resource& res, const YAML::Node &cnode)
+{
+    /* count can have an unsigned interger value */
+    if (cnode.IsScalar()) {
+        res.count.min = cnode.as<unsigned>();
+        res.count.max = res.count.min;
+        return;
+    }
+
+    /* or count may be a more complicated verbose form */
+    if (!cnode.IsMap()) {
+        throw parse_error (cnode, "count is not a mapping");
+    }
+
+    /* Verify existance of required entries */
+    if (!cnode["min"]) {
+        throw parse_error (cnode, "Key \"min\" missing from count");
+    }
+    if (!cnode["min"].IsScalar()) {
+        throw parse_error (cnode["min"], "Value of \"min\" must be a scalar");
+    }
+    if (!cnode["max"]) {
+        throw parse_error (cnode, "Key \"max\" missing from count");
+    }
+    if (!cnode["max"].IsScalar()) {
+        throw parse_error (cnode["max"], "Value of \"max\" must be a scalar");
+    }
+    if (!cnode["operator"]) {
+        throw parse_error (cnode, "Key \"operator\" missing from count");
+    }
+    if (!cnode["operator"].IsScalar()) {
+        throw parse_error (cnode["operator"],
+                           "Value of \"operator\" must be a scalar");
+    }
+    if (!cnode["operand"]) {
+        throw parse_error (cnode, "Key \"operand\" missing from count");
+    }
+    if (!cnode["operand"].IsScalar()) {
+        throw parse_error (cnode["operand"],
+                           "Value of \"operand\" must be a scalar");
+    }
+
+    /* Validate values of entries */
+    res.count.min = cnode["min"].as<unsigned>();
+    if (res.count.min < 1) {
+        throw parse_error (cnode["min"], "\"min\" must be greater than zero");
+    }
+
+    res.count.max = cnode["max"].as<unsigned>();
+    if (res.count.max < 1) {
+        throw parse_error (cnode["max"], "\"max\" must be greater than zero");
+    }
+    if (res.count.max < res.count.min) {
+        throw parse_error (cnode["max"],
+                           "\"max\" must be greater than or equal to \"min\"");
+    }
+
+    res.count.oper = cnode["operator"].as<char>();
+    switch (res.count.oper) {
+    case '+':
+    case '*':
+    case '^':
+        break;
+    default:
+        throw parse_error (cnode["operator"], "Invalid count operator");
+    }
+
+    res.count.operand = cnode["operand"].as<int>();
+}
+}
+
+namespace {
+vector<Resource> parse_yaml_resources (const YAML::Node &resources);
+}
+
+Resource::Resource (const YAML::Node &resnode)
+{
+    unsigned field_count = 0;
+
+    /* The resource must be a mapping */
+    if (!resnode.IsMap()) {
+        throw parse_error (resnode, "resource is not a mapping");
+    }
+    if (!resnode["type"]) {
+        throw parse_error (resnode, "Key \"type\" missing from resource");
+    }
+    if (!resnode["type"].IsScalar()) {
+        throw parse_error (resnode["type"],
+                           "Value of \"type\" must be a scalar");
+    }
+    type = resnode["type"].as<string>();
+    field_count++;
+
+    if (!resnode["count"]) {
+        throw parse_error (resnode, "Key \"count\" missing from resource");
+    }
+    parse_yaml_count (*this, resnode["count"]);
+    field_count++;
+
+    if (resnode["unit"]) {
+        if (!resnode["unit"].IsScalar()) {
+            throw parse_error (resnode["unit"],
+                               "Value of \"unit\" must be a scalar");
+        }
+        field_count++;
+        unit = resnode["unit"].as<string>();
+    }
+    if (resnode["exclusive"]) {
+        if (!resnode["exclusive"].IsScalar()) {
+            throw parse_error (resnode["exclusive"],
+                               "Value of \"exclusive\" must be a scalar");
+        }
+        field_count++;
+        string val = resnode["exclusive"].as<string>();
+        if (val == "false") {
+            exclusive = tristate_t::FALSE;
+        } else if (val == "true") {
+            exclusive = tristate_t::TRUE;
+        } else {
+            throw parse_error (resnode["exclusive"],
+                               "Value of \"exclusive\" must be either \"true\" or \"false\"");
+        }
+    }
+
+    if (resnode["with"]) {
+        field_count++;
+        with = parse_yaml_resources (resnode["with"]);
+    }
+
+    if (resnode["label"]) {
+        if (!resnode["label"].IsScalar()) {
+            throw parse_error (resnode["label"],
+                               "Value of \"label\" must be a scalar");
+        }
+        field_count++;
+        label = resnode["label"].as<string>();
+    } else if (type == "slot") {
+        throw parse_error (resnode, "All slots must be labeled");
+    }
+
+    if (resnode["id"]) {
+        if (!resnode["id"].IsScalar()) {
+            throw parse_error (resnode["id"],
+                               "Value of \"id\" must be a scalar");
+        }
+        field_count++;
+        id = resnode["id"].as<string>();
+    }
+
+    if (field_count != resnode.size()) {
+        throw parse_error (resnode, "Unrecognized key in resource mapping");
+    }
+
+    if (resnode.size() < 2 || resnode.size() > 10) {
+        throw parse_error (resnode,
+                           "impossible number of entries in resource mapping");
+    }
+
+}
+
+Task::Task (const YAML::Node &tasknode)
+{
+    /* The task node must be a mapping */
+    if (!tasknode.IsMap()) {
+        throw parse_error (tasknode, "task is not a mapping");
+    }
+    if (!tasknode["command"]) {
+        throw parse_error (tasknode, "Key \"command\" missing from task");
+    }
+    if (tasknode["command"].IsSequence()) {
+        command = tasknode["command"].as<vector<string>>();
+    } else if (tasknode["command"].IsScalar()) {
+        command.push_back(tasknode["command"].as<string>());
+    } else {
+        throw parse_error (tasknode["command"],
+                           "\"command\" value must be a scalar or a sequence");
+    }
+
+    /* Import slot */
+    if (!tasknode["slot"]) {
+        throw parse_error (tasknode, "Key \"slot\" missing from task");
+    }
+    if (!tasknode["slot"].IsScalar()) {
+        throw parse_error (tasknode["slot"],
+                           "Value of task \"slot\" must be a YAML scalar");
+    }
+    slot = tasknode["slot"].as<string>();
+
+    /* Import count mapping */
+    if (tasknode["count"]) {
+        YAML::Node count_node = tasknode["count"];
+        if (!count_node.IsMap()) {
+            throw parse_error (count_node,
+                               "\"count\" in task is not a mapping");
+        }
+        for (auto&& entry : count_node) {
+            count[entry.first.as<string>()] = entry.second.as<string>();
+        }
+    }
+
+    /* Import distribution if it is present */
+    if (tasknode["distribution"]) {
+        if (!tasknode["distribution"].IsScalar()) {
+            throw parse_error (tasknode["distribution"],
+                               "Value of task \"distribution\" must be a YAML scalar");
+        }
+        distribution = tasknode["distribution"].as<string>();
+    }
+
+    /* Import attributes mapping if it is present */
+    if (tasknode["attributes"]) {
+        YAML::Node attrs = tasknode["attributes"];
+        if (!attrs.IsMap()) {
+            throw parse_error (attrs, "\"attributes\" in task is not a mapping");
+        }
+        for (auto&& attr : attrs) {
+            attributes[attr.first.as<string>()] = attr.second.as<string>();
+        }
+    }
+
+    if (tasknode.size() < 3 || tasknode.size() > 5) {
+        throw parse_error (tasknode,
+                           "impossible number of entries in task mapping");
+    }
+}
+
+namespace {
+vector<Task> parse_yaml_tasks (const YAML::Node &tasks)
+{
+    vector<Task> taskvec;
+
+    /* "tasks" must be a sequence */
+    if (!tasks.IsSequence()) {
+        throw parse_error (tasks, "\"tasks\" is not a sequence");
+    }
+
+    for (auto&& task : tasks) {
+        taskvec.push_back (Task (task));
+    }
+
+    return taskvec;
+}
+}
+
+namespace {
+vector<Resource> parse_yaml_resources (const YAML::Node &resources)
+{
+    vector<Resource> resvec;
+
+    /* "resources" must be a sequence */
+    if (!resources.IsSequence()) {
+        throw parse_error (resources, "\"resources\" is not a sequence");
+    }
+
+    for (auto&& resource : resources) {
+        resvec.push_back (Resource (resource));
+    }
+
+    return resvec;
+}
+}
+
+Jobspec::Jobspec(const YAML::Node &top)
+{
+    try {
+        /* The top yaml node of the jobspec must be a mapping */
+        if (!top.IsMap()) {
+            throw parse_error (top, "Top level of jobspec is not a mapping");
+        }
+        /* The four keys must be the following */
+        if (!top["version"]) {
+            throw parse_error (top, "Missing key \"version\" in top level mapping");
+        }
+        if (!top["resources"]) {
+            throw parse_error (top, "Missing key \"resource\" in top level mapping");
+        }
+        if (!top["tasks"]) {
+            throw parse_error (top, "Missing key \"tasks\" in top level mapping");
+        }
+        if (!top["attributes"]) {
+            throw parse_error (top, "Missing key \"attributes\" in top level mapping");
+        }
+        /* There must be exactly four entries in the mapping */
+        if (top.size() != 4) {
+            throw parse_error (top, "Top mapping in jobspec must have exactly four entries");
+        }
+
+        /* Import version */
+        if (!top["version"].IsScalar()) {
+            throw parse_error (top["version"],
+                               "\"version\" must be an unsigned integer");
+        }
+        version = top["version"].as<unsigned int>();
+        if (version != 1) {
+            throw parse_error (top["version"],
+                               "Only jobspec \"version\" 1 is supported");
+        }
+
+        /* Import attributes mappings */
+        YAML::Node attrs = top["attributes"];
+        /* allow attributes to be present and empty */
+        if (!attrs.IsNull()) {
+            if (!attrs.IsMap()) {
+                throw parse_error (attrs, "\"attributes\" is not a mapping");
+            }
+            if (attrs.size() > 0) {
+                for (auto&& i : attrs) {
+                    if (!i.second.IsMap()) {
+                        throw parse_error (i.second,
+                                           "value of attribute is not a mapping");
+                    }
+                    for (auto&& j : i.second) {
+                        attributes[i.first.as<string>()][j.first.as<string>()] =
+                            j.second.as<string>();
+                    }
+                }
+            }
+        }
+        /* Import resources section */
+        resources = parse_yaml_resources (top["resources"]);
+
+        /* Import tasks section */
+        tasks = parse_yaml_tasks (top["tasks"]);
+    } catch (YAML::Exception& e) {
+        throw parse_error(e.what());
+    }
+}
+
+Jobspec::Jobspec(std::istream &is)
+try
+    : Jobspec {YAML::Load (is)}
+{
+}
+catch (YAML::Exception& e) {
+    throw parse_error(e.what());
+}
+
+Jobspec::Jobspec(std::string &s)
+try
+    : Jobspec {YAML::Load (s)}
+{
+}
+catch (YAML::Exception& e) {
+    throw parse_error(e.what());
+}
+
+namespace {
+/*
+ * This class magically makes everything in 'dest' stream
+ * indented as long as this class is in scope.  Once it
+ * it goes out of scope and is destroyed, the indenting
+ * disappears.
+ */
+class IndentingOStreambuf : public std::streambuf
+{
+    std::streambuf* myDest;
+    bool myIsAtStartOfLine;
+    std::string myIndent;
+    std::ostream* myOwner;
+protected:
+    virtual int overflow( int ch )
+    {
+        if (myIsAtStartOfLine && ch != '\n') {
+            myDest->sputn (myIndent.data(), myIndent.size());
+        }
+        myIsAtStartOfLine = ch == '\n';
+        return myDest->sputc (ch);
+    }
+public:
+    explicit IndentingOStreambuf (std::streambuf* dest, int indent = 2)
+        : myDest (dest)
+        , myIsAtStartOfLine (true)
+        , myIndent (indent, ' ')
+        , myOwner(NULL)
+    {
+    }
+    explicit IndentingOStreambuf (std::ostream& dest, int indent = 2)
+        : myDest (dest.rdbuf ())
+        , myIsAtStartOfLine (true)
+        , myIndent (indent, ' ')
+        , myOwner (&dest)
+    {
+        myOwner->rdbuf (this);
+    }
+    virtual ~IndentingOStreambuf()
+    {
+        if ( myOwner != NULL ) {
+            myOwner->rdbuf (myDest);
+        }
+    }
+};
+}
+
+std::ostream& Flux::Jobspec::operator<<(std::ostream& s, Jobspec const& jobspec)
+{
+    s << "version: " << jobspec.version << endl;
+    s << "resources: " << endl;
+    for (auto&& resource : jobspec.resources) {
+        IndentingOStreambuf indent (s);
+        s << resource;
+    }
+    s << "tasks: " << endl;
+    for (auto&& task : jobspec.tasks) {
+        IndentingOStreambuf indent (s);
+        s << task;
+    }
+    s << "attributes:" << endl;
+    for (auto&& subattr : jobspec.attributes) {
+        s << "  " << subattr.first << ":" << endl;
+        for (auto&& attr : subattr.second) {
+            s << "    " << attr.first << " = " << attr.second << endl;
+        }
+    }
+
+    return s;
+}
+
+std::ostream& Flux::Jobspec::operator<<(std::ostream& s,
+                                        Resource const& resource)
+{
+    s << "- type: " << resource.type << endl;
+    s << "  count:" << endl;
+    s << "    min:  " << resource.count.min << endl;
+    s << "    max: " << resource.count.max << endl;
+    s << "    operator: " << resource.count.oper << endl;
+    s << "    operand: " << resource.count.operand << endl;
+    if (resource.unit.size() > 0)
+        s << "  unit: " << resource.unit << endl;
+    if (resource.label.size() > 0)
+        s << "  label: " << resource.label << endl;
+    if (resource.id.size() > 0)
+        s << "  id: " << resource.id << endl;
+    if (resource.exclusive == tristate_t::TRUE)
+            s << "  exclusive: true" << endl;
+    else if (resource.exclusive == tristate_t::FALSE)
+            s << "  exclusive: false" << endl;
+    if (resource.with.size() > 0) {
+        s << "  with:" << endl;
+        IndentingOStreambuf indent (s, 4);
+        for (auto&& child_resource : resource.with) {
+            s << child_resource;
+        }
+    }
+
+    return s;
+}
+
+std::ostream& Flux::Jobspec::operator<<(std::ostream& s,
+                                        Task const& task)
+{
+    bool first = true;
+    s << "command: [ ";
+    for (auto&& field : task.command) {
+        if (!first)
+            s << ", ";
+        else
+            first = false;
+        s << "\"" << field << "\"";
+    }
+    s << " ]" << endl;
+    s << "slot: " << task.slot << endl;
+    if (task.count.size() > 0) {
+        s << "count:" << endl;
+        IndentingOStreambuf indent (s);
+        for (auto&& c : task.count) {
+            s << c.first << ": " << c.second << endl;
+        }
+    }
+    if (task.distribution.size() > 0)
+        s << "distribution: " << task.distribution << endl;
+    if (task.attributes.size() > 0) {
+        s << "attributes:" << endl;
+        IndentingOStreambuf indent (s);
+        for (auto&& attr : task.attributes) {
+            s << attr.first << ": " << attr.second;
+        }
+    }
+
+    return s;
+}

--- a/resource/libjobspec/jobspec.hpp
+++ b/resource/libjobspec/jobspec.hpp
@@ -1,0 +1,121 @@
+/*****************************************************************************\
+ *  Copyright (c) 2017 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+/*
+ * This jobspec module handles parsing the Flux jobspec format as specified
+ * in Spec 14 in the Flux RFC project: https://github.com/flux-framework/rfc
+ *
+ * The primary interface in the library is the Flux:Jobspec::Jobspec class.
+ * The constructor Flux::Jobspec::Jobspec() can handle jobspec data in a
+ * std::string, std::istream, or the top document YAML::Node as pre-processed
+ * by the yaml-cpp library.
+ *
+ * When errors are found in the jobspec stream the library will raise the
+ * Flux::Jobspec:parse_error exception.  If the library was able to determine
+ * the location that the error occurred in jobspec yaml stream, it will appear
+ * in the position, line, and column members of the parse_error object.  If it
+ * is unable to determine the location, all three of those fields will be -1.
+ *
+ * NOTE: The library will only be able to determine the location of error with
+ * yaml-cpp version 0.5.3 or newer.
+ */
+
+#ifndef JOBSPEC_HPP
+#define JOBSPEC_HPP
+
+#include <iostream>
+#include <stdexcept>
+#include <unordered_map>
+#include <cstdint>
+#include <yaml-cpp/yaml.h>
+
+namespace Flux {
+namespace Jobspec {
+
+class parse_error : public std::runtime_error {
+public:
+    int position;
+    int line;
+    int column;
+    parse_error(const char *msg);
+    parse_error(const YAML::Node& node, const char *msg);
+};
+
+enum class tristate_t { FALSE, TRUE, UNSPECIFIED };
+
+class Resource {
+public:
+    std::string type;
+    struct {
+        unsigned min;
+        unsigned max;
+        char oper = '+';
+        int operand = 1;
+    } count;
+    std::string unit;
+    std::string label;
+    std::string id;
+    tristate_t exclusive = tristate_t::UNSPECIFIED;
+    std::vector<Resource> with;
+
+    // user_data has no library internal usage, it is
+    // entirely for the convenience of external code
+    std::unordered_map<std::string, int64_t> user_data;
+
+    Resource(const YAML::Node&);
+};
+
+class Task {
+public:
+    std::vector<std::string> command;
+    std::string slot;
+    std::unordered_map<std::string, std::string> count;
+    std::string distribution;
+    std::unordered_map<std::string, std::string> attributes;
+
+    Task(const YAML::Node&);
+};
+
+class Jobspec {
+public:
+    unsigned int version;
+    std::vector<Resource> resources;
+    std::vector<Task> tasks;
+    std::unordered_map<std::string,
+        std::unordered_map<std::string, std::string>> attributes;
+
+    Jobspec() = default;
+    Jobspec(const YAML::Node&);
+    Jobspec(std::istream &is);
+    Jobspec(std::string &s);
+};
+
+std::ostream& operator<<(std::ostream& s, Jobspec const& js);
+std::ostream& operator<<(std::ostream& s, Resource const& r);
+std::ostream& operator<<(std::ostream& s, Task const& t);
+
+} // namespace Jobspec
+} // namespace Flux
+
+#endif // JOBSPEC_HPP

--- a/resource/modules/Makefile.am
+++ b/resource/modules/Makefile.am
@@ -25,7 +25,6 @@ resource_la_CXXFLAGS = \
     $(FLUX_CORE_CFLAGS)
 resource_la_LIBADD = \
     ../libresource.la \
-    $(JOBSPEC_LIBS) \
     $(FLUX_CORE_LIBS) \
     $(DL_LIBS) \
     $(HWLOC_LIBS) \

--- a/resource/planner/planner_multi.c
+++ b/resource/planner/planner_multi.c
@@ -411,7 +411,7 @@ int planner_multi_rem_span (planner_multi_t *ctx, int64_t span_id)
     }
 
     for (i = 0, s = zlist_first (list); s; i++, s = zlist_next (list))
-        if (planner_rem_span (ctx->planners[i], (int64_t)s) == -1)
+        if (planner_rem_span (ctx->planners[i], (intptr_t)s) == -1)
             goto done;
 
     zhashx_delete (ctx->span_lookup, key);
@@ -433,7 +433,7 @@ int64_t planner_multi_span_first (planner_multi_t *ctx)
         goto done;
 
     }
-    rc = (int64_t)span;
+    rc = (intptr_t)span;
 done:
     return rc;
 }
@@ -450,7 +450,7 @@ int64_t planner_multi_span_next (planner_multi_t *ctx)
         errno = ENOENT;
         goto done;
     }
-    rc = (int64_t)span;
+    rc = (intptr_t)span;
 done:
     return rc;
 }

--- a/resource/policies/base/dfu_match_cb.hpp
+++ b/resource/policies/base/dfu_match_cb.hpp
@@ -30,7 +30,7 @@
 #include <vector>
 #include <cstdint>
 #include <iostream>
-#include <flux/jobspec.hpp>
+#include "resource/libjobspec/jobspec.hpp"
 #include "resource/schema/resource_graph.hpp"
 #include "resource/evaluators/scoring_api.hpp"
 #include "resource/policies/base/matcher.hpp"

--- a/resource/policies/base/matcher.hpp
+++ b/resource/policies/base/matcher.hpp
@@ -30,7 +30,7 @@
 #include <vector>
 #include <set>
 #include <map>
-#include <flux/jobspec.hpp>
+#include "resource/libjobspec/jobspec.hpp"
 #include "resource/schema/data_std.hpp"
 #include "resource/planner/planner.h"
 

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 #include <cstdlib>
-#include <flux/jobspec.hpp>
+#include "resource/libjobspec/jobspec.hpp"
 #include "resource/config/system_defaults.hpp"
 #include "resource/schema/resource_data.hpp"
 #include "resource/schema/resource_graph.hpp"

--- a/resource/utilities/Makefile.am
+++ b/resource/utilities/Makefile.am
@@ -1,0 +1,40 @@
+AM_CXXFLAGS = \
+    $(WARNING_CXXFLAGS) \
+    -Wno-unused-local-typedefs \
+    -Wno-deprecated-declarations \
+    -Wno-unused-variable \
+    -Wno-error \
+    $(CODE_COVERAGE_CXXFLAGS)
+
+AM_LDFLAGS = $(CODE_COVERAGE_LDFLAGS) \
+             $(BOOST_LDFLAGS)
+
+AM_CPPFLAGS = -I$(top_srcdir) $(CZMQ_CFLAGS) $(FLUX_CORE_CFLAGS) \
+          $(BOOST_CPPFLAGS)
+
+noinst_PROGRAMS = grug2dot resource-query
+
+grug2dot_SOURCES = \
+    grug2dot.cpp
+grug2dot_CXXFLAGS = \
+    $(AM_CXXFLAGS)
+grug2dot_LDADD = \
+    ../libresource.la \
+    $(BOOST_SYSTEM_LIB) \
+    $(BOOST_FILESYSTEM_LIB) \
+    $(BOOST_GRAPH_LIB) \
+    $(BOOST_REGEX_LIB)
+
+resource_query_SOURCES = \
+    resource-query.cpp \
+    command.cpp
+resource_query_CXXFLAGS = \
+    $(AM_CXXFLAGS)
+resource_query_LDADD = \
+    ../libresource.la \
+    $(READLINE_LIBS) \
+    $(BOOST_SYSTEM_LIB) \
+    $(BOOST_FILESYSTEM_LIB) \
+    $(BOOST_GRAPH_LIB) \
+    $(BOOST_REGEX_LIB)
+

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -54,6 +54,7 @@ TESTS = \
     t2001-fcfs-aware.t \
     t2002-easy.t \
     t2003-fcfs-inorder.t \
+    t3000-jobspec.t \
     t3001-resource-basic.t \
     t3002-resource-prefix.t \
     t3003-resource-global.t \

--- a/t/data/resource/jobspecs/validation/invalid/attributes_bad_entry.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/attributes_bad_entry.yaml
@@ -1,0 +1,17 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 1
+  foo: 1

--- a/t/data/resource/jobspecs/validation/invalid/attributes_not_mapping.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/attributes_not_mapping.yaml
@@ -1,0 +1,14 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes: 1

--- a/t/data/resource/jobspecs/validation/invalid/invalid_yaml1.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/invalid_yaml1.yaml
@@ -1,0 +1,1 @@
+foo: bar: baz

--- a/t/data/resource/jobspecs/validation/invalid/missing_attributes.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/missing_attributes.yaml
@@ -1,0 +1,13 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/missing_resources.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/missing_resources.yaml
@@ -1,0 +1,7 @@
+version: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/missing_tasks.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/missing_tasks.yaml
@@ -1,0 +1,9 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/missing_version.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/missing_version.yaml
@@ -1,0 +1,13 @@
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/resource_count_bad_type.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_count_bad_type.yaml
@@ -1,0 +1,16 @@
+version: 1
+resources:
+  - type: slot
+    count:
+      - 1
+      - 2
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/resource_count_missing_max.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_count_missing_max.yaml
@@ -1,0 +1,17 @@
+version: 1
+resources:
+  - type: slot
+    count:
+      min: 1
+      operator: "+"
+      operand: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/resource_count_missing_min.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_count_missing_min.yaml
@@ -1,0 +1,17 @@
+version: 1
+resources:
+  - type: slot
+    count:
+      max: 2
+      operator: "+"
+      operand: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/resource_count_missing_operand.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_count_missing_operand.yaml
@@ -1,0 +1,17 @@
+version: 1
+resources:
+  - type: slot
+    count:
+      min: 1
+      max: 2
+      operator: "+"
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/resource_count_missing_operator.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_count_missing_operator.yaml
@@ -1,0 +1,17 @@
+version: 1
+resources:
+  - type: slot
+    count:
+      min: 1
+      max: 2
+      operand: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/resource_count_scalar_bad_value.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_count_scalar_bad_value.yaml
@@ -1,0 +1,14 @@
+version: 1
+resources:
+  - type: slot
+    count: bar
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/resource_exclusive_invalid.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_exclusive_invalid.yaml
@@ -1,0 +1,15 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+        exclusive: blah
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/resource_exclusive_not_scalar.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_exclusive_not_scalar.yaml
@@ -1,0 +1,17 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    exclusive:
+      - foo
+      - bar
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/resource_id_not_scalar.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_id_not_scalar.yaml
@@ -1,0 +1,17 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    id:
+      - foo
+      - bar
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/resource_label_not_scalar.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_label_not_scalar.yaml
@@ -1,0 +1,16 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label:
+      - foo
+      - bar
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/resource_missing_count.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_missing_count.yaml
@@ -1,0 +1,13 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: node
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/resource_missing_type.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_missing_type.yaml
@@ -1,0 +1,13 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/resource_not_mapping.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_not_mapping.yaml
@@ -1,0 +1,14 @@
+version: 1
+resources:
+  - - type: slot
+    - count: 1
+    - label: foo
+    - with:
+       - type: node
+         count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/resource_slot_not_labelled.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_slot_not_labelled.yaml
@@ -1,0 +1,13 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/resource_unit_not_scalar.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_unit_not_scalar.yaml
@@ -1,0 +1,17 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    unit:
+      - foo
+      - bar
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/resources_not_sequence.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resources_not_sequence.yaml
@@ -1,0 +1,14 @@
+version: 1
+resources:
+  type: slot
+  count: 1
+  label: foo
+  with:
+    - type: node
+      count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/task_count_not_mapping.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/task_count_not_mapping.yaml
@@ -1,0 +1,13 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    slot: foo
+    count: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/task_missing_command.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/task_missing_command.yaml
@@ -1,0 +1,13 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/task_missing_count.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/task_missing_count.yaml
@@ -1,0 +1,12 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    slot: foo
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/task_missing_slot.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/task_missing_slot.yaml
@@ -1,0 +1,13 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    count:
+      per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/task_not_mapping.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/task_not_mapping.yaml
@@ -1,0 +1,11 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - foo
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/tasks_not_sequence.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/tasks_not_sequence.yaml
@@ -1,0 +1,14 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  command: app
+  slot: foo
+  count:
+    per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/version_bad_number.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/version_bad_number.yaml
@@ -1,0 +1,14 @@
+version: 48958
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/version_not_scalar.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/version_not_scalar.yaml
@@ -1,0 +1,15 @@
+version:
+  foo: 1
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/valid/basic.yaml
+++ b/t/data/resource/jobspecs/validation/valid/basic.yaml
@@ -1,0 +1,14 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/valid/example1.yaml
+++ b/t/data/resource/jobspecs/validation/valid/example1.yaml
@@ -1,0 +1,19 @@
+version: 1
+resources:
+  - type: node
+    count: 4
+    with:
+      - type: slot
+        count: 1
+        label: default
+        with:
+          - type: core
+            count: 2
+tasks:
+  - command: app
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 1 hour

--- a/t/data/resource/jobspecs/validation/valid/example2.yaml
+++ b/t/data/resource/jobspecs/validation/valid/example2.yaml
@@ -1,0 +1,16 @@
+version: 1
+resources:
+  - type: slot
+    count: 4
+    label: default
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: hostname
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 1 hour

--- a/t/data/resource/jobspecs/validation/valid/use_case_1.1.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_1.1.yaml
@@ -1,0 +1,16 @@
+version: 1
+resources:
+  - type: slot
+    count: 4
+    label: default
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: [ "flux", "start" ]
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 1 hour

--- a/t/data/resource/jobspecs/validation/valid/use_case_1.2.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_1.2.yaml
@@ -1,0 +1,20 @@
+version: 1
+resources:
+  - type: slot
+    count:
+      min: 3
+      max: 30
+      operator: "+"
+      operand: 1
+    label: default
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: [ "flux", "start" ]
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 1 hour

--- a/t/data/resource/jobspecs/validation/valid/use_case_1.3.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_1.3.yaml
@@ -1,0 +1,22 @@
+version: 1
+resources:
+  - type: slot
+    count: 4
+    label: nodelevel
+    with:
+    - type: node
+      count: 1
+      with:
+        - type: socket
+          count: 2
+          with:
+            - type: core
+              count: 4
+tasks:
+  - command: [ "flux", "start" ]
+    slot: nodelevel
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 1 hour

--- a/t/data/resource/jobspecs/validation/valid/use_case_1.4.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_1.4.yaml
@@ -1,0 +1,22 @@
+version: 1
+resources:
+  - type: slot
+    count: 4
+    label: nodelevel
+    with:
+    - type: node
+      count: 1
+      with:
+        - type: socket
+          count: 2
+          with:
+            - type: core
+              count: 4
+tasks:
+  - command: [ "flux", "start" ]
+    slot: nodelevel
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 1 hour

--- a/t/data/resource/jobspecs/validation/valid/use_case_1.5.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_1.5.yaml
@@ -1,0 +1,41 @@
+version: 1
+resources:
+  - type: cluster
+    count: 1
+    with:
+      - type: slot
+        count: 2
+        label: ib
+        with:
+          - type: node
+            count: 1
+            with:
+              - type: memory
+                count: 4
+                unit: GB
+              - type: ib10g
+                count: 1
+  - type: switch
+    count: 1
+    with:
+      - type: slot
+        count: 2
+        label: bicore
+        with:
+          - type: node
+            count: 1
+            with:
+              - type: core
+                count: 2
+tasks:
+  - command: [ "flux", "start" ]
+    slot: ib
+    count:
+      per_slot: 1
+  - command: [ "flux", "start" ]
+    slot: bicore
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 4 hours

--- a/t/data/resource/jobspecs/validation/valid/use_case_1.6.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_1.6.yaml
@@ -1,0 +1,22 @@
+version: 1
+resources:
+    - type: cluster
+      count: 2
+      with:
+          - type: node
+            count: 15
+            with:
+                - type: slot
+                  count: 1
+                  label: default
+                  with:
+                    - type: core
+                      count: 1
+tasks:
+  - command: [ "flux", "start" ]
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 1 hour

--- a/t/data/resource/jobspecs/validation/valid/use_case_1.7.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_1.7.yaml
@@ -1,0 +1,19 @@
+version: 1
+resources:
+  - type: switch
+    count: 3
+    with:
+      - type: slot
+        count: 1
+        label: default
+        with:
+          - type: core
+            count: 1
+tasks:
+  - command: [ "flux", "start" ]
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 1h

--- a/t/data/resource/jobspecs/validation/valid/use_case_2.1.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_2.1.yaml
@@ -1,0 +1,16 @@
+version: 1
+resources:
+  - type: slot
+    label: default
+    count: 4
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: hostname
+    slot: default
+    count:
+      per_slot: 5
+attributes:
+  system:
+    duration: 1 hour

--- a/t/data/resource/jobspecs/validation/valid/use_case_2.2.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_2.2.yaml
@@ -1,0 +1,16 @@
+version: 1
+resources:
+  - type: slot
+    count: 4
+    label: myslot
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: hostname
+    slot: myslot
+    count:
+      total: 5
+attributes:
+  system:
+    duration: 1 hour

--- a/t/data/resource/jobspecs/validation/valid/use_case_2.3.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_2.3.yaml
@@ -1,0 +1,16 @@
+version: 1
+resources:
+  - type: slot
+    label: default
+    count: 10
+    with:
+      - type: core
+        count: 2
+tasks:
+  - command: myapp
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 1 hour

--- a/t/data/resource/jobspecs/validation/valid/use_case_2.4.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_2.4.yaml
@@ -1,0 +1,35 @@
+version: 1
+resources:
+  - type: node
+    count: 1
+    with:
+      - type: slot
+        label: read-db
+        count: 10
+        with:
+          - type: core
+            count: 1
+          - type: memory
+            count: 4
+            unit: GB
+      - type: slot
+        label: db
+        count: 1
+        with:
+          - type: core
+            count: 6
+          - type: memory
+            count: 24
+            unit: GB
+tasks:
+  - command: read-db
+    slot: read-db
+    count:
+      per_slot: 1
+  - command: db
+    slot: db
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 1 hour

--- a/t/data/resource/jobspecs/validation/valid/use_case_2.5.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_2.5.yaml
@@ -1,0 +1,19 @@
+version: 1
+resources:
+  - type: slot
+    label: default
+    count: 10
+    with:
+    - type: memory
+      count: 2
+      unit: GB
+    - type: core
+      count: 1
+tasks:
+  - command: app
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 1 hour

--- a/t/data/resource/jobspecs/validation/valid/use_case_2.6.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_2.6.yaml
@@ -1,0 +1,20 @@
+version: 1
+resources:
+  - type: slot
+    label: 4GB-node
+    count: 2
+    with:
+    - type: node
+      count: 1
+      with:
+        - type: memory
+          count: 4
+          unit: GB
+tasks:
+  - command: app
+    slot: 4GB-node
+    count:
+      total: 10
+attributes:
+  system:
+    duration: 1 hour

--- a/t/t3000-jobspec.t
+++ b/t/t3000-jobspec.t
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+test_description='Test the jobspec parsing library'
+
+. `dirname $0`/sharness.sh
+
+validate="${SHARNESS_BUILD_DIRECTORY}/resource/libjobspec/flux-jobspec-validate"
+data_dir="data/resource/jobspecs/validation"
+
+# Check that the valid jobspecs all pass
+for jobspec in ${SHARNESS_TEST_SRCDIR}/${data_dir}/valid/*.yaml; do
+    testname=`basename $jobspec`
+    test_expect_success $testname "$validate $jobspec"
+done
+
+# Check that the invalid jobspec all fail
+for jobspec in ${SHARNESS_TEST_SRCDIR}/${data_dir}/invalid/*.yaml; do
+    testname=`basename $jobspec`
+    test_expect_success $testname "test_must_fail $validate $jobspec"
+done
+
+test_done


### PR DESCRIPTION
This PR integrates jobspec internally into the resource infrastructure:

1. Tightly managing `libjobspec` from within `flux-sched` solves odd make-check errors that we are seeing on some platforms (e.g., Sierra). The issues seem to arise due to C++ compiler version mismatches.

2. `flux-core` will transition away from `libjobspec` anyway in a near future, and doing this now will help `flux-core` make this transition without having to worry about any breakage in `flux-sched`.

This PR also has a fix for pointer to 64 integer conversion for 32bit systems.

Resolve #393, #395 and #397.


