### PR TITLE
config: Add libtoolize into autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
-
-echo "Running autoreconf -i ... "
-autoreconf -i
+echo "Running libtoolize --automake --copy ... "
+libtoolize --automake --copy || exit
+echo "Running autoreconf --verbose --install"
+autoreconf --verbose --install || exit
+echo "Moving aclocal.m4 to config/ ..."
+mv aclocal.m4 config/ || exit
 echo "Cleaning up ..."
 rm -rf autom4te.cache
 echo "Now run ./configure."


### PR DESCRIPTION
This PR uses `libtoolize` to resolve Issue #402. It also pulls in some of the options that `flux-core` is using for consistency. 

The autoreconf verbose option catches `autoreconf: configure.ac: not using Gettext`. But I don't think we are ready to add Gettext support so I will leave it this way. 