### PR TITLE
WIP: Add high-level resource API skeleton support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -166,6 +166,9 @@ AC_CONFIG_FILES([Makefile
   resource/utilities/Makefile
   resource/utilities/test/Makefile
   resource/modules/Makefile
+  resource/hlapi/Makefile
+  resource/hlapi/bindings/Makefile
+  resource/hlapi/bindings/c/Makefile
   etc/Makefile
   t/Makefile])
 AC_OUTPUT

--- a/resource/Makefile.am
+++ b/resource/Makefile.am
@@ -11,7 +11,7 @@ AM_LDFLAGS = $(CODE_COVERAGE_LDFLAGS)
 AM_CPPFLAGS = -I$(top_srcdir) $(CZMQ_CFLAGS) $(FLUX_CORE_CFLAGS) \
 	      $(BOOST_CPPFLAGS)
 
-SUBDIRS = libjobspec planner . utilities modules
+SUBDIRS = libjobspec planner . utilities modules hlapi
 
 noinst_LTLIBRARIES = libresource.la
 

--- a/resource/hlapi/Makefile.am
+++ b/resource/hlapi/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = bindings

--- a/resource/hlapi/bindings/Makefile.am
+++ b/resource/hlapi/bindings/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = c

--- a/resource/hlapi/bindings/c++/reapi.hpp
+++ b/resource/hlapi/bindings/c++/reapi.hpp
@@ -1,0 +1,73 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef REAPI_HPP
+#define REAPI_HPP
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+}
+
+#include <cstdint>
+#include <string>
+
+namespace Flux {
+namespace resource_model {
+
+class reapi_t {
+public:
+    static int match_allocate (void *h, bool orelse_reserve,
+                               const std::string &jobspec, const uint64_t jobid,
+                               bool &reserved,
+                               std::string &R, int64_t &at, double &ov)
+    {
+        return -1;
+    }
+    static int cancel (void *h, const uint64_t jobid)
+    {
+        return -1;
+    }
+    static int info (void *h, const uint64_t jobid,
+                     bool &reserved, int64_t &at, double &ov)
+    {
+        return -1;
+    }
+    static int stat (void *h, int64_t &V, int64_t &E,int64_t &J,
+                     double &load, double &min, double &max, double &avg)
+    {
+        return -1;
+    }
+};
+
+} // namespace resource_model
+} // namespace Flux
+
+#endif // REAPI_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/hlapi/bindings/c++/reapi_cli.hpp
+++ b/resource/hlapi/bindings/c++/reapi_cli.hpp
@@ -1,0 +1,65 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef REAPI_CLI_HPP
+#define REAPI_CLI_HPP
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <cstdint>
+#include <cerrno>
+}
+
+#include "resource/hlapi/bindings/c++/reapi.hpp"
+
+namespace Flux {
+namespace resource_model {
+namespace detail {
+
+class reapi_cli_t : public reapi_t {
+public:
+    static int match_allocate (void *h, bool orelse_reserve,
+                               const std::string &jobspec,
+                               const uint64_t jobid, bool &reserved,
+                               std::string &R, int64_t &at, double &ov);
+    static int cancel (void *h, const int64_t jobid);
+    static int info (void *h, const int64_t jobid,
+                     bool &reserved, int64_t &at, double &ov);
+    static int stat (void *h, int64_t &V, int64_t &E,int64_t &J,
+                     double &load, double &min, double &max, double &avg);
+};
+
+
+} // namespace detail
+} // namespace resource_model
+} // namespace Flux
+
+#endif // REAPI_MODULE_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/hlapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/hlapi/bindings/c++/reapi_cli_impl.hpp
@@ -1,0 +1,77 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef REAPI_CLI_IMPL_HPP
+#define REAPI_CLI_IMPL_HPP
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+}
+
+#include "resource/hlapi/bindings/c++/reapi_cli.hpp"
+
+namespace Flux {
+namespace resource_model {
+namespace detail {
+
+const int NOT_YET_IMPLEMENTED = -1;
+
+int reapi_cli_t::match_allocate (void *h, bool orelse_reserve,
+                                 const std::string &jobspec,
+                                 const uint64_t jobid, bool &reserved,
+                                 std::string &R, int64_t &at, double &ov)
+{
+    return NOT_YET_IMPLEMENTED;
+}
+
+int reapi_cli_t::cancel (void *h, const int64_t jobid)
+{
+    return NOT_YET_IMPLEMENTED;
+}
+
+int reapi_cli_t::info (void *h, const int64_t jobid,
+                       bool &reserved, int64_t &at, double &ov)
+{
+    return NOT_YET_IMPLEMENTED;
+}
+
+int reapi_cli_t::stat (void *h, int64_t &V, int64_t &E,int64_t &J,
+                       double &load, double &min, double &max, double &avg)
+{
+    return NOT_YET_IMPLEMENTED;
+}
+
+
+} // namespace detail
+} // namespace resource_model
+} // namespace Flux
+
+#endif // REAPI_CLI_IMPL_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/hlapi/bindings/c++/reapi_module.hpp
+++ b/resource/hlapi/bindings/c++/reapi_module.hpp
@@ -1,0 +1,65 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef REAPI_MODULE_HPP
+#define REAPI_MODULE_HPP
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+}
+
+#include <cstdint>
+#include <string>
+#include "resource/hlapi/bindings/c++/reapi.hpp"
+
+namespace Flux {
+namespace resource_model {
+namespace detail {
+
+class reapi_module_t : public reapi_t {
+public:
+    static int match_allocate (void *h, bool orelse_reserve,
+                               const std::string &jobspec,
+                               const uint64_t jobid, bool &reserved,
+                               std::string &R, int64_t &at, double &ov);
+    static int cancel (void *h, const uint64_t jobid);
+    static int info (void *h, const uint64_t jobid,
+                     bool &reserved, int64_t &at, double &ov);
+    static int stat (void *h, int64_t &V, int64_t &E,int64_t &J,
+                     double &load, double &min, double &max, double &avg);
+};
+
+
+} // namespace detail
+} // namespace resource_model
+} // namespace Flux
+
+#endif // REAPI_MODULE_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/hlapi/bindings/c++/reapi_module_impl.hpp
+++ b/resource/hlapi/bindings/c++/reapi_module_impl.hpp
@@ -1,0 +1,177 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef REAPI_MODULE_IMPL_HPP
+#define REAPI_MODULE_IMPL_HPP
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+}
+
+#include <cerrno>
+#include "resource/hlapi/bindings/c++/reapi_module.hpp"
+
+namespace Flux {
+namespace resource_model {
+namespace detail {
+
+int reapi_module_t::match_allocate (void *h, bool orelse_reserve,
+                                    const std::string &jobspec,
+                                    const uint64_t jobid, bool &reserved,
+                                    std::string &R, int64_t &at, double &ov)
+{
+    int rc = -1;
+    int64_t rj = -1;
+    flux_t *fh = (flux_t *)h;
+    flux_future_t *f = NULL;
+    const char *status = NULL;
+    const char *cmd = (orelse_reserve)? "allocate_orelse_reserve"
+                                      : "allocate";
+
+    if (!fh || jobspec == "" || jobid > INT64_MAX) {
+        errno = EINVAL;
+        goto out;
+    }
+
+    if (!(f = flux_rpc_pack (fh, "resource.match", FLUX_NODEID_ANY, 0,
+                             "{s:s s:I s:s}",
+                             "cmd", cmd, "jobid", (const int64_t)jobid,
+                             "jobspec", jobspec.c_str ()))) {
+        goto out;
+    }
+
+    if (flux_rpc_get_unpack (f, "{s:I s:s s:f s:s s:I}",
+                             "jobid", &rj, "status", &status,
+                             "overhead", &ov, "R", &R, "at", &at) < 0) {
+        goto out;
+    }
+    reserved = (std::string ("RESERVED") == status)? true : false;
+    if (rj != (int64_t)jobid) {
+        errno = EINVAL;
+        goto out;
+    }
+    rc = 0;
+
+out:
+    flux_future_destroy (f);
+    return rc;
+}
+
+int reapi_module_t::cancel (void *h, const uint64_t jobid)
+{
+    int rc = -1;
+    flux_t *fh = (flux_t *)h;
+    flux_future_t *f = NULL;
+
+    if (!fh || jobid > INT64_MAX) {
+        errno = EINVAL;
+        goto out;
+    }
+    if (!(f = flux_rpc_pack (fh, "resource.cancel", FLUX_NODEID_ANY, 0,
+                             "{s:I}", "jobid", (const int64_t)jobid))) {
+        goto out;
+    }
+    if ((rc = flux_rpc_get (f, NULL)) < 0) {
+        goto out;
+    }
+    rc = 0;
+
+out:
+    flux_future_destroy (f);
+    return rc;
+}
+
+int reapi_module_t::info (void *h, const uint64_t jobid,
+                          bool &reserved, int64_t &at, double &ov)
+{
+    int rc = -1;
+    int64_t rj = -1;
+    flux_t *fh = (flux_t *)h;
+    flux_future_t *f = NULL;
+    const char *status = NULL;
+
+    if (!fh || jobid > INT64_MAX) {
+        errno = EINVAL;
+        goto out;
+    }
+    if (!(f = flux_rpc_pack (fh, "resource.info", FLUX_NODEID_ANY, 0,
+                             "{s:I}", "jobid", (const int64_t)jobid))) {
+        goto out;
+    }
+    if (flux_rpc_get_unpack (f, "{s:I s:s s:I s:f}",
+                             "jobid", &rj, "status", &status,
+                             "at", &at, "overhead", &ov) < 0) {
+        goto out;
+    }
+    reserved = (std::string ("RESERVED") == status)? true : false;
+    if (rj != (int64_t)jobid) {
+        errno = EINVAL;
+        goto out;
+    }
+    rc = 0;
+
+out:
+    flux_future_destroy (f);
+    return rc;
+}
+
+int reapi_module_t::stat (void *h, int64_t &V, int64_t &E,int64_t &J,
+                          double &load, double &min, double &max, double &avg)
+{
+    int rc = -1;
+    flux_t *fh = (flux_t *)h;
+    flux_future_t *f = NULL;
+
+    if (!fh) {
+        errno = EINVAL;
+        goto out;
+    }
+
+    if (!(f = flux_rpc (fh, "resource.stat", NULL, FLUX_NODEID_ANY, 0))) {
+        goto out;
+    }
+    if ((rc = flux_rpc_get_unpack (f, "{s:I s:I s:f s:I s:f s:f s:f}",
+                                   "V", &V, "E", &E, "load-time", &load,
+                                   "njobs", &J, "min-match", &min,
+                                   "max-match", &max, "avg-match", &avg)) < 0) {
+        goto out;
+    }
+
+out:
+    flux_future_destroy (f);
+    return rc;
+}
+
+} // namespace detail
+} // namespace resource_model
+} // namespace Flux
+
+#endif // REAPI_MODULE_IMPL_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/hlapi/bindings/c/Makefile.am
+++ b/resource/hlapi/bindings/c/Makefile.am
@@ -1,0 +1,29 @@
+AM_CXXFLAGS = \
+    $(WARNING_CXXFLAGS) \
+    $(CODE_COVERAGE_CXXFLAGS)
+
+AM_CFLAGS = \
+    $(WARNING_CFLAGS) \
+    $(CODE_COVERAGE_CFLAGS)
+
+AM_CPPFLAGS = \
+    -I$(top_srcdir) $(CZMQ_CFLAGS) $(FLUX_CORE_CFLAGS)
+
+AM_LDFLAGS = \
+    $(CODE_COVERAGE_LIBS)
+
+noinst_LTLIBRARIES = libreapi_cli.la libreapi_module.la
+
+libreapi_cli_la_SOURCES = \
+    reapi_cli.cpp \
+    reapi_cli.h \
+    $(top_srcdir)/resource/hlapi/bindings/c++/reapi.hpp \
+    $(top_srcdir)/resource/hlapi/bindings/c++/reapi_cli.hpp \
+    $(top_srcdir)/resource/hlapi/bindings/c++/reapi_cli_impl.hpp
+
+libreapi_module_la_SOURCES = \
+    reapi_module.cpp \
+    reapi_module.h \
+    $(top_srcdir)/resource/hlapi/bindings/c++/reapi.hpp \
+    $(top_srcdir)/resource/hlapi/bindings/c++/reapi_module.hpp \
+    $(top_srcdir)/resource/hlapi/bindings/c++/reapi_module_impl.hpp

