### PR TITLE
RFC20 support + other prep work for future integration with new execution system

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,12 @@ AM_CHECK_PYMOD(yaml,
                [StrictVersion(yaml.__version__) >= StrictVersion('3.10')], [],
                [AC_MSG_ERROR([[could not find python module yaml, version 3.10+ required]])])
 
+AM_CHECK_PYMOD(jsonschema,
+               [StrictVersion(jsonschema.__version__) >= StrictVersion ('2.3.0')],
+               ,
+               [AC_MSG_ERROR([could not find python module jsonschema, version 2.3.0+ required])]
+               )
+
 # Checks for header files.
 AC_CHECK_HEADERS([\
   inttypes.h \

--- a/configure.ac
+++ b/configure.ac
@@ -158,6 +158,7 @@ AC_CONFIG_FILES([Makefile
   resource/planner/test/Makefile
   resource/libjobspec/Makefile
   resource/utilities/Makefile
+  resource/utilities/test/Makefile
   resource/modules/Makefile
   etc/Makefile
   t/Makefile])

--- a/resource/Makefile.am
+++ b/resource/Makefile.am
@@ -36,6 +36,7 @@ libresource_la_SOURCES = \
     generators/spec.cpp \
     evaluators/scoring_api.cpp \
     evaluators/edge_eval_api.cpp \
+    emitters/match_emitters.cpp \
     utilities/command.hpp \
     policies/dfu_match_high_id_first.hpp \
     policies/dfu_match_low_id_first.hpp \
@@ -58,6 +59,7 @@ libresource_la_SOURCES = \
     evaluators/edge_eval_api.hpp \
     evaluators/fold.hpp \
     config/system_defaults.hpp \
+    emitters/match_emitters.hpp \
     planner/planner.h
 
 libresource_la_CXXFLAGS = \

--- a/resource/Makefile.am
+++ b/resource/Makefile.am
@@ -36,7 +36,7 @@ libresource_la_SOURCES = \
     generators/spec.cpp \
     evaluators/scoring_api.cpp \
     evaluators/edge_eval_api.cpp \
-    emitters/match_emitters.cpp \
+    writers/match_writers.cpp \
     utilities/command.hpp \
     policies/dfu_match_high_id_first.hpp \
     policies/dfu_match_low_id_first.hpp \
@@ -59,7 +59,7 @@ libresource_la_SOURCES = \
     evaluators/edge_eval_api.hpp \
     evaluators/fold.hpp \
     config/system_defaults.hpp \
-    emitters/match_emitters.hpp \
+    writers/match_writers.hpp \
     planner/planner.h
 
 libresource_la_CXXFLAGS = \

--- a/resource/emitters/match_emitters.cpp
+++ b/resource/emitters/match_emitters.cpp
@@ -408,7 +408,7 @@ void pretty_jgf_match_writers_t::emit_vtx (const string &prefix,
     m_vout << indent << "          \"name\": " << "\"" << g[u].name
            << "\", " << endl;
     m_vout << indent << "          \"id\": " << g[u].id << ", " << endl;
-    m_vout << indent << "          \"uuid\": " << g[u].uniq_id << ", " << endl;
+    m_vout << indent << "          \"uniq_id\": " << g[u].uniq_id << ", " << endl;
     m_vout << indent << "          \"rank\": " << g[u].rank << ", " << endl;
     m_vout << indent << "          \"exclusive\": " << x << ", " << endl;
     m_vout << indent << "          \"unit\": \"" << g[u].unit << "\", " << endl;

--- a/resource/emitters/match_emitters.cpp
+++ b/resource/emitters/match_emitters.cpp
@@ -1,0 +1,661 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+ \*****************************************************************************/
+
+#include <new>
+#include <cerrno>
+#include "resource/schema/resource_data.hpp"
+#include "resource/schema/resource_graph.hpp"
+#include "resource/emitters/match_emitters.hpp"
+
+namespace Flux {
+namespace resource_model {
+
+using namespace std;
+
+/****************************************************************************
+ *                                                                          *
+ *              Base Writers Class Public Method Definitions                *
+ *                                                                          *
+ ****************************************************************************/
+
+void match_writers_t::compress (stringstream &o, const set<int64_t> &ids)
+{
+    int64_t base = INT64_MIN;
+    int64_t runlen = 0;
+    // set is already sorted, so we iterate in ascending order
+    for (auto &id : ids) {
+        if (id == (base + runlen + 1)) {
+            runlen++;
+        } else {
+            if (runlen != 0)
+                o << "-" + to_string (base + runlen) + ",";
+            else if (base != INT64_MIN)
+                o << ",";
+            o << id;
+            base = id;
+            runlen = 0;
+        }
+    }
+    if (runlen)
+        o << "-" << (base + runlen);
+}
+
+
+/****************************************************************************
+ *                                                                          *
+ *              Simple Writers Class Public Method Definitions              *
+ *                                                                          *
+ ****************************************************************************/
+
+void sim_match_writers_t::emit (stringstream &out)
+{
+    out << m_out.str ();
+}
+
+void sim_match_writers_t::reset ()
+{
+    m_out.str ("");
+    m_out.clear ();
+}
+
+void sim_match_writers_t::emit_vtx (const string &prefix,
+                                    const f_resource_graph_t &g, const vtx_t &u,
+                                    unsigned int needs, bool exclusive)
+{
+    string mode = (exclusive)? "x" : "s";
+    m_out << prefix << g[u].name << "[" << needs << ":" << mode  << "]" << endl;
+}
+
+
+/****************************************************************************
+ *                                                                          *
+ *       JSON Graph Format (JGF) Writers Classs Public Definitions          *
+ *                                                                          *
+ ****************************************************************************/
+
+void jgf_match_writers_t::emit (stringstream &out, bool newline)
+{
+    size_t vout_size = m_vout.str ().size ();
+    size_t eout_size = m_eout.str ().size ();
+
+    if (vout_size > 0 && eout_size > 0) {
+        out << "{\"graph\":{\"nodes\":[";
+        out << m_vout.str ().substr (0, vout_size - 1);
+        out << "],\"edges\":[ ";
+        out << m_eout.str ().substr (0, eout_size - 1);
+        out << "]}}";
+        if (newline)
+           out << endl;
+    }
+}
+
+void jgf_match_writers_t::emit (stringstream &out)
+{
+    emit (out, true);
+}
+
+void jgf_match_writers_t::reset ()
+{
+    m_vout.str ("");
+    m_vout.clear ();
+    m_eout.str ("");
+    m_eout.clear ();
+}
+
+void jgf_match_writers_t::emit_vtx (const string &prefix,
+                                    const f_resource_graph_t &g, const vtx_t &u,
+                                    unsigned int needs, bool exclusive)
+{
+    string x = (exclusive)? "true" : "false";
+    m_vout << "{";
+    m_vout <<     "\"id\":\"" << u << "\",";
+    m_vout <<     "\"metadata\":{";
+    m_vout <<         "\"type\":" << "\"" << g[u].type << "\"" << ",";
+    m_vout <<         "\"basename\":" << "\"" << g[u].basename << "\"" << ",";
+    m_vout <<         "\"name\":" << "\"" << g[u].name << "\"" << ",";
+    m_vout <<         "\"id\":" << g[u].id << ",";
+    m_vout <<         "\"uniq_id\":" << g[u].uniq_id << ",";
+    m_vout <<         "\"rank\":" << g[u].rank << ",";
+    m_vout <<         "\"exclusive\":" << x << ",";
+    m_vout <<         "\"unit\":\"" << g[u].unit << "\",";
+    m_vout <<         "\"size\":" << needs;
+    if (!g[u].properties.empty ()) {
+        stringstream props;
+        m_vout <<                         ", ";
+        m_vout <<     "\"properties\":{";
+        for (auto &kv : g[u].properties)
+            props << "\"" << kv.first << "\":\"" << kv.second << "\",";
+        m_vout << props.str ().substr (0, props.str ().size () - 1);
+        m_vout <<      "}";
+    }
+    m_vout <<    "}";
+    m_vout << "},";
+}
+
+void jgf_match_writers_t::emit_edg (const string &prefix,
+                                    const f_resource_graph_t &g, const edg_t &e)
+{
+    m_eout << "{";
+    m_eout <<     "\"source\":\"" << source (e, g) << "\",";
+    m_eout <<     "\"target\":\"" << target (e, g) << "\",";
+    m_eout <<     "\"metadata\":{";
+    m_eout <<         "\"name\":" << "\"" << g[e].name << "\"";
+    m_eout <<    "}";
+    m_eout << "},";
+}
+
+
+/****************************************************************************
+ *                                                                          *
+ *                 RLITE Writers Class Method Definitions                   *
+ *                                                                          *
+ ****************************************************************************/
+
+rlite_match_writers_t::rlite_match_writers_t()
+{
+    m_reducer["core"] = set<int64_t> ();
+    m_reducer["gpu"] = set<int64_t> ();
+    // Note: GCC 4.8 doesn't support move constructor for stringstream
+    // we use a pointer type although it is not ideal.
+    m_gatherer["node"] = new stringstream ();
+}
+
+rlite_match_writers_t::~rlite_match_writers_t ()
+{
+    for (auto kv : m_gatherer)
+        delete kv.second;
+}
+
+void rlite_match_writers_t::reset ()
+{
+    m_out.str ("");
+    m_out.clear ();
+}
+
+void rlite_match_writers_t::emit (stringstream &out, bool newline)
+{
+    size_t size = m_out.str ().size ();
+    if (size > 1) {
+        out << "{\"R_lite\":[" << m_out.str ().substr (0, size - 1) << "]}";
+        if (newline)
+            out << endl;
+    }
+}
+
+void rlite_match_writers_t::emit (stringstream &out)
+{
+    emit (out, true);
+}
+
+bool rlite_match_writers_t::m_reducer_set ()
+{
+    bool set = false;
+    for (auto &kv : m_reducer) {
+        if (!kv.second.empty ()) {
+            set = true;
+            break;
+        }
+    }
+    return set;
+}
+
+void rlite_match_writers_t::emit_vtx (const string &prefix,
+                                      const f_resource_graph_t &g,
+                                      const vtx_t &u,
+                                      unsigned int needs,
+                                      bool exclusive)
+{
+    if (m_reducer.find (g[u].type) != m_reducer.end ()) {
+        m_reducer[g[u].type].insert (g[u].id);
+    } else if (m_gatherer.find (g[u].type) != m_gatherer.end ()) {
+        if (m_reducer_set ()) {
+            stringstream &gout = *(m_gatherer[g[u].type]);
+            gout << "{";
+            gout << "\"rank\":" << g[u].rank << ",";
+            gout << "\"node\":\"" << g[u].name << "\",";
+            gout << "\"children\":{";
+            for (auto &kv : m_reducer) {
+                if (kv.second.empty ())
+                    continue;
+                gout << "\"" << kv.first << "\":\"";
+                compress (gout, kv.second);
+                gout << "\",";
+                kv.second.clear ();
+            }
+            size_t size = gout.str ().size ();
+            m_out << gout.str ().substr (0, size - 1) << "}},";
+            gout.clear ();
+            gout.str ("");
+        }
+    }
+}
+
+
+/****************************************************************************
+ *                                                                          *
+ *                  RV1 Writers Class Method Definitions                    *
+ *                                                                          *
+ ****************************************************************************/
+
+void rv1_match_writers_t::reset ()
+{
+    rlite.reset ();
+    jgf.reset ();
+}
+
+void rv1_match_writers_t::emit (stringstream &out)
+{
+    string exec_key = "\"execution\":";
+    string sched_key = "\"scheduling\":";
+    size_t base = out.str ().size ();
+    out << "{" << exec_key;
+    rlite.emit (out, false);
+    out << "," << sched_key;
+    jgf.emit (out, false);
+    out << "}" << endl;
+    if (out.str ().size () <= (base + exec_key.size () + sched_key.size () + 3))
+        out.str (out.str ().substr (0, base));
+}
+
+void rv1_match_writers_t::emit_vtx (const string &prefix,
+                                    const f_resource_graph_t &g,
+                                    const vtx_t &u,
+                                    unsigned int needs,
+                                    bool exclusive)
+{
+    rlite.emit_vtx (prefix, g, u, needs, exclusive);
+    jgf.emit_vtx (prefix, g, u, needs, exclusive);
+}
+
+void rv1_match_writers_t::emit_edg (const string &prefix,
+                                    const f_resource_graph_t &g,
+                                    const edg_t &e)
+{
+    rlite.emit_edg (prefix, g, e);
+    jgf.emit_edg (prefix, g, e);
+}
+
+
+/****************************************************************************
+ *                                                                          *
+ *              RV1 Nosched Writers Class Method Definitions                *
+ *                                                                          *
+ ****************************************************************************/
+
+void rv1_nosched_match_writers_t::reset ()
+{
+    rlite.reset ();
+}
+
+void rv1_nosched_match_writers_t::emit (stringstream &out)
+{
+    string exec_key = "\"execution\":";
+    size_t base = out.str ().size ();
+    out << "{" << exec_key;
+    rlite.emit (out, false);
+    out << "}" << endl;
+    if (out.str ().size () <= (base + exec_key.size () + 2))
+        out.str (out.str ().substr (0, base));
+}
+
+void rv1_nosched_match_writers_t::emit_vtx (const string &prefix,
+                                            const f_resource_graph_t &g,
+                                            const vtx_t &u,
+                                            unsigned int needs,
+                                            bool exclusive)
+{
+    rlite.emit_vtx (prefix, g, u, needs, exclusive);
+}
+
+
+/****************************************************************************
+ *                                                                          *
+ *         PRETTY Simple Writers Class Public Method Definitions            *
+ *                                                                          *
+ ****************************************************************************/
+
+void pretty_sim_match_writers_t::emit (stringstream &out)
+{
+    for (auto &s: m_out)
+        out << s;
+}
+
+void pretty_sim_match_writers_t::reset ()
+{
+    m_out.clear ();
+}
+
+void pretty_sim_match_writers_t::emit_vtx (const string &prefix,
+                                           const f_resource_graph_t &g,
+                                           const vtx_t &u,
+                                           unsigned int needs, bool exclusive)
+{
+    stringstream out;
+    string mode = (exclusive)? "exclusive" : "shared";
+    out << prefix << g[u].name << "[" << needs << ":" << mode  << "]" << endl;
+    m_out.push_front (out.str ());
+}
+
+
+/****************************************************************************
+ *                                                                          *
+ *    Pretty JSON Graph Format (JGF) Writers Classs Public Definitions      *
+ *                                                                          *
+ ****************************************************************************/
+
+void pretty_jgf_match_writers_t::emit (stringstream &out)
+{
+    size_t vout_size = m_vout.str ().size ();
+    size_t eout_size = m_eout.str ().size ();
+
+    out << "     {" << endl;
+    out << "      \"graph\": {" << endl;
+    out << "        \"nodes\": [" << endl;
+    if (vout_size > 1)
+        out << m_vout.str ().substr (0, vout_size - 2) << endl;
+    out << "       ]," << endl;
+    out << "        \"edges\": [" << endl;
+    if (eout_size > 1)
+        out << m_eout.str ().substr (0, eout_size - 2) << endl;
+    out << "       ]" << endl;
+    out << "      }" << endl;
+    out << "     }" << endl;
+}
+
+void pretty_jgf_match_writers_t::reset ()
+{
+    m_vout.str ("");
+    m_vout.clear ();
+    m_eout.str ("");
+    m_eout.clear ();
+}
+
+void pretty_jgf_match_writers_t::emit_vtx (const string &prefix,
+                                           const f_resource_graph_t &g,
+                                           const vtx_t &u, unsigned int needs,
+                                           bool exclusive)
+{
+    string x = (exclusive)? "true" : "false";
+    string indent = "        ";
+    m_vout << indent << "  { " << endl;
+    m_vout << indent << "    \"id\": \"" << u << "\", " << endl;
+    m_vout << indent << "    \"metadata\": { " << endl;
+    m_vout << indent << "          \"type\": " << "\"" << g[u].type
+           << "\", " << endl;
+    m_vout << indent << "          \"basename\": " << "\"" << g[u].basename
+           << "\", " << endl;
+    m_vout << indent << "          \"name\": " << "\"" << g[u].name
+           << "\", " << endl;
+    m_vout << indent << "          \"id\": " << g[u].id << ", " << endl;
+    m_vout << indent << "          \"uuid\": " << g[u].uniq_id << ", " << endl;
+    m_vout << indent << "          \"rank\": " << g[u].rank << ", " << endl;
+    m_vout << indent << "          \"exclusive\": " << x << ", " << endl;
+    m_vout << indent << "          \"unit\": \"" << g[u].unit << "\", " << endl;
+    m_vout << indent << "          \"size\": " << needs << endl;
+    if (!g[u].properties.empty ()) {
+        stringstream props;
+        m_vout <<                                     ", ";
+        m_vout << indent << "           \"properties\": { ";
+        for (auto &kv : g[u].properties) {
+            props << indent << "                \"" << kv.first << "\": \""
+                            << kv.second << "\"," << endl;
+        }
+        m_vout << props.str ().substr (0, props.str ().size () - 2) << endl;
+        m_vout << indent << "                     }";
+    }
+    m_vout << indent << "    }" << endl;
+    m_vout << indent << "  }," << endl;
+}
+
+void pretty_jgf_match_writers_t::emit_edg (const string &prefix,
+                                           const f_resource_graph_t &g,
+                                           const edg_t &e)
+{
+    string indent = "        ";
+    m_eout << indent << "{ " << endl;
+    m_eout << indent << "    \"source\": \"" << source (e, g) << "\", " << endl;
+    m_eout << indent << "    \"target\": \"" << target (e, g) << "\", " << endl;
+    m_eout << indent << "    \"metadata\": { " << endl;
+    m_eout << indent << "        \"name\": " << "\"" << g[e].name
+           << "\"" << endl;
+    m_eout << indent << "    }" << endl;
+    m_eout << indent << "}," << endl;
+}
+
+
+/****************************************************************************
+ *                                                                          *
+ *             Pretty RLITE Writers Class Method Definitions                *
+ *                                                                          *
+ ****************************************************************************/
+
+pretty_rlite_match_writers_t::pretty_rlite_match_writers_t()
+{
+    m_reducer["core"] = set<int64_t> ();
+    m_reducer["gpu"] = set<int64_t> ();
+    m_gatherer["node"] = new stringstream ();
+}
+
+pretty_rlite_match_writers_t::~pretty_rlite_match_writers_t ()
+{
+    for (auto kv : m_gatherer)
+        delete kv.second;
+}
+
+void pretty_rlite_match_writers_t::reset ()
+{
+    m_out.str ("");
+    m_out.clear ();
+}
+
+void pretty_rlite_match_writers_t::emit (stringstream &out)
+{
+    size_t size = m_out.str ().size ();
+    if (size > 1) {
+        out << "    {" << endl;
+        out << "      \"R_lite\": [" << endl;
+        out << m_out.str ().substr (0, size - 2) << endl;
+        out << "      ]" << endl;
+        out << "    }" << endl;
+    }
+}
+
+bool pretty_rlite_match_writers_t::m_reducer_set ()
+{
+    bool set = false;
+    for (auto &kv : m_reducer) {
+        if (!kv.second.empty ()) {
+            set = true;
+            break;
+        }
+    }
+    return set;
+}
+
+void pretty_rlite_match_writers_t::emit_vtx (const string &prefix,
+                                             const f_resource_graph_t &g,
+                                             const vtx_t &u,
+                                             unsigned int needs,
+                                             bool exclusive)
+{
+    string indent = "    ";
+    if (m_reducer.find (g[u].type) != m_reducer.end ()) {
+        m_reducer[g[u].type].insert (g[u].id);
+    } else if (m_gatherer.find (g[u].type) != m_gatherer.end ()) {
+        if (m_reducer_set ()) {
+            stringstream &gout = *(m_gatherer[g[u].type]);
+            gout << indent << "    {" << endl;
+            gout << indent << "      \"rank\": " << g[u].rank << "," << endl;
+            gout << indent << "      \"node\": \"" << g[u].name << "\","
+                 << endl;
+            gout << indent << "      \"children\": {" << endl;
+            for (auto &kv : m_reducer) {
+                if (kv.second.empty ())
+                    continue;
+                gout << indent << "         \"" << kv.first << "\": \"";
+                compress (gout, kv.second);
+                gout << "\"," << endl;
+                kv.second.clear ();
+	        }
+            size_t size = gout.str ().size ();
+            m_out << gout.str ().substr (0, size - 2) << endl;
+            m_out << indent << "      }" << endl;
+            m_out << indent << "    }," << endl;
+            gout.clear ();
+            gout.str ("");
+        }
+    }
+}
+
+
+/****************************************************************************
+ *                                                                          *
+ *              Pretty RV1 Writers Class Method Definitions                 *
+ *                                                                          *
+ ****************************************************************************/
+
+void pretty_rv1_match_writers_t::reset ()
+{
+    rlite.reset ();
+    jgf.reset ();
+}
+
+void pretty_rv1_match_writers_t::emit (stringstream &out)
+{
+    out << "{" << endl;
+    out << "  \"execution\": " << endl;
+    rlite.emit (out);
+    out << "     ," << endl;
+    out << "  \"scheduling\": " << endl;
+    jgf.emit (out);
+    out << "}" << endl;
+}
+
+void pretty_rv1_match_writers_t::emit_vtx (const string &prefix,
+                                           const f_resource_graph_t &g,
+                                           const vtx_t &u,
+                                           unsigned int needs,
+                                           bool exclusive)
+{
+    rlite.emit_vtx (prefix, g, u, needs, exclusive);
+    jgf.emit_vtx (prefix, g, u, needs, exclusive);
+}
+
+void pretty_rv1_match_writers_t::emit_edg (const string &prefix,
+                                           const f_resource_graph_t &g,
+                                           const edg_t &e)
+{
+    rlite.emit_edg (prefix, g, e);
+    jgf.emit_edg (prefix, g, e);
+}
+
+
+/****************************************************************************
+ *                                                                          *
+ *             Match Writers Factory Class Method Definitions               *
+ *                                                                          *
+ ****************************************************************************/
+
+match_writers_t *match_writers_factory_t::create (match_format_t f)
+{
+    match_writers_t *w = NULL;
+
+    switch (f) {
+    case match_format_t::SIMPLE:
+        w = new (nothrow)sim_match_writers_t ();
+        break;
+    case match_format_t::JGF:
+        w = new (nothrow)jgf_match_writers_t ();
+        break;
+    case match_format_t::RLITE:
+        w = new (nothrow)rlite_match_writers_t ();
+        break;
+    case match_format_t::RV1_NOSCHED:
+        w = new (nothrow)rv1_nosched_match_writers_t ();
+        break;
+    case match_format_t::PRETTY_SIMPLE:
+        w = new (nothrow)pretty_sim_match_writers_t ();
+        break;
+    case match_format_t::PRETTY_JGF:
+        w = new (nothrow)pretty_jgf_match_writers_t ();
+        break;
+    case match_format_t::PRETTY_RLITE:
+        w = new (nothrow)pretty_rlite_match_writers_t ();
+        break;
+    case match_format_t::PRETTY_RV1:
+        w = new (nothrow)pretty_rv1_match_writers_t ();
+        break;
+    case match_format_t::RV1:
+    default:
+        w = new (nothrow)rv1_match_writers_t ();
+        break;
+    }
+
+    if (!w)
+        errno = ENOMEM;
+
+    return w;
+}
+
+match_format_t match_writers_factory_t::get_writers_type (const string &n)
+{
+    match_format_t format = match_format_t::SIMPLE;
+    if (n == "jgf")
+        format = match_format_t::JGF;
+    else if (n == "rlite")
+        format = match_format_t::RLITE;
+    else if (n == "rv1")
+        format = match_format_t::RV1;
+    else if (n == "rv1_nosched")
+        format = match_format_t::RV1_NOSCHED;
+    else if (n == "pretty_simple")
+        format = match_format_t::PRETTY_SIMPLE;
+    else if (n == "pretty_jgf")
+        format = match_format_t::PRETTY_JGF;
+    else if (n == "pretty_rlite")
+        format = match_format_t::PRETTY_RLITE;
+    else if (n == "pretty_rv1")
+        format = match_format_t::PRETTY_RV1;
+    return format;
+}
+
+bool known_match_format (const string &format)
+{
+   return (format == "simple"
+           || format == "jgf"
+           || format == "rlite"
+           || format == "rv1"
+           || format == "rv1_nosched"
+           || format == "pretty_simple"
+           || format == "pretty_jgf"
+           || format == "pretty_rlite"
+           || format == "pretty_rv1");
+}
+
+} // namespace resource_model
+} // namespace Flux
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/emitters/match_emitters.hpp
+++ b/resource/emitters/match_emitters.hpp
@@ -1,0 +1,240 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+ \*****************************************************************************/
+
+#ifndef MATCH_EMITTERS_HPP
+#define MATCH_EMITTERS_HPP
+
+#include <string>
+#include <sstream>
+#include <set>
+
+namespace Flux {
+namespace resource_model {
+
+enum class match_format_t { SIMPLE,
+                            JGF,
+                            RLITE,
+                            RV1,
+                            RV1_NOSCHED,
+                            PRETTY_SIMPLE,
+                            PRETTY_JGF,
+                            PRETTY_RLITE,
+                            PRETTY_RV1 };
+
+
+/*! Base match writers class for a matched resource set
+ */
+class match_writers_t {
+public:
+    virtual ~match_writers_t () {}
+    virtual void emit (std::stringstream &out) = 0;
+    virtual void reset () = 0;
+    virtual void emit_vtx (const std::string &prefix,
+                           const f_resource_graph_t &g, const vtx_t &u,
+                           unsigned int needs, bool exclusive) = 0;
+    virtual void emit_edg (const std::string &prefix,
+                           const f_resource_graph_t &g, const edg_t &e) {}
+    void compress (std::stringstream &o, const std::set<int64_t> &ids);
+};
+
+
+/*! Simple match writers class for a matched resource set
+ */
+class sim_match_writers_t : public match_writers_t
+{
+public:
+    virtual ~sim_match_writers_t () {}
+    virtual void emit (std::stringstream &out);
+    virtual void reset ();
+    virtual void emit_vtx (const std::string &prefix,
+                           const f_resource_graph_t &g, const vtx_t &u,
+                           unsigned int needs, bool exclusive);
+private:
+    std::stringstream m_out;
+};
+
+
+/*! JGF match writers class for a matched resource set
+ */
+class jgf_match_writers_t : public match_writers_t
+{
+public:
+    virtual ~jgf_match_writers_t () {}
+    virtual void reset ();
+    virtual void emit (std::stringstream &out, bool newline);
+    virtual void emit (std::stringstream &out);
+    virtual void emit_vtx (const std::string &prefix,
+                           const f_resource_graph_t &g, const vtx_t &u,
+                           unsigned int needs, bool exclusive);
+    virtual void emit_edg (const std::string &prefix,
+                           const f_resource_graph_t &g, const edg_t &e);
+private:
+    std::stringstream m_vout;
+    std::stringstream m_eout;
+};
+
+
+/*! RLITE match writers class for a matched resource set
+ */
+class rlite_match_writers_t : public match_writers_t
+{
+public:
+    rlite_match_writers_t ();
+    virtual ~rlite_match_writers_t ();
+    virtual void reset ();
+    virtual void emit (std::stringstream &out, bool newline);
+    virtual void emit (std::stringstream &out);
+    virtual void emit_vtx (const std::string &prefix,
+                           const f_resource_graph_t &g, const vtx_t &u,
+                           unsigned int needs, bool exclusive);
+private:
+    bool m_reducer_set ();
+    std::map<std::string, std::set<int64_t>> m_reducer;
+    std::map<std::string, std::stringstream *> m_gatherer;
+    std::stringstream m_out;
+};
+
+
+/*! R Version 1 match writers class for a matched resource set
+ */
+class rv1_match_writers_t : public match_writers_t
+{
+public:
+    virtual void reset ();
+    virtual void emit (std::stringstream &out);
+    virtual void emit_vtx (const std::string &prefix,
+                           const f_resource_graph_t &g, const vtx_t &u,
+                           unsigned int needs, bool exclusive);
+    virtual void emit_edg (const std::string &prefix,
+                           const f_resource_graph_t &g, const edg_t &e);
+private:
+    rlite_match_writers_t rlite;
+    jgf_match_writers_t jgf;
+};
+
+
+/*! R Version 1 with no "scheduling" key match writers class
+ */
+class rv1_nosched_match_writers_t : public match_writers_t
+{
+public:
+    virtual void reset ();
+    virtual void emit (std::stringstream &out);
+    virtual void emit_vtx (const std::string &prefix,
+                           const f_resource_graph_t &g, const vtx_t &u,
+                           unsigned int needs, bool exclusive);
+private:
+    rlite_match_writers_t rlite;
+};
+
+
+/*! Human-friendly simple match writers class for a matched resource set
+ */
+class pretty_sim_match_writers_t : public match_writers_t
+{
+public:
+    virtual void emit (std::stringstream &out);
+    virtual void reset ();
+    virtual void emit_vtx (const std::string &prefix,
+                           const f_resource_graph_t &g, const vtx_t &u,
+                           unsigned int needs, bool exclusive);
+private:
+    std::list<std::string> m_out;
+};
+
+
+/*! Human-friendly JGF match writers class for a matched resource set
+ */
+class pretty_jgf_match_writers_t : public match_writers_t
+{
+public:
+    virtual void reset ();
+    virtual void emit (std::stringstream &out);
+    virtual void emit_vtx (const std::string &prefix,
+                           const f_resource_graph_t &g, const vtx_t &u,
+                           unsigned int needs, bool exclusive);
+    virtual void emit_edg (const std::string &prefix,
+                           const f_resource_graph_t &g, const edg_t &e);
+private:
+    std::stringstream m_vout;
+    std::stringstream m_eout;
+};
+
+
+/*! Human-friendly RLite match writers class for a matched resource set
+ */
+class pretty_rlite_match_writers_t : public match_writers_t
+{
+public:
+    pretty_rlite_match_writers_t ();
+    virtual ~pretty_rlite_match_writers_t ();
+    virtual void reset ();
+    virtual void emit (std::stringstream &out);
+    virtual void emit_vtx (const std::string &prefix,
+                           const f_resource_graph_t &g, const vtx_t &u,
+                           unsigned int needs, bool exclusive);
+private:
+    bool m_reducer_set ();
+    std::map<std::string, std::set<int64_t>> m_reducer;
+    std::map<std::string, std::stringstream *> m_gatherer;
+    std::stringstream m_out;
+};
+
+
+/*! Human-friendly R Version 1 match writers class for a matched resource set
+ */
+class pretty_rv1_match_writers_t : public match_writers_t
+{
+public:
+    virtual void reset ();
+    virtual void emit (std::stringstream &out);
+    virtual void emit_vtx (const std::string &prefix,
+                           const f_resource_graph_t &g, const vtx_t &u,
+                           unsigned int needs, bool exclusive);
+    virtual void emit_edg (const std::string &prefix,
+                           const f_resource_graph_t &g, const edg_t &e);
+private:
+    pretty_rlite_match_writers_t rlite;
+    pretty_jgf_match_writers_t jgf;
+};
+
+
+/*! Match writer factory-method class
+ */
+class match_writers_factory_t {
+public:
+    static match_format_t get_writers_type (const std::string &n);
+    static match_writers_t *create (match_format_t f);
+};
+
+bool known_match_format (const std::string &format);
+
+} // namespace resource_model
+} // namespace Flux
+
+#endif // MATCH_EMITTERS_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/generators/gen.cpp
+++ b/resource/generators/gen.cpp
@@ -199,8 +199,6 @@ vtx_t dfs_emitter_t::emit_vertex (ggv_t u, gge_t e, const gg_t &recipe,
         db.roots[recipe[u].subsystem] = v;
         id = 0;
     } else {
-        // TODO: should add_vertex really be called a second time?
-        v = add_vertex (db.resource_graph);
         id = gen_id (e, recipe, i, sz, j);
         pref = db.resource_graph[src_v].paths[ssys];
     }

--- a/resource/generators/gen.cpp
+++ b/resource/generators/gen.cpp
@@ -207,6 +207,7 @@ vtx_t dfs_emitter_t::emit_vertex (ggv_t u, gge_t e, const gg_t &recipe,
     db.resource_graph[v].type = recipe[u].type;
     db.resource_graph[v].basename = recipe[u].basename;
     db.resource_graph[v].size = recipe[u].size;
+    db.resource_graph[v].unit = recipe[u].unit;
     db.resource_graph[v].schedule.plans = planner_new (0, INT64_MAX,
                                                        recipe[u].size,
                                                        recipe[u].type.c_str ());
@@ -217,6 +218,7 @@ vtx_t dfs_emitter_t::emit_vertex (ggv_t u, gge_t e, const gg_t &recipe,
     db.resource_graph[v].name = recipe[u].basename + istr;
     db.resource_graph[v].paths[ssys] = pref + "/" + db.resource_graph[v].name;
     db.resource_graph[v].idata.member_of[ssys] = "*";
+    db.resource_graph[v].uniq_id = v;
 
     //
     // Indexing for fast look-up...

--- a/resource/generators/gen.cpp
+++ b/resource/generators/gen.cpp
@@ -471,6 +471,7 @@ ggv_t add_new_vertex(resource_graph_db_t &db, const ggv_t &parent,
     db.resource_graph[v].type = type;
     db.resource_graph[v].basename = basename;
     db.resource_graph[v].size = size;
+    db.resource_graph[v].uniq_id = v;
     db.resource_graph[v].rank = rank;
     db.resource_graph[v].schedule.plans = planner_new (0, INT64_MAX,
                                                        size,

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -59,7 +59,7 @@ struct resource_args_t {
     string match_policy;
     string prune_filters;
     string match_format;
-    int reserve_vtx_vec;           /* Allow for reserving vertex vector size */
+    int reserve_vtx_vec;        /* Allow for reserving vertex vector size */
 };
 
 struct resource_ctx_t {
@@ -208,6 +208,15 @@ static int process_args (resource_ctx_t *ctx, int argc, char **argv)
                            args.match_format.c_str (), dflt.c_str ());
                 args.match_format = dflt;
             }
+        } else if (!strncmp ("reserve-vtx-vec=",
+                             argv[i], sizeof ("reserve-vtx-vec"))) {
+            args.reserve_vtx_vec = atoi (strstr (argv[i], "=") + 1);
+            if ( args.reserve_vtx_vec <= 0 || args.reserve_vtx_vec > 2000000) {
+                flux_log (ctx->h, LOG_ERR,
+                          "out of range specified for reserve-vtx-vec (%d)",
+                          args.reserve_vtx_vec);
+                args.reserve_vtx_vec = 0;
+            }
         } else {
             rc = -1;
             errno = EINVAL;
@@ -332,6 +341,10 @@ static int populate_resource_db (resource_ctx_t *ctx)
 {
     int rc = 0;
     resource_generator_t rgen;
+
+    if (ctx->args.reserve_vtx_vec != 0)
+        ctx->db.resource_graph.m_vertices.reserve (ctx->args.reserve_vtx_vec);
+
     // TODO: include rgen.err_message()
     if (ctx->args.grug != "") {
         if (ctx->args.hwloc_xml != "") {

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -769,7 +769,7 @@ static void stat_request_cb (flux_t *h, flux_msg_handler_t *w,
     return;
 
 error:
-    if (flux_respond (h, msg, errno, NULL) < 0)
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
         flux_log_error (h, "%s", __FUNCTION__);
 }
 

--- a/resource/planner/planner_multi.c
+++ b/resource/planner/planner_multi.c
@@ -194,12 +194,15 @@ void planner_multi_destroy (planner_multi_t **ctx_p)
 {
     int i = 0;
     if (ctx_p && *ctx_p) {
-        for (i = 0; i < (*ctx_p)->size; ++i)
+        for (i = 0; i < (*ctx_p)->size; ++i) {
             planner_destroy (&((*ctx_p)->planners[i]));
-
+            free ((*ctx_p)->resource_types[i]);
+        }
         free ((*ctx_p)->resource_totals);
         free ((*ctx_p)->resource_types);
         free ((*ctx_p)->iter.counts);
+        free ((*ctx_p)->planners);
+        zhashx_destroy (&((*ctx_p)->span_lookup));
         free (*ctx_p);
         *ctx_p = NULL;
     }

--- a/resource/policies/base/matcher.cpp
+++ b/resource/policies/base/matcher.cpp
@@ -163,7 +163,7 @@ int matcher_util_api_t::register_resource_pair (const std::string &subsystem,
     std::string l;
     std::string split = ":";
 
-    if (((pos = r_pair.find (split)) == std::string::npos))
+    if ((pos = r_pair.find (split)) == std::string::npos)
         goto done;
     h = r_pair.substr (0, pos);
     h.erase (std::remove_if (h.begin (), h.end (), ::isspace), h.end ());

--- a/resource/schema/resource_data.cpp
+++ b/resource/schema/resource_data.cpp
@@ -45,7 +45,7 @@ resource_pool_t::resource_pool_t (const resource_pool_t &o)
     name = o.name;
     properties = o.properties;
     id = o.id;
-    memcpy (uuid, o.uuid, sizeof (uuid));
+    uniq_id = o.uniq_id;
     size = o.size;
     unit = o.unit;
     schedule = o.schedule;
@@ -60,7 +60,7 @@ resource_pool_t &resource_pool_t::operator= (const resource_pool_t &o)
     name = o.name;
     properties = o.properties;
     id = o.id;
-    memcpy (uuid, o.uuid, sizeof (uuid));
+    uniq_id = o.uniq_id;
     size = o.size;
     unit = o.unit;
     schedule = o.schedule;

--- a/resource/schema/resource_data.cpp
+++ b/resource/schema/resource_data.cpp
@@ -46,6 +46,7 @@ resource_pool_t::resource_pool_t (const resource_pool_t &o)
     properties = o.properties;
     id = o.id;
     uniq_id = o.uniq_id;
+    rank = o.rank;
     size = o.size;
     unit = o.unit;
     schedule = o.schedule;
@@ -61,6 +62,7 @@ resource_pool_t &resource_pool_t::operator= (const resource_pool_t &o)
     properties = o.properties;
     id = o.id;
     uniq_id = o.uniq_id;
+    rank = o.rank;
     size = o.size;
     unit = o.unit;
     schedule = o.schedule;

--- a/resource/schema/resource_data.hpp
+++ b/resource/schema/resource_data.hpp
@@ -51,7 +51,7 @@ struct resource_pool_t {
     std::string name;
     std::map<std::string, std::string> properties;
     int64_t id = -1;
-    uuid_t uuid;
+    int64_t uniq_id;
     unsigned int size = 0;
     int rank = -1;
     std::string unit;

--- a/resource/traversers/dfu.cpp
+++ b/resource/traversers/dfu.cpp
@@ -185,8 +185,8 @@ int dfu_traverser_t::initialize (f_resource_graph_t *g,
     return initialize ();
 }
 
-int dfu_traverser_t::run (Jobspec::Jobspec &jobspec, match_op_t op,
-                          int64_t jobid, int64_t *at, stringstream &ss)
+int dfu_traverser_t::run (Jobspec::Jobspec &jobspec, match_writers_t *writers,
+                          match_op_t op, int64_t jobid, int64_t *at)
 {
     const subsystem_t &dom = get_match_cb ()->dom_subsystem ();
     if (!get_graph () || !get_roots ()
@@ -206,7 +206,7 @@ int dfu_traverser_t::run (Jobspec::Jobspec &jobspec, match_op_t op,
     meta.build (jobspec, true, jobid, *at);
     if ( (rc = schedule (jobspec, meta, x, op, root, &needs, dfv)) ==  0) {
         *at = meta.at;
-        rc = detail::dfu_impl_t::update (root, meta, needs, x, ss);
+        rc = detail::dfu_impl_t::update (root, writers, meta, needs, x);
     }
     return rc;
 }
@@ -223,19 +223,6 @@ int dfu_traverser_t::remove (int64_t jobid)
 
     vtx_t root = get_roots ()->at(dom);
     return detail::dfu_impl_t::remove (root, jobid);
-}
-
-namespace Flux {
-namespace resource_model {
-
-bool known_R_format (const string &f)
-{
-    bool rc = true;
-    if (f != R_FORMAT || f != R_LITE_FORMAT || f != R_NATIVE_FORMAT)
-        rc = false;
-    return rc;
-}
-}
 }
 
 /*

--- a/resource/traversers/dfu.hpp
+++ b/resource/traversers/dfu.hpp
@@ -32,12 +32,6 @@
 namespace Flux {
 namespace resource_model {
 
-enum class R_format { R, R_LITE, R_NATIVE };
-
-const char R_FORMAT[] = "R";
-const char R_LITE_FORMAT[] = "R_LITE";
-const char R_NATIVE_FORMAT[] = "R_NATIVE";
-
 /*! Depth-First-and-Up traverser. Perform depth-first visit on the dominant
  *  subsystem and upwalk on each and all of the auxiliary subsystems selected
  *  by the matcher callback object (dfu_match_cb_t). Corresponding match
@@ -106,18 +100,18 @@ public:
      *  method is called.
      *
      *  \param jobspec   Jobspec object.
+     *  \param writers   vertex/edge writers to emit the matched labels
      *  \param op        schedule operation:
      *                       allocate or allocate_orelse_reserve.
      *  \param id        job ID to use for the schedule operation.
      *  \param at[out]   when the job is scheduled if reserved.
-     *  \param ss        stringstream into which emitted R infor is stored.
      *  \return          0 on success; -1 on error.
      *                       EINVAL: graph, roots or match callback not set.
      *                       ENOTSUP: roots does not contain a subsystem the
      *                                match callback uses.
      */
-    int run (Jobspec::Jobspec &jobspec, match_op_t op, int64_t id, int64_t *at,
-             std::stringstream &ss);
+    int run (Jobspec::Jobspec &jobspec, match_writers_t *writers,
+             match_op_t op, int64_t id, int64_t *at);
 
     /*! Remove the allocation/reservation referred to by jobid and update
      *  the resource state.
@@ -134,8 +128,6 @@ private:
                   vtx_t root, unsigned int *needs,
                   std::unordered_map<std::string, int64_t> &dfv);
 };
-
-bool known_R_format (const std::string &f);
 
 } // namespace resource_model
 } // namespace Flux

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -707,16 +707,19 @@ int dfu_impl_t::upd_dfv (vtx_t u, match_writers_t *writers, unsigned int needs,
             if ((*m_graph)[*ei].idata.best_k_cnt != m_best_k_cnt)
                 continue;
 
+	    int n_plan_sub = 0;
             bool x = (*m_graph)[*ei].idata.exclusive;
             unsigned int needs = (*m_graph)[*ei].idata.needs;
             vtx_t tgt = target (*ei, *m_graph);
             if (subsystem == dom)
-                n_plans += upd_dfv (tgt, writers, needs, x, meta, dfu);
+                n_plan_sub += upd_dfv (tgt, writers, needs, x, meta, dfu);
             else
-                n_plans += upd_upv (tgt, subsystem, needs, x, meta, dfu);
+                n_plan_sub += upd_upv (tgt, subsystem, needs, x, meta, dfu);
 
-            if (n_plans > 0)
+            if (n_plan_sub > 0) {
                 emit_edg (*ei, writers);
+                n_plans += n_plan_sub;
+	    }
         }
     }
     (*m_graph)[u].idata.colors[dom] = m_color.black ();

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -44,7 +44,7 @@ using namespace Flux::resource_model::detail;
 const std::string dfu_impl_t::level () const
 {
     unsigned int i;
-    std::string prefix = "";
+    std::string prefix = "      ";
     for (i = 0; i < m_trav_level; ++i)
         prefix += "---";
     return prefix;
@@ -595,25 +595,22 @@ int dfu_impl_t::enforce (const subsystem_t &subsystem, scoring_api_t &dfu)
     return rc;
 }
 
-int dfu_impl_t::emit_edge (edg_t e)
+int dfu_impl_t::emit_vtx (vtx_t u, match_writers_t *w, unsigned needs,
+                          bool exclusive)
 {
-    // NYI: We will ultimately need to emit edge info for nested instance
-    // with complex scheduler, pending a discussion on R.
+    w->emit_vtx (level (), (*m_graph), u, needs, exclusive);
     return 0;
 }
 
-int dfu_impl_t::emit_vertex (vtx_t u, unsigned int needs, bool exclusive,
-                             stringstream &ss)
-{
-    string mode = (exclusive)? "x" : "s";
-    ss << "      " << level () << (*m_graph)[u].name << "["
-       << needs << ":" << mode  << "]" << endl;
-    return 0;
+int dfu_impl_t::emit_edg (edg_t e, match_writers_t *w)
+ {
+     w->emit_edg (level (), (*m_graph), e);
+     return 0;
 }
 
 int dfu_impl_t::upd_plan (vtx_t u, const subsystem_t &s, unsigned int needs,
-                           bool excl, const jobmeta_t &meta, int &n,
-                           map<string, int64_t> &to_parent)
+                          bool excl, const jobmeta_t &meta, int &n,
+                          map<string, int64_t> &to_parent)
 {
     int64_t span = 0;
     if (!excl) {
@@ -641,10 +638,11 @@ done:
     return (span == -1)? -1 : 0;
 }
 
-int dfu_impl_t::upd_sched (vtx_t u, const subsystem_t &s, unsigned int needs,
+int dfu_impl_t::upd_sched (vtx_t u, match_writers_t *writers,
+                           const subsystem_t &s, unsigned int needs,
                            bool excl, int n, const jobmeta_t &meta,
                            map<string, int64_t> &dfu,
-                           map<string, int64_t> &to_parent, stringstream &ss)
+                           map<string, int64_t> &to_parent)
 {
     if (upd_plan (u, s, needs, excl, meta, n, to_parent) == -1)
         goto done;
@@ -677,7 +675,7 @@ int dfu_impl_t::upd_sched (vtx_t u, const subsystem_t &s, unsigned int needs,
 
         for (auto &kv : dfu)
             accum_if (s, kv.first, kv.second, to_parent);
-        emit_vertex (u, needs, excl, ss);
+        emit_vtx (u, writers, needs, excl);
     }
     m_trav_level--;
 done:
@@ -692,9 +690,9 @@ int dfu_impl_t::upd_upv (vtx_t u, const subsystem_t &subsystem,
     return 0;
 }
 
-int dfu_impl_t::upd_dfv (vtx_t u, unsigned int needs, bool excl,
-                         const jobmeta_t &meta, map<string, int64_t> &to_parent,
-                         stringstream &ss)
+int dfu_impl_t::upd_dfv (vtx_t u, match_writers_t *writers, unsigned int needs,
+                         bool excl, const jobmeta_t &meta,
+                         map<string, int64_t> &to_parent)
 {
     int n_plans = 0;
     map<string, int64_t> dfu;
@@ -713,16 +711,17 @@ int dfu_impl_t::upd_dfv (vtx_t u, unsigned int needs, bool excl,
             unsigned int needs = (*m_graph)[*ei].idata.needs;
             vtx_t tgt = target (*ei, *m_graph);
             if (subsystem == dom)
-                n_plans += upd_dfv (tgt, needs, x, meta, dfu, ss);
+                n_plans += upd_dfv (tgt, writers, needs, x, meta, dfu);
             else
                 n_plans += upd_upv (tgt, subsystem, needs, x, meta, dfu);
 
             if (n_plans > 0)
-                emit_edge (*ei);
+                emit_edg (*ei, writers);
         }
     }
     (*m_graph)[u].idata.colors[dom] = m_color.black ();
-    return upd_sched (u, dom, needs, excl, n_plans, meta, dfu, to_parent, ss);
+    return upd_sched (u, writers, dom, needs,
+                      excl, n_plans, meta, dfu, to_parent);
 }
 
 int dfu_impl_t::rem_upv (vtx_t u, int64_t jobid)
@@ -1018,12 +1017,12 @@ int dfu_impl_t::select (Jobspec::Jobspec &j, vtx_t root, jobmeta_t &meta,
     return rc;
 }
 
-int dfu_impl_t::update (vtx_t root, jobmeta_t &meta, unsigned int needs,
-                        bool exclusive, stringstream &ss)
+int dfu_impl_t::update (vtx_t root, match_writers_t *writers, jobmeta_t &meta,
+                        unsigned int needs, bool exclusive)
 {
     map<string, int64_t> dfu;
     m_color.reset ();
-    return (upd_dfv (root, needs, exclusive, meta, dfu, ss) > 0)? 0 : -1;
+    return (upd_dfv (root, writers, needs, exclusive, meta, dfu) > 0)? 0 : -1;
 }
 
 int dfu_impl_t::remove (vtx_t root, int64_t jobid)

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -34,6 +34,7 @@
 #include "resource/schema/resource_graph.hpp"
 #include "resource/policies/base/dfu_match_cb.hpp"
 #include "resource/evaluators/scoring_api.hpp"
+#include "resource/emitters/match_emitters.hpp"
 #include "resource/planner/planner.h"
 
 namespace Flux {
@@ -176,16 +177,15 @@ public:
      *  and emit the allocation/reservation information.
      *
      *  \param root      root resource vertex.
+     *  \param writers   vertex/edge writers to emit the matched resources
      *  \param meta      metadata on the job.
      *  \param needs     the number of root resources requested.
      *  \param excl      exclusive access requested.
-     *  \param ss        stringstream into which allocation/reservation
-     *                   information is printed.
      *  \return          0 on success; -1 on error -- call err_message ()
      *                   for detail.
      */
-    int update (vtx_t root, jobmeta_t &meta, unsigned int needs, bool excl,
-                std::stringstream &ss);
+    int update (vtx_t root, match_writers_t *writers,
+                jobmeta_t &meta, unsigned int needs, bool excl);
 
     /*! Remove the allocation/reservation referred to by jobid and update
      *  the resource state.
@@ -261,27 +261,26 @@ private:
                  const std::vector<Jobspec::Resource> &resources, bool *excl,
                  scoring_api_t &to_parent);
 
-    // Emit R
-    int emit_edge (edg_t e);
-    int emit_vertex (vtx_t u, unsigned int needs, bool exclusive,
-                     std::stringstream &ss);
+    // Emit matched resource set
+    int emit_vtx (vtx_t u, match_writers_t *w, unsigned int needs,
+                  bool exclusive);
+    int emit_edg (edg_t e, match_writers_t *w);
 
     // Update resource graph data store
     int upd_plan (vtx_t u, const subsystem_t &s, unsigned int needs,
                   bool excl, const jobmeta_t &meta, int &n_p,
                   std::map<std::string, int64_t> &to_parent);
-    int upd_sched (vtx_t u, const subsystem_t &subsystem, unsigned int needs,
+    int upd_sched (vtx_t u, match_writers_t *writers,
+                   const subsystem_t &subsystem, unsigned int needs,
                    bool excl, int n, const jobmeta_t &meta,
                    std::map<std::string, int64_t> &dfu,
-                   std::map<std::string, int64_t> &to_parent,
-                   std::stringstream &ss);
+                   std::map<std::string, int64_t> &to_parent);
     int upd_upv (vtx_t u, const subsystem_t &subsystem, unsigned int needs,
                  bool excl, const jobmeta_t &meta,
                  std::map<std::string, int64_t> &to_parent);
-    int upd_dfv (vtx_t u, unsigned int needs,
+    int upd_dfv (vtx_t u, match_writers_t *writers, unsigned int needs,
                  bool excl, const jobmeta_t &meta,
-                 std::map<std::string, int64_t> &to_parent,
-                 std::stringstream &ss);
+                 std::map<std::string, int64_t> &to_parent);
 
     // Remove allocation or reservations
     int rem_subtree_plan (vtx_t u, int64_t jobid, const std::string &subsystem);

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -34,7 +34,7 @@
 #include "resource/schema/resource_graph.hpp"
 #include "resource/policies/base/dfu_match_cb.hpp"
 #include "resource/evaluators/scoring_api.hpp"
-#include "resource/emitters/match_emitters.hpp"
+#include "resource/writers/match_writers.hpp"
 #include "resource/planner/planner.h"
 
 namespace Flux {

--- a/resource/utilities/Makefile.am
+++ b/resource/utilities/Makefile.am
@@ -11,6 +11,8 @@ AM_LDFLAGS = $(CODE_COVERAGE_LDFLAGS)
 AM_CPPFLAGS = -I$(top_srcdir) $(CZMQ_CFLAGS) $(FLUX_CORE_CFLAGS) \
           $(BOOST_CPPFLAGS)
 
+SUBDIRS = . test
+
 noinst_PROGRAMS = grug2dot resource-query
 
 grug2dot_SOURCES = \

--- a/resource/utilities/command.cpp
+++ b/resource/utilities/command.cpp
@@ -57,13 +57,6 @@ command_t commands[] = {
     { "NA", "NA", (cmd_func_f *)NULL, "NA" }
 };
 
-static double get_elapse_time (timeval &st, timeval &et)
-{
-    double ts1 = (double)st.tv_sec + (double)st.tv_usec/1000000.0f;
-    double ts2 = (double)et.tv_sec + (double)et.tv_usec/1000000.0f;
-    return ts2 - ts1;
-}
-
 static int do_remove (resource_context_t *ctx, int64_t jobid)
 {
     int rc = -1;
@@ -112,6 +105,13 @@ static void print_schedule_info (resource_context_t *ctx, ostream &out,
         out << "INFO:" << " =============================" << endl;
     }
     ctx->jobid_counter++;
+}
+
+double get_elapse_time (timeval &st, timeval &et)
+{
+    double ts1 = (double)st.tv_sec + (double)st.tv_usec/1000000.0f;
+    double ts2 = (double)et.tv_sec + (double)et.tv_usec/1000000.0f;
+    return ts2 - ts1;
 }
 
 int cmd_match (resource_context_t *ctx, vector<string> &args)

--- a/resource/utilities/command.cpp
+++ b/resource/utilities/command.cpp
@@ -67,14 +67,14 @@ static double get_elapse_time (timeval &st, timeval &et)
 static int do_remove (resource_context_t *ctx, int64_t jobid)
 {
     int rc = -1;
-    if ((rc = ctx->traverser.remove ((int64_t)jobid)) == 0) {
+    if ((rc = ctx->traverser->remove ((int64_t)jobid)) == 0) {
         if (ctx->jobs.find (jobid) != ctx->jobs.end ()) {
            job_info_t *info = ctx->jobs[jobid];
            info->state = job_lifecycle_t::CANCELLED;
         }
     } else {
-        cout << ctx->traverser.err_message ();
-        ctx->traverser.clear_err_message ();
+        cout << ctx->traverser->err_message ();
+        ctx->traverser->clear_err_message ();
     }
     return rc;
 }
@@ -141,12 +141,12 @@ int cmd_match (resource_context_t *ctx, vector<string> &args)
 
         gettimeofday (&st, NULL);
         if (args[1] == "allocate")
-            rc = ctx->traverser.run (job, match_op_t::MATCH_ALLOCATE,
-                                     (int64_t)jobid, &at, r_emitted);
+            rc = ctx->traverser->run (job, match_op_t::MATCH_ALLOCATE,
+                                      (int64_t)jobid, &at, r_emitted);
         else if (args[1] == "allocate_orelse_reserve")
-            rc = ctx->traverser.run (job,
-                                     match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE,
-                                     (int64_t)jobid, &at, r_emitted);
+            rc = ctx->traverser->run (job,
+                                      match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE,
+                                      (int64_t)jobid, &at, r_emitted);
         gettimeofday (&et, NULL);
         elapse = get_elapse_time (st, et);
 

--- a/resource/utilities/command.hpp
+++ b/resource/utilities/command.hpp
@@ -45,7 +45,7 @@ struct test_params_t {
     std::ofstream r_out;        /* Output file stream for emitted R */
     std::string r_fname;        /* Output file to dump the emitted R */
     std::string o_fext;         /* File extension */
-    std::string prune_filters;   /* Raw prune-filter specification */
+    std::string prune_filters;  /* Raw prune-filter specification */
     emit_format_t o_format;
     bool elapse_time;           /* Print elapse time */
     bool flux_hwloc;            /* get hwloc info from flux instance */
@@ -54,13 +54,13 @@ struct test_params_t {
 struct resource_context_t {
     test_params_t params;        /* Parameters for resource-query */
     uint64_t jobid_counter;      /* Hold the current jobid value */
-    resource_graph_db_t db;      /* Resource graph data store */
     dfu_match_cb_t *matcher;     /* Match callback object */
-    dfu_traverser_t traverser;   /* Graph traverser object */
+    dfu_traverser_t *traverser;  /* Graph traverser object */
+    resource_graph_db_t db;      /* Resource graph data store */
+    f_resource_graph_t *fgraph;  /* Graph filtered by subsystems to use */
     std::map<uint64_t, job_info_t *> jobs;     /* Jobs table */
     std::map<uint64_t, uint64_t> allocations;  /* Allocation table */
     std::map<uint64_t, uint64_t> reservations; /* Reservation table */
-    std::map<std::string, f_resource_graph_t *> resource_graph_views;
 };
 
 typedef int cmd_func_f (resource_context_t *, std::vector<std::string> &);

--- a/resource/utilities/command.hpp
+++ b/resource/utilities/command.hpp
@@ -75,6 +75,7 @@ int cmd_info (resource_context_t *ctx, std::vector<std::string> &args);
 int cmd_cat (resource_context_t *ctx, std::vector<std::string> &args);
 int cmd_quit (resource_context_t *ctx, std::vector<std::string> &args);
 int cmd_help (resource_context_t *ctx, std::vector<std::string> &args);
+double get_elapse_time (timeval &st, timeval &et);
 
 } // namespace resource_model
 } // namespace Flux

--- a/resource/utilities/command.hpp
+++ b/resource/utilities/command.hpp
@@ -50,6 +50,7 @@ struct test_params_t {
     emit_format_t o_format;
     bool elapse_time;           /* Print elapse time */
     bool flux_hwloc;            /* get hwloc info from flux instance */
+    size_t reserve_vtx_vec;     /* Allow for reserving vertex vector size */
 };
 
 struct resource_context_t {

--- a/resource/utilities/command.hpp
+++ b/resource/utilities/command.hpp
@@ -49,6 +49,7 @@ struct test_params_t {
     std::string match_format;   /* Format to emit a matched resources */
     emit_format_t o_format;
     bool elapse_time;           /* Print elapse time */
+    bool disable_prompt;        /* Disable resource-query> prompt */
     bool flux_hwloc;            /* get hwloc info from flux instance */
     size_t reserve_vtx_vec;     /* Allow for reserving vertex vector size */
 };

--- a/resource/utilities/command.hpp
+++ b/resource/utilities/command.hpp
@@ -53,6 +53,12 @@ struct test_params_t {
     size_t reserve_vtx_vec;     /* Allow for reserving vertex vector size */
 };
 
+struct match_perf_t {
+    double min;                 /* Min match time */
+    double max;                 /* Max match time */
+    double accum;               /* Total match time accumulated */
+};
+
 struct resource_context_t {
     test_params_t params;        /* Parameters for resource-query */
     uint64_t jobid_counter;      /* Hold the current jobid value */
@@ -61,6 +67,7 @@ struct resource_context_t {
     resource_graph_db_t db;      /* Resource graph data store */
     f_resource_graph_t *fgraph;  /* Graph filtered by subsystems to use */
     match_writers_t *writers;    /* Vertex/Edge writers for a match */
+    match_perf_t perf;           /* Match performance stats */
     std::map<uint64_t, job_info_t *> jobs;     /* Jobs table */
     std::map<uint64_t, uint64_t> allocations;  /* Allocation table */
     std::map<uint64_t, uint64_t> reservations; /* Reservation table */
@@ -73,6 +80,7 @@ int cmd_match (resource_context_t *ctx, std::vector<std::string> &args);
 int cmd_cancel (resource_context_t *ctx, std::vector<std::string> &args);
 int cmd_list (resource_context_t *ctx, std::vector<std::string> &args);
 int cmd_info (resource_context_t *ctx, std::vector<std::string> &args);
+int cmd_stat (resource_context_t *ctx, std::vector<std::string> &args);
 int cmd_cat (resource_context_t *ctx, std::vector<std::string> &args);
 int cmd_quit (resource_context_t *ctx, std::vector<std::string> &args);
 int cmd_help (resource_context_t *ctx, std::vector<std::string> &args);

--- a/resource/utilities/command.hpp
+++ b/resource/utilities/command.hpp
@@ -46,6 +46,7 @@ struct test_params_t {
     std::string r_fname;        /* Output file to dump the emitted R */
     std::string o_fext;         /* File extension */
     std::string prune_filters;  /* Raw prune-filter specification */
+    std::string match_format;   /* Format to emit a matched resources */
     emit_format_t o_format;
     bool elapse_time;           /* Print elapse time */
     bool flux_hwloc;            /* get hwloc info from flux instance */
@@ -58,6 +59,7 @@ struct resource_context_t {
     dfu_traverser_t *traverser;  /* Graph traverser object */
     resource_graph_db_t db;      /* Resource graph data store */
     f_resource_graph_t *fgraph;  /* Graph filtered by subsystems to use */
+    match_writers_t *writers;    /* Vertex/Edge writers for a match */
     std::map<uint64_t, job_info_t *> jobs;     /* Jobs table */
     std::map<uint64_t, uint64_t> allocations;  /* Allocation table */
     std::map<uint64_t, uint64_t> reservations; /* Reservation table */

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -381,6 +381,7 @@ static void write_to_graphml (f_resource_graph_t &fg, fstream &o)
     dp.property ("basename", get (&resource_pool_t::basename, fg));
     dp.property ("name", get (&resource_pool_t::name, fg));
     dp.property ("id", get (&resource_pool_t::id, fg));
+    dp.property ("uniq_id", get (&resource_pool_t::uniq_id, fg));
     dp.property ("size", get (&resource_pool_t::size, fg));
     dp.property ("unit", get (&resource_pool_t::unit, fg));
     // Relation edges

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -424,10 +424,8 @@ static void destory_resource_ctx (resource_context_t *ctx)
     delete ctx->traverser;
     delete ctx->fgraph;
     delete ctx->writers;
-    for (auto &kv : ctx->jobs) {
+    for (auto &kv : ctx->jobs)
         delete kv.second;    /* job_info_t* type */
-        ctx->jobs.erase (kv.first);
-    }
     ctx->jobs.clear ();
     ctx->allocations.clear ();
     ctx->reservations.clear ();

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -375,7 +375,6 @@ static void write_to_graph (resource_context_t *ctx)
     fstream o;
     string fn, mn;
     mn = ctx->matcher->matcher_name ();
-    f_resource_graph_t &fg = *(ctx->resource_graph_views[mn]);
     fn = ctx->params.o_fname + "." + ctx->params.o_fext;
 
     cout << "INFO: Write the target graph of the matcher..." << endl;
@@ -383,10 +382,10 @@ static void write_to_graph (resource_context_t *ctx)
 
     switch (ctx->params.o_format) {
     case emit_format_t::GRAPHVIZ_DOT:
-        write_to_graphviz (fg, ctx->matcher->dom_subsystem (), o);
+        write_to_graphviz (*(ctx->fgraph), ctx->matcher->dom_subsystem (), o);
         break;
     case emit_format_t::GRAPH_ML:
-        write_to_graphml (fg, o);
+        write_to_graphml (*(ctx->fgraph), o);
         break;
     default:
         cout << "ERROR: Unknown graph format" << endl;
@@ -397,6 +396,21 @@ static void write_to_graph (resource_context_t *ctx)
         o.clear ();
     }
     o.close ();
+}
+
+static void destory_resource_ctx (resource_context_t *ctx)
+{
+    delete ctx->matcher;
+    delete ctx->traverser;
+    delete ctx->fgraph;
+    for (auto &kv : ctx->jobs) {
+        delete kv.second;    /* job_info_t* type */
+        ctx->jobs.erase (kv.first);
+    }
+    ctx->jobs.clear ();
+    ctx->allocations.clear ();
+    ctx->reservations.clear ();
+    delete ctx;
 }
 
 static void control_loop (resource_context_t *ctx)
@@ -425,12 +439,93 @@ static void control_loop (resource_context_t *ctx)
     }
 }
 
-int main (int argc, char *argv[])
+static int populate_resource_db (resource_context_t *ctx)
 {
-    int rc, ch;
+    int rc = 0;
+    resource_generator_t rgen;
+
+    if (ctx->params.grug == "" && ctx->params.hwloc_xml == "") {
+        ctx->params.grug = "conf/default";
+    }
+    if (ctx->params.grug != "") {
+        if (ctx->params.hwloc_xml != "") {
+            cout << "WARN: multiple resource inputs provided, using grug" << endl;
+        }
+        if ( (rc = rgen.read_graphml (ctx->params.grug, ctx->db)) != 0) {
+            cerr << "ERROR: " << rgen.err_message () << endl;
+            cerr << "ERROR: error in generating resources" << endl;
+            rc = -1;
+        }
+    } else if (ctx->params.hwloc_xml != "") {
+        if ( (rc = rgen.read_hwloc_xml_file (ctx->params.hwloc_xml.c_str(), ctx->db)) != 0) {
+            cerr << "ERROR: " << rgen.err_message () << endl;
+            cerr << "ERROR: error in generating resources" << endl;
+            rc = -1;
+        }
+    }
+
+    return rc;
+}
+
+static int init_resource_graph (resource_context_t *ctx)
+{
+    int rc = 0;
+
+    if ( (rc = populate_resource_db (ctx)) != 0) {
+        cerr << "ERROR: can't populate graph resource database" << endl;
+        return rc;
+    }
+
+    resource_graph_t &g = ctx->db.resource_graph;
+    // Configure the matcher and its subsystem selector
+    cout << "INFO: Loading a matcher: " << ctx->params.matcher_name << endl;
+    if ( (rc = set_subsystems_use (ctx, ctx->params.matcher_name)) != 0) {
+        cerr << "ERROR: Not all subsystems found" << endl;
+        return rc;
+    }
+
+    vtx_infra_map_t vmap = get (&resource_pool_t::idata, g);
+    edg_infra_map_t emap = get (&resource_relation_t::idata, g);
+    const multi_subsystemsS &filter = ctx->matcher->subsystemsS ();
+    subsystem_selector_t<vtx_t, f_vtx_infra_map_t> vtxsel (vmap, filter);
+    subsystem_selector_t<edg_t, f_edg_infra_map_t> edgsel (emap, filter);
+
+    if (!(ctx->fgraph = new (nothrow)f_resource_graph_t (g, edgsel, vtxsel))) {
+        cerr << "ERROR: out of memory allocating f_resource_graph_t" << endl;
+        return -1;
+    }
+    ctx->jobid_counter = 1;
+    if (ctx->params.prune_filters != ""
+        && ctx->matcher->set_pruning_types_w_spec (ctx->matcher->dom_subsystem (),
+                                                   ctx->params.prune_filters)
+                                                   < 0) {
+        cerr << "ERROR: setting pruning filters with ctx->params.prune_filters: "
+             << ctx->params.prune_filters << endl;
+        return -1;
+    }
+
+    if (ctx->params.r_fname != "") {
+        ctx->params.r_out.exceptions (std::ofstream::failbit
+                                          | std::ofstream::badbit);
+        ctx->params.r_out.open (ctx->params.r_fname);
+    }
+    if ( !(ctx->traverser = new (nothrow)dfu_traverser_t ())) {
+        cerr << "ERROR: out of memory allocating traverser" << endl;
+        return -1;
+    }
+    if ( (rc = ctx->traverser->initialize (ctx->fgraph, &(ctx->db.roots),
+                                           ctx->matcher)) != 0) {
+        cerr << "ERROR: initializing traverser" << endl;
+    }
+
+    return rc;
+}
+
+static void process_args (resource_context_t *ctx, int argc, char *argv[])
+{
+    int rc = 0;
+    int ch = 0;
     std::string token;
-    resource_context_t *ctx = new resource_context_t ();
-    set_default_params (ctx);
 
     while ((ch = getopt_long (argc, argv, OPTIONS, longopts, NULL)) != -1) {
         switch (ch) {
@@ -439,11 +534,9 @@ int main (int argc, char *argv[])
                 break;
             case 'G': /* --grug*/
                 ctx->params.grug = optarg;
-                rc = 0;
                 break;
             case 'X': /* --hwloc-xml*/
                 ctx->params.hwloc_xml = optarg;
-                rc = 0;
                 break;
             case 'S': /* --match-subsystems */
                 ctx->params.matcher_name = optarg;
@@ -484,78 +577,54 @@ int main (int argc, char *argv[])
 
     if (optind != argc)
         usage (1);
+}
 
-    // Create matcher and traverser objects
-    if (!(ctx->matcher = create_match_cb (ctx->params.matcher_policy))) {
+static int init_resource_query (resource_context_t **ctx, int c, char *v[])
+{
+    int rc = 0;
+
+    if (!(*ctx = new (nothrow)resource_context_t ())) {
+        cerr << "ERROR: out of memory allocating resource context" << endl;
+        errno = ENOMEM;
+        rc = -1;
+        goto done;
+    }
+    set_default_params (*ctx);
+    process_args (*ctx, c, v);
+    if ( !((*ctx)->matcher = create_match_cb ((*ctx)->params.matcher_policy))) {
         cerr << "ERROR: unknown match policy " << endl;
-        cerr << "ERROR: " << ctx->params.matcher_policy << endl;
-        return EXIT_FAILURE;
+        cerr << "ERROR: " << (*ctx)->params.matcher_policy << endl;
+        rc = -1;
+    }
+    if (init_resource_graph (*ctx) != 0) {
+        cerr << "ERROR: resource graph initialization" << endl;
+        rc = -1;
     }
 
-    // Generate a resource graph data store
-    resource_generator_t rgen;
-    if (ctx->params.grug == "" && ctx->params.hwloc_xml == "") {
-        ctx->params.grug = "conf/default";
-    }
-    if (ctx->params.grug != "") {
-        if (ctx->params.hwloc_xml != "") {
-            cout << "WARN: multiple resource inputs provided, using grug" << endl;
-        }
-        if ( (rc = rgen.read_graphml (ctx->params.grug, ctx->db)) != 0) {
-            cerr << "ERROR: " << rgen.err_message () << endl;
-            cerr << "ERROR: error in generating resources" << endl;
-            return EXIT_FAILURE;
-        }
-    } else if (ctx->params.hwloc_xml != "") {
-        if ( (rc = rgen.read_hwloc_xml_file (ctx->params.hwloc_xml.c_str(), ctx->db)) != 0) {
-            cerr << "ERROR: " << rgen.err_message () << endl;
-            cerr << "ERROR: error in generating resources" << endl;
-            return EXIT_FAILURE;
-        }
-    }
-    resource_graph_t &g = ctx->db.resource_graph;
+done:
+    return rc;
+}
 
-    // Configure the matcher and its subsystem selector
-    cout << "INFO: Loading a matcher: " << ctx->params.matcher_name << endl;
-    if (set_subsystems_use (ctx, ctx->params.matcher_name) != 0) {
-        cerr << "ERROR: Not all subsystems found" << endl;
-        return EXIT_FAILURE;
-    }
-    vtx_infra_map_t vmap = get (&resource_pool_t::idata, g);
-    edg_infra_map_t emap = get (&resource_relation_t::idata, g);
-    const multi_subsystemsS &filter = ctx->matcher->subsystemsS ();
-
-    subsystem_selector_t<vtx_t, f_vtx_infra_map_t> vtxsel (vmap, filter);
-    subsystem_selector_t<edg_t, f_edg_infra_map_t> edgsel (emap, filter);
-    f_resource_graph_t *fg = new f_resource_graph_t (g, edgsel, vtxsel);
-    ctx->resource_graph_views[ctx->params.matcher_name] = fg;
-    ctx->jobid_counter = 1;
-    if (ctx->params.prune_filters != ""
-        && ctx->matcher->set_pruning_types_w_spec (ctx->matcher->dom_subsystem (),
-                                                   ctx->params.prune_filters)
-                                                   < 0) {
-        cerr << "ERROR: setting pruning filters with ctx->params.prune_filters: "
-             << ctx->params.prune_filters << endl;
-        return EXIT_FAILURE;
-    }
-
-    if (ctx->params.r_fname != "") {
-        ctx->params.r_out.exceptions (std::ofstream::failbit
-                                          | std::ofstream::badbit);
-        ctx->params.r_out.open (ctx->params.r_fname);
-    }
-
-    ctx->traverser.initialize (fg, &(ctx->db.roots), ctx->matcher);
-
-    // Command line begins
-    control_loop (ctx);
-
+static void fini_resource_query (resource_context_t *ctx)
+{
     if (ctx->params.r_fname != "")
         ctx->params.r_out.close ();
-
-    // Output the filtered resource graph
     if (ctx->params.o_fname != "")
         write_to_graph (ctx);
+    destory_resource_ctx (ctx);
+}
+
+int main (int argc, char *argv[])
+{
+    resource_context_t *ctx = NULL;
+    if (init_resource_query (&ctx, argc, argv) != 0) {
+        cerr << "ERROR: resource query initialization" << endl;
+        return EXIT_FAILURE;
+    }
+
+    control_loop (ctx);
+
+    fini_resource_query (ctx);
 
     return EXIT_SUCCESS;
 }

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -48,7 +48,7 @@ extern "C" {
 using namespace std;
 using namespace Flux::resource_model;
 
-#define OPTIONS "S:P:F:G:X:g:o:p:t:r:eh"
+#define OPTIONS "S:P:F:G:X:g:o:p:t:r:edh"
 static const struct option longopts[] = {
     {"match-subsystems", required_argument,  0, 'S'},
     {"match-policy",     required_argument,  0, 'P'},
@@ -61,6 +61,7 @@ static const struct option longopts[] = {
     {"test-output",      required_argument,  0, 't'},
     {"reserve-vtx-vec",  required_argument,  0, 'r'},
     {"elapse-time",      no_argument,        0, 'e'},
+    {"disable-prompt",   no_argument,        0, 'd'},
     {"help",             no_argument,        0, 'h'},
     { 0, 0, 0, 0 },
 };
@@ -168,6 +169,9 @@ static void usage (int code)
 "    -e, --elapse-time\n"
 "            Print the elapse time per scheduling operation.\n"
 "\n"
+"    -d, --disable-prompt\n"
+"            Don't print the prompt.\n"
+"\n"
 "    -o, --graph-output=<basename>\n"
 "            Set the basename of the graph output file\n"
 "            For AT&T Graphviz dot, <basename>.dot\n"
@@ -206,6 +210,7 @@ static void set_default_params (resource_context_t *ctx)
     ctx->params.prune_filters = "ALL:core";
     ctx->params.reserve_vtx_vec = 0;
     ctx->params.elapse_time = false;
+    ctx->params.disable_prompt = false;
 }
 
 static int string_to_graph_format (string st, emit_format_t &format)
@@ -432,7 +437,8 @@ static void control_loop (resource_context_t *ctx)
 {
     cmd_func_f *cmd = NULL;
     while (1) {
-        char *line = readline ("resource-query> ");
+        char *line = ctx->params.disable_prompt? readline ("")
+                                               : readline ("resource-query> ");
         if (line == NULL)
             continue;
         else if(*line)
@@ -625,6 +631,9 @@ static void process_args (resource_context_t *ctx, int argc, char *argv[])
                 break;
             case 'e': /* --elapse-time */
                 ctx->params.elapse_time = true;
+                break;
+            case 'd': /* --disable-prompt */
+                ctx->params.disable_prompt = true;
                 break;
             default:
                 usage (1);

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -450,11 +450,16 @@ static void control_loop (resource_context_t *ctx)
 static int populate_resource_db (resource_context_t *ctx)
 {
     int rc = 0;
+    struct timeval st, et;
+    double elapse;
     resource_generator_t rgen;
 
     if (ctx->params.grug == "" && ctx->params.hwloc_xml == "") {
         ctx->params.grug = "conf/default";
     }
+
+    gettimeofday (&st, NULL);
+
     if (ctx->params.grug != "") {
         if (ctx->params.hwloc_xml != "") {
             cout << "WARN: multiple resource inputs provided, using grug" << endl;
@@ -470,6 +475,17 @@ static int populate_resource_db (resource_context_t *ctx)
             cerr << "ERROR: error in generating resources" << endl;
             rc = -1;
         }
+    }
+
+    gettimeofday (&et, NULL);
+    elapse = get_elapse_time (st, et);
+    if (ctx->params.elapse_time) {
+        cout << "INFO: Graph Load Time: " << elapse
+             << endl;
+        cout << "INFO: Vertex Count: " << num_vertices (ctx->db.resource_graph)
+             << endl;
+        cout << "INFO: Edge Count: " << num_edges (ctx->db.resource_graph)
+             << endl;
     }
 
     return rc;

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -47,7 +47,7 @@ extern "C" {
 using namespace std;
 using namespace Flux::resource_model;
 
-#define OPTIONS "S:P:F:G:X:g:o:p:t:e:h"
+#define OPTIONS "S:P:F:G:X:g:o:p:t:eh"
 static const struct option longopts[] = {
     {"match-subsystems", required_argument,  0, 'S'},
     {"match-policy",     required_argument,  0, 'P'},
@@ -58,7 +58,7 @@ static const struct option longopts[] = {
     {"graph-output",     required_argument,  0, 'o'},
     {"prune-filters",    required_argument,  0, 'p'},
     {"test-output",      required_argument,  0, 't'},
-    {"elapse",           required_argument,  0, 'e'},
+    {"elapse-time",      no_argument,        0, 'e'},
     {"help",             no_argument,        0, 'h'},
     { 0, 0, 0, 0 },
 };

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <iterator>
 #include <cstdint>
+#include <limits>
 #include <readline/readline.h>
 #include <readline/history.h>
 #include <boost/algorithm/string.hpp>
@@ -647,6 +648,9 @@ static int init_resource_query (resource_context_t **ctx, int c, char *v[])
     }
     set_default_params (*ctx);
     process_args (*ctx, c, v);
+    (*ctx)->perf.min = DBL_MAX;
+    (*ctx)->perf.max = 0.0f;
+    (*ctx)->perf.accum = 0.0f;
     if ( !((*ctx)->matcher = create_match_cb ((*ctx)->params.matcher_policy))) {
         cerr << "ERROR: unknown match policy " << endl;
         cerr << "ERROR: " << (*ctx)->params.matcher_policy << endl;

--- a/resource/utilities/test/Makefile.am
+++ b/resource/utilities/test/Makefile.am
@@ -1,0 +1,14 @@
+TESTS = run_sanity_check.sh
+
+check_SCRIPTS = $(TESTS)
+
+CLEANFILES = $(check_SCRIPTS)
+EXTRA_DIST = resource-bench.sh benchmark.graphml.in benchmark.yaml run_sanity_check.sh.in
+
+do_subst = \
+    sed -e 's,@SRC_PATH@,$(top_srcdir)/resource/utilities/test,g'
+
+run_sanity_check.sh : run_sanity_check.sh.in
+	$(do_subst) < $< > $@
+	chmod +x $@
+

--- a/resource/utilities/test/benchmark.graphml.in
+++ b/resource/utilities/test/benchmark.graphml.in
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 1 subsystem, cluster[1]->node[@NNODES@]->core[@NCORES]             -->
+
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns
+        http://graphml.graphdrawing.org/xmlns/1.1/graphml.xsd">
+
+    <!-- resource pool vertex generation spec attributes -->
+    <key id="root" for="node" attr.name="root" attr.type="int">
+        <default>0</default>
+    </key>
+    <key id="type" for="node" attr.name="type" attr.type="string"/>
+    <key id="basename" for="node" attr.name="basename" attr.type="string"/>
+    <key id="unit" for="node" attr.name="unit" attr.type="string"/>
+    <key id="size" for="node" attr.name="size" attr.type="long">
+        <default>1</default>
+    </key>
+    <key id="subsystem" for="node" attr.name="subsystem" attr.type="string">
+        <default>containment</default>
+    </key>
+
+    <!-- resource relationship generation attributes     -->
+    <key id="e_subsystem" for="edge" attr.name="e_subsystem" attr.type="string">
+        <default>containment</default>
+    </key>
+    <key id="relation" for="edge" attr.name="relation" attr.type="string">
+        <default>contains</default>
+    </key>
+    <key id="rrelation" for="edge" attr.name="rrelation" attr.type="string">
+        <default>in</default>
+    </key>
+
+    <!-- id generation method                             -->
+    <key id="id_scope" for="edge" attr.name="id_scope" attr.type="int">
+        <default>0</default>
+    </key>
+    <key id="id_start" for="edge" attr.name="id_start" attr.type="int">
+        <default>0</default>
+    </key>
+    <key id="id_stride" for="edge" attr.name="id_stride" attr.type="int">
+        <default>1</default>
+    </key>
+
+    <!-- resource gen method: multiply or associate-in   -->
+    <key id="gen_method" for="edge" attr.name="gen_method" attr.type="string">
+        <default>MULTIPLY</default>
+    </key>
+    <!-- argument (scaling factor) for multiply method   -->
+    <key id="multi_scale" for="edge" attr.name="multi_scale" attr.type="int">
+        <default>1</default>
+    </key>
+    <!-- 3 arguments for associate-in method             -->
+    <key id="as_tgt_subsystem" for="edge" attr.name="as_tgt_subsystem"
+             attr.type="string">
+        <default>containment</default>
+    </key>
+    <key id="as_tgt_uplvl" for="edge" attr.name="as_tgt_uplvl" attr.type="int">
+        <default>1</default>
+    </key>
+    <key id="as_src_uplvl" for="edge" attr.name="as_src_uplvl" attr.type="int">
+        <default>1</default>
+    </key>
+
+    <!-- generation recipe for the benchmark cluster    -->
+    <graph id="benchmark" edgedefault="directed">
+
+        <!-- containment subsystem generation recipe    -->
+        <node id="cluster">
+            <data key="root">1</data>
+            <data key="type">cluster</data>
+            <data key="basename">benchmark</data>
+        </node>
+        <node id="node">
+            <data key="type">node</data>
+            <data key="basename">node</data>
+        </node>
+        <node id="core">
+            <data key="type">core</data>
+            <data key="basename">core</data>
+        </node>
+        <edge id="cluster2node" source="cluster" target="node">
+            <data key="id_scope">1</data>
+            <data key="multi_scale">@NNODES@</data>
+        </edge>
+        <edge id="node2core" source="node" target="core">
+            <data key="multi_scale">@NCORES@</data>
+        </edge>
+    </graph>
+</graphml>
+

--- a/resource/utilities/test/benchmark.yaml
+++ b/resource/utilities/test/benchmark.yaml
@@ -1,0 +1,24 @@
+version: 1
+resources:
+    - type: cluster
+      count: 1
+      with:
+        - type: node
+          count: 1
+          with:
+            - type: slot
+              count: 1
+              label: default
+              with:
+                - type: core
+                  count: 1
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: app
+    slot: default
+    count:
+      per_slot: 1
+

--- a/resource/utilities/test/resource-bench.sh
+++ b/resource/utilities/test/resource-bench.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+#set -x
+
+NJOBS=4096
+NNODES=256
+NCORES=32
+JOBSTREAM_FN="jobstream.txt"
+PERF_FN="perf.out"
+SCHED_FN="sched.out"
+JOBSPEC_FN="benchmark.yaml"
+GRUG_IN_FN="benchmark.graphml.in"
+GRUG="benchmark.graphml"
+SRC_PATH="./"
+KEEP_FILES="false"
+
+#
+declare -r prog=${0##*/}
+die() { echo -e "$prog: $@"; exit 1; }
+
+#
+declare -r long_opts="help,nnodes:,ncores:,njobs:,grug:,jobspec-fn:,path:,keep"
+declare -r short_opts="hn:c:j:g:s:p:k"
+declare -r usage="
+Usage: $prog [OPTIONS] -- [CONFIGURE_ARGS...]\n\
+Run the performance benchmark for resource-query by matching\n\
+a configurable number of 1-core jobs on a simple configurable cluster.\n\
+\n\
+Options:\n\
+ -h, --help                    Display this message\n\
+ -n, --nnodes                  Num of nodes in cluster (default=${NNODES})\n\
+ -c, --ncores                  Num of cores per node (default=${NCORES})\n\
+ -j, --njobs                   Num of jobs to schedule (default=${NJOBS})\n\
+ -g, --grug                    System GRUG input file (default=${GRUG_IN_FN})\n\
+ -s, --jobspec-fn              Jobspec file name (default=${JOBSPEC_FN})\n\
+ -p, --path                    Where inputs reside (default=${SRC_PATH})\n\
+ -k, --keep                    Keep intermediate files\n\
+"
+
+GETOPTS=`/usr/bin/getopt -u -o ${short_opts} -l ${long_opts} -n ${prog} -- ${@}`
+if [[ $? != 0 ]]; then
+    die "${usage}"
+fi
+eval set -- "${GETOPTS}"
+
+while true; do
+    case "${1}" in
+      -h|--help)                   echo -ne "${usage}";          exit 0  ;;
+      -n|--nnodes)                 NNODES="${2}";                shift 2 ;;
+      -c|--ncores)                 NCORES="${2}";                shift 2 ;;
+      -j|--njobs)                  NJOBS="${2}";                 shift 2 ;;
+      -g|--grug)                   GRUG_IN_FN="${2}";            shift 2 ;;
+      -s|--jobspec-fn)             JOBSPEC_FN="${2}";            shift 2 ;;
+      -p|--path)                   SRC_PATH="${2}";              shift 2 ;;
+      -k|--keep)                   KEEP_FILES="true";            shift 1 ;;
+      --)                          shift; break;                         ;;
+      *)                           die "Invalid option '${1}'\n${usage}" ;;
+    esac
+done
+
+if [[ ! -f ${SRC_PATH}/${GRUG_IN_FN} ]]
+then
+    die "can't find cluster GRUG input file (${GRUG_IN_FN})!"
+fi
+if [[ ! -f ${SRC_PATH}/${JOBSPEC_FN} ]]
+then
+    die "can't find input jobspec file (${JOBSPEC_FN})!"
+fi
+if [[ ! -f ../resource-query ]]
+then
+    die "can't find resource-query!"
+fi
+
+rm -f ${GRUG} ${JOBSTREAM_FN} ${PERF_FN} ${SCHED_FN}
+
+for job in `seq 1 ${NJOBS}`
+do
+    echo "match allocate ${SRC_PATH}/${JOBSPEC_FN}" >> ${JOBSTREAM_FN}
+done
+echo "stat" >> ${JOBSTREAM_FN}
+echo "quit" >> ${JOBSTREAM_FN}
+
+cat ${SRC_PATH}/${GRUG_IN_FN} | sed -e "s/@NNODES@/${NNODES}/" \
+	                            -e "s/@NCORES@/${NCORES}/" > ${GRUG}
+
+../resource-query -G ${GRUG} -e -d -t ${SCHED_FN} < ${JOBSTREAM_FN} > ${PERF_FN}
+
+if test $? -ne 0 || test ! -f ${SCHED_FN} || test ! -f ${PERF_FN}
+then
+    die "errors in resource-query!"
+fi
+
+cat ${PERF_FN} | sed 's/INFO: //'
+
+if [[ ${KEEP_FILES} = "false" ]]
+then
+    rm -f ${GRUG} ${JOBSTREAM_FN} ${PERF_FN} ${SCHED_FN}
+fi
+

--- a/resource/utilities/test/run_sanity_check.sh.in
+++ b/resource/utilities/test/run_sanity_check.sh.in
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec @SRC_PATH@/resource-bench.sh -j 10 -n 8 -c 32 -p @SRC_PATH@

--- a/resource/writers/match_writers.cpp
+++ b/resource/writers/match_writers.cpp
@@ -26,7 +26,7 @@
 #include <cerrno>
 #include "resource/schema/resource_data.hpp"
 #include "resource/schema/resource_graph.hpp"
-#include "resource/emitters/match_emitters.hpp"
+#include "resource/writers/match_writers.hpp"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/writers/match_writers.hpp
+++ b/resource/writers/match_writers.hpp
@@ -22,8 +22,8 @@
  *  See also:  http://www.gnu.org/licenses/
  \*****************************************************************************/
 
-#ifndef MATCH_EMITTERS_HPP
-#define MATCH_EMITTERS_HPP
+#ifndef MATCH_WRITERS_HPP
+#define MATCH_WRITERS_HPP
 
 #include <string>
 #include <sstream>
@@ -233,7 +233,7 @@ bool known_match_format (const std::string &format);
 } // namespace resource_model
 } // namespace Flux
 
-#endif // MATCH_EMITTERS_HPP
+#endif // MATCH_WRITERS_HPP
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -48,7 +48,8 @@ TESTS = \
     t4003-cancel-info.t \
     t4004-match-hwloc.t \
     t5000-valgrind.t \
-    t6000-graph-size.t
+    t6000-graph-size.t \
+    t6001-match-formats.t
 
 check_SCRIPTS = $(TESTS)
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -60,7 +60,8 @@ EXTRA_DIST= \
 	data/resource/jobspecs/basics \
 	scripts \
 	sharness.sh \
-	sharness.d
+	sharness.d \
+	schemas
 
 clean-local:
 	rm -rf *.o test-results trash-directory*

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -47,7 +47,8 @@ TESTS = \
     t4002-match-reserve.t \
     t4003-cancel-info.t \
     t4004-match-hwloc.t \
-    t5000-valgrind.t
+    t5000-valgrind.t \
+    t6000-graph-size.t
 
 check_SCRIPTS = $(TESTS)
 

--- a/t/data/resource/grugs/sierra.graphml
+++ b/t/data/resource/grugs/sierra.graphml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns
+        http://graphml.graphdrawing.org/xmlns/1.1/graphml.xsd">
+
+    <!-- resource pool vertex generation spec attributes -->
+    <key id="root" for="node" attr.name="root" attr.type="int">
+        <default>0</default>
+    </key>
+    <key id="type" for="node" attr.name="type" attr.type="string"/>
+    <key id="basename" for="node" attr.name="basename" attr.type="string"/>
+    <key id="unit" for="node" attr.name="unit" attr.type="string"/>
+    <key id="size" for="node" attr.name="size" attr.type="long">
+        <default>1</default>
+    </key>
+    <key id="subsystem" for="node" attr.name="subsystem" attr.type="string">
+        <default>containment</default>
+    </key>
+
+    <!-- resource relationship generation attributes     -->
+    <key id="e_subsystem" for="edge" attr.name="e_subsystem" attr.type="string">
+        <default>containment</default>
+    </key>
+    <key id="relation" for="edge" attr.name="relation" attr.type="string">
+        <default>contains</default>
+    </key>
+    <key id="rrelation" for="edge" attr.name="rrelation" attr.type="string">
+        <default>in</default>
+    </key>
+
+    <!-- id generation method                             -->
+    <key id="id_scope" for="edge" attr.name="id_scope" attr.type="int">
+        <default>0</default>
+    </key>
+    <key id="id_start" for="edge" attr.name="id_start" attr.type="int">
+        <default>0</default>
+    </key>
+    <key id="id_stride" for="edge" attr.name="id_stride" attr.type="int">
+        <default>1</default>
+    </key>
+
+    <!-- resource gen method: multiply or associate-in   -->
+    <key id="gen_method" for="edge" attr.name="gen_method" attr.type="string">
+        <default>MULTIPLY</default>
+    </key>
+    <!-- argument (scaling factor) for multiply method   -->
+    <key id="multi_scale" for="edge" attr.name="multi_scale" attr.type="int">
+        <default>1</default>
+    </key>
+    <!-- 3 arguments for associate-in method             -->
+    <key id="as_tgt_subsystem" for="edge" attr.name="as_tgt_subsystem"
+             attr.type="string">
+        <default>containment</default>
+    </key>
+    <key id="as_tgt_uplvl" for="edge" attr.name="as_tgt_uplvl" attr.type="int">
+        <default>1</default>
+    </key>
+    <key id="as_src_uplvl" for="edge" attr.name="as_src_uplvl" attr.type="int">
+        <default>1</default>
+    </key>
+
+
+    <!-- generation recipe for the tiny cluster         -->
+    <graph id="tiny" edgedefault="directed">
+
+        <!-- containment subsystem generation recipe    -->
+        <node id="cluster">
+            <data key="root">1</data>
+            <data key="type">cluster</data>
+            <data key="basename">Sierra</data>
+        </node>
+        <node id="rack">
+            <data key="type">rack</data>
+            <data key="basename">rack</data>
+        </node>
+	<node id="storage_rack">
+            <data key="type">storage_rack</data>
+            <data key="basename">storage_rack</data>
+        </node>
+	<node id="storage_node">
+            <data key="type">storage_node</data>
+            <data key="basename">storage_node</data>
+        </node>
+        <node id="node">
+            <data key="type">node</data>
+            <data key="basename">node</data>
+        </node>
+        <node id="socket">
+            <data key="type">socket</data>
+            <data key="basename">socket</data>
+        </node>
+        <node id="core">
+            <data key="type">core</data>
+            <data key="basename">core</data>
+        </node>
+        <node id="memory">
+            <data key="type">memory</data>
+            <data key="basename">memory</data>
+            <data key="size">64</data>
+            <data key="unit">GB</data>
+        </node>
+        <node id="gpu">
+            <data key="type">gpu</data>
+            <data key="basename">gpu</data>
+        </node>
+	<node id="bb">
+            <data key="type">bb</data>
+            <data key="basename">bb</data>
+            <data key="size">64</data>
+            <data key="unit">GB</data>
+        </node>
+        <node id="gpfs">
+            <data key="type">gpfs</data>
+            <data key="basename">gpfs</data>
+            <data key="size">60</data>
+            <data key="unit">TB</data>
+        </node>
+
+
+        <edge id="cluster2rack" source="cluster" target="rack">
+            <data key="multi_scale">240</data>
+        </edge>
+        <edge id="rack2node" source="rack" target="node">
+            <data key="id_scope">1</data>
+            <data key="multi_scale">18</data>
+        </edge>
+        <edge id="node2socket" source="node" target="socket">
+            <data key="multi_scale">2</data>
+        </edge>
+        <edge id="node2bb" source="node" target="bb">
+            <data key="multi_scale">25</data>
+        </edge>
+        <edge id="node2gpu" source="node" target="gpu">
+            <data key="multi_scale">4</data>
+        </edge>
+        <edge id="socket2core" source="socket" target="core">
+            <data key="id_scope">1</data>
+            <data key="multi_scale">22</data>
+        </edge>
+        <edge id="socket2memory" source="socket" target="memory">
+            <data key="id_scope">1</data>
+            <data key="multi_scale">2</data>
+        </edge>
+
+	 <edge id="cluster2storage_rack" source="cluster" target="storage_rack">
+            <data key="multi_scale">24</data>
+        </edge>
+        <edge id="storage_rack2storage_group" source="storage_rack" target="storage_node">
+            <data key="id_scope">1</data>
+            <data key="multi_scale">64</data>
+        </edge>
+        <edge id="storage_node2gpfs" source="storage_node" target="gpfs">
+            <data key="id_scope">1</data>
+            <data key="multi_scale">2</data>
+        </edge>
+    </graph>
+</graphml>
+

--- a/t/data/resource/jobspecs/basics/test011.yaml
+++ b/t/data/resource/jobspecs/basics/test011.yaml
@@ -1,0 +1,24 @@
+version: 1
+resources:
+    - type: node
+      count: 2000
+      with:
+          - type: slot
+            count: 1
+            label: default
+            with:
+              - type: socket
+                count: 2
+                with:
+                  - type: core
+                    count: 22
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: app
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/schemas/json-graph-schema.json
+++ b/t/schemas/json-graph-schema.json
@@ -1,0 +1,139 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "oneOf": [
+        {
+            "type": "object",
+            "properties": {
+                "graph": {
+                    "$ref": "#/definitions/graph"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "graph"
+            ]
+        },
+        {
+            "type": "object",
+            "properties": {
+                "label": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "type": [
+                        "object",
+                        "null"
+                    ]
+                },
+                "graphs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/graph"
+                    }
+                }
+            },
+            "additionalProperties": false
+        }
+    ],
+    "definitions": {
+        "graph": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "label": {
+                    "type": "string"
+                },
+                "directed": {
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "default": true
+                },
+                "type": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "type": [
+                        "object",
+                        "null"
+                    ]
+                },
+                "nodes": {
+                    "type": [
+                        "array",
+                        "null"
+                    ],
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "metadata": {
+                                "type": [
+                                    "object",
+                                    "null"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "id"
+                        ]
+                    }
+                },
+                "edges": {
+                    "type": [
+                        "array",
+                        "null"
+                    ],
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "source": {
+                                "type": "string"
+                            },
+                            "target": {
+                                "type": "string"
+                            },
+                            "relation": {
+                                "type": "string"
+                            },
+                            "directed": {
+                                "type": [
+                                    "boolean",
+                                    "null"
+                                ],
+                                "default": true
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "metadata": {
+                                "type": [
+                                    "object",
+                                    "null"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "source",
+                            "target"
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/t/scripts/flux-jsonschemalint
+++ b/t/scripts/flux-jsonschemalint
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+import argparse
+import errno
+import json
+import jsonschema
+
+"""
+    Print json document and schema as a verbose option
+"""
+def print_verbose (doc, schema):
+    print "=============================================="
+    print " Jsonschema "
+    print "=============================================="
+    print (json.dumps (schema, indent=4, sort_keys=True))
+    print ""
+    print "=============================================="
+    print " Json document "
+    print "=============================================="
+    print (json.dumps (doc, indent=4, sort_keys=True))
+    print ""
+
+
+"""
+    Main entry point
+"""
+def main ():
+    desc = 'Validate an JSON document against an JSON scheme.'
+    parser = argparse.ArgumentParser (description=desc)
+    parser.add_argument ('schema', help='JSON schema file name')
+    parser.add_argument ('json', help='JSON document file name')
+    parser.add_argument ('-v', '--verbose', action='store_true',
+                         help='be verbose')
+    try:
+        doc = ""
+        schema = ""
+        args = parser.parse_args ()
+        with open (args.schema) as f:
+            schema = json.load (f)
+        with open (args.json, 'r') as f2:
+            doc = json.load (f2)
+        if args.verbose:
+            print_verbose (doc, schema)
+
+        jsonschema.validate (doc, schema)
+        valstr = "Document(\"{0}\") validates against schema (\"{1}\")"
+        print valstr.format (args.json, args.schema)
+
+    except IOError as e:
+        print "I/O error({0}): {1}".format (e.errno, e.strerror)
+        exit (1)
+    except EnvironmentError as e:
+        print "Environment error({0}): {1}".format (e.errno, e.strerror)
+        exit (1)
+    except ValueError as estr:
+        print "Value error: {0}".format (str (estr))
+        exit (1)
+    except jsonschema.exceptions.ValidationError as e:
+        print "Jsonschema validation error: {0}".format (e.message)
+        exit (1)
+    except jsonschema.exceptions.SchemaError as e:
+        print "Jsonschema schema error: {0}".format (e.message)
+        exit (1)
+
+if __name__ == "__main__":
+    main ()
+#
+# vi:tabstop=4 shiftwidth=4 expandtab
+#

--- a/t/scripts/flux-resource
+++ b/t/scripts/flux-resource
@@ -41,6 +41,9 @@ class ResourceModuleInterface:
         payload = {'jobid' : jobid}
         return self.f.rpc ("resource.info", payload).get ()
 
+    def rpc_stat (self):
+        return self.f.rpc ("resource.stat").get ()
+
     def rpc_cancel (self, jobid):
         payload = {'jobid' : jobid}
         return self.f.rpc ("resource.cancel", payload).get ()
@@ -91,6 +94,19 @@ def info_action (args):
     print heading ()
     print body (resp['jobid'], resp['status'], resp['at'], resp['overhead'])
 
+"""
+    Action for stat sub-command
+"""
+def stat_action (args):
+    r = ResourceModuleInterface ()
+    resp = r.rpc_stat ()
+    print "Num. of Vertices: ", resp['V']
+    print "Num. of Edges: ", resp['E']
+    print "Graph Load Time: ", resp['load-time']
+    print "Num. of Jobs Matched: ", resp['njobs']
+    print "Min. Match Time: ", resp['min-match']
+    print "Max. Match Time: ", resp['max-match']
+    print "Avg. Match Time: ", resp['avg-match']
 
 """
     Main entry point
@@ -115,9 +131,11 @@ def main ():
                                     help='Additional help')
     mstr = "Find the best matching resources for a jobspec"
     istr = "Print info on a single job"
+    sstr = "Print overall performance statistics"
     cstr = "Cancel an allocated or reserved job"
     parser_m = subpar.add_parser ('match', help=mstr, description=mstr)
     parser_i = subpar.add_parser ('info', help=istr, description=istr)
+    parser_s = subpar.add_parser ('stat', help=sstr, description=sstr)
     parser_c = subpar.add_parser ('cancel', help=cstr, description=cstr)
 
     #
@@ -138,6 +156,11 @@ def main ():
     #
     parser_i.add_argument ('jobid', metavar='Jobid', type=int, help='Jobid')
     parser_i.set_defaults (func=info_action)
+
+    #
+    # Action for stat sub-command
+    #
+    parser_s.set_defaults (func=stat_action)
 
     #
     # Positional argument for cancel sub-command

--- a/t/t6000-graph-size.t
+++ b/t/t6000-graph-size.t
@@ -5,15 +5,35 @@ test_description='Test Correctness of Populating Graph Data Store'
 . $(dirname $0)/sharness.sh
 
 tiny_grug="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/tiny.graphml"
+large_grug="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/sierra.graphml"
 query="../../resource/utilities/resource-query"
 
 test_expect_success "vertex/edge counts for a tiny machine are correct" '
-    echo "quit" >> input1.txt &&
+    echo "quit" > input1.txt &&
     ${query} -G ${tiny_grug} -e -S CA -P high < input1.txt > out1.txt &&
     vtx=$(grep "Vertex" out1.txt  | sed "s/INFO: Vertex Count: //") &&
     edg=$(grep "Edge" out1.txt  | sed "s/INFO: Edge Count: //") &&
     test ${vtx} -eq 100 &&
     test ${edg} -eq 198
 '
+
+test_expect_success "--reserve-vtx-vec works" '
+    echo "quit" > input2.txt &&
+    ${query} -G ${tiny_grug} -e -r 1024 -S CA -P high < input2.txt > out2.txt &&
+    vtx=$(grep "Vertex" out2.txt  | sed "s/INFO: Vertex Count: //") &&
+    edg=$(grep "Edge" out2.txt  | sed "s/INFO: Edge Count: //") &&
+    test ${vtx} -eq 100 &&
+    test ${edg} -eq 198
+'
+
+test_expect_success LONGTEST "--reserve-vtx-vec improves loading performance" '
+    echo "quit" > input3.txt &&
+    ${query} -G ${large_grug} -e -r 400000 < input3.txt > out3A.txt &&
+    ${query} -G ${large_grug} -e < input3.txt > out3B.txt &&
+    with=$(grep "Graph" out3A.txt  | sed "s/INFO: Graph Load Time: //") &&
+    without=$(grep "Graph" out3B.txt  | sed "s/INFO: Graph Load Time: //") &&
+    test $(awk "BEGIN{ print $with<$without }") -eq 1
+'
+
 
 test_done

--- a/t/t6000-graph-size.t
+++ b/t/t6000-graph-size.t
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+test_description='Test Correctness of Populating Graph Data Store'
+
+. $(dirname $0)/sharness.sh
+
+tiny_grug="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/tiny.graphml"
+query="../../resource/utilities/resource-query"
+
+test_expect_success "vertex/edge counts for a tiny machine are correct" '
+    echo "quit" >> input1.txt &&
+    ${query} -G ${tiny_grug} -e -S CA -P high < input1.txt > out1.txt &&
+    vtx=$(grep "Vertex" out1.txt  | sed "s/INFO: Vertex Count: //") &&
+    edg=$(grep "Edge" out1.txt  | sed "s/INFO: Edge Count: //") &&
+    test ${vtx} -eq 100 &&
+    test ${edg} -eq 198
+'
+
+test_done

--- a/t/t6001-match-formats.t
+++ b/t/t6001-match-formats.t
@@ -1,0 +1,80 @@
+#!/bin/sh
+
+test_description='Test Correctness of Match Emit Format'
+
+. $(dirname $0)/sharness.sh
+
+tiny_grug="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/tiny.graphml"
+large_grug="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/sierra.graphml"
+jobspec="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/basics/test001.yaml"
+jobspec2="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/basics/test011.yaml"
+schema="${SHARNESS_TEST_SRCDIR}/schemas/json-graph-schema.json"
+query="../../resource/utilities/resource-query"
+
+test_expect_success "R emitted with -F jgf validates against schema" '
+    echo "match allocate ${jobspec}" > in1.txt &&
+    echo "quit" >> in1.txt &&
+    ${query} -G ${tiny_grug} -F jgf -d -t o1 < in1.txt &&
+    cat o1 | grep -v "INFO:" > o1.json &&
+    flux jsonschemalint -v ${schema} o1.json
+'
+
+test_expect_success "R emitted with -F pretty_jgf validates against schema" '
+    echo "match allocate ${jobspec}" > in2.txt &&
+    echo "quit" >> in2.txt &&
+    ${query} -G ${tiny_grug} -F pretty_jgf -d -t o2 < in2.txt &&
+    cat o2 | grep -v "INFO:" > o2.json &&
+    flux jsonschemalint -v ${schema} o2.json
+'
+
+test_expect_success LONGTEST "Large R emitted with -F jgf validates" '
+    echo "match allocate ${jobspec2}" > in3.txt &&
+    echo "quit" >> in3.txt &&
+    ${query} -G ${large_grug} -r 400000 -F jgf -d -t o3 < in3.txt &&
+    cat o3 | grep -v "INFO:" > o3.json &&
+    flux jsonschemalint -v ${schema} o3.json
+'
+
+test_expect_success LONGTEST "Large R emitted with -F pretty_jgf validates" '
+    echo "match allocate ${jobspec2}" > in4.txt &&
+    echo "quit" >> in4.txt &&
+    ${query} -G ${large_grug} -r 400000 -F pretty_jgf -d -t o4 < in4.txt &&
+    cat o4 | grep -v "INFO:" > o4.json &&
+    flux jsonschemalint -v ${schema} o4.json
+'
+
+test_expect_success "--match-format=rv1 works" '
+    echo "match allocate ${jobspec}" > in5.txt &&
+    echo "quit" >> in5.txt &&
+    ${query} -G ${tiny_grug} -F rv1 -d -t o5 < in5.txt &&
+    cat o5 | grep -v "INFO:" | jq ".scheduling" > o5.json &&
+    flux jsonschemalint -v ${schema} o5.json
+'
+
+test_expect_success "--match-format=pretty_rv1 works" '
+    echo "match allocate ${jobspec}" > in6.txt &&
+    echo "quit" >> in6.txt &&
+    ${query} -G ${tiny_grug} -F pretty_rv1 -d -t o6 < in6.txt &&
+    cat o6 | grep -v "INFO:" | jq ".scheduling" > o6.json &&
+    flux jsonschemalint -v ${schema} o6.json
+'
+
+test_expect_success "--match-format=rv1_nosched and =rlite works" '
+    echo "match allocate ${jobspec}" > in7.txt &&
+    echo "quit" >> in7.txt &&
+    ${query} -G ${tiny_grug} -F rv1_nosched -d -t o7 < in7.txt &&
+    ${query} -G ${tiny_grug} -F rlite -d -t o8 < in7.txt &&
+    cat o7 | grep -v "INFO:" | jq ".execution" > o7.json &&
+    cat o8 | grep -v "INFO:" | jq "" > o8.json &&
+    diff o7.json o8.json
+'
+
+test_expect_success "--match-format=pretty_simple works" '
+    echo "match allocate ${jobspec}" > in8.txt &&
+    echo "quit" >> in8.txt &&
+    ${query} -G ${tiny_grug} -F pretty_simple -d -t o8 < in8.txt &&
+    cat o8 | grep -v "INFO:" > o8.simple &&
+    test -s o8.simple
+'
+
+test_done

--- a/t/t6001-match-formats.t
+++ b/t/t6001-match-formats.t
@@ -2,7 +2,15 @@
 
 test_description='Test Correctness of Match Emit Format'
 
-. $(dirname $0)/sharness.sh
+ORIG_HOME=${HOME}
+
+. `dirname $0`/sharness.sh
+
+#
+# sharness modifies $HOME environment variable, but this interferes
+# with python's package search path, in particular its user site package.
+#
+HOME=${ORIG_HOME}
 
 tiny_grug="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/tiny.graphml"
 large_grug="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/sierra.graphml"


### PR DESCRIPTION
This PR adds a bunch of support needed in preparation for future integration with the new execution systems: 

* Add support for various emit formats including RFC20 RV1 (Issue #436, #443 and #445)
* Add performance improvements such as adding `reserve-vtx-vec` options and remove uuid (Issue #451)
* Add better performance measurement rigs (Issue #448)
* Various bug fixes (Issue #453)

