### PR TITLE
rc3: Fix a bug in RC3 dir definition within configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -136,7 +136,7 @@ AC_SUBST(fluxresourcerc3dir)
 AS_VAR_SET(fluxqmanagerrc1dir, $sysconfdir/flux/rc1.d)
 AC_SUBST(fluxqmanagerrc1dir)
 
-AS_VAR_SET(fluxresourcerc3dir, $sysconfdir/flux/rc3.d)
+AS_VAR_SET(fluxqmanagerrc3dir, $sysconfdir/flux/rc3.d)
 AC_SUBST(fluxqmanagerrc3dir)
 
 ##


### PR DESCRIPTION
Fix a copy-and-paste error in the rc3 directory definition for qmanager. Without a proper rc3, qmanager wasn't cleanly exited when the Flux instance is torn down:

```
module 'qmanager' was not cleanly shutdown
```

Resolve #524.