### PR TITLE
Fix build issues for priority_mod_fair_tree.so

### DIFF
--- a/sched/priority/modified_fair_tree/Makefile.am
+++ b/sched/priority/modified_fair_tree/Makefile.am
@@ -21,7 +21,7 @@ priority_mod_fair_tree_la_LDFLAGS = \
 	$(fluxlib_ldflags) \
 	-avoid-version \
 	-module \
-	-export-symbols-regex '^sched_priority_.*'
+	-export-symbols-regex '^(sched_priority_|mod_name).*'
 
 check_PROGRAMS = parse_sacct
 

--- a/sched/priority/modified_fair_tree/Makefile.am
+++ b/sched/priority/modified_fair_tree/Makefile.am
@@ -11,7 +11,7 @@ libconvenience_la_CXXFLAGS = \
 libconvenience_la_LIBADD = $(top_builddir)/resrc/libflux-resrc.la \
 	$(FLUX_CORE_LIBS) $(JANSSON_LIBS) $(CZMQ_LIBS)
 
-lib_LTLIBRARIES = priority_mod_fair_tree.la
+schedplugin_LTLIBRARIES = priority_mod_fair_tree.la
 # Dummy C++ source to cause C++ linking.
 nodist_EXTRA_priority_mod_fair_tree_la_SOURCES = dummy.cpp
 priority_mod_fair_tree_la_SOURCES =

--- a/sched/priority/modified_fair_tree/priority_external_api.cpp
+++ b/sched/priority/modified_fair_tree/priority_external_api.cpp
@@ -361,6 +361,8 @@ void sched_priority_prioritize_jobs (flux_t *h, zlist_t *jobs)
 
 } // namespace Priority
 } // namespace Flux
+
+MOD_NAME("sched.priority_fair_tree");
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */


### PR DESCRIPTION
As discussed in #433, this PR fixes a couple build issues for the modified fair tree plugin.