### PR TITLE
qmanager: Add hello/exception callback support

### DIFF
--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -162,21 +162,22 @@ static qmanager_ctx_t *qmanager_new (flux_t *h)
         flux_log_error (h, "%s: create_queue_policy", __FUNCTION__);
         goto out;
     }
-    if (schedutil_hello (h, jobmanager_hello_cb, ctx) < 0) {
-        flux_log_error (h, "%s: schedutil_hello", __FUNCTION__);
+    if (!(ctx->ops = schedutil_ops_register (ctx->h,
+                                             jobmanager_alloc_cb,
+                                             jobmanager_free_cb,
+                                             jobmanager_exception_cb, ctx))) {
+        flux_log_error (ctx->h, "%s: schedutil_ops_register", __FUNCTION__);
+        goto out;
+    }
+    if (schedutil_hello (ctx->h, jobmanager_hello_cb, ctx) < 0) {
+        flux_log_error (ctx->h, "%s: schedutil_hello", __FUNCTION__);
         goto out;
     }
     if (schedutil_ready (h, "single", &queue_depth)) {
         flux_log_error (h, "%s: schedutil_ready", __FUNCTION__);
         goto out;
     }
-    if (!(ctx->ops = schedutil_ops_register (h,
-                                             jobmanager_alloc_cb,
-                                             jobmanager_free_cb,
-                                             jobmanager_exception_cb, ctx))) {
-        flux_log_error (h, "%s: schedutil_ops_register", __FUNCTION__);
-        goto out;
-    }
+
 out:
     return ctx;
 }

--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -119,10 +119,8 @@ extern "C" void jobmanager_free_cb (flux_t *h, const flux_msg_t *msg,
                         __FUNCTION__);
         return;
     }
