### PR TITLE
Add EASY/HYBRID/CONSERVATIVE policies

### DIFF
--- a/etc/resource-start
+++ b/etc/resource-start
@@ -12,6 +12,7 @@
 #
 
 if [ -z ${FLUX_RESOURCE_RC_NOOP} ]; then
+    FLUX_RESOURCE_OPTIONS=${FLUX_RESOURCE_OPTIONS:-"hwloc-whitelist=node,core,gpu"}
     flux module load -r 0 resource ${FLUX_RESOURCE_OPTIONS}
 fi
 

--- a/qmanager/config/queue_system_defaults.hpp
+++ b/qmanager/config/queue_system_defaults.hpp
@@ -28,9 +28,9 @@
 // FIXME: These need to be coverted into a scheduler configuration file
 namespace Flux {
 namespace queue_manager {
-    const unsigned int MAX_QUEUE_DEPTH=16384;
-    const unsigned int DEFAULT_QUEUE_DEPTH=8192;
-    const unsigned int MAX_RESERVATION_DEPTH = 4096;
+    const unsigned int MAX_QUEUE_DEPTH = 1000000;
+    const unsigned int DEFAULT_QUEUE_DEPTH = 8192;
+    const unsigned int MAX_RESERVATION_DEPTH = 100000;
     const unsigned int HYBRID_RESERVATION_DEPTH = 64;
 } // namespace resource_model
 } // namespace Flux

--- a/qmanager/config/queue_system_defaults.hpp
+++ b/qmanager/config/queue_system_defaults.hpp
@@ -1,0 +1,42 @@
+/*****************************************************************************\
+ *  Copyright (c) 2014 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef QUEUE_SYSTEM_DEFAULT_HPP
+#define QUEUE_SYSTEM_DEFAULT_HPP
+
+// FIXME: These need to be coverted into a scheduler configuration file
+namespace Flux {
+namespace queue_manager {
+namespace detail {
+    const unsigned int MAX_RESERVATION_DEPTH = 4096;
+    const unsigned int HYBRID_RESERVATION_DEPTH = 64;
+} // namespace detail
+} // namespace resource_model
+} // namespace Flux
+
+#endif // QUEUE_SYSTEM_DEFAULT_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/qmanager/config/queue_system_defaults.hpp
+++ b/qmanager/config/queue_system_defaults.hpp
@@ -28,10 +28,10 @@
 // FIXME: These need to be coverted into a scheduler configuration file
 namespace Flux {
 namespace queue_manager {
-namespace detail {
+    const unsigned int MAX_QUEUE_DEPTH=16384;
+    const unsigned int DEFAULT_QUEUE_DEPTH=8192;
     const unsigned int MAX_RESERVATION_DEPTH = 4096;
     const unsigned int HYBRID_RESERVATION_DEPTH = 64;
-} // namespace detail
 } // namespace resource_model
 } // namespace Flux
 

--- a/qmanager/modules/Makefile.am
+++ b/qmanager/modules/Makefile.am
@@ -21,6 +21,7 @@ qmanager_la_SOURCES = \
     $(top_srcdir)/resource/hlapi/bindings/c++/reapi_cli_impl.hpp \
     $(top_srcdir)/resource/hlapi/bindings/c++/reapi_module.hpp \
     $(top_srcdir)/resource/hlapi/bindings/c++/reapi_module_impl.hpp \
+    $(top_srcdir)/qmanager/config/queue_system_defaults.hpp \
     $(top_srcdir)/qmanager/policies/base/queue_policy_base.hpp \
     $(top_srcdir)/qmanager/policies/base/queue_policy_base_impl.hpp \
     $(top_srcdir)/qmanager/policies/queue_policy_fcfs.hpp \
@@ -29,6 +30,10 @@ qmanager_la_SOURCES = \
     $(top_srcdir)/qmanager/policies/queue_policy_bf_base_impl.hpp \
     $(top_srcdir)/qmanager/policies/queue_policy_easy.hpp \
     $(top_srcdir)/qmanager/policies/queue_policy_easy_impl.hpp \
+    $(top_srcdir)/qmanager/policies/queue_policy_hybrid.hpp \
+    $(top_srcdir)/qmanager/policies/queue_policy_hybrid_impl.hpp \
+    $(top_srcdir)/qmanager/policies/queue_policy_conservative.hpp \
+    $(top_srcdir)/qmanager/policies/queue_policy_conservative_impl.hpp \
     $(top_srcdir)/qmanager/policies/queue_policy_factory.hpp \
     $(top_srcdir)/qmanager/policies/queue_policy_factory_impl.hpp
 

--- a/qmanager/modules/Makefile.am
+++ b/qmanager/modules/Makefile.am
@@ -25,6 +25,8 @@ qmanager_la_SOURCES = \
     $(top_srcdir)/qmanager/policies/base/queue_policy_base_impl.hpp \
     $(top_srcdir)/qmanager/policies/queue_policy_fcfs.hpp \
     $(top_srcdir)/qmanager/policies/queue_policy_fcfs_impl.hpp \
+    $(top_srcdir)/qmanager/policies/queue_policy_bf_base.hpp \
+    $(top_srcdir)/qmanager/policies/queue_policy_bf_base_impl.hpp \
     $(top_srcdir)/qmanager/policies/queue_policy_easy.hpp \
     $(top_srcdir)/qmanager/policies/queue_policy_easy_impl.hpp \
     $(top_srcdir)/qmanager/policies/queue_policy_factory.hpp \

--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -313,7 +313,7 @@ static void qmanager_destroy (qmanager_ctx_t *ctx)
         delete ctx->queue;
         ctx->queue = NULL;
         schedutil_ops_unregister (ctx->ops);
-        free (ctx);
+        delete (ctx);
         errno = saved_errno;
     }
 }

--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -47,6 +47,7 @@ using namespace Flux::queue_manager::detail;
 
 struct qmanager_args_t {
     std::string queue_policy;
+    std::string queue_params;
     std::string policy_params;
 };
 
@@ -210,6 +211,9 @@ static int process_args (qmanager_ctx_t *ctx, int argc, char **argv)
                 args.queue_policy = dflt;
             }
         }
+        else if (!strncmp ("queue-params=", argv[i], sizeof ("queue-params"))) {
+            args.queue_params = strstr (argv[i], "=") + 1;
+        }
         else if (!strncmp ("policy-params=", argv[i],
                                sizeof ("policy-params"))) {
             args.policy_params = strstr (argv[i], "=") + 1;
@@ -260,7 +264,12 @@ static int enforce_queue_policy (qmanager_ctx_t *ctx)
         goto out;
     }
     if (ctx->args.policy_params != ""
-        && ctx->queue->set_params (ctx->args.policy_params) < 0) {
+        && ctx->queue->set_policy_params (ctx->args.policy_params) < 0) {
+        flux_log_error (ctx->h, "%s: queue->set_params", __FUNCTION__);
+        goto out;
+    }
+    if (ctx->args.queue_params != ""
+        && ctx->queue->set_queue_params (ctx->args.queue_params) < 0) {
         flux_log_error (ctx->h, "%s: queue->set_params", __FUNCTION__);
         goto out;
     }

--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -33,6 +33,7 @@ extern "C" {
 }
 
 #include <map>
+#include <unordered_map>
 #include <string>
 #include <memory>
 #include <cstdint>
@@ -136,6 +137,7 @@ protected:
     std::map<uint64_t, flux_jobid_t> m_complete;
     std::map<uint64_t, flux_jobid_t> m_rejected;
     std::map<flux_jobid_t, std::shared_ptr<job_t>> m_jobs;
+    std::unordered_map<std::string, std::string> m_params;
 };
 } // namespace Flux::queue_manager::detail
 
@@ -172,6 +174,19 @@ public:
      *                       EINVAL: invalid argument.
      */
     virtual int run_sched_loop (void *h, bool use_alloced_queue) = 0;
+
+    /*! Set queue policy parameters. Can be called multiple times.
+     *
+     * \param params     comma-delimited key-value pairs string
+     *                   (e.g., "reservation-depth=10,foo=bar")
+     * \return           0 on success; -1 on error.
+     *                       EINVAL: invalid argument.
+     */
+    int set_params (const std::string &params);
+
+    /*! Apply the set policy parameters to the queuing policy.
+     */
+    virtual int apply_params ();
 
     /*! Append a job into the internal pending-job queue.
      *
@@ -238,6 +253,9 @@ public:
      *                   on success; nullptr when the queue is empty.
      */
     std::shared_ptr<job_t> complete_pop ();
+
+private:
+    int set_param (std::string &kv);
 };
 
 } // namespace Flux::queue_manager

--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -131,6 +131,7 @@ protected:
     uint64_t m_rq_cnt = 0;
     uint64_t m_dq_cnt = 0;
     uint64_t m_cq_cnt = 0;
+    uint64_t m_oq_cnt = 0;
     std::map<uint64_t, flux_jobid_t> m_pending;
     std::map<uint64_t, flux_jobid_t> m_running;
     std::map<uint64_t, flux_jobid_t> m_alloced;

