### PR TITLE
qmanager to integrate with the new exec system

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 ACLOCAL_AMFLAGS = -I config
 
-SUBDIRS = src resource etc t
+SUBDIRS = src resource qmanager etc t
 
 EXTRA_DIST= \
 	config/tap-driver.sh \

--- a/configure.ac
+++ b/configure.ac
@@ -166,6 +166,9 @@ AC_CONFIG_FILES([Makefile
   resource/utilities/Makefile
   resource/utilities/test/Makefile
   resource/modules/Makefile
+  resource/hlapi/Makefile
+  resource/hlapi/bindings/Makefile
+  resource/hlapi/bindings/c/Makefile
   etc/Makefile
   t/Makefile])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -126,18 +126,6 @@ AC_SUBST(fluxlibdir)
 AS_VAR_SET(fluxmoddir, $libdir/flux/modules)
 AC_SUBST(fluxmoddir)
 
-AS_VAR_SET(schedplugindir, $libdir/flux/modules/sched)
-AC_SUBST(schedplugindir)
-
-AS_VAR_SET(fluxschedincludedir, $includedir/flux/sched)
-AC_SUBST(fluxschedincludedir)
-
-AS_VAR_SET(fluxschedrc1dir, $sysconfdir/flux/rc1.d)
-AC_SUBST(fluxschedrc1dir)
-
-AS_VAR_SET(fluxschedrc3dir, $sysconfdir/flux/rc3.d)
-AC_SUBST(fluxschedrc3dir)
-
 AS_VAR_SET(fluxresourcerc1dir, $sysconfdir/flux/rc1.d)
 AC_SUBST(fluxresourcerc1dir)
 

--- a/configure.ac
+++ b/configure.ac
@@ -170,6 +170,8 @@ AC_CONFIG_FILES([Makefile
   resource/hlapi/Makefile
   resource/hlapi/bindings/Makefile
   resource/hlapi/bindings/c/Makefile
+  qmanager/Makefile
+  qmanager/modules/Makefile
   etc/Makefile
   t/Makefile])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -144,6 +144,12 @@ AC_SUBST(fluxresourcerc1dir)
 AS_VAR_SET(fluxresourcerc3dir, $sysconfdir/flux/rc3.d)
 AC_SUBST(fluxresourcerc3dir)
 
+AS_VAR_SET(fluxqmanagerrc1dir, $sysconfdir/flux/rc1.d)
+AC_SUBST(fluxqmanagerrc1dir)
+
+AS_VAR_SET(fluxresourcerc3dir, $sysconfdir/flux/rc3.d)
+AC_SUBST(fluxqmanagerrc3dir)
+
 ##
 # Macros to avoid repetition in Makefiles.am's
 ##

