### PR TITLE
resource: Add run-level support for resource matching module

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -130,6 +130,12 @@ AC_SUBST(fluxschedrc1dir)
 AS_VAR_SET(fluxschedrc3dir, $sysconfdir/flux/rc3.d)
 AC_SUBST(fluxschedrc3dir)
 
+AS_VAR_SET(fluxresourcerc1dir, $sysconfdir/flux/rc1.d)
+AC_SUBST(fluxresourcerc1dir)
+
+AS_VAR_SET(fluxresourcerc3dir, $sysconfdir/flux/rc3.d)
+AC_SUBST(fluxresourcerc3dir)
+
 ##
 # Macros to avoid repetition in Makefiles.am's
 ##

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -1,2 +1,5 @@
 dist_fluxschedrc1_SCRIPTS = sched-start
 dist_fluxschedrc3_SCRIPTS = sched-stop
+dist_fluxresourcerc1_SCRIPTS = resource-start
+dist_fluxresourcerc3_SCRIPTS = resource-stop
+

--- a/etc/resource-start
+++ b/etc/resource-start
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+#
+# If resource is not installed into flux-core's $prefix,
+# one should set FLUX_RC_EXTRA environment variable to flux-sched's $prefix/etc/flux
+# so that flux start can automatically execute resource's runlevel 1 and 3.
+#
+# In addition, users can set FLUX_RESOURCE_OPTIONS if they want flux
+# to load in the resource matching service module with non-default options.
+#
+# Finally, if FLUX_RESOURCE_RC_NOOP=1, flux-core
+# won't load in or remove sched as part of runlevel 1 and 3.
+#
+
+if [ -z ${FLUX_RESOURCE_RC_NOOP} ]; then
+    flux module load -r 0 resource ${FLUX_RESOURCE_OPTIONS}
+fi
+

--- a/etc/resource-stop
+++ b/etc/resource-stop
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+if [ -z ${FLUX_RESOURCE_RC_NOOP} ]; then
+    flux module remove resource
+fi
+

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -132,7 +132,7 @@ static void set_default_args (resource_args_t &args)
     args.hwloc_xml = "";
     args.match_subsystems = "containment";
     args.match_policy = "high";
-    args.prune_filters = "ALL:core";
+    args.prune_filters = "ALL:pu";
     args.R_format = "R_NATIVE";
 }
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -27,6 +27,7 @@ TESTS_ENVIRONMENT = \
     FLUX_EXEC_PATH_PREPEND="$${FLUX_SCHED_TEST_INSTALLED:+$(prefix)/libexec/flux/cmd}" \
     FLUX_MODULE_PATH_PREPEND="$${FLUX_SCHED_TEST_INSTALLED:+$(prefix)/lib/flux/modules}" \
     FLUX_SCHED_RC_PATH="$${FLUX_SCHED_TEST_INSTALLED:+$(sysconf)/flux}" \
+    FLUX_RESOURCE_RC_PATH="$${FLUX_SCHED_TEST_INSTALLED:+$(sysconf)/flux}" \
     FLUX_SCHED_CO_INST=`sh -c 'if [ $(FLUX_PREFIX) = $(prefix) ]; then echo co; fi'` \
     PATH="$(FLUX_PREFIX)/bin:$(PATH)"
 

--- a/t/sharness.d/sched-sharness.sh
+++ b/t/sharness.d/sched-sharness.sh
@@ -3,6 +3,7 @@
 # project-local sharness code for flux-sched
 #
 FLUX_SCHED_RC_NOOP=1
+FLUX_RESOURCE_RC_NOOP=1
 if test -n "$FLUX_SCHED_TEST_INSTALLED"; then
   # Test against installed flux-sched, installed under same prefix as
   #   flux-core.
@@ -45,6 +46,8 @@ job_kvs_path () {
 export FLUX_EXEC_PATH_PREPEND
 export FLUX_SCHED_RC_NOOP
 export FLUX_SCHED_RC_PATH
+export FLUX_RESOURCE_RC_NOOP
+export FLUX_RESOURCE_RC_PATH
 export FLUX_SCHED_CO_INST
 export FLUX_MODULE_PATH_PREPEND
 export FLUX_LUA_CPATH_PREPEND

--- a/t/t0003-basic-install.t
+++ b/t/t0003-basic-install.t
@@ -30,8 +30,17 @@ test_expect_success 'sched: module remove/load works with installed sched' '
 	flux module load sched
 '
 
+test_expect_success 'resource: module remove/load works with installed resource' '
+	flux module remove resource &&
+	flux module load resource
+'
+
 test_expect_success 'sched: module unload' '
 	flux module remove sched
+'
+
+test_expect_success 'resource: module unload' '
+	flux module remove resource
 '
 
 test_done

--- a/t/t4001-match-allocate.t
+++ b/t/t4001-match-allocate.t
@@ -35,7 +35,7 @@ test_debug '
 '
 
 test_expect_success 'loading resource module with a tiny machine config works' '
-    flux module load resource grug-conf=${grug} \
+    flux module load resource grug-conf=${grug} prune-filters=ALL:core \
 subsystems=containment policy=high
 '
 

--- a/t/t4002-match-reserve.t
+++ b/t/t4002-match-reserve.t
@@ -35,7 +35,7 @@ test_debug '
 '
 
 test_expect_success 'loading resource module with a tiny machine config works' '
-    flux module load resource grug-conf=${grug} \
+    flux module load resource grug-conf=${grug} prune-filters=ALL:core \
 subsystems=containment policy=low
 '
 

--- a/t/t4003-cancel-info.t
+++ b/t/t4003-cancel-info.t
@@ -33,7 +33,7 @@ test_debug '
 '
 
 test_expect_success 'loading resource module with a tiny machine config works' '
-    flux module load resource grug-conf=${grug} \
+    flux module load resource grug-conf=${grug} prune-filters=ALL:core \
 subsystems=containment policy=high
 '
 

--- a/t/t4004-match-hwloc.t
+++ b/t/t4004-match-hwloc.t
@@ -64,7 +64,7 @@ test_expect_success 'resource-query works on gpu query using xml file' '
 
 # Test using the full resource matching service
 test_expect_success 'loading resource module with a tiny hwloc xml file works' '
-    flux module load -r 0 resource hwloc-xml=${hwloc_4core} prune-filters=ALL:pu
+    flux module load -r 0 resource hwloc-xml=${hwloc_4core}
 '
 
 test_expect_success 'match-allocate works with four one-core jobspecs' '


### PR DESCRIPTION
- Change the default argument of the `prune-filters` load option to `ALL:pu`
- Adjust test cases
- Add `rc1` and `rc3` script for resource
- Update make rules

Resolve Issue #389. 