--- a/resource/hlapi/bindings/c/reapi_cli.cpp
+++ b/resource/hlapi/bindings/c/reapi_cli.cpp
@@ -1,0 +1,137 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include "resource/hlapi/bindings/c/reapi_cli.h"
+}
+
+#include <cstdlib>
+#include <cstdint>
+#include <cerrno>
+#include "resource/hlapi/bindings/c++/reapi_cli.hpp"
+#include "resource/hlapi/bindings/c++/reapi_cli_impl.hpp"
+
+using namespace Flux;
+using namespace Flux::resource_model;
+using namespace Flux::resource_model::detail;
+
+struct reapi_cli_ctx {
+    flux_t *h;
+};
+
+extern "C" reapi_cli_ctx_t *reapi_cli_new ()
+{
+    reapi_cli_ctx_t *ctx = NULL;
+    if (!(ctx = (reapi_cli_ctx_t *)malloc (sizeof (*ctx)))) {
+        errno = ENOMEM;
+        goto out;
+    }
+    ctx->h = NULL;
+out:
+    return ctx;
+}
+
+extern "C" void reapi_cli_destroy (reapi_cli_ctx_t *ctx)
+{
+    free (ctx);
+}
+
+extern "C" int reapi_cli_match_allocate (reapi_cli_ctx_t *ctx,
+                   bool orelse_reserve, const char *jobspec,
+                   const uint64_t jobid, bool *reserved,
+                   char **R, int64_t *at, double *ov)
+{
+    int rc = -1;
+    std::string R_buf = "";
+    if (!ctx || !ctx->h) {
+        errno = EINVAL;
+        goto out;
+    }
+    if ((rc = reapi_cli_t::match_allocate (ctx->h, orelse_reserve, jobspec,
+                                           jobid, *reserved,
+                                           R_buf, *at, *ov)) < 0) {
+        goto out;
+    }
+    (*R) = strdup (R_buf.c_str ());
+
+out:
+    return rc;
+}
+
+extern "C" int reapi_cli_cancel (reapi_cli_ctx_t *ctx, const uint64_t jobid)
+{
+    if (!ctx || !ctx->h) {
+        errno = EINVAL;
+        return -1;
+    }
+    return reapi_cli_t::cancel (ctx->h, jobid);    
+}
+
+extern "C" int reapi_cli_info (reapi_cli_ctx_t *ctx, const uint64_t jobid,
+                               bool *reserved, int64_t *at, double *ov)
+{
+    if (!ctx || !ctx->h) {
+        errno = EINVAL;
+        return -1;
+    }
+    return reapi_cli_t::info (ctx->h, jobid, *reserved, *at, *ov);
+}
+
+extern "C" int reapi_cli_stat (reapi_cli_ctx_t *ctx, int64_t *V,
+                               int64_t *E, int64_t *J, double *load,
+                               double *min, double *max, double *avg)
+{
+    if (!ctx || !ctx->h) {
+        errno = EINVAL;
+        return -1;
+    }
+    return reapi_cli_t::stat (ctx->h, *V, *E, *J, *load, *min, *max, *avg);
+}
+
+extern "C" int reapi_cli_set_handle (reapi_cli_ctx_t *ctx, void *handle)
+{
+    if (!ctx) {
+        errno = EINVAL;
+        return -1;
+    }
+    ctx->h = (flux_t *)handle;
+    return 0;
+}
+
+extern "C" void *reapi_cli_get_handle (reapi_cli_ctx_t *ctx)
+{
+    if (!ctx) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return ctx->h;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/hlapi/bindings/c/reapi_cli.h
+++ b/resource/hlapi/bindings/c/reapi_cli.h
@@ -1,0 +1,62 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef REAPI_CLI_H
+#define REAPI_CLI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+typedef struct reapi_cli_ctx reapi_cli_ctx_t;
+
+reapi_cli_ctx_t *reapi_cli_new ();
+void reapi_cli_destroy (reapi_cli_ctx_t *ctx);
+int reapi_cli_match_allocate (reapi_cli_ctx_t *ctx, bool orelse_reserve,
+                              const char *jobspec, const uint64_t jobid,
+                              bool *reserved,
+                              char **R, int64_t *at, double *ov);
+int reapi_cli_cancel (reapi_cli_ctx_t *ctx, const uint64_t jobid);
+int reapi_cli_info (reapi_cli_ctx_t *ctx, const uint64_t jobid,
+                    bool *reserved, int64_t *at, double *ov);
+int reapi_cli_stat (reapi_cli_ctx_t *ctx, int64_t *V, int64_t *E,
+                    int64_t *J, double *load,
+                    double *min, double *max, double *avg);
+int reapi_cli_set_handle (reapi_cli_ctx_t *ctx, void *handle);
+void *reapi_cli_get_handle (reapi_cli_ctx_t *ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // REAPI_CLI_H
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/hlapi/bindings/c/reapi_module.cpp
+++ b/resource/hlapi/bindings/c/reapi_module.cpp
@@ -1,0 +1,137 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include "resource/hlapi/bindings/c/reapi_module.h"
+}
+
+#include <cstdlib>
+#include <cstdint>
+#include <cerrno>
+#include "resource/hlapi/bindings/c++/reapi_module.hpp"
+#include "resource/hlapi/bindings/c++/reapi_module_impl.hpp"
+
+using namespace Flux;
+using namespace Flux::resource_model;
+using namespace Flux::resource_model::detail;
+
+struct reapi_module_ctx {
+    flux_t *h;
+};
+
+extern "C" reapi_module_ctx_t *reapi_module_new ()
+{
+    reapi_module_ctx_t *ctx = NULL;
+    if (!(ctx = (reapi_module_ctx_t *)malloc (sizeof (*ctx)))) {
+        errno = ENOMEM;
+        goto out;
+    }
+    ctx->h = NULL;
+out:
+    return ctx;
+}
+
+extern "C" void reapi_module_destroy (reapi_module_ctx_t *ctx)
+{
+    free (ctx);
+}
+
+extern "C" int reapi_module_match_allocate (reapi_module_ctx_t *ctx,
+                   bool orelse_reserve, const char *jobspec,
+                   const uint64_t jobid, bool *reserved,
+                   char **R, int64_t *at, double *ov)
+{
+    int rc = -1;
+    std::string R_buf = "";
+    if (!ctx || !ctx->h) {
+        errno = EINVAL;
+        goto out;
+    }
+    if ((rc = reapi_module_t::match_allocate (ctx->h, orelse_reserve, jobspec,
+                                              jobid, *reserved,
+                                              R_buf, *at, *ov)) < 0) {
+        goto out;
+    }
+    (*R) = strdup (R_buf.c_str ());
+
+out:
+    return rc;
+}
+
+extern "C" int reapi_module_cancel (reapi_module_ctx_t *ctx, const uint64_t jobid)
+{
+    if (!ctx || !ctx->h) {
+        errno = EINVAL;
+        return -1;
+    }
+    return reapi_module_t::cancel (ctx->h, jobid);    
+}
+
+extern "C" int reapi_module_info (reapi_module_ctx_t *ctx, const uint64_t jobid,
+                                  bool *reserved, int64_t *at, double *ov)
+{
+    if (!ctx || !ctx->h) {
+        errno = EINVAL;
+        return -1;
+    }
+    return reapi_module_t::info (ctx->h, jobid, *reserved, *at, *ov);
+}
+
+extern "C" int reapi_module_stat (reapi_module_ctx_t *ctx, int64_t *V,
+                                  int64_t *E, int64_t *J, double *load,
+                                  double *min, double *max, double *avg)
+{
+    if (!ctx || !ctx->h) {
+        errno = EINVAL;
+        return -1;
+    }
+    return reapi_module_t::stat (ctx->h, *V, *E, *J, *load, *min, *max, *avg);
+}
+
+extern "C" int reapi_module_set_handle (reapi_module_ctx_t *ctx, void *handle)
+{
+    if (!ctx) {
+        errno = EINVAL;
+        return -1;
+    }
+    ctx->h = (flux_t *)handle;
+    return 0;
+}
+
+extern "C" void *reapi_module_get_handle (reapi_module_ctx_t *ctx)
+{
+    if (!ctx) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return ctx->h;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/hlapi/bindings/c/reapi_module.h
+++ b/resource/hlapi/bindings/c/reapi_module.h
@@ -1,0 +1,62 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef REAPI_MODULE_H
+#define REAPI_MODULE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+typedef struct reapi_module_ctx reapi_module_ctx_t;
+
+reapi_module_ctx_t *reapi_module_new ();
+void reapi_module_destroy (reapi_module_ctx_t *ctx);
+int reapi_module_match_allocate (reapi_module_ctx_t *ctx, bool orelse_reserve,
+                                 const char *jobspec, const uint64_t jobid,
+                                 bool *reserved,
+                                 char **R, int64_t *at, double *ov);
+int reapi_module_cancel (reapi_module_ctx_t *ctx, const uint64_t jobid);
+int reapi_module_info (reapi_module_ctx_t *ctx, const uint64_t jobid,
+                       bool *reserved, int64_t *at, double *ov);
+int reapi_module_stat (reapi_module_ctx_t *ctx, int64_t *V, int64_t *E,
+                       int64_t *J, double *load,
+                       double *min, double *max, double *avg);
+int reapi_module_set_handle (reapi_module_ctx_t *ctx, void *handle);
+void *reapi_module_get_handle (reapi_module_ctx_t *ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // REAPI_MODULE_H
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
This is experimental in case people like @cmisale wants to take a peek at where I'm headed. (So don't even attempt to merge at all!)

For our main work, these high-level resource APIs are required to reduce software complexity for our upcoming queue manager support, the module that will directly interface with `job-manager`. In particular, this helps designing our future queue manager to be layered both with RPC and CLI (i.e., for testing) without having to specialize the main code base for each case.  

As I will start to use these APIs in the upcoming queue manager code, the APIs and implementations will be likely to change, but the structure should remain the same. 