--- a/configure.ac
+++ b/configure.ac
@@ -159,6 +159,7 @@ AC_CONFIG_FILES([Makefile
   src/common/libtap/Makefile
   src/common/libutil/Makefile
   src/common/librbtree/Makefile
+  src/common/libschedutil/Makefile
   resource/Makefile
   resource/planner/Makefile
   resource/planner/test/Makefile

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -1,3 +1,5 @@
 dist_fluxresourcerc1_SCRIPTS = resource-start
 dist_fluxresourcerc3_SCRIPTS = resource-stop
+dist_fluxqmanagerrc1_SCRIPTS = qmanager-start
+dist_fluxqmanagerrc3_SCRIPTS = qmanager-stop
 

--- a/etc/qmanager-start
+++ b/etc/qmanager-start
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+#
+# If qmanager is not installed into flux-core's $prefix,
+# one should set FLUX_RC_EXTRA environment variable to flux-sched's $prefix/etc/flux
+# so that flux start can automatically execute qmanager's runlevel 1 and 3.
+#
+# In addition, users can set FLUX_QMANAGER_OPTIONS if they want flux
+# to load in the queue manager service module with non-default options.
+#
+# Finally, if FLUX_QMANAGER_RC_NOOP=1, flux-core
+# won't load in or remove qmanager as part of runlevel 1 and 3.
+#
+
+if [ -z ${FLUX_QMANAGER_RC_NOOP} ]; then
+    flux module remove sched-simple
+    flux module load -r 0 qmanager ${FLUX_QMANAGER_OPTIONS}
+fi
+

--- a/etc/qmanager-stop
+++ b/etc/qmanager-stop
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+if [ -z ${FLUX_QMANAGER_RC_NOOP} ]; then
+    flux module remove qmanager
+fi
+

--- a/etc/resource-start
+++ b/etc/resource-start
@@ -8,7 +8,7 @@
 # to load in the resource matching service module with non-default options.
 #
 # Finally, if FLUX_RESOURCE_RC_NOOP=1, flux-core
-# won't load in or remove sched as part of runlevel 1 and 3.
+# won't load in or remove resource as part of runlevel 1 and 3.
 #
 
 if [ -z ${FLUX_RESOURCE_RC_NOOP} ]; then

--- a/qmanager/Makefile.am
+++ b/qmanager/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = modules

--- a/qmanager/modules/Makefile.am
+++ b/qmanager/modules/Makefile.am
@@ -1,0 +1,46 @@
+AM_CXXFLAGS = \
+    $(WARNING_CXXFLAGS) \
+    $(CODE_COVERAGE_CXXFLAGS)
+
+AM_LDFLAGS = \
+    $(CODE_COVERAGE_LDFLAGS)
+
+AM_CPPFLAGS = \
+    -I$(top_srcdir) \
+    $(FLUX_CORE_CFLAGS)
+
+fluxmod_LTLIBRARIES = qmanager.la
+
+#
+# queue manager service module
+#
+qmanager_la_SOURCES = \
+    qmanager.cpp \
+    $(top_srcdir)/resource/hlapi/bindings/c++/reapi.hpp \
+    $(top_srcdir)/resource/hlapi/bindings/c++/reapi_cli.hpp \
+    $(top_srcdir)/resource/hlapi/bindings/c++/reapi_cli_impl.hpp \
+    $(top_srcdir)/resource/hlapi/bindings/c++/reapi_module.hpp \
+    $(top_srcdir)/resource/hlapi/bindings/c++/reapi_module_impl.hpp \
+    $(top_srcdir)/qmanager/policies/base/queue_policy_base.hpp \
+    $(top_srcdir)/qmanager/policies/base/queue_policy_base_impl.hpp \
+    $(top_srcdir)/qmanager/policies/queue_policy_fcfs.hpp \
+    $(top_srcdir)/qmanager/policies/queue_policy_fcfs_impl.hpp \
+    $(top_srcdir)/qmanager/policies/queue_policy_easy.hpp \
+    $(top_srcdir)/qmanager/policies/queue_policy_easy_impl.hpp \
+    $(top_srcdir)/qmanager/policies/queue_policy_factory.hpp \
+    $(top_srcdir)/qmanager/policies/queue_policy_factory_impl.hpp
+
+qmanager_la_CXXFLAGS = \
+    $(AM_CXXFLAGS) \
+    $(FLUX_CORE_CFLAGS)
+
+qmanager_la_LIBADD = \
+    $(top_builddir)/src/common/libschedutil/libschedutil.la \
+    $(FLUX_CORE_LIBS) \
+    $(CZMQ_LIBS) \
+    $(JANSSON_LIBS)
+
+qmanager_la_LDFLAGS = \
+    $(AM_LDFLAGS) \
+    $(fluxmod_ldflags) -module
+

--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -1,0 +1,231 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include "src/common/libschedutil/schedutil.h"
+}
+
+#include "qmanager/policies/base/queue_policy_base.hpp"
+#include "qmanager/policies/base/queue_policy_base_impl.hpp"
+#include "qmanager/policies/queue_policy_factory_impl.hpp"
+
+
+using namespace Flux;
+using namespace Flux::queue_manager;
+using namespace Flux::queue_manager::detail;
+
+/******************************************************************************
+ *                                                                            *
+ *                 Queue Manager Service Module Context                       *
+ *                                                                            *
+ ******************************************************************************/
+
+struct qmanager_ctx_t {
+    flux_t *h;
+    ops_context *ops;
+    queue_policy_base_t *queue;
+};
+
+
+/******************************************************************************
+ *                                                                            *
+ *                     Internal Queue Manager APIs                            *
+ *                                                                            *
+ ******************************************************************************/
+
+extern "C" int jobmanager_hello_cb (flux_t *h, const char *R, void *arg)
+{
+    return 0;
+}
+
+extern "C" void jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
+                                     const char *jobspec, void *arg)
+{
+    uint32_t userid;
+    qmanager_ctx_t *ctx = (qmanager_ctx_t *)arg;
+    std::shared_ptr<job_t> job = std::make_shared<job_t> ();
+
+    if (flux_msg_get_userid (msg, &userid) < 0)
+        return;
+
+    flux_log (h, LOG_INFO, "alloc requested by user (%u).", userid);
+
+    if (schedutil_alloc_request_decode (msg, &job->id, &job->priority,
+                                        &job->userid, &job->t_submit) < 0) {
+        flux_log_error (h, "%s: schedutil_alloc_request_decode", __FUNCTION__);
+        return;
+    }
+    job->jobspec = jobspec;
+    job->msg = flux_msg_copy (msg, true);
+    if (ctx->queue->insert (job) < 0) {
+        flux_log_error (h, "%s: queue insert", __FUNCTION__);
+        return;
+    }
+    if (ctx->queue->run_sched_loop ((void *)ctx->h, true) < 0) {
+        flux_log (ctx->h, LOG_DEBUG,
+                  "%s: return code < 0 from schedule loop", __FUNCTION__);
+    }
+    while ((job = ctx->queue->alloced_pop ()) != nullptr) {
+        flux_log (ctx->h, LOG_DEBUG, "jobid (%ju): %s",
+                  (intmax_t)job->id, job->schedule.R.c_str ());
+        if (schedutil_alloc_respond_R (ctx->h, job->msg,
+                                       job->schedule.R.c_str (), NULL) < 0) {
+            flux_log_error (ctx->h, "%s: schedutil_alloc_respond_R",
+                            __FUNCTION__);
+        }
+    }
+}
+
+extern "C" void jobmanager_free_cb (flux_t *h, const flux_msg_t *msg,
+                                    const char *R, void *arg)
+{
+    uint32_t userid;
+    flux_jobid_t id;
+    qmanager_ctx_t *ctx = (qmanager_ctx_t *)arg;
+    std::shared_ptr<job_t> job;
+
+    if (flux_msg_get_userid (msg, &userid) < 0)
+        return;
+
+    flux_log (h, LOG_INFO, "free requested by user (%u).", userid);
+
+    if (schedutil_free_request_decode (msg, &id) < 0) {
+        flux_log_error (h, "%s: schedutil_free_request_decode",
+                        __FUNCTION__);
+        return;
+    }
+    if (ctx->queue->remove (id)) {
+        flux_log_error (h, "%s: remove", __FUNCTION__);
+        return;
+    }
+    if (ctx->queue->run_sched_loop ((void *)ctx->h, true) < 0) {
+        // TODO: Need to tighten up anomalous conditions
+        // returned with a negative return code
+        // (e.g., unsatisfiable jobs).
+        flux_log (ctx->h, LOG_DEBUG,
+                  "%s: return code < 0 from schedule loop", __FUNCTION__);
+    }
+    if (schedutil_free_respond (h, msg) < 0) {
+        flux_log_error (h, "%s: schedutil_free_respond", __FUNCTION__);
+    }
+    while ((job = ctx->queue->alloced_pop ()) != nullptr) {
+        flux_log (ctx->h, LOG_DEBUG, "jobid (%ju): %s",
+                  (intmax_t)job->id, job->schedule.R.c_str ());
+        if (schedutil_alloc_respond_R (ctx->h, job->msg,
+                                       job->schedule.R.c_str (), NULL) < 0) {
+            flux_log_error (ctx->h, "%s: schedutil_alloc_respond_R",
+                            __FUNCTION__);
+        }
+    }
+}
+
+static void jobmanager_exception_cb (flux_t *h, flux_jobid_t id,
+                                     const char *t, int s, void *a)
+{
+    return;
+}
+
+static qmanager_ctx_t *qmanager_new (flux_t *h)
+{
+    int queue_depth = 0;
+    qmanager_ctx_t *ctx = NULL;
+
+    if (!(ctx = new (std::nothrow) qmanager_ctx_t ())) {
+        errno = ENOMEM;
+        goto out;
+    }
+    ctx->h = h;
+    if (!(ctx->queue = create_queue_policy ("fcfs", "module"))) {
+        flux_log_error (h, "%s: create_queue_policy", __FUNCTION__);
+        goto out;
+    }
+    if (schedutil_hello (h, jobmanager_hello_cb, ctx) < 0) {
+        flux_log_error (h, "%s: schedutil_hello", __FUNCTION__);
+        goto out;
+    }
+    if (schedutil_ready (h, "single", &queue_depth)) {
+        flux_log_error (h, "%s: schedutil_ready", __FUNCTION__);
+        goto out;
+    }
+    if (!(ctx->ops = schedutil_ops_register (h,
+                                             jobmanager_alloc_cb,
+                                             jobmanager_free_cb,
+                                             jobmanager_exception_cb, ctx))) {
+        flux_log_error (h, "%s: schedutil_ops_register", __FUNCTION__);
+        goto out;
+    }
+out:
+    return ctx;
+}
+
+static void qmanager_destroy (qmanager_ctx_t *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;
+        std::shared_ptr<job_t> job;
+        while ((job = ctx->queue->pending_pop ()) != nullptr)
+            flux_respond_error (ctx->h, job->msg, ENOSYS, "unloading");
+        while ((job = ctx->queue->complete_pop ()) != nullptr)
+            flux_respond_error (ctx->h, job->msg, ENOSYS, "unloading");
+        delete ctx->queue;
+        ctx->queue = NULL;
+        schedutil_ops_unregister (ctx->ops);
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+
+/******************************************************************************
+ *                                                                            *
+ *                               Module Main                                  *
+ *                                                                            *
+ ******************************************************************************/
+
+extern "C" int mod_main (flux_t *h, int argc, char **argv)
+{
+    int rc = -1;
+    try {
+        qmanager_ctx_t *ctx = NULL;
+        if (!(ctx = qmanager_new (h)))
+            flux_log_error (h, "%s: qmanager_new", __FUNCTION__);
+        if ((rc = flux_reactor_run (flux_get_reactor (h), 0)) < 0)
+            flux_log_error (h, "%s: flux_reactor_run", __FUNCTION__);
+        qmanager_destroy (ctx);
+    }
+    catch (std::exception &e) {
+        flux_log_error (h, "%s: %s", __FUNCTION__, e.what ());
+    }
+    return rc;
+}
+
+MOD_NAME ("qmanager");
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -1,0 +1,194 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef QUEUE_POLICY_BASE_HPP
+#define QUEUE_POLICY_BASE_HPP
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+}
+
+#include <map>
+#include <string>
+#include <memory>
+#include <cstdint>
+
+namespace Flux {
+namespace queue_manager {
+
+enum class job_state_kind_t { INIT,
+                              PENDING,
+                              RUNNING,
+                              ALLOC_RUNNING,
+                              CANCELED,
+                              COMPLETE };
+
+/*! Type to store schedule information such as the
+ *  allocated or reserved (for backfill) resource set (R).
+ */
+struct schedule_t {
+    std::string R = "";
+    bool reserved = false;
+    int64_t at = 0;
+    double ov = 0.0f;
+};
+
+/*! Type to store various time stamps for queuing
+ */
+struct t_stamps_t {
+    uint64_t pending_ts = 0;
+    uint64_t running_ts = 0;
+    uint64_t complete_ts = 0;
+};
+
+/*! Type to store a job's attributes.
+ */
+class job_t {
+public:
+    ~job_t () { flux_msg_destroy (msg); }
+    flux_msg_t *msg = NULL;
+    job_state_kind_t state = job_state_kind_t::INIT;
+    flux_jobid_t id = 0;
+    uint32_t userid = 0;
+    int priority = 0;
+    double t_submit = 0.0f;;
+    std::string jobspec = "";
+    t_stamps_t t_stamps;
+    schedule_t schedule;
+};
+
+
+namespace detail {
+class queue_policy_base_impl_t
+{
+public:
+    int insert (std::shared_ptr<job_t> job);
+    int remove (flux_jobid_t id);
+
+protected:
+    std::shared_ptr<job_t> pending_pop ();
+    std::shared_ptr<job_t> alloced_pop ();
+    std::shared_ptr<job_t> complete_pop ();
+    std::map<uint64_t, flux_jobid_t>::iterator to_running (
+        std::map<uint64_t, flux_jobid_t>::iterator pending_iter,
+        bool use_alloced_queue);
+    std::map<uint64_t, flux_jobid_t>::iterator to_complete (
+        std::map<uint64_t, flux_jobid_t>::iterator running_iter);
+
+    uint64_t m_pq_cnt = 0;
+    uint64_t m_rq_cnt = 0;
+    uint64_t m_cq_cnt = 0;
+    std::map<uint64_t, flux_jobid_t> m_pending;
+    std::map<uint64_t, flux_jobid_t> m_running;
+    std::map<uint64_t, flux_jobid_t> m_alloced;
+    std::map<uint64_t, flux_jobid_t> m_complete;
+    std::map<flux_jobid_t, std::shared_ptr<job_t>> m_jobs;
+};
+} // namespace Flux::queue_manager::detail
+
+
+/*! Queue policy base interface abstract class. Derived classes must
+ *  implement its run_sched_loop and destructor methods. Insert, remove
+ *  and pending_pop interface implementations are provided through
+ *  its parent class (detail::queue_policy_base_impl_t).
+ */
+class queue_policy_base_t : public detail::queue_policy_base_impl_t
+{
+public:
+    /*! The destructor that must be implemented by derived classes.
+     *
+     */
+    virtual ~queue_policy_base_t () {};
+
+    /*! The main schedule loop interface that must be implemented
+     *  by derived classes: how a derived class implements this method
+     *  must determine its queueing policy. For example, a pedantic FCFS
+     *  class should only iterate through the first set of jobs in the
+     *  pending-job queue which it can schedule using the underlying
+     *  resource match infrastructure.
+     *
+     *  \param h         Opaque handle. How it is used is an implementation
+     *                   detail. However, when it is used within a Flux's
+     *                   service module such as qmanager, it is expected
+     *                   to be a pointer to a flux_t object.
+     *  \param use_alloced_queue
+     *                   Boolean indicating if you want to use the
+     *                   allocated job queue or not. This affects the
+     *                   alloced_pop method.
+     *  \return          0 on success; -1 on error.
+     *                       EINVAL: invalid argument.
+     */
+    virtual int run_sched_loop (void *h, bool use_alloced_queue) = 0;
+
+    /*! Append a job into the internal pending-job queue.
+     *
+     *  \param job       a shared pointer pointing to a job_t object.
+     *  \return          0 on success; -1 on error.
+     *                       EINVAL: invalid argument.
+     */
+    int insert (std::shared_ptr<job_t> job);
+
+    /*! Remove a job whose jobid is id from any internal queues
+     *  (e.g., pending queue, running queue, and alloced queue.)
+     *
+     *  \param id        jobid of flux_jobid_t type.
+     *  \return          0 on success; -1 on error.
+     */
+    int remove (flux_jobid_t id);
+
+    /*! Pop the first job from the pending job queue. The popped
+     *  job is completely graduated from the queue policy layer.
+     *
+     *  \return          a shared pointer pointing to a job_t object
+     *                   on success; nullptr when the queue is empty.
+     */
+    std::shared_ptr<job_t> pending_pop ();
+
+    /*! Pop the first job from the alloced job queue. The popped
+     *  job still remains in the queue policy layer (i.e., in the
+     *  internal running job queue).
+     *  \return          a shared pointer pointing to a job_t object
+     *                   on success; nullptr when the queue is empty.
+     */
+    std::shared_ptr<job_t> alloced_pop ();
+
+    /*! Pop the first job from the internal completed job queue.
+     *  The popped is completely graduated from the queue policy layer.
+     *  \return          a shared pointer pointing to a job_t object
+     *                   on success; nullptr when the queue is empty.
+     */
+    std::shared_ptr<job_t> complete_pop ();
+};
+
+} // namespace Flux::queue_manager
+} // namespace Flux
+
+#endif // QUEUE_POLICY_BASE_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/qmanager/policies/base/queue_policy_base_impl.hpp
+++ b/qmanager/policies/base/queue_policy_base_impl.hpp
@@ -1,0 +1,212 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef QUEUE_POLICY_BASE_IMPL_HPP
+#define QUEUE_POLICY_BASE_IMPL_HPP
+
+#include <iostream>
+#include <cerrno>
+#include "qmanager/policies/base/queue_policy_base.hpp"
+
+namespace Flux {
+namespace queue_manager {
+
+int queue_policy_base_t::insert (std::shared_ptr<job_t> job)
+{
+    return detail::queue_policy_base_impl_t::insert (job);
+}
+
+int queue_policy_base_t::remove (flux_jobid_t id)
+{
+    return detail::queue_policy_base_impl_t::remove (id);
+}
+
+std::shared_ptr<job_t> queue_policy_base_t::pending_pop ()
+{
+    return detail::queue_policy_base_impl_t::pending_pop ();
+}
+
+std::shared_ptr<job_t> queue_policy_base_t::alloced_pop ()
+{
+    return detail::queue_policy_base_impl_t::alloced_pop ();
+}
+
+std::shared_ptr<job_t> queue_policy_base_t::complete_pop ()
+{
+    return detail::queue_policy_base_impl_t::complete_pop ();
+}
+
+namespace detail {
+
+int queue_policy_base_impl_t::insert (std::shared_ptr<job_t> job)
+{
+    int rc = -1;
+    if (job == nullptr || m_jobs.find (job->id) != m_jobs.end ()) {
+        errno = EINVAL;
+        goto out;
+    }
+    job->state = job_state_kind_t::PENDING;
+    job->t_stamps.pending_ts = m_pq_cnt++;
+    m_pending.insert (std::pair<uint64_t,
+                      flux_jobid_t> (job->t_stamps.pending_ts, job->id));
+    m_jobs.insert (std::pair<flux_jobid_t, std::shared_ptr<job_t>> (job->id,
+                                                                    job));
+    rc = 0;
+out:
+    return rc;
+}
+
+int queue_policy_base_impl_t::remove (flux_jobid_t id)
+{
+    int rc = -1;
+    std::shared_ptr<job_t> job;
+
+    if (m_jobs.find (id) == m_jobs.end ()) {
+        errno = EINVAL;
+        goto out;
+    }
+
+    job = m_jobs[id];
+    switch (job->state) {
+    case job_state_kind_t::PENDING:
+        m_pending.erase (job->t_stamps.pending_ts);
+        job->state = job_state_kind_t::CANCELED;
+        m_jobs.erase (id);
+        break;
+    case job_state_kind_t::ALLOC_RUNNING:
+        m_alloced.erase (job->t_stamps.running_ts);
+        // deliberately fall through
+    case job_state_kind_t::RUNNING:
+        m_running.erase (job->t_stamps.running_ts);
+        job->t_stamps.complete_ts = m_cq_cnt++;
+        job->state = job_state_kind_t::COMPLETE;
+        m_complete.insert (std::pair<uint64_t, flux_jobid_t> (
+                               job->t_stamps.complete_ts, job->id));
+        break;
+    default:
+        break;
+    }
+    rc = 0;
+out:
+    return rc;
+}
+
+
+std::map<uint64_t, flux_jobid_t>::iterator queue_policy_base_impl_t::
+    to_running (std::map<uint64_t, flux_jobid_t>::iterator pending_iter,
+                bool use_alloced_queue)
+{
+    flux_jobid_t id = pending_iter->second;
+    if (m_jobs.find (id) == m_jobs.end ()) {
+        errno = EINVAL;
+        return pending_iter;
+    }
+
+    std::shared_ptr<job_t> job = m_jobs[id];
+    job->state = job_state_kind_t::RUNNING;
+    job->t_stamps.running_ts = m_rq_cnt++;
+    m_running.insert (std::pair<uint64_t, flux_jobid_t>(
+                          job->t_stamps.running_ts, job->id));
+    if (use_alloced_queue) {
+        job->state = job_state_kind_t::ALLOC_RUNNING;
+        m_alloced.insert (std::pair<uint64_t, flux_jobid_t>(
+                              job->t_stamps.running_ts, job->id));
+    }
+    // Return the next iterator after pending_iter. This way,
+    // the upper layer can modify m_pending while iterating the queue
+    return m_pending.erase (pending_iter);
+}
+
+std::map<uint64_t, flux_jobid_t>::iterator queue_policy_base_impl_t::
+    to_complete (std::map<uint64_t, flux_jobid_t>::iterator running_iter)
+{
+    flux_jobid_t id = running_iter->second;
+    if (m_jobs.find (id) == m_jobs.end ()) {
+        errno = EINVAL;
+        return running_iter;
+    }
+
+    std::shared_ptr<job_t> job = m_jobs[id];
+    job->state = job_state_kind_t::COMPLETE;
+    job->t_stamps.complete_ts = m_cq_cnt++;
+    m_complete.insert (std::pair<uint64_t, flux_jobid_t>(
+                           job->t_stamps.complete_ts, job->id));
+    m_alloced.erase (job->t_stamps.running_ts);
+    return m_running.erase (running_iter);
+}
+
+std::shared_ptr<job_t> queue_policy_base_impl_t::pending_pop ()
+{
+    std::shared_ptr<job_t> job;
+    flux_jobid_t id;
+
+    if (m_pending.empty ())
+        return nullptr; 
+    id = m_pending.begin ()->second;
+    if (m_jobs.find (id) == m_jobs.end ())
+        return nullptr;
+    job = m_jobs[id];
+    m_pending.erase (job->t_stamps.pending_ts);
+    m_jobs.erase (id);
+    return job;
+}
+
+std::shared_ptr<job_t> queue_policy_base_impl_t::alloced_pop ()
+{
+    std::shared_ptr<job_t> job;
+    flux_jobid_t id;
+    if (m_alloced.empty ())
+        return nullptr;
+    id = m_alloced.begin ()->second;
+    if (m_jobs.find (id) == m_jobs.end ())
+        return nullptr;
+    job = m_jobs[id];
+    m_alloced.erase (job->t_stamps.running_ts);
+    return job;
+}
+
+std::shared_ptr<job_t> queue_policy_base_impl_t::complete_pop ()
+{
+    std::shared_ptr<job_t> job;
+    flux_jobid_t id;
+    if (m_complete.empty ())
+        return nullptr;
+    id = m_complete.begin ()->second;
+    if (m_jobs.find (id) == m_jobs.end ())
+        return nullptr;
+    job = m_jobs[id];
+    m_complete.erase (job->t_stamps.complete_ts);
+    m_jobs.erase (id);
+    return job;
+}
+
+} // namespace Flux::queue_manager::detail
+} // namespace Flux::queue_manager
+} // namespace Flux
+
+#endif // QUEUE_POLICY_BASE_IMPL_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/qmanager/policies/queue_policy_easy.hpp
+++ b/qmanager/policies/queue_policy_easy.hpp
@@ -1,0 +1,51 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef QUEUE_POLICY_EASY_HPP
+#define QUEUE_POLICY_EASY_HPP
+
+#include "qmanager/policies/base/queue_policy_base.hpp"
+
+namespace Flux {
+namespace queue_manager {
+namespace detail {
+
+template<class reapi_type>
+class queue_policy_easy_t : public queue_policy_base_t
+{
+public:
+    virtual ~queue_policy_easy_t ();
+    virtual int run_sched_loop (void *h, bool use_alloced_queue);
+};
+
+} // namespace Flux::queue_manager::detail
+} // namespace Flux::queue_manager
+} // namespace Flux
+
+#endif // QUEUE_POLICY_EASY_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/qmanager/policies/queue_policy_easy_impl.hpp
+++ b/qmanager/policies/queue_policy_easy_impl.hpp
@@ -1,0 +1,55 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef QUEUE_POLICY_EASY_IMPL_HPP
+#define QUEUE_POLICY_EASY_IMPL_HPP
+
+#include "qmanager/policies/queue_policy_easy.hpp"
+
+namespace Flux {
+namespace queue_manager {
+namespace detail {
+
+template<class reapi_type>
+queue_policy_easy_t<reapi_type>::~queue_policy_easy_t ()
+{
+
+}
+
+template<class reapi_type>
+int queue_policy_easy_t<reapi_type>::run_sched_loop (void *h,
+                                                     bool use_alloced_queue)
+{
+    return -1;
+}
+
+} // namespace Flux::queue_manager::detail
+} // namespace Flux::queue_manager
+} // namespace Flux
+
+#endif // QUEUE_POLICY_EASY_IMPL_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/qmanager/policies/queue_policy_factory.hpp
+++ b/qmanager/policies/queue_policy_factory.hpp
@@ -1,0 +1,43 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef QUEUE_POLICY_FACTORY_HPP
+#define QUEUE_POLICY_FACTORY_HPP
+
+#include <string>
+
+namespace Flux {
+namespace queue_manager {
+
+bool known_queue_policy (const std::string &policy);
+queue_policy_base_t *create_queue_policy (const std::string &policy);
+
+} // namespace Flux::queue_manager
+} // namespace Flux
+
+#endif // QUEUE_POLICY_FACTORY_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/qmanager/policies/queue_policy_factory_impl.hpp
+++ b/qmanager/policies/queue_policy_factory_impl.hpp
@@ -1,0 +1,91 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef QUEUE_POLICY_FACTORY_IMPL_HPP
+#define QUEUE_POLICY_FACTORY_IMPL_HPP
+
+#include "resource/hlapi/bindings/c++/reapi.hpp"
+#include "resource/hlapi/bindings/c++/reapi_module.hpp"
+#include "resource/hlapi/bindings/c++/reapi_module_impl.hpp"
+#include "resource/hlapi/bindings/c++/reapi_cli.hpp"
+#include "resource/hlapi/bindings/c++/reapi_cli_impl.hpp"
+#include "qmanager/policies/base/queue_policy_base.hpp"
+#include "qmanager/policies/base/queue_policy_base_impl.hpp"
+#include "qmanager/policies/queue_policy_fcfs.hpp"
+#include "qmanager/policies/queue_policy_fcfs_impl.hpp"
+#include "qmanager/policies/queue_policy_easy.hpp"
+#include "qmanager/policies/queue_policy_easy_impl.hpp"
+#include <string>
+
+namespace Flux {
+namespace queue_manager {
+namespace detail {
+
+using namespace resource_model;
+using namespace resource_model::detail;
+
+bool known_queue_policy (const std::string &policy)
+{
+    bool rc = true;
+    if (policy != "fcfs" && policy != "easy")
+        rc = false;
+    return rc;
+}
+
+queue_policy_base_t *create_queue_policy (const std::string &policy,
+                                          const std::string &reapi)
+{
+    queue_policy_base_t *p = NULL;
+    if (policy == "fcfs") {
+        if (reapi == "module") {
+            p = (queue_policy_base_t *)
+                    new (std::nothrow)queue_policy_fcfs_t<reapi_module_t> ();
+        }
+        else if (reapi == "cli") {
+            p = (queue_policy_base_t *)
+                    new (std::nothrow)queue_policy_fcfs_t<reapi_cli_t> ();
+        }
+    }
+    else if (policy == "easy") {
+        if (reapi == "module") {
+            p = (queue_policy_base_t *)
+                    new (std::nothrow)queue_policy_easy_t<reapi_module_t> ();
+        }
+        else if (reapi == "cli") {
+            p = (queue_policy_base_t *)
+                    new (std::nothrow)queue_policy_easy_t<reapi_cli_t> ();
+        }
+    }
+    return p;
+}
+
+} // namespace Flux::queue_manager::detail
+} // namespace Flux::queue_manager
+} // namespace Flux
+
+#endif // QUEUE_POLICY_FACTORY_IMPL_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/qmanager/policies/queue_policy_fcfs.hpp
+++ b/qmanager/policies/queue_policy_fcfs.hpp
@@ -1,0 +1,50 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef QUEUE_POLICY_FCFS_HPP
+#define QUEUE_POLICY_FCFS_HPP
+
+#include "qmanager/policies/base/queue_policy_base.hpp"
+
+namespace Flux {
+namespace queue_manager {
+namespace detail {
+
+template<class reapi_type>
+class queue_policy_fcfs_t : public queue_policy_base_t
+{
+public:
+    virtual ~queue_policy_fcfs_t ();
+    virtual int run_sched_loop (void *h, bool use_alloced_queue);
+};
+
+} // namespace Flux::queue_manager::detail
+} // namespace Flux::queue_manager
+} // namespace Flux
+
+#endif // QUEUE_POLICY_FCFS_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/qmanager/policies/queue_policy_fcfs_impl.hpp
+++ b/qmanager/policies/queue_policy_fcfs_impl.hpp
@@ -1,0 +1,91 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef QUEUE_POLICY_FCFS_IMPL_HPP
+#define QUEUE_POLICY_FCFS_IMPL_HPP
+
+#include "qmanager/policies/queue_policy_fcfs.hpp"
+#include "qmanager/policies/base/queue_policy_base_impl.hpp"
+
+namespace Flux {
+namespace queue_manager {
+namespace detail {
+
+template<class reapi_type>
+queue_policy_fcfs_t<reapi_type>::~queue_policy_fcfs_t ()
+{
+
+}
+
+template<class reapi_type>
+int queue_policy_fcfs_t<reapi_type>::run_sched_loop (void *h,
+                                                     bool use_alloced_queue)
+{
+    int rc1 = 0;
+    int rc2 = 0;
+    std::shared_ptr<job_t> job;
+    std::map<uint64_t, flux_jobid_t>::iterator iter = m_pending.begin ();
+
+    //
+    // Pop newly completed jobs (e.g., per a free request from job-manager
+    // as received by qmanager) to remove them from the resource infrastructure.
+    //
+    while ((job = complete_pop ()) != nullptr) {
+        if ((rc1 = reapi_type::cancel (h, job->id)) < 0)
+            break;
+    }
+
+    //
+    // Iterate jobs in the pending job queue and try to allocate each
+    // until you can't.
+    //
+    while (iter != m_pending.end ()) {
+        job = m_jobs[iter->second];
+        if ((rc2 = reapi_type::match_allocate (h, false, job->jobspec, job->id,
+                                               job->schedule.reserved,
+                                               job->schedule.R,
+                                               job->schedule.at,
+                                               job->schedule.ov)) < 0)
+            break;
+
+        // move the job to the running queue and make sure the job
+        // is enqueued into allocated job queue as well.
+        // When this is used within a module (qmanager), it allows the module
+        // to fetch those newly allocated jobs, which have flux_msg_t to
+        // respond to job-manager.
+        iter = to_running (iter, use_alloced_queue);
+    }
+
+    return rc1 + rc2;
+}
+
+} // namespace Flux::queue_manager::detail
+} // namespace Flux::queue_manager
+} // namespace Flux
+
+#endif // QUEUE_POLICY_FCFS_IMPL_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/Makefile.am
+++ b/resource/Makefile.am
@@ -11,7 +11,7 @@ AM_LDFLAGS = $(CODE_COVERAGE_LDFLAGS)
 AM_CPPFLAGS = -I$(top_srcdir) $(CZMQ_CFLAGS) $(FLUX_CORE_CFLAGS) \
 	      $(BOOST_CPPFLAGS)
 
