### PR TITLE
Add support for checking a job's satisfiability 

### DIFF
--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -58,6 +58,37 @@ struct qmanager_ctx_t {
  *                                                                            *
  ******************************************************************************/
 
+static int post_sched_loop (qmanager_ctx_t *ctx)
+{
+    int rc = -1;
+    std::shared_ptr<job_t> job = nullptr;
+
+    while ((job = ctx->queue->alloced_pop ()) != nullptr) {
+        if (schedutil_alloc_respond_R (ctx->h, job->msg,
+                                       job->schedule.R.c_str (), NULL) < 0) {
+            flux_log_error (ctx->h, "%s: schedutil_alloc_respond_R",
+                            __FUNCTION__);
+            goto out;
+        }
+        flux_log (ctx->h, LOG_DEBUG,
+                  "alloc success (id=%jd)", (intmax_t)job->id);
+    }
+    while ((job = ctx->queue->rejected_pop ()) != nullptr) {
+        std::string note = "alloc denied due to type=\"" + job->note + "\"";
+        if (schedutil_alloc_respond_denied (ctx->h, job->msg, note.c_str ()) < 0) {
+            flux_log_error (ctx->h, "%s: schedutil_alloc_respond_denied",
+                            __FUNCTION__);
+            goto out;
+        }
+        flux_log (ctx->h, LOG_DEBUG,
+                  "%s (id=%jd)", note.c_str (), (intmax_t)job->id);
+    }
+    rc = 0;
+
+out:
+    return rc;
+}
+
 // FIXME: This will be expanded when we implement full scheduler
 // resilency schemes: Issue #470.
 extern "C" int jobmanager_hello_cb (flux_t *h,
@@ -104,18 +135,10 @@ extern "C" void jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
         flux_log_error (h, "%s: queue insert", __FUNCTION__);
         return;
     }
-    if (ctx->queue->run_sched_loop ((void *)ctx->h, true) < 0) {
-        flux_log (ctx->h, LOG_DEBUG,
-                  "%s: return code < 0 from schedule loop", __FUNCTION__);
-    }
-    while ((job = ctx->queue->alloced_pop ()) != nullptr) {
-        flux_log (ctx->h, LOG_DEBUG, "jobid (%ju): %s",
-                  (intmax_t)job->id, job->schedule.R.c_str ());
-        if (schedutil_alloc_respond_R (ctx->h, job->msg,
-                                       job->schedule.R.c_str (), NULL) < 0) {
-            flux_log_error (ctx->h, "%s: schedutil_alloc_respond_R",
-                            __FUNCTION__);
-        }
+    if (ctx->queue->run_sched_loop ((void *)ctx->h, true) < 0
+        || post_sched_loop (ctx) < 0) {
+        flux_log_error (ctx->h, "%s: schedule loop", __FUNCTION__);
+        return;
     }
 }
 
@@ -149,14 +172,10 @@ extern "C" void jobmanager_free_cb (flux_t *h, const flux_msg_t *msg,
     if (schedutil_free_respond (h, msg) < 0) {
         flux_log_error (h, "%s: schedutil_free_respond", __FUNCTION__);
     }
-    while ((job = ctx->queue->alloced_pop ()) != nullptr) {
-        flux_log (ctx->h, LOG_DEBUG, "jobid (%ju): %s",
-                  (intmax_t)job->id, job->schedule.R.c_str ());
-        if (schedutil_alloc_respond_R (ctx->h, job->msg,
-                                       job->schedule.R.c_str (), NULL) < 0) {
-            flux_log_error (ctx->h, "%s: schedutil_alloc_respond_R",
-                            __FUNCTION__);
-        }
+    flux_log (ctx->h, LOG_DEBUG, "free succeeded (id=%jd)", (intmax_t)id);
+    if (post_sched_loop (ctx) < 0) {
+        flux_log_error (ctx->h, "%s: post_sched_loop", __FUNCTION__);
+        return;
     }
 }
 

--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -102,8 +102,7 @@ extern "C" int jobmanager_hello_cb (flux_t *h,
                                    RUNNING, id, uid, prio, ts, R);
 
     if (ctx->queue->reconstruct (running_job) < 0) {
-        flux_log_error (h, "%s: reconstruct (jobid=%ju)",
-                        __FUNCTION__, (intmax_t)running_job->id);
+        flux_log_error (h, "%s: reconstruct (id=%jd)", __FUNCTION__, (intmax_t)id);
         goto out;
     }
     rc = 0;
@@ -115,14 +114,8 @@ out:
 extern "C" void jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
                                      const char *jobspec, void *arg)
 {
-    uint32_t userid;
     qmanager_ctx_t *ctx = (qmanager_ctx_t *)arg;
     std::shared_ptr<job_t> job = std::make_shared<job_t> ();
-
-    if (flux_msg_get_userid (msg, &userid) < 0)
-        return;
-
-    flux_log (h, LOG_INFO, "alloc requested by user (%u).", userid);
 
     if (schedutil_alloc_request_decode (msg, &job->id, &job->priority,
                                         &job->userid, &job->t_submit) < 0) {
@@ -132,7 +125,8 @@ extern "C" void jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
     job->jobspec = jobspec;
     job->msg = flux_msg_copy (msg, true);
     if (ctx->queue->insert (job) < 0) {
-        flux_log_error (h, "%s: queue insert", __FUNCTION__);
+        flux_log_error (h, "%s: queue insert (id=%jd)",
+                        __FUNCTION__, (intmax_t)job->id);
         return;
     }
     if (ctx->queue->run_sched_loop ((void *)ctx->h, true) < 0
@@ -145,32 +139,24 @@ extern "C" void jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
 extern "C" void jobmanager_free_cb (flux_t *h, const flux_msg_t *msg,
                                     const char *R, void *arg)
 {
-    uint32_t userid;
     flux_jobid_t id;
     qmanager_ctx_t *ctx = (qmanager_ctx_t *)arg;
-    std::shared_ptr<job_t> job;
-
-    if (flux_msg_get_userid (msg, &userid) < 0)
-        return;
-
-    flux_log (h, LOG_INFO, "free requested by user (%u).", userid);
 
     if (schedutil_free_request_decode (msg, &id) < 0) {
-        flux_log_error (h, "%s: schedutil_free_request_decode",
-                        __FUNCTION__);
+        flux_log_error (h, "%s: schedutil_free_request_decode", __FUNCTION__);
         return;
     }
-    if ((ctx->queue->remove (id)) < 0)
-        flux_log_error (h, "%s: remove job (%ju)", __FUNCTION__, (intmax_t)id);
+    if ((ctx->queue->remove (id)) < 0) {
+        flux_log_error (h, "%s: remove (id=%jd)", __FUNCTION__, (intmax_t)id);
+        return;
+    }
     if (ctx->queue->run_sched_loop ((void *)ctx->h, true) < 0) {
-        // TODO: Need to tighten up anomalous conditions
-        // returned with a negative return code
-        // (e.g., unsatisfiable jobs).
-        flux_log (ctx->h, LOG_DEBUG,
-                  "%s: return code < 0 from schedule loop", __FUNCTION__);
+        flux_log_error (ctx->h, "%s: run_sched_loop", __FUNCTION__);
+        return;
     }
     if (schedutil_free_respond (h, msg) < 0) {
         flux_log_error (h, "%s: schedutil_free_respond", __FUNCTION__);
+        return;
     }
     flux_log (ctx->h, LOG_DEBUG, "free succeeded (id=%jd)", (intmax_t)id);
     if (post_sched_loop (ctx) < 0) {
@@ -189,13 +175,15 @@ static void jobmanager_exception_cb (flux_t *h, flux_jobid_t id,
         || !job->is_pending ())
         return;
     if (ctx->queue->remove (id) < 0) {
-        flux_log_error (h, "%s: remove job (%ju)", __FUNCTION__, (intmax_t)id);
+        flux_log_error (h, "%s: remove job (%jd)", __FUNCTION__, (intmax_t)id);
         return;
     }
     std::string note = std::string ("alloc aborted due to exception type=") + t;
     if (schedutil_alloc_respond_denied (h, job->msg, note.c_str ()) < 0) {
         flux_log_error (h, "%s: schedutil_alloc_respond_denied", __FUNCTION__);
+        return;
     }
+    flux_log (h, LOG_DEBUG, "%s (id=%jd)", note.c_str (), (intmax_t)id);
 }
 
 static qmanager_ctx_t *qmanager_new (flux_t *h)

--- a/resource/hlapi/bindings/c++/reapi_module_impl.hpp
+++ b/resource/hlapi/bindings/c++/reapi_module_impl.hpp
@@ -51,7 +51,7 @@ int reapi_module_t::match_allocate (void *h, bool orelse_reserve,
     const char *rset = NULL;
     const char *status = NULL;
     const char *cmd = (orelse_reserve)? "allocate_orelse_reserve"
-                                      : "allocate";
+                                      : "allocate_with_satisfiability";
 
     if (!fh || jobspec == "" || jobid > INT64_MAX) {
         errno = EINVAL;

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -624,7 +624,6 @@ static int run_remove (resource_ctx_t *ctx, int64_t jobid)
         if (is_existent_jobid (ctx, jobid)) {
            job_info_t *info = ctx->jobs[jobid];
            info->state = job_lifecycle_t::ERROR;
-           flux_log (ctx->h, LOG_INFO, "can't remove %ld.", (intmax_t)jobid);
         }
         goto out;
     }
@@ -685,13 +684,7 @@ static void cancel_request_cb (flux_t *h, flux_msg_handler_t *w,
                                const flux_msg_t *msg, void *arg)
 {
     resource_ctx_t *ctx = getctx ((flux_t *)arg);
-    uint32_t userid = 0;
     int64_t jobid = -1;
-
-    if (flux_msg_get_userid (msg, &userid) < 0)
-        goto error;
-
-    flux_log (h, LOG_INFO, "cancel requested by user (%u).", userid);
 
     if (flux_request_unpack (msg, NULL, "{s:I}", "jobid", &jobid) < 0)
         goto error;
@@ -713,7 +706,6 @@ static void cancel_request_cb (flux_t *h, flux_msg_handler_t *w,
     if (flux_respond_pack (h, msg, "{}") < 0)
         flux_log_error (h, "%s", __FUNCTION__);
 
-    flux_log (h, LOG_INFO, "cancel request succeeded.");
     return;
 
 error:

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -274,7 +274,7 @@ static resource_ctx_t *init_module (flux_t *h, int argc, char **argv)
     }
     process_args (ctx, argc, argv);
     if (flux_msg_handler_addvec (h, htab, (void *)h, &ctx->handlers) < 0) {
-        flux_log (h, LOG_ERR, "error registering resource event handler");
+        flux_log_error (h, "error registering resource event handler");
         goto error;
     }
     return ctx;
@@ -508,8 +508,13 @@ static int init_resource_graph (resource_ctx_t *ctx)
     }
 
     // Initialize the DFU traverser
-    ctx->traverser->initialize (ctx->fgraph, &(ctx->db.roots), ctx->matcher);
-    return rc;
+    if (ctx->traverser->initialize (ctx->fgraph,
+                                    &(ctx->db.roots), ctx->matcher) < 0) {
+        flux_log (ctx->h, LOG_ERR, "traverser initialization");
+        return -1;
+
+    }
+    return 0;
 }
 
 
@@ -815,7 +820,7 @@ extern "C" int mod_main (flux_t *h, int argc, char **argv)
         flux_log (h, LOG_ERR, "can't initialize resource module");
         goto done;
     }
-    flux_log (h, LOG_INFO, "resource module starting...");
+    flux_log (h, LOG_DEBUG, "resource module starting...");
 
     if ((rc = init_resource_graph (ctx)) != 0) {
         flux_log (h, LOG_ERR, "can't initialize resource graph database");

--- a/resource/policies/base/matcher.hpp
+++ b/resource/policies/base/matcher.hpp
@@ -41,7 +41,9 @@ const std::string ANY_RESOURCE_TYPE = "*";
 
 enum match_score_t { MATCH_UNMET = 0, MATCH_MET = 1 };
 
-enum class match_op_t { MATCH_ALLOCATE, MATCH_ALLOCATE_ORELSE_RESERVE };
+enum class match_op_t { MATCH_ALLOCATE,
+                        MATCH_ALLOCATE_W_SATISFIABILITY,
+                        MATCH_ALLOCATE_ORELSE_RESERVE };
 
 /*! Base matcher data class.
  *  Provide idioms to specify the target subsystems and

--- a/resource/traversers/dfu.hpp
+++ b/resource/traversers/dfu.hpp
@@ -109,6 +109,10 @@ public:
      *                       EINVAL: graph, roots or match callback not set.
      *                       ENOTSUP: roots does not contain a subsystem the
      *                                match callback uses.
+     *                       EBUSY: cannot match because resources/devices
+     *                              are currently in use.
+     *                       ENODEV: unsatifiable jobspec becuase no
+     *                               resources/devices can satisfy the request.
      */
     int run (Jobspec::Jobspec &jobspec, match_writers_t *writers,
              match_op_t op, int64_t id, int64_t *at);

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -190,6 +190,13 @@ public:
     int update (vtx_t root, match_writers_t *writers,
                 jobmeta_t &meta, unsigned int needs, bool excl);
 
+    /*! Update to make the resource state ready for the next selection.
+     *  Ignore the previous select invocation.
+     *
+     *  \return          0 on success.
+     */
+    int update ();
+
     /*! Remove the allocation/reservation referred to by jobid and update
      *  the resource state.
      *

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -45,6 +45,7 @@ TESTS = \
     t3010-resource-power.t \
     t3011-resource-filt.t \
     t3012-resource-properties.t \
+    t3013-resource-unsat.t \
     t4000-match-params.t \
     t4001-match-allocate.t \
     t4002-match-reserve.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -51,6 +51,7 @@ TESTS = \
     t4002-match-reserve.t \
     t4003-cancel-info.t \
     t4004-match-hwloc.t \
+    t4005-match-unsat.t \
     t5000-valgrind.t \
     t6000-graph-size.t \
     t6001-match-formats.t

--- a/t/data/resource/commands/satisfiability/cmds01.in
+++ b/t/data/resource/commands/satisfiability/cmds01.in
@@ -1,0 +1,21 @@
+# cluster[1]->rack[1]->node[1]->slot[1]->socket[1]->core[19]
+match allocate_with_satisfiability @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test001.yaml
+match allocate_orelse_reserve @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test001.yaml
+
+# slot[1]->socket[1]->core[30]
+match allocate_with_satisfiability @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test002.yaml
+match allocate_orelse_reserve @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test002.yaml
+
+# slot[1]->socket[3]->core[1]
+match allocate_with_satisfiability @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test003.yaml
+match allocate_orelse_reserve @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test003.yaml
+
+# node[1]->slot[2]->socket[2]->core[1]
+match allocate_with_satisfiability @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test004.yaml
+match allocate_orelse_reserve @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test004.yaml
+
+# node[3]->slot[1]->socket[1]->core[1]
+match allocate_with_satisfiability @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test005.yaml
+match allocate_orelse_reserve @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test005.yaml
+
+quit

--- a/t/data/resource/commands/satisfiability/cmds02.in
+++ b/t/data/resource/commands/satisfiability/cmds02.in
@@ -1,0 +1,17 @@
+# cluster[1]->rack[2]->node[1]->slot[1]->socket[1]->core[1]
+match allocate_with_satisfiability @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test006.yaml
+match allocate_orelse_reserve @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test006.yaml
+
+# cluster[2]->rack[1]->node[1]->slot[1]->socket[1]->core[1]
+match allocate_with_satisfiability @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test007.yaml
+match allocate_orelse_reserve @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test007.yaml
+
+# rack[3]->node[1]->slot[1]->socket[1]->core[1]
+match allocate_with_satisfiability @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test008.yaml
+match allocate_orelse_reserve @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test008.yaml
+
+# zone[1]->cluster[1]->rack[1]->node[1]->slot[1]->socket[1]->core[1]
+match allocate_with_satisfiability @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test009.yaml
+match allocate_orelse_reserve @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test009.yaml
+
+quit

--- a/t/data/resource/commands/satisfiability/cmds03.in
+++ b/t/data/resource/commands/satisfiability/cmds03.in
@@ -1,0 +1,31 @@
+# cluster[1]->rack[1]->node[2]->socket[2]->slot[1]->core[1]
+match allocate_with_satisfiability @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test010.yaml
+match allocate_orelse_reserve @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test010.yaml
+
+# cluster[1]->rack[1]->node[1]->socket[1]->slot[1]->core[19]
+match allocate_with_satisfiability @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test011.yaml
+match allocate_orelse_reserve @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test011.yaml
+
+# slot[1]->core[18]
+match allocate_with_satisfiability @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test012.yaml
+match allocate_orelse_reserve @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test012.yaml
+
+# socket[1]->slot[1]->core[18]
+match allocate_with_satisfiability @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test013.yaml
+match allocate_orelse_reserve @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test013.yaml
+
+# socket[2]->slot[1]->core[18]
+match allocate_with_satisfiability @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test014.yaml
+match allocate_orelse_reserve @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test014.yaml
+
+# slot[1]->socket[1]->core[1]
+# FIXME: you should not able to allocate this
+# Need a bug fix for by_excl()
+#match allocate_with_satisfiability @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test015.yaml
+#match allocate_orelse_reserve @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test015.yaml
+
+# slot[1]->socket[3]->core[1]
+match allocate_with_satisfiability @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test016.yaml
+match allocate_orelse_reserve @TEST_SRCDIR@/data/resource/jobspecs/satisfiability/test016.yaml
+
+quit

--- a/t/data/resource/expected/satisfiability/001.R.out
+++ b/t/data/resource/expected/satisfiability/001.R.out
@@ -1,0 +1,50 @@
+INFO: =============================
+INFO: No matching resources found
+INFO: Unsatisfiable request
+INFO: JOBID=1
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: Unsatisfiable request
+INFO: JOBID=2
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: Unsatisfiable request
+INFO: JOBID=3
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: Unsatisfiable request
+INFO: JOBID=4
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: Unsatisfiable request
+INFO: JOBID=5
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: Unsatisfiable request
+INFO: JOBID=6
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: Unsatisfiable request
+INFO: JOBID=7
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: Unsatisfiable request
+INFO: JOBID=8
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: Unsatisfiable request
+INFO: JOBID=9
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: Unsatisfiable request
+INFO: JOBID=10
+INFO: =============================

--- a/t/data/resource/expected/satisfiability/002.R.out
+++ b/t/data/resource/expected/satisfiability/002.R.out
@@ -1,0 +1,40 @@
+INFO: =============================
+INFO: No matching resources found
+INFO: Unsatisfiable request
+INFO: JOBID=1
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: Unsatisfiable request
+INFO: JOBID=2
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: Unsatisfiable request
+INFO: JOBID=3
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: Unsatisfiable request
+INFO: JOBID=4
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: Unsatisfiable request
+INFO: JOBID=5
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: Unsatisfiable request
+INFO: JOBID=6
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: Unsatisfiable request
+INFO: JOBID=7
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: Unsatisfiable request
+INFO: JOBID=8
+INFO: =============================

--- a/t/data/resource/expected/satisfiability/003.R.out
+++ b/t/data/resource/expected/satisfiability/003.R.out
@@ -1,0 +1,167 @@
+      ---tiny0[1:shared]
+      ------rack0[1:shared]
+      ---------node1[1:shared]
+      ------------socket1[1:shared]
+      ---------------core18[1:exclusive]
+      ------------socket0[1:shared]
+      ---------------core0[1:exclusive]
+      ---------node0[1:shared]
+      ------------socket1[1:shared]
+      ---------------core18[1:exclusive]
+      ------------socket0[1:shared]
+      ---------------core0[1:exclusive]
+INFO: =============================
+INFO: JOBID=1
+INFO: RESOURCES=ALLOCATED
+INFO: SCHEDULED AT=Now
+INFO: =============================
+      ---tiny0[1:shared]
+      ------rack0[1:shared]
+      ---------node1[1:shared]
+      ------------socket1[1:shared]
+      ---------------core19[1:exclusive]
+      ------------socket0[1:shared]
+      ---------------core1[1:exclusive]
+      ---------node0[1:shared]
+      ------------socket1[1:shared]
+      ---------------core19[1:exclusive]
+      ------------socket0[1:shared]
+      ---------------core1[1:exclusive]
+INFO: =============================
+INFO: JOBID=2
+INFO: RESOURCES=ALLOCATED
+INFO: SCHEDULED AT=Now
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: Unsatisfiable request
+INFO: JOBID=3
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: Unsatisfiable request
+INFO: JOBID=4
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: JOBID=5
+INFO: =============================
+      ---tiny0[1:shared]
+      ------rack0[1:shared]
+      ---------node0[1:shared]
+      ------------socket0[1:shared]
+      ---------------core17[1:exclusive]
+      ---------------core16[1:exclusive]
+      ---------------core15[1:exclusive]
+      ---------------core14[1:exclusive]
+      ---------------core13[1:exclusive]
+      ---------------core12[1:exclusive]
+      ---------------core11[1:exclusive]
+      ---------------core10[1:exclusive]
+      ---------------core9[1:exclusive]
+      ---------------core8[1:exclusive]
+      ---------------core7[1:exclusive]
+      ---------------core6[1:exclusive]
+      ---------------core5[1:exclusive]
+      ---------------core4[1:exclusive]
+      ---------------core3[1:exclusive]
+      ---------------core2[1:exclusive]
+      ---------------core1[1:exclusive]
+      ---------------core0[1:exclusive]
+INFO: =============================
+INFO: JOBID=6
+INFO: RESOURCES=RESERVED
+INFO: SCHEDULED AT=3600
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: JOBID=7
+INFO: =============================
+      ---tiny0[1:shared]
+      ------rack0[1:shared]
+      ---------node1[1:shared]
+      ------------socket0[1:shared]
+      ---------------core17[1:exclusive]
+      ---------------core16[1:exclusive]
+      ---------------core15[1:exclusive]
+      ---------------core14[1:exclusive]
+      ---------------core13[1:exclusive]
+      ---------------core12[1:exclusive]
+      ---------------core11[1:exclusive]
+      ---------------core10[1:exclusive]
+      ---------------core9[1:exclusive]
+      ---------------core8[1:exclusive]
+      ---------------core7[1:exclusive]
+      ---------------core6[1:exclusive]
+      ---------------core5[1:exclusive]
+      ---------------core4[1:exclusive]
+      ---------------core3[1:exclusive]
+      ---------------core2[1:exclusive]
+      ---------------core1[1:exclusive]
+      ---------------core0[1:exclusive]
+INFO: =============================
+INFO: JOBID=8
+INFO: RESOURCES=RESERVED
+INFO: SCHEDULED AT=3600
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: JOBID=9
+INFO: =============================
+      ---tiny0[1:shared]
+      ------rack0[1:shared]
+      ---------node1[1:shared]
+      ------------socket1[1:shared]
+      ---------------core35[1:exclusive]
+      ---------------core34[1:exclusive]
+      ---------------core33[1:exclusive]
+      ---------------core32[1:exclusive]
+      ---------------core31[1:exclusive]
+      ---------------core30[1:exclusive]
+      ---------------core29[1:exclusive]
+      ---------------core28[1:exclusive]
+      ---------------core27[1:exclusive]
+      ---------------core26[1:exclusive]
+      ---------------core25[1:exclusive]
+      ---------------core24[1:exclusive]
+      ---------------core23[1:exclusive]
+      ---------------core22[1:exclusive]
+      ---------------core21[1:exclusive]
+      ---------------core20[1:exclusive]
+      ---------------core19[1:exclusive]
+      ---------------core18[1:exclusive]
+      ---------node0[1:shared]
+      ------------socket1[1:shared]
+      ---------------core35[1:exclusive]
+      ---------------core34[1:exclusive]
+      ---------------core33[1:exclusive]
+      ---------------core32[1:exclusive]
+      ---------------core31[1:exclusive]
+      ---------------core30[1:exclusive]
+      ---------------core29[1:exclusive]
+      ---------------core28[1:exclusive]
+      ---------------core27[1:exclusive]
+      ---------------core26[1:exclusive]
+      ---------------core25[1:exclusive]
+      ---------------core24[1:exclusive]
+      ---------------core23[1:exclusive]
+      ---------------core22[1:exclusive]
+      ---------------core21[1:exclusive]
+      ---------------core20[1:exclusive]
+      ---------------core19[1:exclusive]
+      ---------------core18[1:exclusive]
+INFO: =============================
+INFO: JOBID=10
+INFO: RESOURCES=RESERVED
+INFO: SCHEDULED AT=3600
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: Unsatisfiable request
+INFO: JOBID=11
+INFO: =============================
+INFO: =============================
+INFO: No matching resources found
+INFO: Unsatisfiable request
+INFO: JOBID=12
+INFO: =============================

--- a/t/data/resource/jobspecs/satisfiability/test001.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test001.yaml
@@ -1,0 +1,30 @@
+version: 1
+resources:
+    - type: cluster
+      count: 1
+      with:
+        - type: rack
+          count: 1
+          with:
+            - type: node
+              count: 1
+              with:
+                  - type: slot
+                    count: 1
+                    label: default
+                    with:
+                      - type: socket
+                        count: 1
+                        with:
+                          - type: core
+                            count: 19
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: app
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/data/resource/jobspecs/satisfiability/test002.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test002.yaml
@@ -1,0 +1,21 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: default
+    with:
+      - type: socket
+        count: 1
+        with:
+          - type: core
+            count: 30
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: app
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/data/resource/jobspecs/satisfiability/test003.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test003.yaml
@@ -1,0 +1,21 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: default
+    with:
+      - type: socket
+        count: 3
+        with:
+          - type: core
+            count: 1
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: app
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/data/resource/jobspecs/satisfiability/test004.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test004.yaml
@@ -1,0 +1,24 @@
+version: 1
+resources:
+  - type: node
+    count: 1
+    with:
+      - type: slot
+        count: 2
+        label: default
+        with:
+          - type: socket
+            count: 2
+            with:
+              - type: core
+                count: 1
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: app
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/data/resource/jobspecs/satisfiability/test005.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test005.yaml
@@ -1,0 +1,24 @@
+version: 1
+resources:
+  - type: node
+    count: 3
+    with:
+      - type: slot
+        count: 1
+        label: default
+        with:
+          - type: socket
+            count: 1
+            with:
+              - type: core
+                count: 1
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: app
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/data/resource/jobspecs/satisfiability/test006.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test006.yaml
@@ -1,0 +1,30 @@
+version: 1
+resources:
+    - type: cluster
+      count: 1
+      with:
+        - type: rack
+          count: 2
+          with:
+            - type: node
+              count: 1
+              with:
+                  - type: slot
+                    count: 1
+                    label: default
+                    with:
+                      - type: socket
+                        count: 1
+                        with:
+                          - type: core
+                            count: 1
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: app
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/data/resource/jobspecs/satisfiability/test007.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test007.yaml
@@ -1,0 +1,30 @@
+version: 1
+resources:
+  - type: cluster
+    count: 2
+    with:
+      - type: rack
+        count: 1
+        with:
+          - type: node
+            count: 1
+            with:
+              - type: slot
+                count: 1
+                label: default
+                with:
+                  - type: socket
+                    count: 1
+                    with:
+                      - type: core
+                        count: 1
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: app
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/data/resource/jobspecs/satisfiability/test008.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test008.yaml
@@ -1,0 +1,27 @@
+version: 1
+resources:
+  - type: rack
+    count: 3
+    with:
+      - type: node
+        count: 1
+        with:
+          - type: slot
+            count: 1
+            label: default
+            with:
+              - type: socket
+                count: 1
+                with:
+                  - type: core
+                    count: 1
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: app
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/data/resource/jobspecs/satisfiability/test009.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test009.yaml
@@ -1,0 +1,33 @@
+version: 1
+resources:
+  - type: zone
+    count: 1
+    with:
+      - type: cluster
+        count: 1
+        with:
+          - type: rack
+            count: 1
+            with:
+              - type: node
+                count: 1
+                with:
+                  - type: slot
+                    count: 1
+                    label: default
+                    with:
+                      - type: socket
+                        count: 1
+                        with:
+                          - type: core
+                            count: 1
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: app
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/data/resource/jobspecs/satisfiability/test010.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test010.yaml
@@ -1,0 +1,30 @@
+version: 1
+resources:
+    - type: cluster
+      count: 1
+      with:
+        - type: rack
+          count: 1
+          with:
+            - type: node
+              count: 2
+              with:
+                - type: socket
+                  count: 2
+                  with:
+                    - type: slot
+                      label: default
+                      count: 1
+                      with:
+                        - type: core
+                          count: 1
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: app
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/data/resource/jobspecs/satisfiability/test011.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test011.yaml
@@ -1,0 +1,31 @@
+version: 1
+resources:
+    - type: cluster
+      count: 1
+      with:
+        - type: rack
+          count: 1
+          with:
+            - type: node
+              count: 1
+              with:
+                - type: socket
+                  count: 1
+                  with:
+                    - type: slot
+                      label: default
+                      count: 1
+                      with:
+                        - type: core
+                          count: 19
+
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: app
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/data/resource/jobspecs/satisfiability/test012.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test012.yaml
@@ -1,0 +1,18 @@
+version: 1
+resources:
+  - type: slot
+    label: default
+    count: 1
+    with:
+      - type: core
+        count: 18
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: app
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/data/resource/jobspecs/satisfiability/test013.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test013.yaml
@@ -1,0 +1,21 @@
+version: 1
+resources:
+  - type: socket
+    count: 1
+    with:
+      - type: slot
+        label: default
+        count: 1
+        with:
+          - type: core
+            count: 18
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: app
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/data/resource/jobspecs/satisfiability/test014.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test014.yaml
@@ -1,0 +1,21 @@
+version: 1
+resources:
+  - type: socket
+    count: 2
+    with:
+      - type: slot
+        label: default
+        count: 1
+        with:
+          - type: core
+            count: 18
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: app
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/data/resource/jobspecs/satisfiability/test015.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test015.yaml
@@ -1,0 +1,21 @@
+version: 1
+resources:
+  - type: slot
+    label: default
+    count: 1
+    with:
+      - type: socket
+        count: 1
+        with:
+          - type: core
+            count: 1
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: app
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/data/resource/jobspecs/satisfiability/test016.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test016.yaml
@@ -1,0 +1,21 @@
+version: 1
+resources:
+  - type: slot
+    label: default
+    count: 1
+    with:
+      - type: socket
+        count: 3
+        with:
+          - type: core
+            count: 1
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: app
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/scripts/flux-resource
+++ b/t/scripts/flux-resource
@@ -32,6 +32,11 @@ class ResourceModuleInterface:
         payload = {'cmd' : 'allocate', 'jobid' : jobid, 'jobspec' : jobspec_str}
         return self.f.rpc ("resource.match", payload).get ()
 
+    def rpc_allocate_with_satisfiability (self, jobid, jobspec_str):
+        payload = {'cmd' : 'allocate_with_satisfiability',
+                   'jobid' : jobid, 'jobspec' : jobspec_str}
+        return self.f.rpc ("resource.match", payload).get ()
+
     def rpc_reserve (self, jobid, jobspec_str):
         payload = {'cmd' : 'allocate_orelse_reserve',
                    'jobid' : jobid, 'jobspec' : jobspec_str}
@@ -56,6 +61,21 @@ def match_alloc_action (args):
         jobspec_str = yaml.dump (yaml.load (stream))
         r = ResourceModuleInterface ()
         resp = r.rpc_allocate (r.rpc_next_jobid (), jobspec_str)
+        print heading ()
+        print body (resp['jobid'], resp['status'], resp['at'], resp['overhead'])
+        print ("=" * width ())
+        print "MATCHED RESOURCES:"
+        print resp['R']
+
+"""
+    Action for match allocate_with_satisfiability sub-command
+"""
+def match_alloc_sat_action (args):
+    with open (args.jobspec, 'r') as stream:
+        jobspec_str = yaml.dump (yaml.load (stream))
+        r = ResourceModuleInterface ()
+        resp = r.rpc_allocate_with_satisfiability (r.rpc_next_jobid (),
+                                                   jobspec_str)
         print heading ()
         print body (resp['jobid'], resp['status'], resp['at'], resp['overhead'])
         print ("=" * width ())
@@ -146,9 +166,13 @@ def main ():
                                            help='Additional help')
 
     mastr = "Allocate the best matching resources if found"
+    msstr = "Allocate the best matching resources if found. "\
+            "If not found, check jobspec's overall satisfiability"
     mrstr = "Allocate the best matching resources if found. "\
             "If not found, reserve them instead at earliest time"
     parser_ma = subparsers_m.add_parser ('allocate', help=mastr)
+    parser_ms = subparsers_m.add_parser ('allocate_with_satisfiability',
+                                          help=msstr)
     parser_mr = subparsers_m.add_parser ('allocate_orelse_reserve', help=mrstr)
 
     #
@@ -176,6 +200,13 @@ def main ():
     parser_ma.set_defaults (func=match_alloc_action)
 
     #
+    # Positional argument for match allocate_with_satisfiability sub-command
+    #
+    parser_ms.add_argument ('jobspec', metavar='Jobspec', type=str,
+                            help='Jobspec file name')
+    parser_ms.set_defaults (func=match_alloc_sat_action)
+
+    #
     # Positional argument for match allocate_orelse_reserve sub-command
     #
     parser_mr.add_argument ('jobspec', metavar='Jobspec', type=str,
@@ -195,8 +226,10 @@ def main ():
 
     except EnvironmentError as e:
         print "Environment error({0}): {1}".format (e.errno, e.strerror)
-        if e.errno == errno.EBUSY:
+        if e.errno == errno.EBUSY:  # resource currently unavailable
             exit (16)
+        if e.errno == errno.ENODEV: # unsatisfiable jobspec
+            exit (19)
         else:
             exit (1)
 

--- a/t/t3013-resource-unsat.t
+++ b/t/t3013-resource-unsat.t
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+test_description='Test the correctness of allocate with satisfiability check'
+
+. $(dirname $0)/sharness.sh
+
+cmd_dir="${SHARNESS_TEST_SRCDIR}/data/resource/commands/satisfiability"
+exp_dir="${SHARNESS_TEST_SRCDIR}/data/resource/expected/satisfiability"
+grugs="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/tiny.graphml"
+query="../../resource/utilities/resource-query"
+
+cmds001="${cmd_dir}/cmds01.in"
+test001_desc="detect unsatisfiables due to low-level constraints"
+test_expect_success "${test001_desc}" '
+    sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds001} > cmds001 &&
+    ${query} -G ${grugs} -S CA -P low -F pretty_simple -t 001.R.out < cmds001 &&
+    test_cmp 001.R.out ${exp_dir}/001.R.out
+'
+
+cmds002="${cmd_dir}/cmds02.in"
+test002_desc="detect unsatisfiables due to high-level constraints"
+test_expect_success "${test002_desc}" '
+    sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds002} > cmds002 &&
+    ${query} -G ${grugs} -S CA -P low -F pretty_simple -t 002.R.out < cmds002 &&
+    test_cmp 002.R.out ${exp_dir}/002.R.out
+'
+
+cmds003="${cmd_dir}/cmds03.in"
+test003_desc="distinguish unsatisfiables vs. resource currently unavailable"
+test_expect_success "${test003_desc}" '
+    sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds003} > cmds003 &&
+    ${query} -G ${grugs} -S CA -P low -F pretty_simple -t 003.R.out < cmds003 &&
+    test_cmp 003.R.out ${exp_dir}/003.R.out
+'
+
+test_done

--- a/t/t4005-match-unsat.t
+++ b/t/t4005-match-unsat.t
@@ -1,0 +1,73 @@
+#!/bin/sh
+#set -x
+
+test_description='Test the basic functionality of allocate_with_satisfiability
+'
+
+ORIG_HOME=${HOME}
+
+. `dirname $0`/sharness.sh
+
+#
+# sharness modifies $HOME environment variable, but this interferes
+# with python's package search path, in particular its user site package.
+#
+HOME=${ORIG_HOME}
+
+grug="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/tiny.graphml"
+jobspec1="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/basics/test001.yaml"
+jobspec2="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/satisfiability/test001.yaml"
+
+#
+# test_under_flux is under sharness.d/
+#
+test_under_flux 1
+
+#
+# print only with --debug
+#
+test_debug '
+    echo ${grug} &&
+    echo ${jobspec1} &&
+    echo ${jobspec2} &&
+'
+
+test_expect_success 'loading resource module with a tiny machine config works' '
+    flux module load resource grug-conf=${grug} prune-filters=ALL:core \
+subsystems=containment policy=high
+'
+
+test_expect_success 'satisfiability works with a 1-node, 1-socket jobspec' '
+    flux resource match allocate_with_satisfiability ${jobspec1} &&
+    flux resource match allocate_with_satisfiability ${jobspec1} &&
+    flux resource match allocate_with_satisfiability ${jobspec1} &&
+    flux resource match allocate_with_satisfiability ${jobspec1}
+'
+
+test_expect_success 'satisfiability returns EBUSY when no available resources' '
+    test_expect_code 16 flux resource \
+match allocate_with_satisfiability ${jobspec1} &&
+    test_expect_code 16 flux resource \
+match allocate_with_satisfiability ${jobspec1} &&
+    test_expect_code 16 flux resource \
+match allocate_with_satisfiability ${jobspec1} &&
+    test_expect_code 16 flux resource \
+match allocate_with_satisfiability ${jobspec1}
+'
+
+test_expect_success 'satisfiability returns ENODEV on unsatisfiable jobspec' '
+    test_expect_code 19 flux resource \
+match allocate_with_satisfiability ${jobspec2} &&
+    test_expect_code 19 flux resource \
+match allocate_with_satisfiability ${jobspec2} &&
+    test_expect_code 19 flux resource \
+match allocate_with_satisfiability ${jobspec2} &&
+    test_expect_code 19 flux resource \
+match allocate_with_satisfiability ${jobspec2}
+'
+
+test_expect_success 'removing resource works' '
+    flux module remove resource
+'
+
+test_done


### PR DESCRIPTION
This PR adds the following support:

- Detect unsatisfiable jobs
As discussed in Issue #478, the match RPC within `resource` only supports two match operations: `allocate` and `allocate_orelse_reserve`. The former doesn't tell whether the allocation request failed because of the current resource state (i.e., no resource available now) or the jobspec cannot be satisfied at all. By contrast, if the latter fails, that means the jobspec is not satisfiable: no matter how far in the timeline I move my schedule point, the jobspec cannot be matched.
The main feature of this PR is to add  `allocate_with_satisfiability` to overcome the challenge with `allocate`.  It first attempts to allocate. If succeeds, it returns the matching info as before. If fails, however, it sets the scheduled time to a point as late as possible within the time box of the planner and try the match. Then, if it still can't find matching resources at that scheduled point, the jobspec is deemed unsatisfiable. This add no additional overhead for those "qualified" jobspec. However, for "unqualified" jobspecs, checking satisfiability requires an entire tree walk. Going forward, we will more rigorously validate the input job specs before they come to `resource`, so we will be able to manage this cost better.

- Tighten up `qmanager`'s error handling 
Integrate this feature to the rest of the systems including `qmanager` and its queue policy layer. This tightens up error handling of `qmanager` to become more robust.

- Trim message logging for `resource` and `qmanager`
Significantly reduce the number of per-job messages in particular.

Resolve #495, #478, and #489.