### PR TITLE
resource: add set- and get-property support to match service

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -54,6 +54,7 @@ TESTS = \
     t4003-cancel-info.t \
     t4004-match-hwloc.t \
     t4005-match-unsat.t \
+    t4006-properties.t \
     t5000-valgrind.t \
     t6000-graph-size.t \
     t6001-match-formats.t

--- a/t/scripts/flux-resource
+++ b/t/scripts/flux-resource
@@ -53,6 +53,16 @@ class ResourceModuleInterface:
     def rpc_cancel (self, jobid):
         payload = {'jobid' : jobid}
         return self.f.rpc ("resource.cancel", payload).get ()
+   
+    def rpc_set_property (self, sp_resource_path, sp_keyval):
+        payload = {'sp_resource_path' : sp_resource_path, 
+            'sp_keyval' : sp_keyval}
+        return self.f.rpc ("resource.set_property", payload).get ()
+    
+    def rpc_get_property (self, gp_resource_path, gp_key):
+        payload = {'gp_resource_path' : gp_resource_path, 'gp_key' : gp_key}
+        return self.f.rpc ("resource.get_property", payload).get ()
+    
 
 """
     Action for match allocate sub-command
@@ -130,6 +140,25 @@ def stat_action (args):
     print "Avg. Match Time: ", resp['avg-match'], "Secs"
 
 """
