### PR TITLE
Ensure scheduling correctness with different prune filter configurations

### DIFF
--- a/resource/generators/gen.cpp
+++ b/resource/generators/gen.cpp
@@ -690,6 +690,9 @@ int resource_generator_t::read_hwloc_xml_file (const char *ifn,
 
     ggv_t cluster_vertex = create_cluster_vertex (db);
     std::ifstream infile (ifn);
+    if (!infile.good ())
+        return -1;
+
     std::string xml_str ((std::istreambuf_iterator<char> (infile)),
                          std::istreambuf_iterator<char> ());
     read_ranked_hwloc_xml (xml_str.c_str(), -1, cluster_vertex, db);

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -420,8 +420,9 @@ static int init_resource_graph (resource_ctx_t *ctx)
         return -1;
      }
 
-    if (ctx->matcher->set_pruning_types_w_spec (ctx->matcher->dom_subsystem (),
-                                                ctx->args.prune_filters) < 0) {
+    if (ctx->args.prune_filters != ""
+        && ctx->matcher->set_pruning_types_w_spec (ctx->matcher->dom_subsystem (),
+                                                   ctx->args.prune_filters) < 0) {
         flux_log (ctx->h, LOG_ERR, "error setting pruning types with: %s",
                   ctx->args.prune_filters.c_str ());
         return -1;

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -186,8 +186,11 @@ static int process_args (resource_ctx_t *ctx, int argc, char **argv)
                 args.match_policy = dflt;
             }
         } else if (!strncmp ("prune-filters=", argv[i], sizeof ("prune-filters"))) {
-            dflt = args.prune_filters;
-            args.prune_filters = strstr (argv[i], "=") + 1;
+            std::string token = strstr (argv[i], "=") + 1;
+            if(token.find_first_not_of(' ') != std::string::npos) {
+                args.prune_filters += ",";
+                args.prune_filters += token;
+            }
         } else if (!strncmp ("R-format=", argv[i], sizeof ("R-format"))) {
             dflt = args.R_format;
             args.R_format = strstr (argv[i], "=") + 1;

--- a/resource/planner/planner.c
+++ b/resource/planner/planner.c
@@ -683,7 +683,7 @@ planner_t *planner_new (int64_t base_time, uint64_t duration,
 {
     planner_t *ctx = NULL;
 
-    if (duration < 1 || !resource_totals || !resource_type) {
+    if (duration < 1 || !resource_type) {
         errno = EINVAL;
         goto done;
     } else if (resource_totals > INT64_MAX) {

--- a/resource/policies/base/matcher.cpp
+++ b/resource/policies/base/matcher.cpp
@@ -273,7 +273,8 @@ bool matcher_util_api_t::get_my_pruning_types (const std::string &subsystem,
             for (auto &k : m)
                 out.push_back (k);
         }
-        if (s.find (ANY_RESOURCE_TYPE) != s.end ()) {
+        if (anchor_type != ANY_RESOURCE_TYPE
+            && s.find (ANY_RESOURCE_TYPE) != s.end ()) {
             auto &m = s.at (ANY_RESOURCE_TYPE);
             for (auto &k : m)
                 out.push_back (k);

--- a/resource/policies/base/matcher.cpp
+++ b/resource/policies/base/matcher.cpp
@@ -220,6 +220,7 @@ void matcher_util_api_t::set_pruning_type (const std::string &subsystem,
                                            const std::string &anchor_type,
                                            const std::string &prune_type)
 {
+    // Note the final container is "set" so it will only allow uniqe prune_types
     m_pruning_types[subsystem][anchor_type].insert (prune_type);
     m_total_set[subsystem].insert (prune_type);
 }

--- a/resource/policies/base/matcher.cpp
+++ b/resource/policies/base/matcher.cpp
@@ -258,6 +258,32 @@ bool matcher_util_api_t::is_pruning_type (const std::string &subsystem,
     return rc;
 }
 
+bool matcher_util_api_t::get_my_pruning_types (const std::string &subsystem,
+                                               const std::string &anchor_type,
+                                               std::vector<std::string> &out)
+{
+    bool rc = true;
+    try {
+        // Get the value of the subsystem, which is a map
+        // of <string, set> type.
+        auto &s = m_pruning_types.at (subsystem);
+        if (s.find (anchor_type) != s.end ()) {
+            // Get the value of the anchor map, which is a set
+            auto &m = s.at (anchor_type);
+            for (auto &k : m)
+                out.push_back (k);
+        }
+        if (s.find (ANY_RESOURCE_TYPE) != s.end ()) {
+            auto &m = s.at (ANY_RESOURCE_TYPE);
+            for (auto &k : m)
+                out.push_back (k);
+        }
+    } catch (std::out_of_range &e) {
+        rc = false;
+    }
+    return rc;
+}
+
 } // resource_model
 } // Flux
 /*

--- a/resource/policies/base/matcher.hpp
+++ b/resource/policies/base/matcher.hpp
@@ -147,6 +147,11 @@ public:
     bool is_pruning_type (const std::string &subsystem,
                           const std::string &prune_type);
 
+
+    bool get_my_pruning_types (const std::string &subsystem,
+                               const std::string &anchor_type,
+                               std::vector<std::string> &out_prune_types);
+
 private:
 
     int register_resource_pair (const std::string &subsystem,

--- a/resource/traversers/dfu.cpp
+++ b/resource/traversers/dfu.cpp
@@ -62,7 +62,7 @@ int dfu_traverser_t::schedule (Jobspec::Jobspec &jobspec,
         planner_multi_t *p = (*get_graph ())[root].idata.subplans.at (dom);
         size_t len = planner_multi_resources_len (p);
         uint64_t duration = meta.duration;
-        detail::dfu_impl_t::count (p, dfv, agg);
+        detail::dfu_impl_t::count_relevant_types (p, dfv, agg);
         // TODO: examine correctness when a jobspec doesn't include
         // the subtree plan resource type
         for (t = planner_multi_avail_time_first (p, t, duration, &agg[0], len);

--- a/resource/traversers/dfu.cpp
+++ b/resource/traversers/dfu.cpp
@@ -63,8 +63,6 @@ int dfu_traverser_t::schedule (Jobspec::Jobspec &jobspec,
         size_t len = planner_multi_resources_len (p);
         uint64_t duration = meta.duration;
         detail::dfu_impl_t::count_relevant_types (p, dfv, agg);
-        // TODO: examine correctness when a jobspec doesn't include
-        // the subtree plan resource type
         for (t = planner_multi_avail_time_first (p, t, duration, &agg[0], len);
              (t != -1 && rc != 0); t = planner_multi_avail_time_next (p)) {
             meta.at = t;

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -946,21 +946,26 @@ int dfu_impl_t::prime_pruning_filter (const subsystem_t &s, vtx_t u,
     vector<const char *> types;
     map<string, int64_t> dfv;
     string type = (*m_graph)[u].type;
+    std::vector<std::string> out_prune_types;
 
     (*m_graph)[u].idata.colors[s] = m_color.gray ();
     accum_if (s, type, (*m_graph)[u].size, to_parent);
     if (prime_exp (s, u, dfv) != 0)
         goto done;
 
-    for (auto &aggr : dfv) {
-        /* If the aggregate type is any filter type, accume for the parent */
+    for (auto &aggr : dfv)
         accum_if (s, aggr.first, aggr.second, to_parent);
-        /* If the aggregate type is "my" filter type, track them in my filter */
-        if (m_match->is_my_pruning_type (s, (*m_graph)[u].type, aggr.first)) {
-            types.push_back (strdup (aggr.first.c_str ()));
-            avail.push_back (aggr.second);
+
+    if (m_match->get_my_pruning_types (s, (*m_graph)[u].type, out_prune_types)) {
+        for (auto &type : out_prune_types) {
+            types.push_back (strdup (type.c_str ()));
+            if (dfv.find (type) != dfv.end ())
+                avail.push_back (dfv.at (type));
+            else
+                avail.push_back (0);
         }
     }
+
     if (!avail.empty () && !types.empty ()) {
         planner_multi_t *p = NULL;
         if (!(p = subtree_plan (u, avail, types)) ) {

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -958,7 +958,7 @@ int dfu_impl_t::prime_pruning_filter (const subsystem_t &s, vtx_t u,
 
     if (m_match->get_my_pruning_types (s, (*m_graph)[u].type, out_prune_types)) {
         for (auto &type : out_prune_types) {
-            types.push_back (strdup (type.c_str ()));
+            types.push_back (type.c_str ());
             if (dfv.find (type) != dfv.end ())
                 avail.push_back (dfv.at (type));
             else
@@ -979,9 +979,6 @@ int dfu_impl_t::prime_pruning_filter (const subsystem_t &s, vtx_t u,
     rc = 0;
 done:
     (*m_graph)[u].idata.colors[s] = m_color.black ();
-    if (!types.empty ())
-        for (size_t i = 0; i < types.size (); ++i)
-            free ((void *)types[i]);
     return rc;
 }
 

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -153,7 +153,7 @@ int dfu_impl_t::by_subplan (const jobmeta_t &meta, const std::string &s, vtx_t u
     vector<uint64_t> aggs;
     planner_multi_t *p = (*m_graph)[u].idata.subplans[s];
 
-    count (p, resource.user_data, aggs);
+    count_relevant_types (p, resource.user_data, aggs);
     if (aggs.empty ()) {
         rc = 0;
         goto done;
@@ -663,7 +663,7 @@ int dfu_impl_t::upd_sched (vtx_t u, const subsystem_t &s, unsigned int needs,
         planner_multi_t *subtree_plan = (*m_graph)[u].idata.subplans[s];
         if (subtree_plan && !dfu.empty ()) {
             vector<uint64_t> aggregate;
-            count (subtree_plan, dfu, aggregate);
+            count_relevant_types (subtree_plan, dfu, aggregate);
             span = planner_multi_add_span (subtree_plan, meta.at, meta.duration,
                                            &(aggregate[0]), aggregate.size ());
             if (span == -1) {

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -661,7 +661,7 @@ int dfu_impl_t::upd_sched (vtx_t u, const subsystem_t &s, unsigned int needs,
 
         // Update subtree plan
         planner_multi_t *subtree_plan = (*m_graph)[u].idata.subplans[s];
-        if (subtree_plan && !dfu.empty ()) {
+        if (subtree_plan) {
             vector<uint64_t> aggregate;
             count_relevant_types (subtree_plan, dfu, aggregate);
             span = planner_multi_add_span (subtree_plan, meta.at, meta.duration,
@@ -700,6 +700,7 @@ int dfu_impl_t::upd_dfv (vtx_t u, unsigned int needs, bool excl,
     map<string, int64_t> dfu;
     const string &dom = m_match->dom_subsystem ();
     f_out_edg_iterator_t ei, ei_end;
+
     m_trav_level++;
     for (auto &subsystem : m_match->subsystems ()) {
         for (tie (ei, ei_end) = out_edges (u, *m_graph); ei != ei_end; ++ei) {

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -145,8 +145,8 @@ public:
      *  \return          0 on success; -1 on error.
      */
     template <class lookup_t>
-    int count (planner_multi_t *plan, const lookup_t &lookup,
-               std::vector<uint64_t> &resource_counts);
+    int count_relevant_types (planner_multi_t *plan, const lookup_t &lookup,
+                              std::vector<uint64_t> &resource_counts);
 
     /*! Entry point for graph matching and scoring depth-first-and-up (DFU) walk.
      *  It finds best-matching resources and resolves hierarchical constraints.
@@ -307,7 +307,8 @@ private:
 }; // the end of class dfu_impl_t
 
 template <class lookup_t>
-int dfu_impl_t::count (planner_multi_t *plan, const lookup_t &lookup,
+int dfu_impl_t::count_relevant_types (planner_multi_t *plan,
+                       const lookup_t &lookup,
                        std::vector<uint64_t> &resource_counts)
 {
     int rc = 0;

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -525,11 +525,12 @@ int main (int argc, char *argv[])
     f_resource_graph_t *fg = new f_resource_graph_t (g, edgsel, vtxsel);
     ctx->resource_graph_views[ctx->params.matcher_name] = fg;
     ctx->jobid_counter = 1;
-    if (ctx->matcher->set_pruning_types_w_spec (ctx->matcher->dom_subsystem (),
-                                                ctx->params.prune_filters)
-                                                < 0) {
-        cerr << "ERROR: setting pruning filters with "
-             << "ctx->params.prune_filters" << endl;
+    if (ctx->params.prune_filters != ""
+        && ctx->matcher->set_pruning_types_w_spec (ctx->matcher->dom_subsystem (),
+                                                   ctx->params.prune_filters)
+                                                   < 0) {
+        cerr << "ERROR: setting pruning filters with ctx->params.prune_filters: "
+             << ctx->params.prune_filters << endl;
         return EXIT_FAILURE;
     }
 

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -428,6 +428,7 @@ static void control_loop (resource_context_t *ctx)
 int main (int argc, char *argv[])
 {
     int rc, ch;
+    std::string token;
     resource_context_t *ctx = new resource_context_t ();
     set_default_params (ctx);
 
@@ -462,8 +463,12 @@ int main (int argc, char *argv[])
             case 'o': /* --graph-output */
                 ctx->params.o_fname = optarg;
                 break;
-            case 'p': /* --prune-filter */
-                ctx->params.prune_filters = optarg;
+            case 'p': /* --prune-filters */
+                token = optarg;
+                if(token.find_first_not_of(' ') != std::string::npos) {
+                    ctx->params.prune_filters += ",";
+                    ctx->params.prune_filters += token;
+                }
                 break;
             case 't': /* --test-output */
                 ctx->params.r_fname = optarg;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -66,6 +66,7 @@ TESTS = \
     t3008-resource-cancel.t \
     t3009-resource-minmax.t \
     t3010-resource-power.t \
+    t3011-resource-filt.t \
     t4001-match-allocate.t \
     t4002-match-reserve.t \
     t4003-cancel-info.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -67,6 +67,7 @@ TESTS = \
     t3009-resource-minmax.t \
     t3010-resource-power.t \
     t3011-resource-filt.t \
+    t4000-match-params.t \
     t4001-match-allocate.t \
     t4002-match-reserve.t \
     t4003-cancel-info.t \

--- a/t/t3011-resource-filt.t
+++ b/t/t3011-resource-filt.t
@@ -1,0 +1,98 @@
+#!/bin/sh
+
+test_description='Test Scheduling with various prune filter configurations'
+
+. $(dirname $0)/sharness.sh
+
+cmd_dir="${SHARNESS_TEST_SRCDIR}/data/resource/commands/basics"
+exp_dir="${SHARNESS_TEST_SRCDIR}/data/resource/expected/basics"
+grugs="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/tiny.graphml"
+query="../../resource/utilities/resource-query"
+
+#
+# Selection Policy -- High ID first (-P high)
+#     The resource vertex with higher ID is preferred among its kind
+#     (e.g., node1 is preferred over node0 if available)
+#
+
+cmds003="${cmd_dir}/cmds03.in"
+test003_desc="allocate_orelse_reserve 10 jobspecs works with default filter"
+test_expect_success "${test003_desc}" '
+    sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds003} > cmds003 &&
+    ${query} -G ${grugs} -S CA -P high -t 003.R.out < cmds003 &&
+    test_cmp 003.R.out ${exp_dir}/003.R.out
+'
+
+cmds003="${cmd_dir}/cmds03.in"
+test003_desc="allocate_orelse_reserve 10 jobspecs works with no additional filter"
+test_expect_success "${test003_desc}" '
+    sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds003} > cmds003 &&
+    ${query} -G ${grugs} -S CA -P high --prune-filters="" -t 003.R.out < cmds003 &&
+    test_cmp 003.R.out ${exp_dir}/003.R.out
+'
+
+cmds003="${cmd_dir}/cmds03.in"
+test003_desc="allocate_orelse_reserve 10 jobspecs works with ALL:core"
+test_expect_success "${test003_desc}" '
+    sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds003} > cmds003 &&
+    ${query} -G ${grugs} -S CA -P high --prune-filters="ALL:core" -t 003.R.out < cmds003 &&
+    test_cmp 003.R.out ${exp_dir}/003.R.out
+'
+
+cmds003="${cmd_dir}/cmds03.in"
+test003_desc="allocate_orelse_reserve 10 jobspecs works with ALL:core,ALL:gpu"
+test_expect_success "${test003_desc}" '
+    sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds003} > cmds003 &&
+    ${query} -G ${grugs} -S CA -P high --prune-filters="ALL:core,ALL:gpu" -t 003.R.out < cmds003 &&
+    test_cmp 003.R.out ${exp_dir}/003.R.out
+'
+
+cmds003="${cmd_dir}/cmds03.in"
+test003_desc="allocate_orelse_reserve 10 jobspecs works with ALL:core,ALL:gpu,ALL:memory"
+test_expect_success "${test003_desc}" '
+    sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds003} > cmds003 &&
+    ${query} -G ${grugs} -S CA -P high --prune-filters="ALL:core,ALL:gpu" -t 003.R.out < cmds003 &&
+    test_cmp 003.R.out ${exp_dir}/003.R.out
+'
+
+cmds005="${cmd_dir}/cmds05.in"
+test005_desc="match allocate_orelse_reserve 100 jobspecs instead (pol=hi)"
+test_expect_success "${test005_desc}" '
+    sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds005} > cmds005 &&
+    ${query} -G ${grugs} -S CA -P high -t 005.R.out < cmds005 &&
+    test_cmp 005.R.out ${exp_dir}/005.R.out
+'
+
+cmds005="${cmd_dir}/cmds05.in"
+test005_desc="match allocate_orelse_reserve 100 jobspecs with no additional filter"
+test_expect_success "${test005_desc}" '
+    sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds005} > cmds005 &&
+    ${query} -G ${grugs} -S CA -P high --prune-filters="" -t 005.R.out < cmds005 &&
+    test_cmp 005.R.out ${exp_dir}/005.R.out
+'
+
+cmds005="${cmd_dir}/cmds05.in"
+test005_desc="match allocate_orelse_reserve 100 jobspecs with ALL:core"
+test_expect_success "${test005_desc}" '
+    sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds005} > cmds005 &&
+    ${query} -G ${grugs} -S CA -P high --prune-filters="ALL:core" -t 005.R.out < cmds005 &&
+    test_cmp 005.R.out ${exp_dir}/005.R.out
+'
+
+cmds005="${cmd_dir}/cmds05.in"
+test005_desc="match allocate_orelse_reserve 100 jobspecs with ALL:core,ALL:gpu"
+test_expect_success "${test005_desc}" '
+    sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds005} > cmds005 &&
+    ${query} -G ${grugs} -S CA -P high --prune-filters="ALL:core,ALL:gpu" -t 005.R.out < cmds005 &&
+    test_cmp 005.R.out ${exp_dir}/005.R.out
+'
+
+cmds005="${cmd_dir}/cmds05.in"
+test005_desc="match allocate_orelse_reserve 100 jobspecs with ALL:core,ALL:gpu,ALL:memory"
+test_expect_success "${test005_desc}" '
+    sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds005} > cmds005 &&
+    ${query} -G ${grugs} -S CA -P high --prune-filters="ALL:core,ALL:gpu,ALL:memory" -t 005.R.out < cmds005 &&
+    test_cmp 005.R.out ${exp_dir}/005.R.out
+'
+
+test_done

--- a/t/t4000-match-params.t
+++ b/t/t4000-match-params.t
@@ -1,0 +1,92 @@
+#!/bin/sh
+
+test_description='Test the module load options of resource-match service'
+
+
+ORIG_HOME=${HOME}
+
+. `dirname $0`/sharness.sh
+
+#
+# sharness modifies $HOME environment variable, but this interferes
+# with python's package search path, in particular its user site package.
+#
+HOME=${ORIG_HOME}
+
+grug="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/tiny.graphml"
+ne_grug="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/ne.graphml"
+xml="${SHARNESS_TEST_SRCDIR}/data/hwloc-data/001N/exclusive/04-brokers/0.xml"
+ne_xml="${SHARNESS_TEST_SRCDIR}/data/hwloc-data/001N/exclusive/ne/0.xml"
+
+#
+# test_under_flux is under sharness.d/
+#
+test_under_flux 1
+
+#
+# print only with --debug
+#
+test_debug '
+    echo ${grug} &&
+    echo ${jobspec} &&
+    echo ${malform}
+'
+
+test_expect_success 'loading resource module with a tiny machine GRUG works' '
+    flux module remove resource &&
+    flux module load -r 0 resource grug-conf=${grug} prune-filters=ALL:core
+'
+
+test_expect_success 'loading resource module with an XML works' '
+    flux module remove resource &&
+    flux module load -r 0 resource hwloc-xml=${xml} prune-filters=ALL:core
+'
+
+test_expect_success 'loading resource module with a GRUG + XML works' '
+    flux module remove resource &&
+    flux module load -r 0 resource grug-conf=${grug} hwloc-xml=${xml} \
+prune-filters=ALL:core
+'
+
+test_expect_success 'loading resource module with no option works' '
+    flux module remove resource &&
+    flux module load -r 0 resource prune-filters=ALL:core
+'
+
+test_expect_success 'loading resource module with a nonexistent GRUG fails' '
+    flux module remove resource &&
+    test_expect_code 1 flux module load -r 0 resource grug-conf=${ne_grug} \
+prune-filters=ALL:core
+'
+
+test_expect_success 'loading resource module with a nonexistent XML fails' '
+    test_expect_code 1 flux module load -r 0 resource hwloc-xml=${ne_xml} \
+prune-filters=ALL:core
+'
+
+test_expect_success 'loading resource module with a nonexistent GRUG+XML fails' '
+    test_expect_code 1 flux module load -r 0 resource grug-conf=${ne_grug} \
+hwloc-xml=${ne_xml} prune-filters=ALL:core
+'
+
+test_expect_success 'loading resource module with known policies works' '
+    flux module load -r 0 resource policy=high &&
+    flux module remove resource &&
+    flux module load -r 0 resource policy=low &&
+    flux module remove resource &&
+    flux module load -r 0 resource policy=locality
+'
+
+test_expect_success 'loading resource module with unknown policies is tolerated' '
+    flux module remove resource &&
+    flux module load -r 0 resource policy=foo &&
+    flux module remove resource &&
+    flux module load -r 0 resource policy=bar
+'
+
+test_expect_success 'removing resource works' '
+    flux module remove resource
+'
+
+test_done
+


### PR DESCRIPTION
This PR add various fixes to ensure correctness around the use of pruning filters.

- Use at least one pruning filter type to ensure the schedule method within dfu.cpp can traverse resource state changing scheduled points for all cases.

- Enable the pruning filter planner, even if the specified filter types are not present at the subtree of the anchor type. This ensures correctness when such a condition ever arises.

- Add test cases using previous failed test codes

- Add test cases to test various module load options for the resource match service

- Other misc. changes

Resolve Issue #400
Resolve Issue #388 