### PR TITLE
docker: update repo tag names, ensure flux-sched installed with prefix=/usr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_install:
      -a "$TRAVIS_REPO_SLUG" = "flux-framework/flux-sched" \
      -a "$TRAVIS_PULL_REQUEST" = "false" \
      -a \( "$TRAVIS_BRANCH" = "master" -o -n "$TRAVIS_TAG" \); then
-      export TAGNAME="${DOCKERREPO}:${IMG}-${TRAVIS_TAG:-latest}"
+      export TAGNAME="${DOCKERREPO}:${IMG}${TRAVIS_TAG:+-${TRAVIS_TAG}}"
       echo "Tagging new image $TAGNAME"
    fi
 
@@ -73,8 +73,8 @@ after_success:
      echo "$DOCKER_PASSWORD" | \
        docker login -u "$DOCKER_USERNAME" --password-stdin && \
      docker push ${TAGNAME}
-     # If this is the bionic-base build, then also tag without image name:
-     if echo "$TAGNAME" | grep -q "bionic-base"; then
+     # If this is the bionic build, then also tag without image name:
+     if echo "$TAGNAME" | grep -q "bionic"; then
        t="${DOCKERREPO}:${TRAVIS_TAG:-latest}"
        docker tag "$TAGNAME" ${t} && \
        docker push ${t}

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,13 @@ matrix:
     - name: "Ubuntu: TEST_INSTALL docker-deploy"
       compiler: gcc
       env:
+       - ARGS="--prefix=/usr"
        - TEST_INSTALL=t
        - DOCKER_TAG=t
     - name: "Centos 7: docker-deploy"
       compiler: gcc
       env:
+       - ARGS="--prefix=/usr"
        - IMG=centos7
        - DOCKER_TAG=t
 
@@ -62,7 +64,8 @@ script:
   - |
    src/test/docker/docker-run-checks.sh -j2 \
      --image=${IMG} \
-     ${TAGNAME:+--tag=${TAGNAME}}
+     ${TAGNAME:+--tag=${TAGNAME}} \
+     -- ${ARGS}
 
 after_success:
  - ccache -s

--- a/src/test/docker/bionic/Dockerfile
+++ b/src/test/docker/bionic/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluxrm/flux-core:bionic-base-latest
+FROM fluxrm/flux-core:bionic
 
 ARG USER=flux
 ARG UID=1000

--- a/src/test/docker/centos7/Dockerfile
+++ b/src/test/docker/centos7/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluxrm/flux-core:centos7-base-latest
+FROM fluxrm/flux-core:centos7
 
 ARG USER=flux
 ARG UID=1000


### PR DESCRIPTION
Ok, a couple more cleanups of the Docker build/deploy here:
 
 * Update Dockerfiles to pull from `fluxrm/flux-core:bionic` or `:centos7` tags
 * Pass `--prefix=/usr` to docker-deploy builds so that flux-sched is installed to the same prefix as flux-core.