+    Action for set-property sub-command
+"""
+def set_property_action (args):
+    r = ResourceModuleInterface ()
+    sp_resource_path = args.sp_resource_path
+    sp_keyval = args.sp_keyval
+    resp = r.rpc_set_property (sp_resource_path, sp_keyval)
+
+"""
+    Action for get-property sub-command
+"""
+def get_property_action (args):
+    r = ResourceModuleInterface ()
+    gp_resource_path = args.gp_resource_path
+    gp_key = args.gp_key
+    resp = r.rpc_get_property (gp_resource_path, gp_key)
+    print args.gp_key, "=", resp['value']
+
+"""
     Main entry point
 """
 def main ():
@@ -154,10 +183,14 @@ def main ():
     istr = "Print info on a single job"
     sstr = "Print overall performance statistics"
     cstr = "Cancel an allocated or reserved job"
+    pstr = "Set property-key=value for specified resource."
+    gstr = "Get value for specified resource and property-key."
     parser_m = subpar.add_parser ('match', help=mstr, description=mstr)
     parser_i = subpar.add_parser ('info', help=istr, description=istr)
     parser_s = subpar.add_parser ('stat', help=sstr, description=sstr)
     parser_c = subpar.add_parser ('cancel', help=cstr, description=cstr)
+    parser_sp = subpar.add_parser ('set-property', help=pstr, description=pstr)
+    parser_gp = subpar.add_parser ('get-property', help=gstr, description=gstr)
 
     #
     # Add subparser for the match sub-command
@@ -213,6 +246,22 @@ def main ():
     parser_mr.add_argument ('jobspec', metavar='Jobspec', type=str,
                             help='Jobspec file name')
     parser_mr.set_defaults (func=match_reserve_action)
+
+    # Positional arguments for set-property sub-command
+    #
+    parser_sp.add_argument ('sp_resource_path', metavar='ResourcePath', 
+            type=str, help='set-property resource_path property-key=val')
+    parser_sp.add_argument ('sp_keyval', metavar='PropertyKeyVal', type=str,
+                            help='set-property resource_path property-key=val')
+    parser_sp.set_defaults (func=set_property_action)
+
+    # Positional argument for get-property sub-command
+    #
+    parser_gp.add_argument ('gp_resource_path', metavar='ResourcePath', 
+                type=str, help='get-property resource_path property-key')
+    parser_gp.add_argument ('gp_key', metavar='PropertyKey', type=str,
+                            help='get-property resource_path property-key')
+    parser_gp.set_defaults (func=get_property_action)
 
     #
     # Parse the args and call an action routine as part of that

--- a/t/t4006-properties.t
+++ b/t/t4006-properties.t
@@ -1,0 +1,120 @@
+#!/bin/sh
+#set -x
+
+test_description='Test the basic functionality of properties (get/set) within resource
+'
+
+ORIG_HOME=${HOME}
+
+. `dirname $0`/sharness.sh
+
+#
+# sharness modifies $HOME environment variable, but this interferes
+# with python's package search path, in particular its user site package.
+#
+HOME=${ORIG_HOME}
+
+grug="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/tiny.graphml"
+jobspec="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/basics/test001.yaml"
+
+#
+# test_under_flux is under sharness.d/
+#
+test_under_flux 1
+
+#
+# print only with --debug
+#
+
+test_debug '
+	echo ${grug} &&
+	echo ${jobspec}
+'
+
+test_expect_success 'loading resource module with a tiny machine config works' '
+	flux module load resource grug-conf=${grug} prune-filters=ALL:core \
+	subsystems=containment policy=high
+'
+
+test_expect_success 'set/get property basic test works' '
+	flux resource set-property /tiny0/rack0/node0 class=one &&
+	flux resource get-property /tiny0/rack0/node0 class > sp.0 &&
+	echo "class = one" > expected &&
+	test_cmp expected sp.0
+'
+
+test_expect_success 'set/get property multiple resources works' '
+	flux resource set-property /tiny0/rack0/node0 nodeprop=1 &&
+	flux resource set-property /tiny0/rack0/node0/socket1 sockprop=abc &&
+	flux resource set-property /tiny0/rack0/node1/socket0/core17 coreprop=z &&
+	flux resource get-property /tiny0/rack0/node0 nodeprop > sp.1 &&
+	flux resource get-property /tiny0/rack0/node0/socket1 sockprop >> sp.1 &&
+	flux resource get-property /tiny0/rack0/node1/socket0/core17 coreprop >> sp.1 &&
+	cat <<-EOF >expected &&
+	nodeprop = 1
+	sockprop = abc
+	coreprop = z
+	EOF
+	test_cmp expected sp.1
+'
+
+test_expect_success 'set/get property multiple properties works' '
+	flux resource set-property /tiny0/rack0/node0 prop1=a && 
+	flux resource set-property /tiny0/rack0/node0 prop2=foo &&
+	flux resource set-property /tiny0/rack0/node0 prop3=123 &&
+	flux resource set-property /tiny0/rack0/node0 prop4=bar &&
+	flux resource set-property /tiny0/rack0/node0 prop5=baz &&
+	flux resource get-property /tiny0/rack0/node0 prop1 > sp.2 &&
+	flux resource get-property /tiny0/rack0/node0 prop2 >> sp.2 &&
+	flux resource get-property /tiny0/rack0/node0 prop3 >> sp.2 &&
+	flux resource get-property /tiny0/rack0/node0 prop4 >> sp.2 &&
+	flux resource get-property /tiny0/rack0/node0 prop5 >> sp.2 &&
+	cat <<-EOF >expected &&
+	prop1 = a
+	prop2 = foo
+	prop3 = 123
+	prop4 = bar
+	prop5 = baz
+	EOF
+	test_cmp expected sp.2
+'
+
+test_expect_success 'test with no path works' '
+	test_expect_code 1 flux resource set-property /dont/exist random=1
+'
+
+test_expect_success 'test with no property works' '
+	test_expect_code 1 flux resource get-property /tiny0/rack0/node0 dontexist
+'
+
+test_expect_success 'test with malformed inputs works' '
+	test_expect_code 1 flux resource set-property /tiny0/rack0/node0 badprop &&
+	test_expect_code 1 flux resource get-property /tiny0/rack0/node0 badprop &&
+	test_expect_code 1 flux resource set-property /tiny0/rack0/node0 badprop= &&
+	test_expect_code 1 flux resource get-property /tiny0/rack0/node0 badprop &&
+	test_expect_code 1 flux resource set-property /tiny0/rack0/node0 =badprop &&
+	test_expect_code 1 flux resource get-property /tiny0/rack0/node0 badprop &&
+	test_expect_code 1 flux resource set-property /tiny0/rack0/node0 = && 
+	test_expect_code 1 flux resource get-property /tiny0/rack0/node0 badprop
+'
+
+test_expect_success 'test with complex inputs works' '
+	flux resource set-property /tiny0/rack0/node0 badprop==1 && 
+	flux resource get-property /tiny0/rack0/node0 badprop > sp.5 &&
+	flux resource set-property /tiny0/rack0/node0 badprop=1=class=random && 
+	flux resource get-property /tiny0/rack0/node0 badprop >> sp.5 &&
+	flux resource set-property /tiny0/rack0/node0 badprop=1 && 
+	flux resource get-property /tiny0/rack0/node0 badprop >> sp.5 &&
+	cat <<-EOF >expected &&
+	badprop = =1
+	badprop = 1=class=random
+	badprop = 1
+	EOF
+	test_cmp expected sp.5
+'
+
+test_expect_success 'removing resource works' '
+	flux module remove resource
+'
+
+test_done


### PR DESCRIPTION
Resolve issue #494, get/set property is now supported in `flux resource` through RPC. 