--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -38,6 +38,8 @@ extern "C" {
 #include <memory>
 #include <cstdint>
 
+#include "qmanager/config/queue_system_defaults.hpp"
+
 namespace Flux {
 namespace queue_manager {
 
@@ -132,13 +134,15 @@ protected:
     uint64_t m_dq_cnt = 0;
     uint64_t m_cq_cnt = 0;
     uint64_t m_oq_cnt = 0;
+    unsigned int m_queue_depth = DEFAULT_QUEUE_DEPTH;
     std::map<uint64_t, flux_jobid_t> m_pending;
     std::map<uint64_t, flux_jobid_t> m_running;
     std::map<uint64_t, flux_jobid_t> m_alloced;
     std::map<uint64_t, flux_jobid_t> m_complete;
     std::map<uint64_t, flux_jobid_t> m_rejected;
     std::map<flux_jobid_t, std::shared_ptr<job_t>> m_jobs;
-    std::unordered_map<std::string, std::string> m_params;
+    std::unordered_map<std::string, std::string> m_qparams;
+    std::unordered_map<std::string, std::string> m_pparams;
 };
 } // namespace Flux::queue_manager::detail
 
@@ -176,6 +180,15 @@ public:
      */
     virtual int run_sched_loop (void *h, bool use_alloced_queue) = 0;
 
+    /*! Set queue parameters. Can be called multiple times.
+     *
+     * \param params     comma-delimited key-value pairs string
+     *                   (e.g., "queue-depth=1024,foo=bar")
+     * \return           0 on success; -1 on error.
+     *                       EINVAL: invalid argument.
+     */
+    int set_queue_params (const std::string &params);
+
     /*! Set queue policy parameters. Can be called multiple times.
      *
      * \param params     comma-delimited key-value pairs string
@@ -183,7 +196,7 @@ public:
      * \return           0 on success; -1 on error.
      *                       EINVAL: invalid argument.
      */
-    int set_params (const std::string &params);
+    int set_policy_params (const std::string &params);
 
     /*! Apply the set policy parameters to the queuing policy.
      */
@@ -256,7 +269,10 @@ public:
     std::shared_ptr<job_t> complete_pop ();
 
 private:
-    int set_param (std::string &kv);
+    int set_params (const std::string &params,
+                    std::unordered_map<std::string, std::string> &p_map);
+    int set_param (std::string &kv,
+                   std::unordered_map<std::string, std::string> &p_map);
 };
 
 } // namespace Flux::queue_manager

--- a/qmanager/policies/base/queue_policy_base_impl.hpp
+++ b/qmanager/policies/base/queue_policy_base_impl.hpp
@@ -113,6 +113,8 @@ int queue_policy_base_t::apply_params ()
             unsigned int depth = std::stoi (i->second);
             if (depth < MAX_QUEUE_DEPTH)
                 queue_policy_base_impl_t::m_queue_depth = depth;
