### PR TITLE
Bug fix for incorrectly handling implicit exclusivity

### DIFF
--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -115,14 +115,27 @@ done:
 }
 
 int dfu_impl_t::by_excl (const jobmeta_t &meta, const std::string &s, vtx_t u,
-                         const Jobspec::Resource &resource)
+                         bool exclusive_in, const Jobspec::Resource &resource)
 {
     int rc = -1;
     planner_t *p = NULL;
     int64_t at = meta.at;
     int64_t njobs = -1;
     uint64_t duration = meta.duration;
-    if (resource.exclusive == Jobspec::tristate_t::TRUE) {
+
+    // If a non-exclusive resource request is explicitly given on a
+    // resource that lies under slot, this spec is invalid.
+    if (exclusive_in && resource.exclusive == Jobspec::tristate_t::FALSE) {
+        errno = EINVAL;
+        m_err_msg += "by_excl: exclusivity conflicts at jobspec=";
+        m_err_msg += resource.label + " : vertex=" + (*m_graph)[u].name;
+        goto done;
+    }
+
+    // If a resource request is under slot or an explict exclusivity is
+    // requested, we check the validity of the visiting vertex using
+    // its x_checker planner.
+    if (exclusive_in || resource.exclusive == Jobspec::tristate_t::TRUE) {
         p = (*m_graph)[u].schedule.x_checker;
         njobs = planner_avail_resources_during (p, at, duration);
         if (njobs == -1) {
@@ -137,6 +150,8 @@ int dfu_impl_t::by_excl (const jobmeta_t &meta, const std::string &s, vtx_t u,
             goto done;
         }
     }
+
+    // All cases reached this point indicate further walk is needed.
     rc = 0;
 
 done:
@@ -187,7 +202,7 @@ int dfu_impl_t::prune (const jobmeta_t &meta, bool exclusive,
         if ((*m_graph)[u].type != resource.type)
             continue;
         // Prune by exclusivity checker
-        if ( (rc = by_excl (meta, s, u, resource)) == -1)
+        if ( (rc = by_excl (meta, s, u, exclusive, resource)) == -1)
             break;
         // Prune by the subtree planner quantities
         if ( (rc = by_subplan (meta, s, u, resource)) == -1)

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -211,7 +211,7 @@ private:
     int by_avail (const jobmeta_t &meta, const std::string &s, vtx_t u,
                   const std::vector<Jobspec::Resource> &resources);
     int by_excl (const jobmeta_t &meta, const std::string &s, vtx_t u,
-                 const Jobspec::Resource &resource);
+                 bool exclusive_in, const Jobspec::Resource &resource);
     int by_subplan (const jobmeta_t &meta, const std::string &s, vtx_t u,
                     const Jobspec::Resource &resource);
     int prune (const jobmeta_t &meta, bool excl, const std::string &subsystem,

--- a/t/data/resource/commands/basics/cmds40.in
+++ b/t/data/resource/commands/basics/cmds40.in
@@ -1,0 +1,21 @@
+# 4x cluster[1]->rack[1]->node[1]->slot[1]->socket[1]->core[1]
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/basics/test001.yaml
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/basics/test001.yaml
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/basics/test001.yaml
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/basics/test001.yaml
+
+# 4x cluster[1]->rack[1]->node[1]->slot[1]->socket[1]->core[1]
+# match must fail for all of them
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/basics/test001.yaml
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/basics/test001.yaml
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/basics/test001.yaml
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/basics/test001.yaml
+
+# 4x slot[1]->core[1]
+# match must fail for all of them
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/basics/test008.yaml
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/basics/test008.yaml
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/basics/test008.yaml
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/basics/test008.yaml
+
+quit

--- a/t/data/resource/expected/basics/040.R.out
+++ b/t/data/resource/expected/basics/040.R.out
@@ -1,0 +1,72 @@
+      ---------------core0[1:x]
+      ------------socket0[1:x]
+      ---------node0[1:s]
+      ------rack0[1:s]
+      ---tiny0[1:s]
+INFO: =============================
+INFO: JOBID=1
+INFO: RESOURCES=ALLOCATED
+INFO: SCHEDULED AT=Now
+INFO: =============================
+      ---------------core18[1:x]
+      ------------socket1[1:x]
+      ---------node0[1:s]
+      ------rack0[1:s]
+      ---tiny0[1:s]
+INFO: =============================
+INFO: JOBID=2
+INFO: RESOURCES=ALLOCATED
+INFO: SCHEDULED AT=Now
+INFO: =============================
+      ---------------core0[1:x]
+      ------------socket0[1:x]
+      ---------node1[1:s]
+      ------rack0[1:s]
+      ---tiny0[1:s]
+INFO: =============================
+INFO: JOBID=3
+INFO: RESOURCES=ALLOCATED
+INFO: SCHEDULED AT=Now
+INFO: =============================
+      ---------------core18[1:x]
+      ------------socket1[1:x]
+      ---------node1[1:s]
+      ------rack0[1:s]
+      ---tiny0[1:s]
+INFO: =============================
+INFO: JOBID=4
+INFO: RESOURCES=ALLOCATED
+INFO: SCHEDULED AT=Now
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: JOBID=5
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: JOBID=6
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: JOBID=7
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: JOBID=8
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: JOBID=9
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: JOBID=10
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: JOBID=11
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: JOBID=12
+INFO: =============================

--- a/t/t1001-qmanager-basic.t
+++ b/t/t1001-qmanager-basic.t
@@ -55,10 +55,10 @@ test_expect_success 'qmanager: canceling job during execution works' '
     flux job wait-event -vt 2.5 ${jobid} start &&
     flux job cancel ${jobid} &&
     flux job wait-event -t 2.5 ${jobid} exception &&
-    flux job wait-event -t 2.5 ${jobid} finish | grep status=9 &&
+    flux job wait-event -t 2.5 ${jobid} finish | grep status=15 &&
     flux job wait-event -t 2.5 ${jobid} release &&
     flux job wait-event -t 2.5 ${jobid} clean &&
-    exec_eventlog $jobid | grep "complete" | grep "\"status\":9"
+    exec_eventlog $jobid | grep "complete" | grep "\"status\":15"
 '
 
 test_expect_success 'qmanager: exception during initialization is supported' '
@@ -83,7 +83,7 @@ test_expect_success 'qmanager: exception during run is supported' '
 	grep "mock run exception generated" exception.2.out &&
 	flux job wait-event -qt 2.5 ${jobid} clean &&
 	flux job eventlog ${jobid} > eventlog.${jobid}.out &&
-	grep "finish status=9" eventlog.${jobid}.out
+	grep "finish status=15" eventlog.${jobid}.out
 '
 
 test_expect_success 'removing resource and qmanager modules' '

--- a/t/t3001-resource-basic.t
+++ b/t/t3001-resource-basic.t
@@ -152,4 +152,12 @@ test_expect_success "${test016_desc}" '
     test_cmp 016.R.out ${exp_dir}/016.R.out
 '
 
+cmds040="${cmd_dir}/cmds40.in"
+test040_desc="Once all sockets are exclusively allocated, no jobs can match"
+test_expect_success "${test040_desc}" '
+    sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds040} > cmds040 &&
+    ${query} -G ${grugs} -S CA -P low -t 040.R.out < cmds040 &&
+    test_cmp 040.R.out ${exp_dir}/040.R.out
+'
+
 test_done


### PR DESCRIPTION
This PR fixes a bug where an implicit resource exclusivity created by slot is incorrectly handled.

Problem: When we have some sub-resources under the visiting resource have been allocated to another job, we can prune the further walk even though the visiting resource itself has not been exclusively allocated to another job. But it appears `dfu_impl_t::by_excl ()` does not factor into account the implicit exclusivity that can arise from slot: e.g., with slot[2]->socket[1]->core[1], sockets and cores under slots are implicitly exclusive.

Augment `dfu_impl_t::by_excl ()` to handle this case. 

Augment `t/t3001-resource-basic.t` to cover this case.