-SUBDIRS = libjobspec planner . utilities modules
+SUBDIRS = libjobspec planner . utilities modules hlapi
 
 noinst_LTLIBRARIES = libresource.la
 

--- a/resource/config/system_defaults.hpp
+++ b/resource/config/system_defaults.hpp
@@ -29,7 +29,8 @@
 namespace Flux {
 namespace resource_model {
 namespace detail {
-    const uint64_t SYSTEM_DEFAULT_DURATION = 43200;
+    const uint64_t SYSTEM_DEFAULT_DURATION = 43200; // 12 hours
+    const uint64_t SYSTEM_MAX_DURATION = 604800;    //  7 days
 } // namespace detail
 } // namespace resource_model
 } // namespace Flux

--- a/resource/hlapi/Makefile.am
+++ b/resource/hlapi/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = bindings

--- a/resource/hlapi/bindings/Makefile.am
+++ b/resource/hlapi/bindings/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = c

--- a/resource/hlapi/bindings/c++/reapi.hpp
+++ b/resource/hlapi/bindings/c++/reapi.hpp
@@ -1,0 +1,146 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef REAPI_HPP
+#define REAPI_HPP
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+}
+
+#include <cstdint>
+#include <string>
+
+namespace Flux {
+namespace resource_model {
+
+
+/*! High-level resource API base class. Derived classes must implement
+ *  the methods.
+ */
+class reapi_t {
+public:
+    /*! Match a jobspec to the "best" resources and either allocate
+     *  orelse reserve them. The best resources are determined by
+     *  the selected match policy.
+     *
+     *  \param h         Opaque handle. How it is used is an implementation
+     *                   detail. However, when it is used within a Flux's
+     *                   service module, it is expected to be a pointer
+     *                   to a flux_t object.
+     *  \param orelse_reserve
+     *                   Boolean: if false, only allocate; otherwise, first try
+     *                   to allocate and if that fails, reserve.
+     *  \param jobspec   jobspec string.
+     *  \param jobid     jobid of the uint64_t type.
+     *  \param reserved  Boolean into which to return true if this job has been
+     *                   reserved instead of allocated.
+     *  \param R         String into which to return the resource set either
+     *                   allocated or reserved.
+     *  \param at        If allocated, 0 is returned; if reserved, actual time
+     *                   at which the job is reserved.
+     *  \param ov        Double into which to return performance overhead
+     *                   in terms of elapse time needed to complete
+     *                   the match operation.
+     *  \return          0 on success; -1 on error.
+     */
+    static int match_allocate (void *h, bool orelse_reserve,
+                               const std::string &jobspec, const uint64_t jobid,
+                               bool &reserved,
+                               std::string &R, int64_t &at, double &ov)
+    {
+        return -1;
+    }
+
+    /*! Cancel the allocation or reservation corresponding to jobid.
+     *
+     *  \param h         Opaque handle. How it is used is an implementation
+     *                   detail. However, when it is used within a Flux's
+     *                   service module, it is expected to be a pointer
+     *                   to a flux_t object.
+     *  \param jobid     jobid of the uint64_t type.
+     *  \return          0 on success; -1 on error.
+     */
+    static int cancel (void *h, const uint64_t jobid)
+    {
+        return -1;
+    }
+
+
+    /*! Get the information on the allocation or reservation corresponding
+     *  to jobid.
+     *
+     *  \param h         Opaque handle. How it is used is an implementation
+     *                   detail. However, when it is used within a Flux's
+     *                   service module, it is expected to be a pointer
+     *                   to a flux_t object.
+     *  \param jobid     const jobid of the uint64_t type.
+     *  \param reserved  Boolean into which to return true if this job has been
+     *                   reserved instead of allocated.
+     *  \param at        If allocated, 0 is returned; if reserved, actual time
+     *                   at which the job is reserved.
+     *  \param ov        Double into which to return performance overhead
+     *                   in terms of elapse time needed to complete
+     *                   the match operation.
+     *  \return          0 on success; -1 on error.
+     */
+    static int info (void *h, const uint64_t jobid,
+                     bool &reserved, int64_t &at, double &ov)
+    {
+        return -1;
+    }
+
+    /*! Get the performance information about the resource infrastructure.
+     *
+     *  \param h         Opaque handle. How it is used is an implementation
+     *                   detail. However, when it is used within a Flux's
+     *                   service module, it is expected to be a pointer
+     *                   to a flux_t object.
+     *  \param V         Number of resource vertices
+     *  \param E         Number of edges
+     *  \param J         Number of jobs
+     *  \param load      Graph load time
+     *  \param min       Min match time
+     *  \param max       Max match time
+     *  \param avg       Avg match time
+     *  \return          0 on success; -1 on error.
+     */
+    static int stat (void *h, int64_t &V, int64_t &E,int64_t &J,
+                     double &load, double &min, double &max, double &avg)
+    {
+        return -1;
+    }
+};
+
+} // namespace Flux::resource_model
+} // namespace Flux
+
+#endif // REAPI_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/hlapi/bindings/c++/reapi_cli.hpp
+++ b/resource/hlapi/bindings/c++/reapi_cli.hpp
@@ -1,0 +1,65 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef REAPI_CLI_HPP
+#define REAPI_CLI_HPP
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <cstdint>
+#include <cerrno>
+}
+
+#include "resource/hlapi/bindings/c++/reapi.hpp"
+
+namespace Flux {
+namespace resource_model {
+namespace detail {
+
+class reapi_cli_t : public reapi_t {
+public:
+    static int match_allocate (void *h, bool orelse_reserve,
+                               const std::string &jobspec,
+                               const uint64_t jobid, bool &reserved,
+                               std::string &R, int64_t &at, double &ov);
+    static int cancel (void *h, const int64_t jobid);
+    static int info (void *h, const int64_t jobid,
+                     bool &reserved, int64_t &at, double &ov);
+    static int stat (void *h, int64_t &V, int64_t &E,int64_t &J,
+                     double &load, double &min, double &max, double &avg);
+};
+
+
+} // namespace Flux::resource_model::detail
+} // namespace Flux::resource_model
+} // namespace Flux
+
+#endif // REAPI_MODULE_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/hlapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/hlapi/bindings/c++/reapi_cli_impl.hpp
@@ -1,0 +1,77 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef REAPI_CLI_IMPL_HPP
+#define REAPI_CLI_IMPL_HPP
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+}
+
+#include "resource/hlapi/bindings/c++/reapi_cli.hpp"
+
+namespace Flux {
+namespace resource_model {
+namespace detail {
+
+const int NOT_YET_IMPLEMENTED = -1;
+
+int reapi_cli_t::match_allocate (void *h, bool orelse_reserve,
+                                 const std::string &jobspec,
+                                 const uint64_t jobid, bool &reserved,
+                                 std::string &R, int64_t &at, double &ov)
+{
+    return NOT_YET_IMPLEMENTED;
+}
+
+int reapi_cli_t::cancel (void *h, const int64_t jobid)
+{
+    return NOT_YET_IMPLEMENTED;
+}
+
+int reapi_cli_t::info (void *h, const int64_t jobid,
+                       bool &reserved, int64_t &at, double &ov)
+{
+    return NOT_YET_IMPLEMENTED;
+}
+
+int reapi_cli_t::stat (void *h, int64_t &V, int64_t &E,int64_t &J,
+                       double &load, double &min, double &max, double &avg)
+{
+    return NOT_YET_IMPLEMENTED;
+}
+
+
+} // namespace Flux::resource_model::detail
+} // namespace Flux::resource_model
+} // namespace Flux
+
+#endif // REAPI_CLI_IMPL_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/hlapi/bindings/c++/reapi_module.hpp
+++ b/resource/hlapi/bindings/c++/reapi_module.hpp
@@ -1,0 +1,65 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef REAPI_MODULE_HPP
+#define REAPI_MODULE_HPP
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+}
+
+#include <cstdint>
+#include <string>
+#include "resource/hlapi/bindings/c++/reapi.hpp"
+
+namespace Flux {
+namespace resource_model {
+namespace detail {
+
+class reapi_module_t : public reapi_t {
+public:
+    static int match_allocate (void *h, bool orelse_reserve,
+                               const std::string &jobspec,
+                               const uint64_t jobid, bool &reserved,
+                               std::string &R, int64_t &at, double &ov);
+    static int cancel (void *h, const uint64_t jobid);
+    static int info (void *h, const uint64_t jobid,
+                     bool &reserved, int64_t &at, double &ov);
+    static int stat (void *h, int64_t &V, int64_t &E,int64_t &J,
+                     double &load, double &min, double &max, double &avg);
+};
+
+
+} // namespace Flux::resource_model::detail
+} // namespace Flux::resource_model
+} // namespace Flux
+
+#endif // REAPI_MODULE_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/hlapi/bindings/c++/reapi_module_impl.hpp
+++ b/resource/hlapi/bindings/c++/reapi_module_impl.hpp
@@ -1,0 +1,179 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef REAPI_MODULE_IMPL_HPP
+#define REAPI_MODULE_IMPL_HPP
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+}
+
+#include <cerrno>
+#include "resource/hlapi/bindings/c++/reapi_module.hpp"
+
+namespace Flux {
+namespace resource_model {
+namespace detail {
+
+int reapi_module_t::match_allocate (void *h, bool orelse_reserve,
+                                    const std::string &jobspec,
+                                    const uint64_t jobid, bool &reserved,
+                                    std::string &R, int64_t &at, double &ov)
+{
+    int rc = -1;
+    int64_t rj = -1;
+    flux_t *fh = (flux_t *)h;
+    flux_future_t *f = NULL;
+    const char *rset = NULL;
+    const char *status = NULL;
+    const char *cmd = (orelse_reserve)? "allocate_orelse_reserve"
+                                      : "allocate";
+
+    if (!fh || jobspec == "" || jobid > INT64_MAX) {
+        errno = EINVAL;
+        goto out;
+    }
+
+    if (!(f = flux_rpc_pack (fh, "resource.match", FLUX_NODEID_ANY, 0,
+                             "{s:s s:I s:s}",
+                             "cmd", cmd, "jobid", (const int64_t)jobid,
+                             "jobspec", jobspec.c_str ()))) {
+        goto out;
+    }
+
+    if (flux_rpc_get_unpack (f, "{s:I s:s s:f s:s s:I}",
+                             "jobid", &rj, "status", &status,
+                             "overhead", &ov, "R", &rset, "at", &at) < 0) {
+        goto out;
+    }
+    reserved = (std::string ("RESERVED") == status)? true : false;
+    R = rset;
+    if (rj != (int64_t)jobid) {
+        errno = EINVAL;
+        goto out;
+    }
+    rc = 0;
+
+out:
+    flux_future_destroy (f);
+    return rc;
+}
+
+int reapi_module_t::cancel (void *h, const uint64_t jobid)
+{
+    int rc = -1;
+    flux_t *fh = (flux_t *)h;
+    flux_future_t *f = NULL;
+
+    if (!fh || jobid > INT64_MAX) {
+        errno = EINVAL;
+        goto out;
+    }
+    if (!(f = flux_rpc_pack (fh, "resource.cancel", FLUX_NODEID_ANY, 0,
+                             "{s:I}", "jobid", (const int64_t)jobid))) {
+        goto out;
+    }
+    if ((rc = flux_rpc_get (f, NULL)) < 0) {
+        goto out;
+    }
+    rc = 0;
+
+out:
+    flux_future_destroy (f);
+    return rc;
+}
+
+int reapi_module_t::info (void *h, const uint64_t jobid,
+                          bool &reserved, int64_t &at, double &ov)
+{
+    int rc = -1;
+    int64_t rj = -1;
+    flux_t *fh = (flux_t *)h;
+    flux_future_t *f = NULL;
+    const char *status = NULL;
+
+    if (!fh || jobid > INT64_MAX) {
+        errno = EINVAL;
+        goto out;
+    }
+    if (!(f = flux_rpc_pack (fh, "resource.info", FLUX_NODEID_ANY, 0,
+                             "{s:I}", "jobid", (const int64_t)jobid))) {
+        goto out;
+    }
+    if (flux_rpc_get_unpack (f, "{s:I s:s s:I s:f}",
+                             "jobid", &rj, "status", &status,
+                             "at", &at, "overhead", &ov) < 0) {
+        goto out;
+    }
+    reserved = (std::string ("RESERVED") == status)? true : false;
+    if (rj != (int64_t)jobid) {
+        errno = EINVAL;
+        goto out;
+    }
+    rc = 0;
+
+out:
+    flux_future_destroy (f);
+    return rc;
+}
+
+int reapi_module_t::stat (void *h, int64_t &V, int64_t &E,int64_t &J,
+                          double &load, double &min, double &max, double &avg)
+{
+    int rc = -1;
+    flux_t *fh = (flux_t *)h;
+    flux_future_t *f = NULL;
+
+    if (!fh) {
+        errno = EINVAL;
+        goto out;
+    }
+
+    if (!(f = flux_rpc (fh, "resource.stat", NULL, FLUX_NODEID_ANY, 0))) {
+        goto out;
+    }
+    if ((rc = flux_rpc_get_unpack (f, "{s:I s:I s:f s:I s:f s:f s:f}",
+                                   "V", &V, "E", &E, "load-time", &load,
+                                   "njobs", &J, "min-match", &min,
+                                   "max-match", &max, "avg-match", &avg)) < 0) {
+        goto out;
+    }
+
+out:
+    flux_future_destroy (f);
+    return rc;
+}
+
+} // namespace Flux::resource_model::detail
+} // namespace Flux::resource_model
+} // namespace Flux
+
+#endif // REAPI_MODULE_IMPL_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/hlapi/bindings/c/Makefile.am
+++ b/resource/hlapi/bindings/c/Makefile.am
@@ -1,0 +1,29 @@
+AM_CXXFLAGS = \
+    $(WARNING_CXXFLAGS) \
+    $(CODE_COVERAGE_CXXFLAGS)
+
+AM_CFLAGS = \
+    $(WARNING_CFLAGS) \
+    $(CODE_COVERAGE_CFLAGS)
+
+AM_CPPFLAGS = \
+    -I$(top_srcdir) $(CZMQ_CFLAGS) $(FLUX_CORE_CFLAGS)
+
+AM_LDFLAGS = \
+    $(CODE_COVERAGE_LIBS)
+
+noinst_LTLIBRARIES = libreapi_cli.la libreapi_module.la
+
+libreapi_cli_la_SOURCES = \
+    reapi_cli.cpp \
+    reapi_cli.h \
+    $(top_srcdir)/resource/hlapi/bindings/c++/reapi.hpp \
+    $(top_srcdir)/resource/hlapi/bindings/c++/reapi_cli.hpp \
+    $(top_srcdir)/resource/hlapi/bindings/c++/reapi_cli_impl.hpp
+
+libreapi_module_la_SOURCES = \
+    reapi_module.cpp \
+    reapi_module.h \
+    $(top_srcdir)/resource/hlapi/bindings/c++/reapi.hpp \
+    $(top_srcdir)/resource/hlapi/bindings/c++/reapi_module.hpp \
+    $(top_srcdir)/resource/hlapi/bindings/c++/reapi_module_impl.hpp