+            else
+                queue_policy_base_impl_t::m_queue_depth = MAX_QUEUE_DEPTH;
         }
     } catch (const std::invalid_argument &e) {
         rc = -1;

--- a/qmanager/policies/base/queue_policy_base_impl.hpp
+++ b/qmanager/policies/base/queue_policy_base_impl.hpp
@@ -33,7 +33,9 @@
 namespace Flux {
 namespace queue_manager {
 
-int queue_policy_base_t::set_param (std::string &p_pair)
+int queue_policy_base_t::set_param (std::string &p_pair,
+                                    std::unordered_map<std::string,
+                                                       std::string> &p_map)
 {
     int rc = -1;
     size_t pos = 0;
@@ -52,16 +54,18 @@ int queue_policy_base_t::set_param (std::string &p_pair)
     }
     v = p_pair.erase (0, pos + split.length ());
     v.erase (std::remove_if (v.begin (), v.end (), ::isspace), v.end ());
-    if (m_params.find (k) != m_params.end ())
-        m_params.erase (k);
-    m_params.insert (std::pair<std::string, std::string>(k, v));
+    if (p_map.find (k) != p_map.end ())
+        p_map.erase (k);
+    p_map.insert (std::pair<std::string, std::string>(k, v));
     rc = 0;
 done:
     return rc;
 }
 
 
-int queue_policy_base_t::set_params (const std::string &params)
+int queue_policy_base_t::set_params (const std::string &params,
+                                     std::unordered_map<std::string,
+                                                        std::string> &p_map)
 {
     int rc = -1;
     size_t pos = 0;
@@ -71,11 +75,11 @@ int queue_policy_base_t::set_params (const std::string &params)
     try {
         while ((pos = p_copy.find (delim)) != std::string::npos) {
             std::string p_pair = p_copy.substr (0, pos);
-            if (set_param (p_pair) < 0)
+            if (set_param (p_pair, p_map) < 0)
                 goto done;
             p_copy.erase (0, pos + delim.length ());
         }
-        if (set_param (p_copy) < 0)
+        if (set_param (p_copy, p_map) < 0)
             goto done;
         rc = 0;
     } catch (std::out_of_range &e) {
@@ -89,9 +93,35 @@ done:
     return rc;
 }
 
+int queue_policy_base_t::set_queue_params (const std::string &params)
+{
+    return set_params (params, m_qparams);
+}
+
+int queue_policy_base_t::set_policy_params (const std::string &params)
+{
+    return set_params (params, m_pparams);
+}
+
 int queue_policy_base_t::apply_params ()
 {
-    return 0;
+    int rc = 0;
+    try {
+        std::unordered_map<std::string, std::string>::const_iterator i;
+        if ((i = queue_policy_base_impl_t::m_qparams.find ("queue-depth"))
+             != queue_policy_base_impl_t::m_qparams.end ()) {
+            unsigned int depth = std::stoi (i->second);
+            if (depth < MAX_QUEUE_DEPTH)
+                queue_policy_base_impl_t::m_queue_depth = depth;
+        }
+    } catch (const std::invalid_argument &e) {
+        rc = -1;
+        errno = EINVAL;
+    } catch (const std::out_of_range &e) {
+        rc = -1;
+        errno = ERANGE;
+    }
+    return rc;
 }
 
 int queue_policy_base_t::insert (std::shared_ptr<job_t> job)

--- a/qmanager/policies/queue_policy_bf_base.hpp
+++ b/qmanager/policies/queue_policy_bf_base.hpp
@@ -37,6 +37,7 @@ class queue_policy_bf_base_t : public queue_policy_base_t
 public:
     virtual ~queue_policy_bf_base_t ();
     virtual int run_sched_loop (void *h, bool use_alloced_queue);
+    virtual int apply_params ();
 
 protected:
     unsigned int m_reservation_depth;

--- a/qmanager/policies/queue_policy_bf_base.hpp
+++ b/qmanager/policies/queue_policy_bf_base.hpp
@@ -22,32 +22,46 @@
  *  See also:  http://www.gnu.org/licenses/
 \*****************************************************************************/
 
-#ifndef QUEUE_POLICY_EASY_HPP
-#define QUEUE_POLICY_EASY_HPP
+#ifndef QUEUE_POLICY_BF_BASE_HPP
+#define QUEUE_POLICY_BF_BASE_HPP
 
-#include "qmanager/policies/queue_policy_bf_base.hpp"
+#include "qmanager/policies/base/queue_policy_base.hpp"
 
 namespace Flux {
 namespace queue_manager {
 namespace detail {
 
 template<class reapi_type>
-class queue_policy_easy_t : public queue_policy_bf_base_t<reapi_type>
+class queue_policy_bf_base_t : public queue_policy_base_t
 {
 public:
-    virtual ~queue_policy_easy_t ();
-    queue_policy_easy_t ();
-    queue_policy_easy_t (const queue_policy_easy_t &p) = default;
-    queue_policy_easy_t (queue_policy_easy_t &&p) = default;
-    queue_policy_easy_t &operator= (const queue_policy_easy_t &p) = default;
-    queue_policy_easy_t &operator= (queue_policy_easy_t &&p) = default;
+    virtual ~queue_policy_bf_base_t ();
+    virtual int run_sched_loop (void *h, bool use_alloced_queue);
+
+protected:
+    unsigned int m_reservation_depth;
+
+private:
+    int cancel_completed_jobs (void *h);
+    int cancel_reserved_jobs (void *h);
+    std::map<uint64_t, flux_jobid_t>::iterator &
+        allocate_orelse_reserve (void *h, std::shared_ptr<job_t> job,
+                                 bool use_alloced_queue,
+                                 std::map<uint64_t,
+                                     flux_jobid_t>::iterator &iter);
+    std::map<uint64_t, flux_jobid_t>::iterator &
+        allocate (void *h, std::shared_ptr<job_t> job, bool use_alloced_queue,
+        std::map<uint64_t, flux_jobid_t>::iterator &iter);
+    int allocate_orelse_reserve_jobs (void *h, bool use_alloced_queue);
+    std::map<uint64_t, flux_jobid_t> m_reserved;
+    unsigned int m_reservation_cnt;
 };
 
 } // namespace Flux::queue_manager::detail
 } // namespace Flux::queue_manager
 } // namespace Flux
 
-#endif // QUEUE_POLICY_EASY_HPP
+#endif // QUEUE_POLICY_BF_BASE_HPP
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/qmanager/policies/queue_policy_bf_base_impl.hpp
+++ b/qmanager/policies/queue_policy_bf_base_impl.hpp
@@ -1,0 +1,188 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef QUEUE_POLICY_BF_BASE_IMPL_HPP
+#define QUEUE_POLICY_BF_BASE_IMPL_HPP
+
+#include "qmanager/policies/queue_policy_bf_base.hpp"
+
+namespace Flux {
+namespace queue_manager {
+namespace detail {
+
+/******************************************************************************
+ *                                                                            *
+ *                 Private Methods of Queue Policy Backfill Base              *
+ *                                                                            *
+ ******************************************************************************/
+
+template<class reapi_type>
+int queue_policy_bf_base_t<reapi_type>::cancel_completed_jobs (void *h)
+{
+    int rc = 0;
+    std::shared_ptr<job_t> job;
+
+    // Pop newly completed jobs (e.g., per a free request from job-manager
+    // as received by qmanager) to remove them from the resource infrastructure.
+    while ((job = complete_pop ()) != nullptr)
+        rc += reapi_type::cancel (h, job->id);
+    return rc;
+}
+
+template<class reapi_type>
+int queue_policy_bf_base_t<reapi_type>::cancel_reserved_jobs (void *h)
+{
+    int rc = 0;
+    std::map<uint64_t, flux_jobid_t>::const_iterator citer;
+    for (citer = m_reserved.begin (); citer != m_reserved.end (); citer++)
+        rc += reapi_type::cancel (h, citer->second);
+    m_reserved.clear ();
+    return rc;
+}
+
+template<class reapi_type>
+std::map<uint64_t, flux_jobid_t>::iterator &
+queue_policy_bf_base_t<reapi_type>::allocate_orelse_reserve (void *h,
+                                               std::shared_ptr<job_t> job,
+                                               bool use_alloced_queue,
+                                               std::map<uint64_t,
+                                                  flux_jobid_t>::iterator &iter)
+
+
+{
+    if (reapi_type::match_allocate (h, true, job->jobspec, job->id,
+                                    job->schedule.reserved, job->schedule.R,
+                                    job->schedule.at, job->schedule.ov) == 0) {
+
+        if (job->schedule.reserved) {
+            // High-priority job has been reserved, continue
+            m_reserved.insert (std::pair<uint64_t, flux_jobid_t> (m_oq_cnt++,
+                                                                  job->id));
+            m_reservation_cnt++;
+            iter++;
+        } else {
+            // move the job to the running queue and make sure the job
+            // is enqueued into allocated job queue as well.
+            // When this is used within a module, it allows the module
+            // to fetch those newly allocated jobs, which have flux_msg_t to
+            // respond to job-manager.
+            iter = to_running (iter, use_alloced_queue);
+        }
+    } else {
+        // The request must be rejected. The job is enqueued into
+        // rejected job queue to the upper layer to react on this.
+        iter = to_rejected (iter, (errno == ENODEV)? "unsatisfiable"
+                                                   : "match error");
+    }
+    return iter;
+}
+
+template<class reapi_type>
+std::map<uint64_t, flux_jobid_t>::iterator &
+queue_policy_bf_base_t<reapi_type>::allocate (void *h, std::shared_ptr<job_t> job,
+                                              bool use_alloced_queue,
+                                              std::map<uint64_t,
+                                                  flux_jobid_t>::iterator &iter)
+{
+    if (reapi_type::match_allocate (h, false, job->jobspec, job->id,
+                                    job->schedule.reserved, job->schedule.R,
+                                    job->schedule.at, job->schedule.ov) == 0) {
+        // move the job to the running queue and make sure the job
+        // is enqueued into allocated job queue as well.
+        // When this is used within a module, it allows the module
+        // to fetch those newly allocated jobs, which have flux_msg_t to
+        // respond to job-manager.
+        iter = to_running (iter, use_alloced_queue);
+    } else {
+        if (errno != EBUSY) {
+            // The request must be rejected. The job is enqueued into
+            // rejected job queue to the upper layer to react on this.
+            iter = to_rejected (iter, (errno == ENODEV)? "unsatisfiable"
+                                                       : "match error");
+        } else {
+            iter++;
+        }
+    }
+    return iter;
+}
+
+template<class reapi_type>
+int queue_policy_bf_base_t<reapi_type>::allocate_orelse_reserve_jobs (void *h,
+                                            bool use_alloced_queue)
+{
+    unsigned int i = 0;
+    std::shared_ptr<job_t> job;
+
+    // Iterate jobs in the pending job queue and try to allocate each
+    // until you can't. When you can't allocate a job, you reserve it
+    // and then try to backfill later jobs.
+    std::map<uint64_t, flux_jobid_t>::iterator iter = m_pending.begin ();
+    m_reservation_cnt = 0;
+    int saved_errno = errno;
+    while ((iter != m_pending.end ())) {
+        errno = 0;
+        job = m_jobs[iter->second];
+        if (m_reservation_cnt < m_reservation_depth)
+            iter = allocate_orelse_reserve (h, job, use_alloced_queue, iter);
+        else
+            iter = allocate (h, job, use_alloced_queue, iter);
+       i++;
+    }
+    errno = saved_errno;
+    return 0;
+}
+
+
+/******************************************************************************
+ *                                                                            *
+ *                 Public API of Queue Policy Backfill Base                   *
+ *                                                                            *
+ ******************************************************************************/
+
+template<class reapi_type>
+queue_policy_bf_base_t<reapi_type>::~queue_policy_bf_base_t ()
+{
+
+}
+
+template<class reapi_type>
+int queue_policy_bf_base_t<reapi_type>::run_sched_loop (void *h,
+                                                        bool use_alloced_queue)
+{
+    int rc = 0;
+    rc = cancel_completed_jobs (h);
+    rc += allocate_orelse_reserve_jobs (h, use_alloced_queue);
+    rc += cancel_reserved_jobs (h);
+    return rc;
+}
+
+} // namespace Flux::queue_manager::detail
+} // namespace Flux::queue_manager
+} // namespace Flux
+
+#endif // QUEUE_POLICY_BF_BASE_IMPL_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/qmanager/policies/queue_policy_bf_base_impl.hpp
+++ b/qmanager/policies/queue_policy_bf_base_impl.hpp
@@ -140,7 +140,7 @@ int queue_policy_bf_base_t<reapi_type>::allocate_orelse_reserve_jobs (void *h,
     std::map<uint64_t, flux_jobid_t>::iterator iter = m_pending.begin ();
     m_reservation_cnt = 0;
     int saved_errno = errno;
-    while ((iter != m_pending.end ())) {
+    while ((iter != m_pending.end ()) && (i < m_queue_depth)) {
         errno = 0;
         job = m_jobs[iter->second];
         if (m_reservation_cnt < m_reservation_depth)
@@ -164,6 +164,12 @@ template<class reapi_type>
 queue_policy_bf_base_t<reapi_type>::~queue_policy_bf_base_t ()
 {
 
+}
+
+template<class reapi_type>
+int queue_policy_bf_base_t<reapi_type>::apply_params ()
+{
+    return 0;
 }
 
 template<class reapi_type>

--- a/qmanager/policies/queue_policy_conservative.hpp
+++ b/qmanager/policies/queue_policy_conservative.hpp
@@ -1,0 +1,58 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef QUEUE_POLICY_CONSERVATIVE_HPP
+#define QUEUE_POLICY_CONSERVATIVE_HPP
+
+#include "qmanager/config/queue_system_defaults.hpp"
+#include "qmanager/policies/queue_policy_bf_base.hpp"
+
+namespace Flux {
+namespace queue_manager {
+namespace detail {
+
+template<class reapi_type>
+class queue_policy_conservative_t : public queue_policy_bf_base_t<reapi_type>
+{
+public:
+    virtual ~queue_policy_conservative_t ();
+    queue_policy_conservative_t ();
+    queue_policy_conservative_t (
+        const queue_policy_conservative_t &p) = default;
+    queue_policy_conservative_t (queue_policy_conservative_t &&p) = default;
+    queue_policy_conservative_t &operator= (
+        const queue_policy_conservative_t &p) = default;
+    queue_policy_conservative_t &operator= (
+        queue_policy_conservative_t &&p) = default;
+};
+
+} // namespace Flux::queue_manager::detail
+} // namespace Flux::queue_manager
+} // namespace Flux
+
+#endif // QUEUE_POLICY_CONSERVATIVE_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/qmanager/policies/queue_policy_conservative.hpp
+++ b/qmanager/policies/queue_policy_conservative.hpp
@@ -25,7 +25,6 @@
 #ifndef QUEUE_POLICY_CONSERVATIVE_HPP
 #define QUEUE_POLICY_CONSERVATIVE_HPP
 
-#include "qmanager/config/queue_system_defaults.hpp"
 #include "qmanager/policies/queue_policy_bf_base.hpp"
 
 namespace Flux {
@@ -45,6 +44,8 @@ public:
         const queue_policy_conservative_t &p) = default;
     queue_policy_conservative_t &operator= (
         queue_policy_conservative_t &&p) = default;
+
+    virtual int apply_params ();
 };
 
 } // namespace Flux::queue_manager::detail

--- a/qmanager/policies/queue_policy_conservative_impl.hpp
+++ b/qmanager/policies/queue_policy_conservative_impl.hpp
@@ -1,0 +1,55 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef QUEUE_POLICY_CONSERVATIVE_IMPL_HPP
+#define QUEUE_POLICY_CONSERVATIVE_IMPL_HPP
+
+#include "qmanager/policies/queue_policy_conservative.hpp"
+
+namespace Flux {
+namespace queue_manager {
+namespace detail {
+
+template<class reapi_type>
+queue_policy_conservative_t<reapi_type>::~queue_policy_conservative_t ()
+{
+
+}
+
+template<class reapi_type>
+queue_policy_conservative_t<reapi_type>::queue_policy_conservative_t ()
+{
+    queue_policy_bf_base_t<reapi_type>::
+        m_reservation_depth = MAX_RESERVATION_DEPTH;
+}
+
+} // namespace Flux::queue_manager::detail
+} // namespace Flux::queue_manager
+} // namespace Flux
+
+#endif // QUEUE_POLICY_CONSERVATIVE_IMPL_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/qmanager/policies/queue_policy_conservative_impl.hpp
+++ b/qmanager/policies/queue_policy_conservative_impl.hpp
@@ -38,6 +38,18 @@ queue_policy_conservative_t<reapi_type>::~queue_policy_conservative_t ()
 }
 
 template<class reapi_type>
+int queue_policy_conservative_t<reapi_type>::apply_params ()
+{
+    int rc = -1;
+    if ( (rc = queue_policy_base_t::apply_params ()) == 0) {
+        unsigned int depth = queue_policy_bf_base_t<reapi_type>::m_queue_depth;
+        if (queue_policy_bf_base_t<reapi_type>::m_reservation_depth > depth)
+            queue_policy_bf_base_t<reapi_type>::m_reservation_depth = depth;
+    }
+    return rc;
+}
+
+template<class reapi_type>
 queue_policy_conservative_t<reapi_type>::queue_policy_conservative_t ()
 {
     queue_policy_bf_base_t<reapi_type>::

--- a/qmanager/policies/queue_policy_easy.hpp
+++ b/qmanager/policies/queue_policy_easy.hpp
@@ -41,6 +41,7 @@ public:
     queue_policy_easy_t (queue_policy_easy_t &&p) = default;
     queue_policy_easy_t &operator= (const queue_policy_easy_t &p) = default;
     queue_policy_easy_t &operator= (queue_policy_easy_t &&p) = default;
+    virtual int apply_params ();
 };
 
 } // namespace Flux::queue_manager::detail

--- a/qmanager/policies/queue_policy_easy_impl.hpp
+++ b/qmanager/policies/queue_policy_easy_impl.hpp
@@ -25,7 +25,7 @@
 #ifndef QUEUE_POLICY_EASY_IMPL_HPP
 #define QUEUE_POLICY_EASY_IMPL_HPP
 
-#include "qmanager/policies/queue_policy_easy.hpp"
+#include "qmanager/policies/queue_policy_bf_base_impl.hpp"
 
 namespace Flux {
 namespace queue_manager {
@@ -38,10 +38,9 @@ queue_policy_easy_t<reapi_type>::~queue_policy_easy_t ()
 }
 
 template<class reapi_type>
-int queue_policy_easy_t<reapi_type>::run_sched_loop (void *h,
-                                                     bool use_alloced_queue)
+queue_policy_easy_t<reapi_type>::queue_policy_easy_t ()
 {
-    return -1;
+    queue_policy_bf_base_t<reapi_type>::m_reservation_depth = 1;
 }
 
 } // namespace Flux::queue_manager::detail

--- a/qmanager/policies/queue_policy_easy_impl.hpp
+++ b/qmanager/policies/queue_policy_easy_impl.hpp
@@ -38,6 +38,12 @@ queue_policy_easy_t<reapi_type>::~queue_policy_easy_t ()
 }
 
 template<class reapi_type>
+int queue_policy_easy_t<reapi_type>::apply_params ()
+{
+    return queue_policy_base_t::apply_params ();
+}
+
+template<class reapi_type>
 queue_policy_easy_t<reapi_type>::queue_policy_easy_t ()
 {
     queue_policy_bf_base_t<reapi_type>::m_reservation_depth = 1;

--- a/qmanager/policies/queue_policy_factory_impl.hpp
+++ b/qmanager/policies/queue_policy_factory_impl.hpp
@@ -36,6 +36,10 @@
 #include "qmanager/policies/queue_policy_fcfs_impl.hpp"
 #include "qmanager/policies/queue_policy_easy.hpp"
 #include "qmanager/policies/queue_policy_easy_impl.hpp"
+#include "qmanager/policies/queue_policy_hybrid.hpp"
+#include "qmanager/policies/queue_policy_hybrid_impl.hpp"
+#include "qmanager/policies/queue_policy_conservative.hpp"
+#include "qmanager/policies/queue_policy_conservative_impl.hpp"
 #include <string>
 
 namespace Flux {
@@ -48,7 +52,8 @@ using namespace resource_model::detail;
 bool known_queue_policy (const std::string &policy)
 {
     bool rc = false;
-    if (policy == "fcfs" || policy == "easy")
+    if (policy == "fcfs" || policy == "easy"
+        || policy == "hybrid" || policy == "conservative")
         rc = true;
     return rc;
 }
@@ -75,6 +80,26 @@ queue_policy_base_t *create_queue_policy (const std::string &policy,
         else if (reapi == "cli") {
             p = (queue_policy_base_t *)
                     new (std::nothrow)queue_policy_easy_t<reapi_cli_t> ();
+        }
+    }
+    else if (policy == "hybrid") {
+        if (reapi == "module") {
+            p = (queue_policy_base_t *)
+                    new (std::nothrow)queue_policy_hybrid_t<reapi_module_t> ();
+        }
+        else if (reapi == "cli") {
+            p = (queue_policy_base_t *)
+                    new (std::nothrow)queue_policy_hybrid_t<reapi_cli_t> ();
+        }
+    }
+    else if (policy == "conservative") {
+        if (reapi == "module") {
+            p = (queue_policy_base_t *) new (std::nothrow)
+                    queue_policy_conservative_t<reapi_module_t> ();
+        }
+        else if (reapi == "cli") {
+            p = (queue_policy_base_t *) new (std::nothrow)
+                    queue_policy_conservative_t<reapi_cli_t> ();
         }
     }
     return p;

--- a/qmanager/policies/queue_policy_factory_impl.hpp
+++ b/qmanager/policies/queue_policy_factory_impl.hpp
@@ -47,9 +47,9 @@ using namespace resource_model::detail;
 
 bool known_queue_policy (const std::string &policy)
 {
-    bool rc = true;
-    if (policy != "fcfs" && policy != "easy")
-        rc = false;
+    bool rc = false;
+    if (policy == "fcfs" || policy == "easy")
+        rc = true;
     return rc;
 }
 

--- a/qmanager/policies/queue_policy_fcfs.hpp
+++ b/qmanager/policies/queue_policy_fcfs.hpp
@@ -37,6 +37,10 @@ class queue_policy_fcfs_t : public queue_policy_base_t
 public:
     virtual ~queue_policy_fcfs_t ();
     virtual int run_sched_loop (void *h, bool use_alloced_queue);
+
+private:
+    int cancel_completed_jobs (void *h);
+    int allocate_jobs (void *h, bool use_alloced_queue);
 };
 
 } // namespace Flux::queue_manager::detail

--- a/qmanager/policies/queue_policy_fcfs.hpp
+++ b/qmanager/policies/queue_policy_fcfs.hpp
@@ -37,6 +37,7 @@ class queue_policy_fcfs_t : public queue_policy_base_t
 public:
     virtual ~queue_policy_fcfs_t ();
     virtual int run_sched_loop (void *h, bool use_alloced_queue);
+    virtual int apply_params ();
 
 private:
     int cancel_completed_jobs (void *h);

--- a/qmanager/policies/queue_policy_fcfs_impl.hpp
+++ b/qmanager/policies/queue_policy_fcfs_impl.hpp
@@ -32,28 +32,33 @@ namespace Flux {
 namespace queue_manager {
 namespace detail {
 
-template<class reapi_type>
-queue_policy_fcfs_t<reapi_type>::~queue_policy_fcfs_t ()
-{
 
-}
+/******************************************************************************
+ *                                                                            *
+ *                    Private Methods of Queue Policy FCFS                    *
+ *                                                                            *
+ ******************************************************************************/
 
 template<class reapi_type>
-int queue_policy_fcfs_t<reapi_type>::run_sched_loop (void *h,
-                                                     bool use_alloced_queue)
+int queue_policy_fcfs_t<reapi_type>::cancel_completed_jobs (void *h)
 {
     int rc = 0;
     std::shared_ptr<job_t> job;
-    std::map<uint64_t, flux_jobid_t>::iterator iter;
 
-    //
     // Pop newly completed jobs (e.g., per a free request from job-manager
     // as received by qmanager) to remove them from the resource infrastructure.
-    //
     while ((job = complete_pop ()) != nullptr)
         rc += reapi_type::cancel (h, job->id);
+    return rc;
+}
 
-    //
+template<class reapi_type>
+int queue_policy_fcfs_t<reapi_type>::allocate_jobs (void *h,
+                                                    bool use_alloced_queue)
+{
+    std::shared_ptr<job_t> job;
+    std::map<uint64_t, flux_jobid_t>::iterator iter;
+
     // Iterate jobs in the pending job queue and try to allocate each
     // until you can't.
     //
@@ -86,6 +91,29 @@ int queue_policy_fcfs_t<reapi_type>::run_sched_loop (void *h,
         }
     }
     errno = saved_errno;
+    return 0;
+}
+
+
+/******************************************************************************
+ *                                                                            *
+ *                    Public API of Queue Policy FCFS                         *
+ *                                                                            *
+ ******************************************************************************/
+
+template<class reapi_type>
+queue_policy_fcfs_t<reapi_type>::~queue_policy_fcfs_t ()
+{
+
+}
+
+template<class reapi_type>
+int queue_policy_fcfs_t<reapi_type>::run_sched_loop (void *h,
+                                                     bool use_alloced_queue)
+{
+    int rc = 0;
+    rc = cancel_completed_jobs (h);
+    rc += allocate_jobs (h, use_alloced_queue);
     return rc;
 }
 

--- a/qmanager/policies/queue_policy_fcfs_impl.hpp
+++ b/qmanager/policies/queue_policy_fcfs_impl.hpp
@@ -56,6 +56,7 @@ template<class reapi_type>
 int queue_policy_fcfs_t<reapi_type>::allocate_jobs (void *h,
                                                     bool use_alloced_queue)
 {
+    unsigned int i = 0;
     std::shared_ptr<job_t> job;
     std::map<uint64_t, flux_jobid_t>::iterator iter;
 
@@ -64,7 +65,7 @@ int queue_policy_fcfs_t<reapi_type>::allocate_jobs (void *h,
     //
     int saved_errno = errno;
     iter = m_pending.begin ();
-    while (iter != m_pending.end ()) {
+    while (iter != m_pending.end () && i < m_queue_depth) {
         errno = 0;
         job = m_jobs[iter->second];
         if (reapi_type::match_allocate (h, false, job->jobspec, job->id,
@@ -89,6 +90,7 @@ int queue_policy_fcfs_t<reapi_type>::allocate_jobs (void *h,
                 break;
             }
         }
+        i++;
     }
     errno = saved_errno;
     return 0;
@@ -105,6 +107,12 @@ template<class reapi_type>
 queue_policy_fcfs_t<reapi_type>::~queue_policy_fcfs_t ()
 {
 
+}
+
+template<class reapi_type>
+int queue_policy_fcfs_t<reapi_type>::apply_params ()
+{
+    return queue_policy_base_t::apply_params ();
 }
 
 template<class reapi_type>

--- a/qmanager/policies/queue_policy_hybrid.hpp
+++ b/qmanager/policies/queue_policy_hybrid.hpp
@@ -1,0 +1,57 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef QUEUE_POLICY_HYBRID_HPP
+#define QUEUE_POLICY_HYBRID_HPP
+
+#include "qmanager/config/queue_system_defaults.hpp"
+#include "qmanager/policies/queue_policy_bf_base.hpp"
+
+namespace Flux {
+namespace queue_manager {
+namespace detail {
+
+template<class reapi_type>
+class queue_policy_hybrid_t : public queue_policy_bf_base_t<reapi_type>
+{
+public:
+    virtual ~queue_policy_hybrid_t ();
+    queue_policy_hybrid_t ();
+    queue_policy_hybrid_t (const queue_policy_hybrid_t &p) = default;
+    queue_policy_hybrid_t (queue_policy_hybrid_t &&p) = default;
+    queue_policy_hybrid_t &operator= (const queue_policy_hybrid_t &p) = default;
+    queue_policy_hybrid_t &operator= (queue_policy_hybrid_t &&p) = default;
+
+    virtual int apply_params ();
+};
+
+} // namespace Flux::queue_manager::detail
+} // namespace Flux::queue_manager
+} // namespace Flux
+
+#endif // QUEUE_POLICY_HYBRID_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/qmanager/policies/queue_policy_hybrid.hpp
+++ b/qmanager/policies/queue_policy_hybrid.hpp
@@ -25,7 +25,6 @@
 #ifndef QUEUE_POLICY_HYBRID_HPP
 #define QUEUE_POLICY_HYBRID_HPP
 
-#include "qmanager/config/queue_system_defaults.hpp"
 #include "qmanager/policies/queue_policy_bf_base.hpp"
 
 namespace Flux {

--- a/qmanager/policies/queue_policy_hybrid_impl.hpp
+++ b/qmanager/policies/queue_policy_hybrid_impl.hpp
@@ -53,8 +53,12 @@ int queue_policy_hybrid_t<reapi_type>::apply_params ()
         if ((i = queue_policy_base_impl_t::m_pparams.find ("reservation-depth"))
              != queue_policy_base_impl_t::m_pparams.end ()) {
             unsigned int depth = std::stoi (i->second);
-            if (depth < MAX_RESERVATION_DEPTH)
+            if (depth < MAX_RESERVATION_DEPTH) {
                 queue_policy_bf_base_t<reapi_type>::m_reservation_depth = depth;
+            } else {
+                queue_policy_bf_base_t<reapi_type>::m_reservation_depth
+                    = MAX_RESERVATION_DEPTH;
+            }
         }
         rc += 0;
     } catch (const std::invalid_argument &e) {

--- a/qmanager/policies/queue_policy_hybrid_impl.hpp
+++ b/qmanager/policies/queue_policy_hybrid_impl.hpp
@@ -1,0 +1,82 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef QUEUE_POLICY_HYBRID_IMPL_HPP
+#define QUEUE_POLICY_HYBRID_IMPL_HPP
+
+#include "qmanager/policies/queue_policy_hybrid.hpp"
+
+namespace Flux {
+namespace queue_manager {
+namespace detail {
+
+template<class reapi_type>
+queue_policy_hybrid_t<reapi_type>::~queue_policy_hybrid_t ()
+{
+
+}
+
+template<class reapi_type>
+queue_policy_hybrid_t<reapi_type>::queue_policy_hybrid_t ()
+{
+    queue_policy_bf_base_t<reapi_type>::m_reservation_depth =
+        HYBRID_RESERVATION_DEPTH;
+}
+
+template<class reapi_type>
+int queue_policy_hybrid_t<reapi_type>::apply_params ()
+{
+    int rc = -1;
+    try {
+        std::unordered_map<std::string, std::string>::const_iterator i;
+        if ((i = queue_policy_base_impl_t::m_params.find ("queue-depth"))
+             != queue_policy_base_impl_t::m_params.end ()) {
+            unsigned int depth = std::stoi (i->second);
+            if (depth < MAX_QUEUE_DEPTH)
+                queue_policy_base_impl_t::m_queue_depth = depth;
+        }
+        if ((i = queue_policy_base_impl_t::m_params.find ("reservation-depth"))
+             != queue_policy_base_impl_t::m_params.end ()) {
+            unsigned int depth = std::stoi (i->second);
+            if (depth < MAX_RESERVATION_DEPTH)
+                queue_policy_bf_base_t<reapi_type>::m_reservation_depth = depth;
+        }
+        rc = 0;
+    } catch (const std::invalid_argument &e) {
+        errno = EINVAL;
+    } catch (const std::out_of_range &e) {
+        errno = ERANGE;
+    }
+    return rc;
+}
+
+} // namespace Flux::queue_manager::detail
+} // namespace Flux::queue_manager
+} // namespace Flux
+
+#endif // QUEUE_POLICY_HYBRID_IMPL_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/qmanager/policies/queue_policy_hybrid_impl.hpp
+++ b/qmanager/policies/queue_policy_hybrid_impl.hpp
@@ -47,22 +47,16 @@ queue_policy_hybrid_t<reapi_type>::queue_policy_hybrid_t ()
 template<class reapi_type>
 int queue_policy_hybrid_t<reapi_type>::apply_params ()
 {
-    int rc = -1;
+    int rc = queue_policy_base_t::apply_params ();
     try {
         std::unordered_map<std::string, std::string>::const_iterator i;
-        if ((i = queue_policy_base_impl_t::m_params.find ("queue-depth"))
-             != queue_policy_base_impl_t::m_params.end ()) {
-            unsigned int depth = std::stoi (i->second);
-            if (depth < MAX_QUEUE_DEPTH)
-                queue_policy_base_impl_t::m_queue_depth = depth;
-        }
-        if ((i = queue_policy_base_impl_t::m_params.find ("reservation-depth"))
-             != queue_policy_base_impl_t::m_params.end ()) {
+        if ((i = queue_policy_base_impl_t::m_pparams.find ("reservation-depth"))
+             != queue_policy_base_impl_t::m_pparams.end ()) {
             unsigned int depth = std::stoi (i->second);
             if (depth < MAX_RESERVATION_DEPTH)
                 queue_policy_bf_base_t<reapi_type>::m_reservation_depth = depth;
         }
-        rc = 0;
+        rc += 0;
     } catch (const std::invalid_argument &e) {
         errno = EINVAL;
     } catch (const std::out_of_range &e) {

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -157,7 +157,7 @@ static void set_default_args (resource_args_t &args)
     args.hwloc_whitelist = "";
     args.match_subsystems = "containment";
     args.match_policy = "high";
-    args.prune_filters = "ALL:pu";
+    args.prune_filters = "ALL:core";
     args.match_format = "rv1_nosched";
     args.reserve_vtx_vec = 0;
 }

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -534,29 +534,30 @@ static void update_match_perf (resource_ctx_t *ctx, double elapse)
     ctx->perf.accum += elapse;
 }
 
-static inline string get_status_string (int64_t at)
+static inline string get_status_string (int64_t now, int64_t at)
 {
-    return (at == 0)? "ALLOCATED" : "RESERVED";
+    return (at == now)? "ALLOCATED" : "RESERVED";
 }
 
-static int track_schedule_info (resource_ctx_t *ctx, int64_t id, int64_t at,
-                                string &jspec, stringstream &R, double elapse)
+static int track_schedule_info (resource_ctx_t *ctx, int64_t id, int64_t now,
+                                int64_t at, string &jspec, stringstream &R,
+                                double elapse)
 {
     job_lifecycle_t state = job_lifecycle_t::INIT;
 
-    if (id < 0 || at < 0) {
+    if (id < 0 || now < 0 || at < 0) {
         errno = EINVAL;
         return -1;
     }
 
-    state = (at == 0)? job_lifecycle_t::ALLOCATED : job_lifecycle_t::RESERVED;
+    state = (at == now)? job_lifecycle_t::ALLOCATED : job_lifecycle_t::RESERVED;
     if (!(ctx->jobs[id] = new ((nothrow))job_info_t (id, state, at, "", jspec,
                                                      R.str (), elapse))) {
         errno = ENOMEM;
         return -1;
     }
 
-    if (at == 0)
+    if (at == now)
         ctx->allocations[id] = id;
     else
         ctx->reservations[id] = id;
@@ -583,7 +584,8 @@ static int run (resource_ctx_t *ctx, int64_t jobid,
 }
 
 static int run_match (resource_ctx_t *ctx, int64_t jobid, const char *cmd,
-                      string jstr, int64_t *at, double *ov, stringstream &o)
+                      string jstr, int64_t *now, int64_t *at, double *ov,
+                      stringstream &o)
 {
     int rc = 0;
     double elapse = 0.0f;
@@ -600,6 +602,8 @@ static int run_match (resource_ctx_t *ctx, int64_t jobid, const char *cmd,
         flux_log_error (ctx->h, "unknown cmd: %s", cmd);
         goto done;
     }
+
+    *at = *now = (int64_t)start.tv_sec;
     if ((rc = run (ctx, jobid, cmd, jstr, at)) < 0)
         goto done;
 
@@ -608,7 +612,7 @@ static int run_match (resource_ctx_t *ctx, int64_t jobid, const char *cmd,
     *ov = get_elapse_time (start, end);
     update_match_perf (ctx, *ov);
 
-    if ((rc = track_schedule_info (ctx, jobid, *at, jstr, o, *ov)) != 0) {
+    if ((rc = track_schedule_info (ctx, jobid, *now, *at, jstr, o, *ov)) != 0) {
         errno = EINVAL;
         flux_log_error (ctx->h, "can't add job info (id=%jd)", (intmax_t)jobid);
         goto done;
@@ -654,14 +658,15 @@ static void match_request_cb (flux_t *h, flux_msg_handler_t *w,
                               const flux_msg_t *msg, void *arg)
 {
     int64_t at = 0;
+    int64_t now = 0;
     int64_t jobid = -1;
     double ov = 0.0f;
     string status = "";
     const char *cmd = NULL;
     const char *js_str = NULL;
     stringstream R;
-    resource_ctx_t *ctx = getctx ((flux_t *)arg);
 
+    resource_ctx_t *ctx = getctx ((flux_t *)arg);
     if (flux_request_unpack (msg, NULL, "{s:s s:I s:s}", "cmd", &cmd,
                              "jobid", &jobid, "jobspec", &js_str) < 0)
         goto error;
@@ -670,14 +675,14 @@ static void match_request_cb (flux_t *h, flux_msg_handler_t *w,
         flux_log_error (h, "existent job (%jd).", (intmax_t)jobid);
         goto error;
     }
-    if (run_match (ctx, jobid, cmd, js_str, &at, &ov, R) < 0) {
+    if (run_match (ctx, jobid, cmd, js_str, &now, &at, &ov, R) < 0) {
         if (errno != EBUSY && errno != ENODEV)
             flux_log_error (ctx->h, "match failed due to match error (id=%jd)",
                            (intmax_t)jobid);
         goto error;
     }
 
-    status = get_status_string (at);
+    status = get_status_string (now, at);
     if (flux_respond_pack (h, msg, "{s:I s:s s:f s:s s:I}",
                                    "jobid", jobid,
                                    "status", status.c_str (),

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -65,6 +65,7 @@ struct resource_args_t {
 
 struct match_perf_t {
     double load;                   /* Graph load time */
+    uint64_t njobs;                /* Total match count */
     double min;                    /* Min match time */
     double max;                    /* Max match time */
     double accum;                  /* Total match time accumulated */
@@ -174,6 +175,7 @@ static resource_ctx_t *getctx (flux_t *h)
         ctx->handlers = NULL;
         set_default_args (ctx->args);
         ctx->perf.load = 0.0f;
+        ctx->perf.njobs = 0;
         ctx->perf.min = DBL_MAX;
         ctx->perf.max = 0.0f;
         ctx->perf.accum = 0.0f;
@@ -526,6 +528,7 @@ static int init_resource_graph (resource_ctx_t *ctx)
 
 static void update_match_perf (resource_ctx_t *ctx, double elapse)
 {
+    ctx->perf.njobs++;
     ctx->perf.min = (ctx->perf.min > elapse)? elapse : ctx->perf.min;
     ctx->perf.max = (ctx->perf.max < elapse)? elapse : ctx->perf.max;
     ctx->perf.accum += elapse;
@@ -627,16 +630,21 @@ static int run_remove (resource_ctx_t *ctx, int64_t jobid)
 
     if ((rc = tr.remove (jobid)) < 0) {
         if (is_existent_jobid (ctx, jobid)) {
+           // When this condition arises, we will be less likely
+           // to be able to reuse this jobid. Having the errored job
+           // in the jobs map will prevent us from reusing the jobid
+           // up front.  Note that a same jobid can be reserved and
+           // removed multiple times by the upper queuing layer
+           // as part of providing advanced queueing policies
+           // (e.g., conservative backfill).
            job_info_t *info = ctx->jobs[jobid];
            info->state = job_lifecycle_t::ERROR;
         }
         goto out;
     }
+    if (is_existent_jobid (ctx, jobid))
+        ctx->jobs.erase (jobid);
 
-    if (is_existent_jobid (ctx, jobid)) {
-        job_info_t *info = ctx->jobs[jobid];
-        info->state = job_lifecycle_t::CANCELLED;
-    }
     rc = 0;
 out:
     return rc;
@@ -757,15 +765,15 @@ static void stat_request_cb (flux_t *h, flux_msg_handler_t *w,
     double avg = 0.0f;
     double min = 0.0f;
 
-    if (ctx->jobs.size ()) {
-        avg = ctx->perf.accum / (double)ctx->jobs.size ();
+    if (ctx->perf.njobs) {
+        avg = ctx->perf.accum / (double)ctx->perf.njobs;
         min = ctx->perf.min;
     }
     if (flux_respond_pack (h, msg, "{s:I s:I s:f s:I s:f s:f s:f}",
                                    "V", num_vertices (ctx->db.resource_graph),
                                    "E", num_edges (ctx->db.resource_graph),
                                    "load-time", ctx->perf.load,
-                                   "njobs", ctx->jobs.size (),
+                                   "njobs", ctx->perf.njobs,
                                    "min-match", min,
                                    "max-match", ctx->perf.max,
                                    "avg-match", avg) < 0)

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -139,6 +139,7 @@ int dfu_impl_t::by_excl (const jobmeta_t &meta, const std::string &s, vtx_t u,
     // requested, we check the validity of the visiting vertex using
     // its x_checker planner.
     if (exclusive_in || resource.exclusive == Jobspec::tristate_t::TRUE) {
+        errno = 0;
         p = (*m_graph)[u].schedule.x_checker;
         njobs = planner_avail_resources_during (p, at, duration);
         if (njobs == -1) {

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -32,6 +32,7 @@ TESTS = \
     t0003-basic-install.t \
     t1001-qmanager-basic.t \
     t1002-qmanager-reload.t \
+    t1003-qmanager-policy.t \
     t3000-jobspec.t \
     t3001-resource-basic.t \
     t3002-resource-prefix.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -33,6 +33,7 @@ TESTS = \
     t1001-qmanager-basic.t \
     t1002-qmanager-reload.t \
     t1003-qmanager-policy.t \
+    t1004-qmanager-optimize.t \
     t3000-jobspec.t \
     t3001-resource-basic.t \
     t3002-resource-prefix.t \

--- a/t/scripts/flux-resource
+++ b/t/scripts/flux-resource
@@ -122,11 +122,11 @@ def stat_action (args):
     resp = r.rpc_stat ()
     print "Num. of Vertices: ", resp['V']
     print "Num. of Edges: ", resp['E']
-    print "Graph Load Time: ", resp['load-time']
+    print "Graph Load Time: ", resp['load-time'], "Secs"
     print "Num. of Jobs Matched: ", resp['njobs']
-    print "Min. Match Time: ", resp['min-match']
-    print "Max. Match Time: ", resp['max-match']
-    print "Avg. Match Time: ", resp['avg-match']
+    print "Min. Match Time: ", resp['min-match'], "Secs"
+    print "Max. Match Time: ", resp['max-match'], "Secs"
+    print "Avg. Match Time: ", resp['avg-match'], "Secs"
 
 """
     Main entry point

--- a/t/scripts/flux-resource
+++ b/t/scripts/flux-resource
@@ -4,13 +4,14 @@ import argparse
 import errno
 import yaml
 import flux
+import time
 
 def heading ():
     return '{:20} {:20} {:20} {:20}'.format ('JOBID', 'STATUS',
                                              'AT', 'OVERHEAD (Secs)')
 
 def body (jobid, status, at, overhead):
-    t = "Now" if at == 0 else str (at)
+    t = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime (at))
     o = str (overhead)
     return '{:20} {:20} {:20} {:20}'.format (str (jobid), status, t, o)
 

--- a/t/t1003-qmanager-policy.t
+++ b/t/t1003-qmanager-policy.t
@@ -30,7 +30,7 @@ test_expect_success 'qmanager: generate jobspecs of varying requirements' '
     flux jobspec srun -n4 -t 179 hostname | exec_test > C04.T10800.json && #7
     flux jobspec srun -n4 -t 239 hostname | exec_test > C04.T14400.json && #8
     flux jobspec srun -n2 -t 239 hostname | exec_test > C02.T14400.json && #9
-    flux jobspec srun -n2 -t 299 hostname | exec_test > C02.T18000.json #10
+    flux jobspec srun -n2 -t 299 hostname | exec_test > C02.T18000.json && #10
     flux jobspec srun -n2 -t 59 hostname | exec_test > C02.T3600.json #11
 '
 

--- a/t/t1003-qmanager-policy.t
+++ b/t/t1003-qmanager-policy.t
@@ -1,0 +1,138 @@
+#!/bin/sh
+
+test_description='Test the correctness of different queuing policies'
+
+. `dirname $0`/sharness.sh
+
+hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+# 4 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
+excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers"
+
+test_under_flux 1
+
+#  Set path to jq(1)
+#
+jq=$(which jq 2>/dev/null)
+if test -z "$jq"; then
+    skip_all='jq not found. Skipping all tests'
+    test_done
+fi
+
+exec_test()     { ${jq} '.attributes.system.exec.test = {}'; }
+
+test_expect_success 'qmanager: generate jobspecs of varying requirements' '
+    flux jobspec srun  -n8 -t 60 hostname | exec_test > C08.T3600.json && #1
+    flux jobspec srun -n10 -t 60 hostname | exec_test > C10.T3600.json && #2
+    flux jobspec srun -n12 -t 60 hostname | exec_test > C12.T3600.json && #3
+    flux jobspec srun -n14 -t 60 hostname | exec_test > C14.T3600.json && #4
+    flux jobspec srun -n16 -t 60 hostname | exec_test > C16.T3600.json && #5
+    flux jobspec srun -n6 -t 121 hostname | exec_test > C06.T7260.json && #6
+    flux jobspec srun -n4 -t 179 hostname | exec_test > C04.T10800.json && #7
+    flux jobspec srun -n4 -t 239 hostname | exec_test > C04.T14400.json && #8
+    flux jobspec srun -n2 -t 239 hostname | exec_test > C02.T14400.json && #9
+    flux jobspec srun -n2 -t 299 hostname | exec_test > C02.T18000.json #10
+    flux jobspec srun -n2 -t 59 hostname | exec_test > C02.T3600.json #11
+'
+
+test_expect_success 'qmanager: hwloc reload works' '
+    flux hwloc reload ${excl_4N4B}
+'
+
+test_expect_success 'qmanager: loading qmanager (queue-policy=easy)' '
+    flux module remove sched-simple &&
+    flux module load resource prune-filters=ALL:core \
+subsystems=containment policy=low hwloc-whitelist=cluster,node,core &&
+    flux module load qmanager queue-policy=easy
+'
+
+test_expect_success 'qmanager: EASY policy correctly schedules jobs' '
+    jobid1=$(flux job submit C08.T3600.json) &&
+    jobid2=$(flux job submit C10.T3600.json) && # reserved
+    jobid3=$(flux job submit C12.T3600.json) &&
+    jobid4=$(flux job submit C14.T3600.json) &&
+    jobid5=$(flux job submit C16.T3600.json) &&
+    jobid6=$(flux job submit C06.T7260.json) && # BF A
+    jobid7=$(flux job submit C04.T10800.json) && # BF C when 7 completes
+    jobid8=$(flux job submit C04.T14400.json) &&
+    jobid9=$(flux job submit C02.T14400.json) && # BF D when 7 completes
+    jobid10=$(flux job submit C02.T18000.json) &&
+    jobid11=$(flux job submit C02.T3600.json) && # BF B
+
+    flux job wait-event -t 2 ${jobid1} start &&
+    flux job wait-event -t 2 ${jobid6} start &&
+    flux job wait-event -t 2 ${jobid11} start &&
+    flux job cancel ${jobid6} &&
+    flux job wait-event -t 2 ${jobid7} start &&
+    flux job wait-event -t 2 ${jobid9} start &&
+    test $(flux job list | wc -l) -eq 11 &&
+    test $(flux job list | grep -v USERID | grep R | wc -l) -eq 4 &&
+    flux job list | grep -v USERID | xargs -L 1 flux job cancel &&
+    flux job wait-event -t 2 ${jobid10} clean
+'
+
+test_expect_success 'qmanager: loading qmanager (queue-policy=hybrid)' '
+    flux module remove qmanager &&
+    flux module load qmanager queue-policy=hybrid \
+policy-params=reservation-depth=3
+'
+
+test_expect_success 'qmanager: HYBRID policy correctly schedules jobs' '
+    jobid1=$(flux job submit C08.T3600.json) &&
+    jobid2=$(flux job submit C10.T3600.json) && # reserved
+    jobid3=$(flux job submit C12.T3600.json) && # reserved
+    jobid4=$(flux job submit C14.T3600.json) && # reserved
+    jobid5=$(flux job submit C16.T3600.json) &&
+    jobid6=$(flux job submit C06.T7260.json) &&
+    jobid7=$(flux job submit C04.T10800.json) && # BF A
+    jobid8=$(flux job submit C04.T14400.json) &&
+    jobid9=$(flux job submit C02.T14400.json) && # BF C when 8 completes
+    jobid10=$(flux job submit C02.T18000.json) &&
+    jobid11=$(flux job submit C02.T3600.json) && # BF B
+
+    flux job wait-event -t 2 ${jobid1} start &&
+    flux job wait-event -t 2 ${jobid7} start &&
+    flux job wait-event -t 2 ${jobid11} start &&
+    flux job cancel ${jobid7} &&
+    flux job wait-event -t 2 ${jobid9} start &&
+    test $(flux job list | wc -l) -eq 11 &&
+    test $(flux job list | grep -v USERID | grep R | wc -l) -eq 3 &&
+    flux job list | grep -v USERID | xargs -L 1 flux job cancel &&
+    flux job wait-event -t 2 ${jobid11} clean
+'
+
+
+test_expect_success 'qmanager: loading qmanager (queue-policy=conservative)' '
+    flux module remove qmanager &&
+    flux module load qmanager queue-policy=conservative
+'
+
+test_expect_success 'qmanager: CONSERVATIVE correctly schedules jobs' '
+    jobid1=$(flux job submit C08.T3600.json) &&
+    jobid2=$(flux job submit C10.T3600.json) && # reserved
+    jobid3=$(flux job submit C12.T3600.json) && # reserved
+    jobid4=$(flux job submit C16.T3600.json) && # reserved
+    jobid5=$(flux job submit C14.T3600.json) && # reserved
+    jobid6=$(flux job submit C06.T7260.json) && # reserved
+    jobid7=$(flux job submit C04.T10800.json) && # BF A
+    jobid8=$(flux job submit C04.T14400.json) && # reserved
+    jobid9=$(flux job submit C02.T14400.json) && # reserved
+    jobid10=$(flux job submit C02.T18000.json) && # reserved
+    jobid11=$(flux job submit C02.T3600.json) && # BF B
+
+    flux job wait-event -t 2 ${jobid1} start &&
+    flux job wait-event -t 2 ${jobid7} start &&
+    flux job wait-event -t 2 ${jobid11} start &&
+    flux job cancel ${jobid7} &&
+    flux job wait-event -t 2 ${jobid7} clean &&
+    test $(flux job list | wc -l) -eq 11 &&
+    test $(flux job list | grep -v USERID | grep R | wc -l) -eq 2 &&
+    flux job list | grep -v USERID | xargs -L 1 flux job cancel &&
+    flux job wait-event -t 2 ${jobid11} clean
+'
+
+test_expect_success 'removing resource and qmanager modules' '
+    flux module remove -r 0 qmanager &&
+    flux module remove -r 0 resource
+'
+
+test_done

--- a/t/t1004-qmanager-optimize.t
+++ b/t/t1004-qmanager-optimize.t
@@ -1,0 +1,130 @@
+#!/bin/sh
+
+test_description='Test the correctness of various queuing optimization'
+
+. `dirname $0`/sharness.sh
+
+hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+# 4 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
+excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers"
+
+test_under_flux 1
+
+#  Set path to jq(1)
+#
+jq=$(which jq 2>/dev/null)
+if test -z "$jq"; then
+    skip_all='jq not found. Skipping all tests'
+    test_done
+fi
+
+exec_test()     { ${jq} '.attributes.system.exec.test = {}'; }
+
+test_expect_success 'qmanager: generate jobspecs of varying requirements' '
+    flux jobspec srun  -n8 -t 60 hostname | exec_test > C08.T3600.json && #1
+    flux jobspec srun -n10 -t 60 hostname | exec_test > C10.T3600.json && #2
+    flux jobspec srun -n12 -t 60 hostname | exec_test > C12.T3600.json && #3
+    flux jobspec srun -n14 -t 60 hostname | exec_test > C14.T3600.json && #4
+    flux jobspec srun -n16 -t 60 hostname | exec_test > C16.T3600.json && #5
+    flux jobspec srun -n6 -t 121 hostname | exec_test > C06.T7260.json && #6
+    flux jobspec srun -n4 -t 179 hostname | exec_test > C04.T10800.json && #7
+    flux jobspec srun -n4 -t 239 hostname | exec_test > C04.T14400.json && #8
+    flux jobspec srun -n2 -t 239 hostname | exec_test > C02.T14400.json && #9
+    flux jobspec srun -n2 -t 299 hostname | exec_test > C02.T18000.json && #10
+    flux jobspec srun -n2 -t 59 hostname | exec_test > C02.T3600.json #11
+'
+
+test_expect_success 'qmanager: hwloc reload works' '
+    flux hwloc reload ${excl_4N4B}
+'
+
+test_expect_success 'qmanager: loading with easy+queue-depth=5' '
+    flux module remove sched-simple &&
+    flux module load resource prune-filters=ALL:core \
+subsystems=containment policy=low hwloc-whitelist=cluster,node,core &&
+    flux module load qmanager queue-policy=easy queue-params=queue-depth=5
+'
+
+test_expect_success 'qmanager: EASY policy conforms to queue-depth=5' '
+    jobid1=$(flux job submit C08.T3600.json) &&
+    jobid2=$(flux job submit C10.T3600.json) && # reserved
+    jobid3=$(flux job submit C12.T3600.json) &&
+    jobid4=$(flux job submit C14.T3600.json) &&
+    jobid5=$(flux job submit C16.T3600.json) &&
+    jobid6=$(flux job submit C06.T7260.json) && # BF A
+    jobid7=$(flux job submit C04.T10800.json) && # BF B when 6 completes
+    jobid8=$(flux job submit C04.T14400.json) && # BF C when 7 completes
+    jobid9=$(flux job submit C02.T14400.json) && # Cannot start because qd
+    jobid10=$(flux job submit C02.T18000.json) && # Cannot start because qd
+    jobid11=$(flux job submit C02.T3600.json) &&
+
+    flux job wait-event -t 2 ${jobid1} start &&
+    flux job wait-event -t 2 ${jobid6} start &&
+    flux job cancel ${jobid6} &&
+    flux job wait-event -t 2 ${jobid7} start &&
+    flux job cancel ${jobid7} &&
+    flux job wait-event -t 2 ${jobid8} start &&
+    test $(flux job list | wc -l) -eq 10 &&
+    test $(flux job list | grep -v USERID | grep R | wc -l) -eq 2 &&
+    flux job list | grep -v USERID | xargs -L 1 flux job cancel &&
+    flux job wait-event -t 2 ${jobid11} clean
+'
+
+test_expect_success 'qmanager: loading with hybrid+queue-depth=5' '
+    flux module remove qmanager &&
+    flux module load qmanager queue-policy=hybrid queue-params=queue-depth=5 \
+policy-params=reservation-depth=3
+'
+
+test_expect_success 'qmanager: HYBRID policy conforms to queue-depth=5' '
+    jobid1=$(flux job submit C08.T3600.json) &&
+    jobid2=$(flux job submit C10.T3600.json) && # reserved
+    jobid3=$(flux job submit C12.T3600.json) && # reserved
+    jobid4=$(flux job submit C14.T3600.json) && # reserved
+    jobid5=$(flux job submit C16.T3600.json) &&
+    jobid6=$(flux job submit C06.T7260.json) &&
+    jobid7=$(flux job submit C04.T10800.json) && # Cannot start because of qd
+    jobid8=$(flux job submit C04.T14400.json) &&
+    jobid9=$(flux job submit C02.T14400.json) &&
+    jobid10=$(flux job submit C02.T18000.json) &&
+    jobid11=$(flux job submit C02.T3600.json) &&
+
+    flux job wait-event -t 2 ${jobid1} start &&
+    test $(flux job list | wc -l) -eq 12 &&
+    test $(flux job list | grep -v USERID | grep R | wc -l) -eq 1 &&
+    flux job list | grep -v USERID | xargs -L 1 flux job cancel &&
+    flux job wait-event -t 2 ${jobid11} clean
+'
+
+test_expect_success 'qmanager: loading with conservative+queue-depth=5' '
+    flux module remove qmanager &&
+    flux module load qmanager queue-policy=conservative \
+queue-params=queue-depth=5
+'
+
+test_expect_success 'qmanager: CONSERVATIVE policy conforms to queue-depth=5' '
+    jobid1=$(flux job submit C08.T3600.json) &&
+    jobid2=$(flux job submit C10.T3600.json) && # reserved
+    jobid3=$(flux job submit C12.T3600.json) && # reserved
+    jobid4=$(flux job submit C14.T3600.json) && # reserved
+    jobid5=$(flux job submit C16.T3600.json) && # reserved
+    jobid6=$(flux job submit C06.T7260.json) && # reserved
+    jobid7=$(flux job submit C04.T10800.json) && # Cannot start because of qd
+    jobid8=$(flux job submit C04.T14400.json) &&
+    jobid9=$(flux job submit C02.T14400.json) &&
+    jobid10=$(flux job submit C02.T18000.json) &&
+    jobid11=$(flux job submit C02.T3600.json) &&
+
+    flux job wait-event -t 2 ${jobid1} start &&
+    test $(flux job list | wc -l) -eq 12 &&
+    test $(flux job list | grep -v USERID | grep R | wc -l) -eq 1 &&
+    flux job list | grep -v USERID | xargs -L 1 flux job cancel &&
+    flux job wait-event -t 2 ${jobid11} clean
+'
+
+test_expect_success 'removing resource and qmanager modules' '
+    flux module remove -r 0 qmanager &&
+    flux module remove -r 0 resource
+'
+
+test_done

--- a/t/t4003-cancel-info.t
+++ b/t/t4003-cancel-info.t
@@ -41,22 +41,15 @@ test_expect_success 'resource-cancel works' '
     flux resource match allocate ${jobspec} &&
     flux resource cancel 0 &&
     flux resource match allocate ${jobspec} &&
-    flux resource cancel 1 &&
+    flux resource cancel 0 &&
     flux resource match allocate ${jobspec} &&
-    flux resource cancel 2 &&
+    flux resource cancel 0 &&
     flux resource match allocate ${jobspec} &&
-    flux resource cancel 3
+    flux resource cancel 0
 '
 
-test_expect_success 'resource-info on cancelled jobs works' '
-    flux resource info 0 > info.0 &&
-    flux resource info 1 > info.1 &&
-    flux resource info 2 > info.2 &&
-    flux resource info 3 > info.3 &&
-    grep CANCELLED info.0 &&
-    grep CANCELLED info.1 &&
-    grep CANCELLED info.2 &&
-    grep CANCELLED info.3
+test_expect_success 'resource-info will not report for cancelled jobs' '
+    test_must_fail flux resource info 0
 '
 
 test_expect_success 'allocate works with 1-node/1-socket after cancels' '
@@ -67,14 +60,14 @@ test_expect_success 'allocate works with 1-node/1-socket after cancels' '
 '
 
 test_expect_success 'resource-info on allocated jobs works' '
-    flux resource info 4 > info.4 &&
-    flux resource info 5 > info.5 &&
-    flux resource info 6 > info.6 &&
-    flux resource info 7 > info.7 &&
-    grep ALLOCATED info.4 &&
-    grep ALLOCATED info.5 &&
-    grep ALLOCATED info.6 &&
-    grep ALLOCATED info.7
+    flux resource info 0 > info.0 &&
+    flux resource info 1 > info.1 &&
+    flux resource info 2 > info.2 &&
+    flux resource info 3 > info.3 &&
+    grep ALLOCATED info.0 &&
+    grep ALLOCATED info.1 &&
+    grep ALLOCATED info.2 &&
+    grep ALLOCATED info.3
 '
 
 test_expect_success 'cancel on nonexistent jobid is handled gracefully' '


### PR DESCRIPTION
This PR adds various backfill queuing polices and queue-depth support for optimization:

- Add EASY/HYBRID/CONSERVATIVE policies
Introduce queue_policy_bf_base.hpp and queue_policy_bf_base_impl.hpp that implement core algorithms for a majority of backfillling strategies. Derive from this class to implement EASY/HYBRID/CONSERVATIVE policies.

- Add queue-depth support for backfill policies

This PR builds on PR #502 and PR #503 so please don't merge it before those PRs land. Resolve #476, #482, and #498.