-    if (ctx->queue->remove (id)) {
-        flux_log_error (h, "%s: remove", __FUNCTION__);
-        return;
-    }
+    if ((ctx->queue->remove (id)) < 0)
+        flux_log_error (h, "%s: remove job (%ju)", __FUNCTION__, (intmax_t)id);
     if (ctx->queue->run_sched_loop ((void *)ctx->h, true) < 0) {
         // TODO: Need to tighten up anomalous conditions
         // returned with a negative return code

--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -51,6 +51,12 @@ enum class job_state_kind_t { INIT,
  *  allocated or reserved (for backfill) resource set (R).
  */
 struct schedule_t {
+    schedule_t () = default;
+    schedule_t (const std::string &r) : R (r) { }
+    schedule_t (schedule_t &&s) = default;
+    schedule_t (const schedule_t &s) = default;
+    schedule_t& operator= (schedule_t &&s) = default;
+    schedule_t& operator= (const schedule_t &s) = default;
     std::string R = "";
     bool reserved = false;
     int64_t at = 0;
@@ -70,6 +76,18 @@ struct t_stamps_t {
 class job_t {
 public:
     ~job_t () { flux_msg_destroy (msg); }
+    job_t () = default;
+    job_t (job_state_kind_t s, flux_jobid_t jid,
+           uint32_t uid, int p, double t_s, const std::string &R)
+	   : state (s), id (jid), userid (uid),
+	     priority (p), t_submit (t_s), schedule (R) { }
+    job_t (job_t &&j) = default;
+    job_t (const job_t &j) = default;
+    job_t& operator= (job_t &&s) = default;
+    job_t& operator= (const job_t &s) = default;
+
+    bool is_pending () { return state == job_state_kind_t::PENDING; }
+
     flux_msg_t *msg = NULL;
     job_state_kind_t state = job_state_kind_t::INIT;
     flux_jobid_t id = 0;

--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -106,8 +106,10 @@ class queue_policy_base_impl_t
 public:
     int insert (std::shared_ptr<job_t> job);
     int remove (flux_jobid_t id);
+    const std::shared_ptr<job_t> lookup (flux_jobid_t id);
 
 protected:
+    int reconstruct (std::shared_ptr<job_t> running_job);
     std::shared_ptr<job_t> pending_pop ();
     std::shared_ptr<job_t> alloced_pop ();
     std::shared_ptr<job_t> complete_pop ();
@@ -179,6 +181,24 @@ public:
      *                       ENOENT: unknown id.
      */
     int remove (flux_jobid_t id);
+
+    /*! Look up a job whose jobid is id
+     *
+     *  \param id        jobid of flux_jobid_t type.
+     *  \return          a shared pointer pointing to the job on success;
+     *                       nullptr on error. ENOENT: unknown id.
+     */
+    const std::shared_ptr<job_t> lookup (flux_jobid_t id);
+
+    /*! Append a job into the internal running-job queue to reconstruct
+     *  the queue state.
+     *
+     *  \param running_job
+     *                   a shared pointer pointing to a job_t object.
+     *  \return          0 on success; -1 on error.
+     *                       EINVAL: invalid argument.
+     */
+    int reconstruct (std::shared_ptr<job_t> running_job);
 
     /*! Pop the first job from the pending job queue. The popped
      *  job is completely graduated from the queue policy layer.

--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -164,11 +164,12 @@ public:
 
     /*! Append a job into the internal pending-job queue.
      *
-     *  \param job       a shared pointer pointing to a job_t object.
+     *  \param pending_job
+     *                   a shared pointer pointing to a job_t object.
      *  \return          0 on success; -1 on error.
      *                       EINVAL: invalid argument.
      */
-    int insert (std::shared_ptr<job_t> job);
+    int insert (std::shared_ptr<job_t> pending_job);
 
     /*! Remove a job whose jobid is id from any internal queues
      *  (e.g., pending queue, running queue, and alloced queue.)

--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -176,6 +176,7 @@ public:
      *
      *  \param id        jobid of flux_jobid_t type.
      *  \return          0 on success; -1 on error.
+     *                       ENOENT: unknown id.
      */
     int remove (flux_jobid_t id);
 

--- a/qmanager/policies/base/queue_policy_base_impl.hpp
+++ b/qmanager/policies/base/queue_policy_base_impl.hpp
@@ -80,7 +80,7 @@ out:
 int queue_policy_base_impl_t::remove (flux_jobid_t id)
 {
     int rc = -1;
-    std::shared_ptr<job_t> job;
+    std::shared_ptr<job_t> job = nullptr;
 
     if (m_jobs.find (id) == m_jobs.end ()) {
         errno = EINVAL;

--- a/qmanager/policies/base/queue_policy_base_impl.hpp
+++ b/qmanager/policies/base/queue_policy_base_impl.hpp
@@ -42,6 +42,16 @@ int queue_policy_base_t::remove (flux_jobid_t id)
     return detail::queue_policy_base_impl_t::remove (id);
 }
 
+const std::shared_ptr<job_t> queue_policy_base_t::lookup (flux_jobid_t id)
+{
+    return detail::queue_policy_base_impl_t::lookup (id);
+}
+
+int queue_policy_base_t::reconstruct (std::shared_ptr<job_t> running_job)
+{
+    return detail::queue_policy_base_impl_t::reconstruct (running_job);
+}
+
 std::shared_ptr<job_t> queue_policy_base_t::pending_pop ()
 {
     return detail::queue_policy_base_impl_t::pending_pop ();
@@ -112,6 +122,32 @@ out:
     return rc;
 }
 
+const std::shared_ptr<job_t> queue_policy_base_impl_t::lookup (flux_jobid_t id)
+{
+    std::shared_ptr<job_t> job = nullptr;
+    if (m_jobs.find (id) == m_jobs.end ()) {
+        errno = ENOENT;
+        return job;
+    }
+    return m_jobs[id];
+}
+
+int queue_policy_base_impl_t::reconstruct (std::shared_ptr<job_t> job)
+{
+    int rc = -1;
+    if (job == nullptr || m_jobs.find (job->id) != m_jobs.end ()) {
+        errno = EINVAL;
+        goto out;
+    }
+    job->t_stamps.running_ts = m_rq_cnt++;
+    m_running.insert (std::pair<uint64_t, flux_jobid_t>(job->t_stamps.running_ts,
+                                                        job->id));
+    m_jobs.insert (std::pair<flux_jobid_t, std::shared_ptr<job_t>> (job->id,
+                                                                    job));
+    rc = 0;
+out:
+    return rc;
+}
 
 std::map<uint64_t, flux_jobid_t>::iterator queue_policy_base_impl_t::
     to_running (std::map<uint64_t, flux_jobid_t>::iterator pending_iter,

--- a/src/common/libschedutil/hello.h
+++ b/src/common/libschedutil/hello.h
@@ -13,16 +13,23 @@
 
 #include <flux/core.h>
 
-/* Callback for ingesting allocated R's.
+/* Callback for ingesting R + metadata for jobs that have resources
  * Return 0 on success, -1 on failure with errno set.
  * Failure of the callback aborts iteration and causes schedutil_hello()
  * to return -1 with errno passed through.
  */
-typedef int (hello_f)(flux_t *h, const char *R, void *arg);
+typedef int (hello_f)(flux_t *h,
+                      flux_jobid_t id,
+                      int priority,
+                      uint32_t userid,
+                      double t_submit,
+                      const char *R,
+                      void *arg);
 
 /* Send hello announcement to job-manager.
  * The job-manager responds with a list of jobs that have resources assigned.
- * This function looks up R for each job and passes it 'cb' with 'arg'.
+ * This function looks up R for each job and passes R + metadata to 'cb'
+ * with 'arg'.
  */
 int schedutil_hello (flux_t *h, hello_f *cb, void *arg);
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -31,6 +31,7 @@ TESTS = \
     t0000-sharness.t \
     t0003-basic-install.t \
     t1001-qmanager-basic.t \
+    t1002-qmanager-reload.t \
     t3000-jobspec.t \
     t3001-resource-basic.t \
     t3002-resource-prefix.t \

--- a/t/t1002-qmanager-reload.t
+++ b/t/t1002-qmanager-reload.t
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+test_description='Test qmanager service reloading'
+
+. `dirname $0`/sharness.sh
+
+hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+# 4 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
+excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers"
+
+test_under_flux 1
+
+#  Set path to jq(1)
+#
+jq=$(which jq 2>/dev/null)
+if test -z "$jq"; then
+    skip_all='jq not found. Skipping all tests'
+    test_done
+fi
+
+exec_test()     { ${jq} '.attributes.system.exec.test = {}'; }
+submit_jobs()   {
+    local id
+    for i in `seq 1 $2`
+    do
+        id=$(flux job submit $1)
+    done
+    echo ${id}
+}
+
+test_expect_success 'qmanager: generate jobspec for a simple test job' '
+    flux jobspec srun -n1 -t 1 hostname | exec_test > basic.json
+'
+
+test_expect_success 'qmanager: hwloc reload works' '
+    flux hwloc reload ${excl_4N4B}
+'
+
+test_expect_success 'qmanager: loading resource and qmanager modules works' '
+    flux module remove sched-simple &&
+    flux module load resource prune-filters=ALL:core \
+subsystems=containment policy=low hwloc-whitelist=node,socket,core,gpu &&
+    flux module load qmanager
+'
+
+test_expect_success 'qmanager: submit 2 more as many jobs as there are cores ' '
+    jobid1=$(submit_jobs basic.json 16) &&
+    jobid2=$(flux job submit basic.json) &&
+    jobid3=$(flux job submit basic.json) &&
+    flux job wait-event -t 2 ${jobid3} submit &&
+    flux job list > jobs.list &&
+    echo ${jobid1} > jobid1.out &&
+    echo ${jobid2} > jobid2.out &&
+    echo ${jobid3} > jobid3.out
+'
+
+test_expect_success 'qmanager: restart keeps the main job queue intact' '
+    flux module remove qmanager &&
+    flux module load qmanager &&
+    flux job list > jobs.list2 &&
+    diff jobs.list2 jobs.list
+'
+
+test_expect_success 'qmanager: handle the alloc resubmitted by job-manager' '
+    jobid1=$(cat jobid1.out) &&
+    jobid2=$(cat jobid2.out) &&
+    jobid3=$(cat jobid3.out) &&
+    flux job cancel ${jobid1} &&
+    flux job wait-event -t 2 ${jobid2} start
+'
+
+test_expect_success 'qmanager: canceling a pending job works' '
+    jobid3=$(cat jobid3.out) &&
+    flux job cancel ${jobid3} &&
+    flux job wait-event -t 2 ${jobid3} exception
+'
+
+test_expect_success 'removing resource and qmanager modules' '
+    flux module remove -r 0 qmanager &&
+    flux module remove -r 0 resource
+'
+
+test_done


### PR DESCRIPTION
This PR fills in hello callback and exception callback as required by job-manager. The hello callback allows `qmanager` to fill in its running queue as part of load sequence and the exception callback allows for canceling the pending jobs (i.e., jobs with pending alloc requests).

Note that the hello callback is working in progress towards full resilience. More comprehensive solution with respect to `resource` will require a solution for Issue #470. This isn't planned until later this year.

Resolve #492. 