--- a/resource/hlapi/bindings/c/reapi_cli.cpp
+++ b/resource/hlapi/bindings/c/reapi_cli.cpp
@@ -1,0 +1,137 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include "resource/hlapi/bindings/c/reapi_cli.h"
+}
+
+#include <cstdlib>
+#include <cstdint>
+#include <cerrno>
+#include "resource/hlapi/bindings/c++/reapi_cli.hpp"
+#include "resource/hlapi/bindings/c++/reapi_cli_impl.hpp"
+
+using namespace Flux;
+using namespace Flux::resource_model;
+using namespace Flux::resource_model::detail;
+
+struct reapi_cli_ctx {
+    flux_t *h;
+};
+
+extern "C" reapi_cli_ctx_t *reapi_cli_new ()
+{
+    reapi_cli_ctx_t *ctx = NULL;
+    if (!(ctx = (reapi_cli_ctx_t *)malloc (sizeof (*ctx)))) {
+        errno = ENOMEM;
+        goto out;
+    }
+    ctx->h = NULL;
+out:
+    return ctx;
+}
+
+extern "C" void reapi_cli_destroy (reapi_cli_ctx_t *ctx)
+{
+    free (ctx);
+}
+
+extern "C" int reapi_cli_match_allocate (reapi_cli_ctx_t *ctx,
+                   bool orelse_reserve, const char *jobspec,
+                   const uint64_t jobid, bool *reserved,
+                   char **R, int64_t *at, double *ov)
+{
+    int rc = -1;
+    std::string R_buf = "";
+    if (!ctx || !ctx->h) {
+        errno = EINVAL;
+        goto out;
+    }
+    if ((rc = reapi_cli_t::match_allocate (ctx->h, orelse_reserve, jobspec,
+                                           jobid, *reserved,
+                                           R_buf, *at, *ov)) < 0) {
+        goto out;
+    }
+    (*R) = strdup (R_buf.c_str ());
+
+out:
+    return rc;
+}
+
+extern "C" int reapi_cli_cancel (reapi_cli_ctx_t *ctx, const uint64_t jobid)
+{
+    if (!ctx || !ctx->h) {
+        errno = EINVAL;
+        return -1;
+    }
+    return reapi_cli_t::cancel (ctx->h, jobid);    
+}
+
+extern "C" int reapi_cli_info (reapi_cli_ctx_t *ctx, const uint64_t jobid,
+                               bool *reserved, int64_t *at, double *ov)
+{
+    if (!ctx || !ctx->h) {
+        errno = EINVAL;
+        return -1;
+    }
+    return reapi_cli_t::info (ctx->h, jobid, *reserved, *at, *ov);
+}
+
+extern "C" int reapi_cli_stat (reapi_cli_ctx_t *ctx, int64_t *V,
+                               int64_t *E, int64_t *J, double *load,
+                               double *min, double *max, double *avg)
+{
+    if (!ctx || !ctx->h) {
+        errno = EINVAL;
+        return -1;
+    }
+    return reapi_cli_t::stat (ctx->h, *V, *E, *J, *load, *min, *max, *avg);
+}
+
+extern "C" int reapi_cli_set_handle (reapi_cli_ctx_t *ctx, void *handle)
+{
+    if (!ctx) {
+        errno = EINVAL;
+        return -1;
+    }
+    ctx->h = (flux_t *)handle;
+    return 0;
+}
+
+extern "C" void *reapi_cli_get_handle (reapi_cli_ctx_t *ctx)
+{
+    if (!ctx) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return ctx->h;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/hlapi/bindings/c/reapi_cli.h
+++ b/resource/hlapi/bindings/c/reapi_cli.h
@@ -1,0 +1,142 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef REAPI_CLI_H
+#define REAPI_CLI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+typedef struct reapi_cli_ctx reapi_cli_ctx_t;
+
+/*! Create and initialize reapi_cli context
+ */
+reapi_cli_ctx_t *reapi_cli_new ();
+
+/*! Destroy reapi cli context
+ *
+ * \param ctx           reapi_cli_ctx_t context object
+ */
+void reapi_cli_destroy (reapi_cli_ctx_t *ctx);
+
+/*! Match a jobspec to the "best" resources and either allocate
+ *  orelse reserve them. The best resources are determined by
+ *  the selected match policy.
+ *
+ *  \param ctx       reapi_cli_ctx_t context object
+ *  \param orelse_reserve
+ *                   Boolean: if false, only allocate; otherwise, first try
+ *                   to allocate and if that fails, reserve.
+ *  \param jobspec   jobspec string.
+ *  \param jobid     jobid of the uint64_t type.
+ *  \param reserved  Boolean into which to return true if this job has been
+ *                   reserved instead of allocated.
+ *  \param R         String into which to return the resource set either
+ *                   allocated or reserved.
+ *  \param at        If allocated, 0 is returned; if reserved, actual time
+ *                   at which the job is reserved.
+ *  \param ov        Double into which to return performance overhead
+ *                   in terms of elapse time needed to complete
+ *                   the match operation.
+ *  \return          0 on success; -1 on error.
+ */
+int reapi_cli_match_allocate (reapi_cli_ctx_t *ctx, bool orelse_reserve,
+                              const char *jobspec, const uint64_t jobid,
+                              bool *reserved,
+                              char **R, int64_t *at, double *ov);
+
+/*! Cancel the allocation or reservation corresponding to jobid.
+ *
+ *  \param ctx       reapi_cli_ctx_t context object
+ *  \param jobid     jobid of the uint64_t type.
+ *  \return          0 on success; -1 on error.
+ */
+int reapi_cli_cancel (reapi_cli_ctx_t *ctx, const uint64_t jobid);
+
+/*! Get the information on the allocation or reservation corresponding
+ *  to jobid.
+ *
+ *  \param ctx       reapi_cli_ctx_t context object
+ *  \param jobid     const jobid of the uint64_t type.
+ *  \param reserved  Boolean into which to return true if this job has been
+ *                   reserved instead of allocated.
+ *  \param at        If allocated, 0 is returned; if reserved, actual time
+ *                   at which the job is reserved.
+ *  \param ov        Double into which to return performance overhead
+ *                   in terms of elapse time needed to complete
+ *                   the match operation.
+ *  \return          0 on success; -1 on error.
+ */
+int reapi_cli_info (reapi_cli_ctx_t *ctx, const uint64_t jobid,
+                    bool *reserved, int64_t *at, double *ov);
+
+/*! Get the performance information about the resource infrastructure.
+ *
+ *  \param ctx       reapi_cli_ctx_t context object
+ *  \param V         Number of resource vertices
+ *  \param E         Number of edges
+ *  \param J         Number of jobs
+ *  \param load      Graph load time
+ *  \param min       Min match time
+ *  \param max       Max match time
+ *  \param avg       Avg match time
+ *  \return          0 on success; -1 on error.
+ */
+int reapi_cli_stat (reapi_cli_ctx_t *ctx, int64_t *V, int64_t *E,
+                    int64_t *J, double *load,
+                    double *min, double *max, double *avg);
+
+/*! Set the opaque handle to the reapi cli context.
+ *
+ *  \param ctx       reapi_cli_ctx_t context object
+ *  \param h         Opaque handle. How it is used is an implementation
+ *                   detail. However, when it is used within a Flux's
+ *                   service cli, it is expected to be a pointer
+ *                   to a flux_t object.
+ *  \return          0 on success; -1 on error.
+ */
+int reapi_cli_set_handle (reapi_cli_ctx_t *ctx, void *handle);
+
+/*! Set the opaque handle to the reapi cli context.
+ *
+ *  \param ctx       reapi_cli_ctx_t context object
+ *  \return          handle
+ */
+void *reapi_cli_get_handle (reapi_cli_ctx_t *ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // REAPI_CLI_H
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/hlapi/bindings/c/reapi_module.cpp
+++ b/resource/hlapi/bindings/c/reapi_module.cpp
@@ -1,0 +1,137 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include "resource/hlapi/bindings/c/reapi_module.h"
+}
+
+#include <cstdlib>
+#include <cstdint>
+#include <cerrno>
+#include "resource/hlapi/bindings/c++/reapi_module.hpp"
+#include "resource/hlapi/bindings/c++/reapi_module_impl.hpp"
+
+using namespace Flux;
+using namespace Flux::resource_model;
+using namespace Flux::resource_model::detail;
+
+struct reapi_module_ctx {
+    flux_t *h;
+};
+
+extern "C" reapi_module_ctx_t *reapi_module_new ()
+{
+    reapi_module_ctx_t *ctx = NULL;
+    if (!(ctx = (reapi_module_ctx_t *)malloc (sizeof (*ctx)))) {
+        errno = ENOMEM;
+        goto out;
+    }
+    ctx->h = NULL;
+out:
+    return ctx;
+}
+
+extern "C" void reapi_module_destroy (reapi_module_ctx_t *ctx)
+{
+    free (ctx);
+}
+
+extern "C" int reapi_module_match_allocate (reapi_module_ctx_t *ctx,
+                   bool orelse_reserve, const char *jobspec,
+                   const uint64_t jobid, bool *reserved,
+                   char **R, int64_t *at, double *ov)
+{
+    int rc = -1;
+    std::string R_buf = "";
+    if (!ctx || !ctx->h) {
+        errno = EINVAL;
+        goto out;
+    }
+    if ((rc = reapi_module_t::match_allocate (ctx->h, orelse_reserve, jobspec,
+                                              jobid, *reserved,
+                                              R_buf, *at, *ov)) < 0) {
+        goto out;
+    }
+    (*R) = strdup (R_buf.c_str ());
+
+out:
+    return rc;
+}
+
+extern "C" int reapi_module_cancel (reapi_module_ctx_t *ctx, const uint64_t jobid)
+{
+    if (!ctx || !ctx->h) {
+        errno = EINVAL;
+        return -1;
+    }
+    return reapi_module_t::cancel (ctx->h, jobid);    
+}
+
+extern "C" int reapi_module_info (reapi_module_ctx_t *ctx, const uint64_t jobid,
+                                  bool *reserved, int64_t *at, double *ov)
+{
+    if (!ctx || !ctx->h) {
+        errno = EINVAL;
+        return -1;
+    }
+    return reapi_module_t::info (ctx->h, jobid, *reserved, *at, *ov);
+}
+
+extern "C" int reapi_module_stat (reapi_module_ctx_t *ctx, int64_t *V,
+                                  int64_t *E, int64_t *J, double *load,
+                                  double *min, double *max, double *avg)
+{
+    if (!ctx || !ctx->h) {
+        errno = EINVAL;
+        return -1;
+    }
+    return reapi_module_t::stat (ctx->h, *V, *E, *J, *load, *min, *max, *avg);
+}
+
+extern "C" int reapi_module_set_handle (reapi_module_ctx_t *ctx, void *handle)
+{
+    if (!ctx) {
+        errno = EINVAL;
+        return -1;
+    }
+    ctx->h = (flux_t *)handle;
+    return 0;
+}
+
+extern "C" void *reapi_module_get_handle (reapi_module_ctx_t *ctx)
+{
+    if (!ctx) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return ctx->h;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/hlapi/bindings/c/reapi_module.h
+++ b/resource/hlapi/bindings/c/reapi_module.h
@@ -1,0 +1,142 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef REAPI_MODULE_H
+#define REAPI_MODULE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+typedef struct reapi_module_ctx reapi_module_ctx_t;
+
+/*! Create and initialize reapi_module context
+ */
+reapi_module_ctx_t *reapi_module_new ();
+
+/*! Destroy reapi module context
+ *
+ * \param ctx           reapi_module_ctx_t context object
+ */
+void reapi_module_destroy (reapi_module_ctx_t *ctx);
+
+/*! Match a jobspec to the "best" resources and either allocate
+ *  orelse reserve them. The best resources are determined by
+ *  the selected match policy.
+ *
+ *  \param ctx       reapi_module_ctx_t context object
+ *  \param orelse_reserve
+ *                   Boolean: if false, only allocate; otherwise, first try
+ *                   to allocate and if that fails, reserve.
+ *  \param jobspec   jobspec string.
+ *  \param jobid     jobid of the uint64_t type.
+ *  \param reserved  Boolean into which to return true if this job has been
+ *                   reserved instead of allocated.
+ *  \param R         String into which to return the resource set either
+ *                   allocated or reserved.
+ *  \param at        If allocated, 0 is returned; if reserved, actual time
+ *                   at which the job is reserved.
+ *  \param ov        Double into which to return performance overhead
+ *                   in terms of elapse time needed to complete
+ *                   the match operation.
+ *  \return          0 on success; -1 on error.
+ */
+int reapi_module_match_allocate (reapi_module_ctx_t *ctx, bool orelse_reserve,
+                                 const char *jobspec, const uint64_t jobid,
+                                 bool *reserved,
+                                 char **R, int64_t *at, double *ov);
+
+/*! Cancel the allocation or reservation corresponding to jobid.
+ *
+ *  \param ctx       reapi_module_ctx_t context object
+ *  \param jobid     jobid of the uint64_t type.
+ *  \return          0 on success; -1 on error.
+ */
+int reapi_module_cancel (reapi_module_ctx_t *ctx, const uint64_t jobid);
+
+/*! Get the information on the allocation or reservation corresponding
+ *  to jobid.
+ *
+ *  \param ctx       reapi_module_ctx_t context object
+ *  \param jobid     const jobid of the uint64_t type.
+ *  \param reserved  Boolean into which to return true if this job has been
+ *                   reserved instead of allocated.
+ *  \param at        If allocated, 0 is returned; if reserved, actual time
+ *                   at which the job is reserved.
+ *  \param ov        Double into which to return performance overhead
+ *                   in terms of elapse time needed to complete
+ *                   the match operation.
+ *  \return          0 on success; -1 on error.
+ */
+int reapi_module_info (reapi_module_ctx_t *ctx, const uint64_t jobid,
+                       bool *reserved, int64_t *at, double *ov);
+
+/*! Get the performance information about the resource infrastructure.
+ *
+ *  \param ctx       reapi_module_ctx_t context object
+ *  \param V         Number of resource vertices
+ *  \param E         Number of edges
+ *  \param J         Number of jobs
+ *  \param load      Graph load time
+ *  \param min       Min match time
+ *  \param max       Max match time
+ *  \param avg       Avg match time
+ *  \return          0 on success; -1 on error.
+ */
+int reapi_module_stat (reapi_module_ctx_t *ctx, int64_t *V, int64_t *E,
+                       int64_t *J, double *load,
+                       double *min, double *max, double *avg);
+
+/*! Set the opaque handle to the reapi module context.
+ *
+ *  \param ctx       reapi_module_ctx_t context object
+ *  \param h         Opaque handle. How it is used is an implementation
+ *                   detail. However, when it is used within a Flux's
+ *                   service module, it is expected to be a pointer
+ *                   to a flux_t object.
+ *  \return          0 on success; -1 on error.
+ */
+int reapi_module_set_handle (reapi_module_ctx_t *ctx, void *handle);
+
+/*! Set the opaque handle to the reapi module context.
+ *
+ *  \param ctx       reapi_module_ctx_t context object
+ *  \return          handle
+ */
+void *reapi_module_get_handle (reapi_module_ctx_t *ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // REAPI_MODULE_H
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/libjobspec/jobspec.hpp
+++ b/resource/libjobspec/jobspec.hpp
@@ -97,13 +97,36 @@ public:
     Task(const YAML::Node&);
 };
 
+struct System {
+    double duration = 0.0f;
+    std::string cwd = "";
+    std::unordered_map<std::string, std::string> environment;
+    std::unordered_map<std::string, YAML::Node> optional;
+
+    System() = default;
+    System(const System &s) = delete; // Force to use move ctor
+    System(System &&s) = default;
+    System& operator=(const System &&a) = delete; // Force to use move operator=
+    System& operator=(System &&a) = default;
+};
+
+struct Attributes {
+    YAML::Node user;
+    System system;
+
+    Attributes() = default;
+    Attributes(const Attributes &a) = delete; // Force to use move ctor
+    Attributes(Attributes &&a) = default;
+    Attributes& operator=(const Attributes &&a) = delete;
+    Attributes& operator=(Attributes &&a) = default;
+};
+
 class Jobspec {
 public:
     unsigned int version;
     std::vector<Resource> resources;
     std::vector<Task> tasks;
-    std::unordered_map<std::string,
-        std::unordered_map<std::string, std::string>> attributes;
+    Attributes attributes;
 
     Jobspec() = default;
     Jobspec(const YAML::Node&);

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -28,6 +28,7 @@
 #include <iostream>
 #include <sstream>
 #include <cstdlib>
+#include <cstdint>
 #include "resource/libjobspec/jobspec.hpp"
 #include "resource/config/system_defaults.hpp"
 #include "resource/schema/resource_data.hpp"
@@ -60,13 +61,11 @@ struct jobmeta_t {
         at = t;
         jobid = id;
         allocate = alloc;
-        std::string system_key = "system";
-        std::string duration_key = "duration";
-        auto i = jobspec.attributes.find (system_key);
-        if (i->second.find (duration_key) != i->second.end ()) {
-            auto j = i->second.find (duration_key);
-            duration = (uint64_t)std::atoll (j->second.c_str ());
-        }
+        if (jobspec.attributes.system.duration == 0.0f
+            || jobspec.attributes.system.duration > (double)UINT64_MAX)
+            duration = SYSTEM_MAX_DURATION; // need config support ultimately
+        else
+            duration = (int64_t)jobspec.attributes.system.duration;
     }
 };
 

--- a/resource/writers/match_writers.cpp
+++ b/resource/writers/match_writers.cpp
@@ -232,7 +232,7 @@ void rlite_match_writers_t::emit_vtx (const string &prefix,
         if (m_reducer_set ()) {
             stringstream &gout = *(m_gatherer[g[u].type]);
             gout << "{";
-            gout << "\"rank\":" << g[u].rank << ",";
+            gout << "\"rank\":\"" << g[u].rank << "\",";
             gout << "\"node\":\"" << g[u].name << "\",";
             gout << "\"children\":{";
             for (auto &kv : m_reducer) {
@@ -266,15 +266,18 @@ void rv1_match_writers_t::reset ()
 
 void rv1_match_writers_t::emit (stringstream &out)
 {
+    string ver = "\"version\":1";
     string exec_key = "\"execution\":";
     string sched_key = "\"scheduling\":";
     size_t base = out.str ().size ();
-    out << "{" << exec_key;
+    out << "{" << ver;
+    out << "," << exec_key;
     rlite.emit (out, false);
     out << "," << sched_key;
     jgf.emit (out, false);
     out << "}" << endl;
-    if (out.str ().size () <= (base + exec_key.size () + sched_key.size () + 3))
+    if (out.str ().size () <= (base + ver.size () + exec_key.size ()
+                                    + sched_key.size () + 4))
         out.str (out.str ().substr (0, base));
 }
 
@@ -310,12 +313,14 @@ void rv1_nosched_match_writers_t::reset ()
 
 void rv1_nosched_match_writers_t::emit (stringstream &out)
 {
+    string ver = "\"version\":1";
     string exec_key = "\"execution\":";
     size_t base = out.str ().size ();
-    out << "{" << exec_key;
+    out << "{" << ver;
+    out << "," << exec_key;
     rlite.emit (out, false);
     out << "}" << endl;
-    if (out.str ().size () <= (base + exec_key.size () + 2))
+    if (out.str ().size () <= (base + ver.size () + exec_key.size () + 3))
         out.str (out.str ().substr (0, base));
 }
 
@@ -506,7 +511,8 @@ void pretty_rlite_match_writers_t::emit_vtx (const string &prefix,
         if (m_reducer_set ()) {
             stringstream &gout = *(m_gatherer[g[u].type]);
             gout << indent << "    {" << endl;
-            gout << indent << "      \"rank\": " << g[u].rank << "," << endl;
+            gout << indent << "      \"rank\": " << "\"" << g[u].rank << "\""
+                                                         << "," << endl;
             gout << indent << "      \"node\": \"" << g[u].name << "\","
                  << endl;
             gout << indent << "      \"children\": {" << endl;

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = libtap libutil librbtree
+SUBDIRS = libtap libutil librbtree libschedutil

--- a/src/common/libschedutil/Makefile.am
+++ b/src/common/libschedutil/Makefile.am
@@ -1,0 +1,26 @@
+AM_CFLAGS = \
+    $(WARNING_CFLAGS) \
+    $(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+    $(CODE_COVERAGE_LDFLAGS)
+
+AM_CPPFLAGS = \
+    $(FLUX_CORE_CFLAGS) \
+    $(ZMQ_CFLAGS)
+
+noinst_LTLIBRARIES = \
+    libschedutil.la
+
+libschedutil_la_SOURCES = \
+    schedutil.h \
+    hello.h \
+    hello.c \
+    ready.h \
+    ready.c \
+    ops.h \
+    ops.c \
+    alloc.h \
+    alloc.c \
+    free.h \
+    free.c

--- a/src/common/libschedutil/alloc.c
+++ b/src/common/libschedutil/alloc.c
@@ -1,0 +1,153 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "alloc.h"
+
+int schedutil_alloc_request_decode (const flux_msg_t *msg,
+                                    flux_jobid_t *id,
+                                    int *priority,
+                                    uint32_t *userid,
+                                    double *t_submit)
+{
+    return flux_request_unpack (msg, NULL, "{s:I s:i s:i s:f}",
+                                           "id", id,
+                                           "priority", priority,
+                                           "userid", userid,
+                                           "t_submit", t_submit);
+}
+
+static int schedutil_alloc_respond (flux_t *h, const flux_msg_t *msg,
+                                    int type, const char *note)
+{
+    flux_jobid_t id;
+    int rc;
+
+    if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0)
+        return -1;
+    if (note)
+        rc = flux_respond_pack (h, msg, "{s:I s:i s:s}",
+                                        "id", id,
+                                        "type", type,
+                                        "note", note);
+    else
+        rc = flux_respond_pack (h, msg, "{s:I s:i}",
+                                        "id", id,
+                                        "type", type);
+    return rc;
+}
+
+int schedutil_alloc_respond_note (flux_t *h, const flux_msg_t *msg,
+                                  const char *note)
+{
+    return schedutil_alloc_respond (h, msg, 1, note);
+}
+
+int schedutil_alloc_respond_denied (flux_t *h, const flux_msg_t *msg,
+                                    const char *note)
+{
+    return schedutil_alloc_respond (h, msg, 2, note);
+}
+
+struct alloc {
+    char *note;
+    flux_msg_t *msg;
+    flux_kvs_txn_t *txn;
+};
+
+static void alloc_destroy (struct alloc *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;
+        flux_kvs_txn_destroy (ctx->txn);
+        flux_msg_destroy (ctx->msg);
+        free (ctx->note);
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+static struct alloc *alloc_create (const flux_msg_t *msg, const char *R,
+                                   const char *note)
+{
+    struct alloc *ctx;
+    flux_jobid_t id;
+    char key[64];
+
+    if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0)
+        return NULL;
+    if (flux_job_kvs_key (key, sizeof (key), id, "R") < 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(ctx = calloc (1, sizeof (*ctx))))
+        return NULL;
+    if (!(ctx->msg = flux_msg_copy (msg, true)))
+        goto error;
+    if (note && !(ctx->note = strdup (note)))
+        goto error;
+    if (!(ctx->txn = flux_kvs_txn_create ()))
+        goto error;
+    if (flux_kvs_txn_put (ctx->txn, 0, key, R) < 0)
+        goto error;
+    return ctx;
+error:
+    alloc_destroy (ctx);
+    return NULL;
+}
+
+static void alloc_continuation (flux_future_t *f, void *arg)
+{
+    flux_t *h = flux_future_get_flux (f);
+    struct alloc *ctx = arg;
+
+    if (flux_future_get (f, NULL) < 0) {
+        flux_log_error (h, "commit R");
+        goto error;
+    }
+    if (schedutil_alloc_respond (h, ctx->msg, 0, ctx->note) < 0) {
+        flux_log_error (h, "alloc response");
+        goto error;
+    }
+    alloc_destroy (ctx);
+    flux_future_destroy (f);
+    return;
+error:
+    flux_reactor_stop_error (flux_get_reactor (h)); // XXX
+    alloc_destroy (ctx);
+    flux_future_destroy (f);
+}
+
+int schedutil_alloc_respond_R (flux_t *h, const flux_msg_t *msg,
+                               const char *R, const char *note)
+{
+    struct alloc *ctx;
+    flux_future_t *f;
+
+    if (!(ctx = alloc_create (msg, R, note)))
+        return -1;
+    if (!(f = flux_kvs_commit (h, NULL, 0, ctx->txn)))
+        goto error;
+    if (flux_future_then (f, -1, alloc_continuation, ctx) < 0)
+        goto error;
+    return 0;
+error:
+    alloc_destroy (ctx);
+    flux_future_destroy (f);
+    return -1;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libschedutil/alloc.h
+++ b/src/common/libschedutil/alloc.h
@@ -1,0 +1,53 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_SCHEDUTIL_ALLOC_H
+#define _FLUX_SCHEDUTIL_ALLOC_H
+
+#include <stdint.h>
+#include <flux/core.h>
+
+/* Decode an alloc request message.
+ * Return 0 on success, -1 on error with errno set.
+ */
+int schedutil_alloc_request_decode (const flux_msg_t *msg,
+                                    flux_jobid_t *id,
+                                    int *priority,
+                                    uint32_t *userid,
+                                    double *t_submit);
+
+/* Respond to alloc request message - update annotation.
+ * A job's annotation may be updated any number of times before alloc request
+ * is finally terminated with alloc_respond_denied() or alloc_respond_R().
+ * Return 0 on success, -1 on error with errno set.
+ */
+int schedutil_alloc_respond_note (flux_t *h, const flux_msg_t *msg,
+                                  const char *note);
+
+/* Respond to alloc request message - the job cannot run.
+ * Include human readable error message in 'note'.
+ * Return 0 on success, -1 on error with errno set.
+ */
+int schedutil_alloc_respond_denied (flux_t *h, const flux_msg_t *msg,
+                                    const char *note);
+
+/* Respond to alloc request message - allocate R.
+ * R is committed to the KVS first, then the response is sent.
+ * If something goes wrong after this function returns, the reactor is stopped.
+ */
+int schedutil_alloc_respond_R (flux_t *h, const flux_msg_t *msg,
+                               const char *R, const char *note);
+
+
+#endif /* !_FLUX_SCHEDUTIL_ALLOC_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libschedutil/free.c
+++ b/src/common/libschedutil/free.c
@@ -1,0 +1,35 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "free.h"
+
+
+int schedutil_free_request_decode (const flux_msg_t *msg, flux_jobid_t *id)
+{
+    return flux_request_unpack (msg, NULL, "{s:I}", "id", id);
+}
+
+int schedutil_free_respond (flux_t *h, const flux_msg_t *msg)
+{
+    flux_jobid_t id;
+
+    if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0)
+        return -1;
+    return flux_respond_pack (h, msg, "{s:I}", "id", id);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libschedutil/free.h
+++ b/src/common/libschedutil/free.h
@@ -1,0 +1,29 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_SCHEDUTIL_FREE_H
+#define _FLUX_SCHEDUTIL_FREE_H
+
+#include <flux/core.h>
+
+/* Decode a free request.
+ * Returns 0 on success, -1 on failure with errno set.
+ */
+int schedutil_free_request_decode (const flux_msg_t *msg, flux_jobid_t *id);
+
+/* Respond to a free request.
+ */
+int schedutil_free_respond (flux_t *h, const flux_msg_t *msg);
+
+#endif /* !_FLUX_SCHEDUTIL_FREE_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libschedutil/hello.c
+++ b/src/common/libschedutil/hello.c
@@ -1,0 +1,75 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <jansson.h>
+
+#include "hello.h"
+
+static int schedutil_hello_job (flux_t *h, flux_jobid_t id,
+                                hello_f *cb, void *arg)
+{
+    char key[64];
+    flux_future_t *f;
+    const char *s;
+
+    if (flux_job_kvs_key (key, sizeof (key), id, "R") < 0) {
+        errno = EPROTO;
+        return -1;
+    }
+    if (!(f = flux_kvs_lookup (h, NULL, 0, key)))
+        return -1;
+    if (flux_kvs_lookup_get (f, &s) < 0)
+        goto error;
+    if (cb (h, s, arg) < 0)
+        goto error;
+    flux_future_destroy (f);
+    return 0;
+error:
+    flux_log_error (h, "hello: error loading R for id=%llu",
+                    (unsigned long long)id);
+    flux_future_destroy (f);
+    return -1;
+}
+
+int schedutil_hello (flux_t *h, hello_f *cb, void *arg)
+{
+    flux_future_t *f;
+    json_t *ids;
+    json_t *id;
+    size_t index;
+
+    if (!h || !cb) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(f = flux_rpc (h, "job-manager.sched-hello",
+                        NULL, FLUX_NODEID_ANY, 0)))
+        return -1;
+    if (flux_rpc_get_unpack (f, "{s:o}", "alloc", &ids) < 0)
+        goto error;
+    json_array_foreach (ids, index, id) {
+        flux_jobid_t jobid = json_integer_value (id);
+        if (schedutil_hello_job (h, jobid, cb, arg) < 0)
+            goto error;
+    }
+    flux_future_destroy (f);
+    return 0;
+error:
+    flux_future_destroy (f);
+    return -1;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libschedutil/hello.h
+++ b/src/common/libschedutil/hello.h
@@ -1,0 +1,33 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_SCHEDUTIL_HELLO_H
+#define _FLUX_SCHEDUTIL_HELLO_H
+
+#include <flux/core.h>
+
+/* Callback for ingesting allocated R's.
+ * Return 0 on success, -1 on failure with errno set.
+ * Failure of the callback aborts iteration and causes schedutil_hello()
+ * to return -1 with errno passed through.
+ */
+typedef int (hello_f)(flux_t *h, const char *R, void *arg);
+
+/* Send hello announcement to job-manager.
+ * The job-manager responds with a list of jobs that have resources assigned.
+ * This function looks up R for each job and passes it 'cb' with 'arg'.
+ */
+int schedutil_hello (flux_t *h, hello_f *cb, void *arg);
+
+#endif /* !_FLUX_SCHEDUTIL_HELLO_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libschedutil/ops.c
+++ b/src/common/libschedutil/ops.c
@@ -1,0 +1,247 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <flux/core.h>
+#include <jansson.h>
+
+#include "ops.h"
+
+struct ops_context {
+    flux_t *h;
+    flux_msg_handler_t **handlers;
+    op_alloc_f *alloc_cb;
+    op_free_f *free_cb;
+    op_exception_f *exception_cb;
+    void *arg;
+};
+
+static void alloc_continuation (flux_future_t *f, void *arg)
+{
+    struct ops_context *ctx = arg;
+    flux_msg_t *msg = flux_future_aux_get (f, "flux::alloc_request");
+    const char *jobspec;
+
+    if (flux_kvs_lookup_get (f, &jobspec) < 0) {
+        flux_log_error (ctx->h, "sched.free lookup R");
+        goto error;
+    }
+    ctx->alloc_cb (ctx->h, msg, jobspec, ctx->arg);
+    flux_future_destroy (f);
+    return;
+error:
+    flux_log_error (ctx->h, "sched.alloc");
+    if (flux_respond_error (ctx->h, msg, errno, NULL) < 0)
+        flux_log_error (ctx->h, "sched.alloc respond_error");
+    flux_future_destroy (f);
+}
+
+static void alloc_cb (flux_t *h, flux_msg_handler_t *mh,
+                      const flux_msg_t *msg, void *arg)
+{
+    struct ops_context *ctx = arg;
+    flux_jobid_t id;
+    char key[64];
+    flux_future_t *f;
+    flux_msg_t *cpy;
+
+    if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0)
+        goto error;
+    if (flux_job_kvs_key (key, sizeof (key), id, "jobspec") < 0) {
+        errno = EPROTO;
+        goto error;
+    }
+    if (!(f = flux_kvs_lookup (h, NULL, 0, key)))
+        goto error;
+    if (!(cpy = flux_msg_copy (msg, true)))
+        goto error_future;
+    if (flux_future_aux_set (f, "flux::alloc_request",
+                             cpy, (flux_free_f)flux_msg_destroy) < 0) {
+        flux_msg_destroy (cpy);
+        goto error_future;
+    }
+    if (flux_future_then (f, -1, alloc_continuation, ctx) < 0)
+        goto error_future;
+    return;
+error_future:
+    flux_future_destroy (f);
+error:
+    flux_log_error (h, "sched.alloc");
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "sched.alloc respond_error");
+}
+
+static void free_continuation (flux_future_t *f, void *arg)
+{
+    struct ops_context *ctx = arg;
+    flux_msg_t *msg = flux_future_aux_get (f, "flux::free_request");
+    const char *R;
+
+    if (flux_kvs_lookup_get (f, &R) < 0) {
+        flux_log_error (ctx->h, "sched.free lookup R");
+        goto error;
+    }
+    ctx->free_cb (ctx->h, msg, R, ctx->arg);
+    flux_future_destroy (f);
+    return;
+error:
+    flux_log_error (ctx->h, "sched.alloc");
+    if (flux_respond_error (ctx->h, msg, errno, NULL) < 0)
+        flux_log_error (ctx->h, "sched.free respond_error");
+    flux_future_destroy (f);
+}
+
+static void free_cb (flux_t *h, flux_msg_handler_t *mh,
+                     const flux_msg_t *msg, void *arg)
+{
+    struct ops_context *ctx = arg;
+    flux_jobid_t id;
+    flux_future_t *f;
+    char key[64];
+    flux_msg_t *cpy;
+
+    if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0)
+        goto error;
+    if (flux_job_kvs_key (key, sizeof (key), id, "R") < 0) {
+        errno = EPROTO;
+        goto error;
+    }
+    if (!(f = flux_kvs_lookup (h, NULL, 0, key)))
+        goto error;
+    if (!(cpy = flux_msg_copy (msg, true)))
+        goto error_future;
+    if (flux_future_aux_set (f, "flux::free_request",
+                             cpy, (flux_free_f)flux_msg_destroy) < 0) {
+        flux_msg_destroy (cpy);
+        goto error_future;
+    }
+    if (flux_future_then (f, -1, free_continuation, ctx) < 0)
+        goto error_future;
+    return;
+error_future:
+    flux_future_destroy (f);
+error:
+    flux_log_error (h, "sched.free");
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "sched.free respond_error");
+}
+
+static void exception_cb (flux_t *h, flux_msg_handler_t *mh,
+                          const flux_msg_t *msg, void *arg)
+{
+    struct ops_context *ctx = arg;
+    flux_jobid_t id;
+    const char *type;
+    int severity;
+
+    if (flux_event_unpack (msg, NULL, "{s:I s:s s:i}",
+                                      "id", &id,
+                                      "type", &type,
+                                      "severity", &severity) < 0) {
+        flux_log_error (h, "job-exception event");
+        return;
+    }
+    ctx->exception_cb (h, id, type, severity, ctx->arg);
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST,  "sched.alloc", alloc_cb, 0},
+    { FLUX_MSGTYPE_REQUEST,  "sched.free", free_cb, 0},
+    { FLUX_MSGTYPE_EVENT,  "job-exception", exception_cb, 0},
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+/* Register dynamic service named 'sched'
+ */
+static int service_register (flux_t *h)
+{
+    flux_future_t *f;
+
+    if (!(f = flux_service_register (h, "sched")))
+        return -1;
+    if (flux_future_get (f, NULL) < 0) {
+        flux_future_destroy (f);
+        return -1;
+    }
+    flux_log (h, LOG_DEBUG, "service_register");
+    flux_future_destroy (f);
+    return 0;
+}
+
+/* Unregister dynamic service name 'sched'
+ */
+static void service_unregister (flux_t *h)
+{
+    flux_future_t *f;
+
+    if (!(f = flux_service_unregister (h, "sched"))) {
+        flux_log_error (h, "service_unregister");
+        return;
+    }
+    if (flux_future_get (f, NULL) < 0) {
+        flux_log_error (h, "service_unregister");
+        flux_future_destroy (f);
+        return;
+    }
+    flux_log (h, LOG_DEBUG, "service_unregister");
+    flux_future_destroy (f);
+}
+
+struct ops_context *schedutil_ops_register (flux_t *h,
+                                            op_alloc_f *alloc_cb,
+                                            op_free_f *free_cb,
+                                            op_exception_f *exception_cb,
+                                            void *arg)
+{
+    struct ops_context *ctx;
+
+    if (!h || !alloc_cb || !free_cb || !exception_cb) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(ctx = calloc (1, sizeof (*ctx))))
+        return NULL;
+    if (service_register (h) < 0)
+        goto error;
+    ctx->h = h;
+    ctx->alloc_cb = alloc_cb;
+    ctx->free_cb = free_cb;
+    ctx->exception_cb = exception_cb;
+    ctx->arg = arg;
+
+    if (flux_msg_handler_addvec (h, htab, ctx, &ctx->handlers) < 0)
+        goto error;
+    if (flux_event_subscribe (h, "job-exception") < 0)
+        goto error;
+    return ctx;
+error:
+    schedutil_ops_unregister (ctx);
+    return NULL;
+}
+
+
+void schedutil_ops_unregister (struct ops_context *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;
+        (void)service_unregister (ctx->h);
+        (void)flux_event_unsubscribe (ctx->h, "job-exception");
+        flux_msg_handler_delvec (ctx->handlers);
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libschedutil/ops.h
+++ b/src/common/libschedutil/ops.h
@@ -1,0 +1,66 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_SCHEDUTIL_OPS_H
+#define _FLUX_SCHEDUTIL_OPS_H
+
+#include <flux/core.h>
+
+/* Callback for an alloc request.  jobspec is looked up as a convenience.
+ * Decode msg with schedutil_alloc_request_decode().
+ * 'msg' and 'jobspec' are only valid for hte duration of this call.
+ * You should either respond to the request immediately (see alloc.h),
+ * or cache this information for later response.
+ */
+typedef void (op_alloc_f)(flux_t *h,
+                          const flux_msg_t *msg,
+                          const char *jobspec,
+                          void *arg);
+
+/* Callback for a free request.  R is looked up as a convenience.
+ * Decode msg with schedutil_free_request_decode().
+ * 'msg' and 'R' are only valid for the duration of this call.
+ * You should either respond to the request immediately (see free.h),
+ * or cache this information for later response.
+ */
+typedef void (op_free_f)(flux_t *h,
+                         const flux_msg_t *msg,
+                         const char *R,
+                         void *arg);
+
+/* An exception occurred for job 'id'.
+ * If the severity is zero, and there is an allocation pending for 'id',
+ * you must fail it immediately using schedutil_alloc_respond_denied(),
+ * setting the note field to something like "alloc aborted due to
+ * exception type=%s"
+ */
+typedef void (op_exception_f)(flux_t *h,
+                              flux_jobid_t id,
+                              const char *type,
+                              int severity,
+                              void *arg);
+
+/* Register callbacks for alloc, free, exception.
+ */
+struct ops_context *schedutil_ops_register (flux_t *h,
+                                            op_alloc_f *alloc_cb,
+                                            op_free_f *free_cb,
+                                            op_exception_f *exception_cb,
+                                            void *arg);
+
+/* Unregister callbacks.
+ */
+void schedutil_ops_unregister (struct ops_context *ctx);
+
+#endif /* !_FLUX_SCHEDUTIL_OPS_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libschedutil/ready.c
+++ b/src/common/libschedutil/ready.c
@@ -1,0 +1,46 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <jansson.h>
+
+#include "ready.h"
+
+int schedutil_ready (flux_t *h, const char *mode, int *queue_depth)
+{
+    flux_future_t *f;
+    int count;
+
+    if (!h || !mode) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(f = flux_rpc_pack (h, "job-manager.sched-ready",
+                             FLUX_NODEID_ANY, 0,
+                             "{s:s}", "mode", mode)))
+        return -1;
+    if (flux_rpc_get_unpack (f, "{s:i}", "count", &count) < 0)
+        goto error;
+    if (queue_depth)
+        *queue_depth = count;
+    flux_future_destroy (f);
+    return 0;
+error:
+    flux_future_destroy (f);
+    return -1;
+}
+
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libschedutil/ready.h
+++ b/src/common/libschedutil/ready.h
@@ -1,0 +1,27 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_SCHEDUTIL_READY_H
+#define _FLUX_SCHEDUTIL_READY_H
+
+#include <flux/core.h>
+
+/* Send ready request to job-manager, selecting interface 'mode'
+ * ("single", "unlimited", ...).  'queue_depth', if non-NULL,
+ * is set to the number of jobs in SCHED state that have not yet requested
+ * resources.  Returns 0 on success, -1 on failure with errno set.
+ */
+int schedutil_ready (flux_t *h, const char *mode, int *queue_depth);
+
+#endif /* !_FLUX_SCHEDUTIL_READY_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libschedutil/schedutil.h
+++ b/src/common/libschedutil/schedutil.h
@@ -1,0 +1,32 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_SCHEDUTIL_H
+#define _FLUX_SCHEDUTIL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "hello.h"
+#include "ready.h"
+#include "alloc.h"
+#include "free.h"
+#include "ops.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !_FLUX_SCHEDUTIL_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/test/travis_run.sh
+++ b/src/test/travis_run.sh
@@ -91,6 +91,10 @@ fi
 if ! test -d $HOME/.flux/curve; then
     travis_fold "flux_keygen" "flux keygen ..." flux keygen
 fi
+
+echo "Starting MUNGE"
+sudo /sbin/runuser -u munge /usr/sbin/munged
+
 travis_fold "autogen.sh" "./autogen.sh..." ./autogen.sh
 travis_fold "configure"  "./configure ${ARGS}..." ./configure ${ARGS}
 travis_fold "make_clean" "make clean..." make clean

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -30,6 +30,7 @@ TESTS_ENVIRONMENT = \
 TESTS = \
     t0000-sharness.t \
     t0003-basic-install.t \
+    t1001-qmanager-basic.t \
     t3000-jobspec.t \
     t3001-resource-basic.t \
     t3002-resource-prefix.t \

--- a/t/data/resource/jobspecs/validation/valid/example1.yaml
+++ b/t/data/resource/jobspecs/validation/valid/example1.yaml
@@ -16,4 +16,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.0

--- a/t/data/resource/jobspecs/validation/valid/example2.yaml
+++ b/t/data/resource/jobspecs/validation/valid/example2.yaml
@@ -13,4 +13,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.0

--- a/t/data/resource/jobspecs/validation/valid/use_case_1.1.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_1.1.yaml
@@ -13,4 +13,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.0

--- a/t/data/resource/jobspecs/validation/valid/use_case_1.2.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_1.2.yaml
@@ -17,4 +17,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.0

--- a/t/data/resource/jobspecs/validation/valid/use_case_1.3.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_1.3.yaml
@@ -19,4 +19,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.0

--- a/t/data/resource/jobspecs/validation/valid/use_case_1.4.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_1.4.yaml
@@ -19,4 +19,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.0

--- a/t/data/resource/jobspecs/validation/valid/use_case_1.5.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_1.5.yaml
@@ -38,4 +38,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 4 hours
+    duration: 14400.0

--- a/t/data/resource/jobspecs/validation/valid/use_case_1.6.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_1.6.yaml
@@ -19,4 +19,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.0

--- a/t/data/resource/jobspecs/validation/valid/use_case_1.7.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_1.7.yaml
@@ -16,4 +16,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1h
+    duration: 3600.0

--- a/t/data/resource/jobspecs/validation/valid/use_case_2.1.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_2.1.yaml
@@ -13,4 +13,4 @@ tasks:
       per_slot: 5
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.0

--- a/t/data/resource/jobspecs/validation/valid/use_case_2.2.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_2.2.yaml
@@ -13,4 +13,4 @@ tasks:
       total: 5
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.0

--- a/t/data/resource/jobspecs/validation/valid/use_case_2.3.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_2.3.yaml
@@ -13,4 +13,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.0

--- a/t/data/resource/jobspecs/validation/valid/use_case_2.4.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_2.4.yaml
@@ -32,4 +32,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.0

--- a/t/data/resource/jobspecs/validation/valid/use_case_2.5.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_2.5.yaml
@@ -16,4 +16,4 @@ tasks:
       per_slot: 1
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.0

--- a/t/data/resource/jobspecs/validation/valid/use_case_2.6.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_2.6.yaml
@@ -17,4 +17,4 @@ tasks:
       total: 10
 attributes:
   system:
-    duration: 1 hour
+    duration: 3600.0

--- a/t/sharness.d/sched-sharness.sh
+++ b/t/sharness.d/sched-sharness.sh
@@ -2,20 +2,20 @@
 #
 # project-local sharness code for flux-sched
 #
-FLUX_SCHED_RC_NOOP=1
 FLUX_RESOURCE_RC_NOOP=1
+FLUX_QMANAGER_RC_NOOP=1
 if test -n "$FLUX_SCHED_TEST_INSTALLED"; then
   # Test against installed flux-sched, installed under same prefix as
   #   flux-core.
-  # (Assume sched modules installed under PREFIX/lib/flux/modeuls/sched)
+  # (Assume sched modules installed under PREFIX/lib/flux/modules)
   # (We also support testing this when sched is installed
   # another location, but only via make check)
-  FLUX_MODULE_PATH_PREPEND=$(which flux | sed -s 's|/bin/flux|/lib/flux/modules/resource|'):${FLUX_MODULE_PATH_PREPEND}
   FLUX_EXEC_PATH_PREPEND=${SHARNESS_TEST_SRCDIR}/scripts:${FLUX_EXEC_PATH_PREPEND}
 else
   # Set up environment so that we find flux-sched modules,
   #  commands, and Lua libs from the build directories:
   FLUX_MODULE_PATH_PREPEND="${SHARNESS_BUILD_DIRECTORY}/resource/modules/.libs"
+  FLUX_MODULE_PATH_PREPEND="${SHARNESS_BUILD_DIRECTORY}/qmanager/modules/.libs":${FLUX_MODULE_PATH_PREPEND}
   FLUX_EXEC_PATH_PREPEND=":${SHARNESS_TEST_SRCDIR}/scripts"
 fi
 
@@ -34,9 +34,8 @@ sched_src_path () {
 }
 
 export FLUX_EXEC_PATH_PREPEND
-export FLUX_SCHED_RC_NOOP
-export FLUX_SCHED_RC_PATH
 export FLUX_RESOURCE_RC_NOOP
+export FLUX_QMANAGER_RC_NOOP
 export FLUX_RESOURCE_RC_PATH
 export FLUX_SCHED_CO_INST
 export FLUX_MODULE_PATH_PREPEND

--- a/t/t1001-qmanager-basic.t
+++ b/t/t1001-qmanager-basic.t
@@ -1,0 +1,94 @@
+#!/bin/sh
+
+test_description='Test qmanager service in simulated mode'
+
+. `dirname $0`/sharness.sh
+
+hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+# 4 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
+excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers"
+
+test_under_flux 1
+
+#  Set path to jq(1)
+#
+jq=$(which jq 2>/dev/null)
+if test -z "$jq"; then
+    skip_all='jq not found. Skipping all tests'
+    test_done
+fi
+
+job_kvsdir()    { flux job id --to=kvs $1; }
+exec_eventlog() { flux kvs get -r $(job_kvsdir $1).guest.exec.eventlog; }
+exec_test()     { ${jq} '.attributes.system.exec.test = {}'; }
+exec_testattr() {
+    ${jq} --arg key "$1" --arg value $2 \
+        '.attributes.system.exec.test[$key] = $value'
+}
+
+test_expect_success 'qmanager: generate jobspec for a simple test job' '
+    flux jobspec srun -n1 -t 0:1 hostname | exec_test > basic.json
+'
+
+test_expect_success 'qmanager: hwloc reload works' '
+    flux hwloc reload ${excl_4N4B}
+'
+
+test_expect_success 'qmanager: loading resource and qmanager modules works' '
+    flux module remove sched-simple &&
+    flux module load resource prune-filters=ALL:core \
+subsystems=containment policy=low &&
+    flux module load qmanager
+'
+
+test_expect_success 'qmanager: basic job runs in simulated mode' '
+    jobid=$(flux job submit basic.json) &&
+    flux job wait-event -t 2 ${jobid} start &&
+    flux job wait-event -t 2 ${jobid} finish &&
+    flux job wait-event -t 2 ${jobid} release &&
+    flux job wait-event -t 2 ${jobid} clean
+'
+
+test_expect_success 'qmanager: canceling job during execution works' '
+    jobid=$(flux jobspec srun -t 1 hostname | \
+        exec_test | flux job submit) &&
+    flux job wait-event -vt 2.5 ${jobid} start &&
+    flux job cancel ${jobid} &&
+    flux job wait-event -t 2.5 ${jobid} exception &&
+    flux job wait-event -t 2.5 ${jobid} finish | grep status=9 &&
+    flux job wait-event -t 2.5 ${jobid} release &&
+    flux job wait-event -t 2.5 ${jobid} clean &&
+    exec_eventlog $jobid | grep "complete" | grep "\"status\":9"
+'
+
+test_expect_success 'qmanager: exception during initialization is supported' '
+    flux jobspec srun hostname | \
+      exec_testattr mock_exception init > ex1.json &&
+    jobid=$(flux job submit ex1.json) &&
+    flux job wait-event -t 2.5 ${jobid} exception > exception.1.out &&
+    test_debug "flux job eventlog ${jobid}" &&
+    grep "type=\"exec\"" exception.1.out &&
+    grep "mock initialization exception generated" exception.1.out &&
+    flux job wait-event -qt 2.5 ${jobid} clean &&
+    flux job eventlog ${jobid} > eventlog.${jobid}.out &&
+    test_must_fail grep "finish" eventlog.${jobid}.out
+'
+
+test_expect_success 'qmanager: exception during run is supported' '
+	flux jobspec srun hostname | \
+	  exec_testattr mock_exception run > ex2.json &&
+	jobid=$(flux job submit ex2.json) &&
+	flux job wait-event -t 2.5 ${jobid} exception > exception.2.out &&
+	grep "type=\"exec\"" exception.2.out &&
+	grep "mock run exception generated" exception.2.out &&
+	flux job wait-event -qt 2.5 ${jobid} clean &&
+	flux job eventlog ${jobid} > eventlog.${jobid}.out &&
+	grep "finish status=9" eventlog.${jobid}.out
+'
+
+test_expect_success 'removing resource and qmanager modules' '
+    flux module remove -r 0 qmanager &&
+    flux module remove -r 0 resource
+'
+
+test_done


### PR DESCRIPTION
This PR has the following:

- Define the high level resource API so that our resource infrastructure can be better used by other module users and CLI users. This will also facilitate other language binding (such as Golang) creations.
- Implement this API for the module users.
- Incorporate schedutil from flux-core into flux-sched.
- Introduce the new queuing policy interface. I expect that many classical queueing polices can be implemented by deriving from this class and overriding its `run_sched_loop` interface. Basic queuing operations are already supported by the base classes using C++ STL containers. To make certain queuing operation efficient, I decided not to use `std::list` but use `std::map` keyed by monotonically increasing queuing time.
- Implement the FCFS policy derived class and also added a skeleton EASY policy class with no implementation as a placeholder. Note that the queuing policy interface is designed to be used by future CLI users as well as module users -- useful for testing.
- Use these primitives to implement the first baseline version of qmanager which provides the schedule loop service integrating both the new execution system within flux-core and the resource match service within flux-sched.
- Fix a few RV1 compatibility issues including libjobspec fix

Resolve Issue #480, #468, and #471, #483, and #477.
