### PR TITLE
Add smart pointer support and misc. cleanup

### DIFF
--- a/qmanager/policies/queue_policy_factory.hpp
+++ b/qmanager/policies/queue_policy_factory.hpp
@@ -25,13 +25,16 @@
 #ifndef QUEUE_POLICY_FACTORY_HPP
 #define QUEUE_POLICY_FACTORY_HPP
 
+#include <memory>
 #include <string>
 
 namespace Flux {
 namespace queue_manager {
 
 bool known_queue_policy (const std::string &policy);
-queue_policy_base_t *create_queue_policy (const std::string &policy);
+std::shared_ptr<queue_policy_base_t> create_queue_policy (
+                                         const std::string &policy,
+                                         const std::string &reapi);
 
 } // namespace Flux::queue_manager
 } // namespace Flux

--- a/qmanager/policies/queue_policy_factory_impl.hpp
+++ b/qmanager/policies/queue_policy_factory_impl.hpp
@@ -58,50 +58,46 @@ bool known_queue_policy (const std::string &policy)
     return rc;
 }
 
-queue_policy_base_t *create_queue_policy (const std::string &policy,
-                                          const std::string &reapi)
+std::shared_ptr<queue_policy_base_t> create_queue_policy (
+                                         const std::string &policy,
+                                         const std::string &reapi)
 {
-    queue_policy_base_t *p = NULL;
-    if (policy == "fcfs") {
-        if (reapi == "module") {
-            p = (queue_policy_base_t *)
-                    new (std::nothrow)queue_policy_fcfs_t<reapi_module_t> ();
+    std::shared_ptr<queue_policy_base_t> p = nullptr;
+
+    try {
+        if (policy == "fcfs") {
+            if (reapi == "module")
+                p = std::make_shared<queue_policy_fcfs_t<reapi_module_t>> ();
+            else if (reapi == "cli")
+                p = std::make_shared<queue_policy_fcfs_t<reapi_cli_t>> ();
         }
-        else if (reapi == "cli") {
-            p = (queue_policy_base_t *)
-                    new (std::nothrow)queue_policy_fcfs_t<reapi_cli_t> ();
+        else if (policy == "easy") {
+            if (reapi == "module")
+                p = std::make_shared<queue_policy_easy_t<reapi_module_t>> ();
+            else if (reapi == "cli")
+                p = std::make_shared<queue_policy_easy_t<reapi_cli_t>> ();
         }
+        else if (policy == "hybrid") {
+            if (reapi == "module")
+                p = std::make_shared<queue_policy_hybrid_t<reapi_module_t>> ();
+            else if (reapi == "cli")
+                p = std::make_shared<queue_policy_hybrid_t<reapi_cli_t>> ();
+        }
+        else if (policy == "conservative") {
+            if (reapi == "module") {
+                p = std::make_shared<queue_policy_conservative_t<
+                                         reapi_module_t>> ();
+            }
+            else if (reapi == "cli") {
+                p = std::make_shared<queue_policy_conservative_t<
+                                         reapi_cli_t>> ();
+            }
+        }
+    } catch (std::bad_alloc &e) {
+        errno = ENOMEM;
+        p = nullptr;
     }
-    else if (policy == "easy") {
-        if (reapi == "module") {
-            p = (queue_policy_base_t *)
-                    new (std::nothrow)queue_policy_easy_t<reapi_module_t> ();
-        }
-        else if (reapi == "cli") {
-            p = (queue_policy_base_t *)
-                    new (std::nothrow)queue_policy_easy_t<reapi_cli_t> ();
-        }
-    }
-    else if (policy == "hybrid") {
-        if (reapi == "module") {
-            p = (queue_policy_base_t *)
-                    new (std::nothrow)queue_policy_hybrid_t<reapi_module_t> ();
-        }
-        else if (reapi == "cli") {
-            p = (queue_policy_base_t *)
-                    new (std::nothrow)queue_policy_hybrid_t<reapi_cli_t> ();
-        }
-    }
-    else if (policy == "conservative") {
-        if (reapi == "module") {
-            p = (queue_policy_base_t *) new (std::nothrow)
-                    queue_policy_conservative_t<reapi_module_t> ();
-        }
-        else if (reapi == "cli") {
-            p = (queue_policy_base_t *) new (std::nothrow)
-                    queue_policy_conservative_t<reapi_cli_t> ();
-        }
-    }
+
     return p;
 }
 

--- a/resource/libjobspec/jobspec.cpp
+++ b/resource/libjobspec/jobspec.cpp
@@ -418,7 +418,7 @@ catch (YAML::Exception& e) {
     throw parse_error(e.what());
 }
 
-Jobspec::Jobspec(std::string &s)
+Jobspec::Jobspec(const std::string &s)
 try
     : Jobspec {YAML::Load (s)}
 {

--- a/resource/libjobspec/jobspec.cpp
+++ b/resource/libjobspec/jobspec.cpp
@@ -34,7 +34,6 @@ extern "C" {
 #endif
 }
 
-using namespace std;
 using namespace Flux::Jobspec;
 
 parse_error::parse_error(const char *msg)
@@ -130,7 +129,7 @@ void parse_yaml_count (Resource& res, const YAML::Node &cnode)
 }
 
 namespace {
-vector<Resource> parse_yaml_resources (const YAML::Node &resources);
+std::vector<Resource> parse_yaml_resources (const YAML::Node &resources);
 }
 
 Resource::Resource (const YAML::Node &resnode)
@@ -148,7 +147,7 @@ Resource::Resource (const YAML::Node &resnode)
         throw parse_error (resnode["type"],
                            "Value of \"type\" must be a scalar");
     }
-    type = resnode["type"].as<string>();
+    type = resnode["type"].as<std::string>();
     field_count++;
 
     if (!resnode["count"]) {
@@ -163,7 +162,7 @@ Resource::Resource (const YAML::Node &resnode)
                                "Value of \"unit\" must be a scalar");
         }
         field_count++;
-        unit = resnode["unit"].as<string>();
+        unit = resnode["unit"].as<std::string>();
     }
     if (resnode["exclusive"]) {
         if (!resnode["exclusive"].IsScalar()) {
@@ -171,7 +170,7 @@ Resource::Resource (const YAML::Node &resnode)
                                "Value of \"exclusive\" must be a scalar");
         }
         field_count++;
-        string val = resnode["exclusive"].as<string>();
+        std::string val = resnode["exclusive"].as<std::string>();
         if (val == "false") {
             exclusive = tristate_t::FALSE;
         } else if (val == "true") {
@@ -193,7 +192,7 @@ Resource::Resource (const YAML::Node &resnode)
                                "Value of \"label\" must be a scalar");
         }
         field_count++;
-        label = resnode["label"].as<string>();
+        label = resnode["label"].as<std::string>();
     } else if (type == "slot") {
         throw parse_error (resnode, "All slots must be labeled");
     }
@@ -204,7 +203,7 @@ Resource::Resource (const YAML::Node &resnode)
                                "Value of \"id\" must be a scalar");
         }
         field_count++;
-        id = resnode["id"].as<string>();
+        id = resnode["id"].as<std::string>();
     }
 
     if (field_count != resnode.size()) {
@@ -228,9 +227,9 @@ Task::Task (const YAML::Node &tasknode)
         throw parse_error (tasknode, "Key \"command\" missing from task");
     }
     if (tasknode["command"].IsSequence()) {
-        command = tasknode["command"].as<vector<string>>();
+        command = tasknode["command"].as<std::vector<std::string>>();
     } else if (tasknode["command"].IsScalar()) {
-        command.push_back(tasknode["command"].as<string>());
+        command.push_back(tasknode["command"].as<std::string>());
     } else {
         throw parse_error (tasknode["command"],
                            "\"command\" value must be a scalar or a sequence");
@@ -244,7 +243,7 @@ Task::Task (const YAML::Node &tasknode)
         throw parse_error (tasknode["slot"],
                            "Value of task \"slot\" must be a YAML scalar");
     }
-    slot = tasknode["slot"].as<string>();
+    slot = tasknode["slot"].as<std::string>();
 
     /* Import count mapping */
     if (tasknode["count"]) {
@@ -254,7 +253,8 @@ Task::Task (const YAML::Node &tasknode)
                                "\"count\" in task is not a mapping");
         }
         for (auto&& entry : count_node) {
-            count[entry.first.as<string>()] = entry.second.as<string>();
+            count[entry.first.as<std::string>()]
+                = entry.second.as<std::string>();
         }
     }
 
@@ -264,7 +264,7 @@ Task::Task (const YAML::Node &tasknode)
             throw parse_error (tasknode["distribution"],
                                "Value of task \"distribution\" must be a YAML scalar");
         }
-        distribution = tasknode["distribution"].as<string>();
+        distribution = tasknode["distribution"].as<std::string>();
     }
 
     /* Import attributes mapping if it is present */
@@ -274,7 +274,8 @@ Task::Task (const YAML::Node &tasknode)
             throw parse_error (attrs, "\"attributes\" in task is not a mapping");
         }
         for (auto&& attr : attrs) {
-            attributes[attr.first.as<string>()] = attr.second.as<string>();
+            attributes[attr.first.as<std::string>()]
+                = attr.second.as<std::string>();
         }
     }
 
@@ -285,9 +286,9 @@ Task::Task (const YAML::Node &tasknode)
 }
 
 namespace {
-vector<Task> parse_yaml_tasks (const YAML::Node &tasks)
+std::vector<Task> parse_yaml_tasks (const YAML::Node &tasks)
 {
-    vector<Task> taskvec;
+    std::vector<Task> taskvec;
 
     /* "tasks" must be a sequence */
     if (!tasks.IsSequence()) {
@@ -303,9 +304,9 @@ vector<Task> parse_yaml_tasks (const YAML::Node &tasks)
 }
 
 namespace {
-vector<Resource> parse_yaml_resources (const YAML::Node &resources)
+std::vector<Resource> parse_yaml_resources (const YAML::Node &resources)
 {
-    vector<Resource> resvec;
+    std::vector<Resource> resvec;
 
     /* "resources" must be a sequence */
     if (!resources.IsSequence()) {
@@ -329,25 +330,25 @@ Attributes parse_yaml_attributes (const YAML::Node &attrs)
         throw parse_error (attrs, "\"attributes\" is not a map");
     }
     for (auto&& kv : attrs) {
-        if (kv.first.as<string>() == "user") {
+        if (kv.first.as<std::string>() == "user") {
             a.user = kv.second;
         }
-        else if (kv.first.as<string>() == "system") {
+        else if (kv.first.as<std::string>() == "system") {
             for (auto&& s : kv.second) {
-                if (s.first.as<string>() == "duration") {
+                if (s.first.as<std::string>() == "duration") {
                     a.system.duration = s.second.as<double>();
                 }
-                else if (s.first.as<string>() == "cwd") {
-                    a.system.cwd = s.second.as<string>();
+                else if (s.first.as<std::string>() == "cwd") {
+                    a.system.cwd = s.second.as<std::string>();
                 }
-                else if (s.first.as<string>() == "environment") {
+                else if (s.first.as<std::string>() == "environment") {
                     for (auto&& e : s.second) {
-                        a.system.environment[e.first.as<string>()]
-                            = e.second.as<string>();
+                        a.system.environment[e.first.as<std::string>()]
+                            = e.second.as<std::string>();
                     }
                 }
                 else {
-                    a.system.optional[s.first.as<string>()] = s.second;
+                    a.system.optional[s.first.as<std::string>()] = s.second;
                 }
             }
         }
@@ -476,24 +477,25 @@ public:
 
 std::ostream& Flux::Jobspec::operator<<(std::ostream& s, Jobspec const& jobspec)
 {
-    s << "version: " << jobspec.version << endl;
-    s << "resources: " << endl;
+    s << "version: " << jobspec.version << std::endl;
+    s << "resources: " << std::endl;
     for (auto&& resource : jobspec.resources) {
         IndentingOStreambuf indent (s);
         s << resource;
     }
-    s << "tasks: " << endl;
+    s << "tasks: " << std::endl;
     for (auto&& task : jobspec.tasks) {
         IndentingOStreambuf indent (s);
         s << task;
     }
-    s << "attributes:" << endl;
-    s << "  " << "system:" << endl;
-    s << "    " << "duration: " << jobspec.attributes.system.duration << endl;
-    s << "    " << "cwd: " << jobspec.attributes.system.cwd << endl;
-    s << "    " << "environment:" << endl;
+    s << "attributes:" << std::endl;
+    s << "  " << "system:" << std::endl;
+    s << "    " << "duration: " << jobspec.attributes.system.duration
+      << std::endl;
+    s << "    " << "cwd: " << jobspec.attributes.system.cwd << std::endl;
+    s << "    " << "environment:" << std::endl;
     for (auto&& e : jobspec.attributes.system.environment) {
-        s << "      " << e.first << ": " << e.second << endl;
+        s << "      " << e.first << ": " << e.second << std::endl;
     }
 
     return s;
@@ -502,24 +504,24 @@ std::ostream& Flux::Jobspec::operator<<(std::ostream& s, Jobspec const& jobspec)
 std::ostream& Flux::Jobspec::operator<<(std::ostream& s,
                                         Resource const& resource)
 {
-    s << "- type: " << resource.type << endl;
-    s << "  count:" << endl;
-    s << "    min: " << resource.count.min << endl;
-    s << "    max: " << resource.count.max << endl;
-    s << "    operator: " << resource.count.oper << endl;
-    s << "    operand: " << resource.count.operand << endl;
+    s << "- type: " << resource.type << std::endl;
+    s << "  count:" << std::endl;
+    s << "    min: " << resource.count.min << std::endl;
+    s << "    max: " << resource.count.max << std::endl;
+    s << "    operator: " << resource.count.oper << std::endl;
+    s << "    operand: " << resource.count.operand << std::endl;
     if (resource.unit.size() > 0)
-        s << "  unit: " << resource.unit << endl;
+        s << "  unit: " << resource.unit << std::endl;
     if (resource.label.size() > 0)
-        s << "  label: " << resource.label << endl;
+        s << "  label: " << resource.label << std::endl;
     if (resource.id.size() > 0)
-        s << "  id: " << resource.id << endl;
+        s << "  id: " << resource.id << std::endl;
     if (resource.exclusive == tristate_t::TRUE)
-            s << "  exclusive: true" << endl;
+            s << "  exclusive: true" << std::endl;
     else if (resource.exclusive == tristate_t::FALSE)
-            s << "  exclusive: false" << endl;
+            s << "  exclusive: false" << std::endl;
     if (resource.with.size() > 0) {
-        s << "  with:" << endl;
+        s << "  with:" << std::endl;
         IndentingOStreambuf indent (s, 4);
         for (auto&& child_resource : resource.with) {
             s << child_resource;
@@ -541,19 +543,19 @@ std::ostream& Flux::Jobspec::operator<<(std::ostream& s,
             first = false;
         s << "\"" << field << "\"";
     }
-    s << " ]" << endl;
-    s << "slot: " << task.slot << endl;
+    s << " ]" << std::endl;
+    s << "slot: " << task.slot << std::endl;
     if (task.count.size() > 0) {
-        s << "count:" << endl;
+        s << "count:" << std::endl;
         IndentingOStreambuf indent (s);
         for (auto&& c : task.count) {
-            s << c.first << ": " << c.second << endl;
+            s << c.first << ": " << c.second << std::endl;
         }
     }
     if (task.distribution.size() > 0)
-        s << "distribution: " << task.distribution << endl;
+        s << "distribution: " << task.distribution << std::endl;
     if (task.attributes.size() > 0) {
-        s << "attributes:" << endl;
+        s << "attributes:" << std::endl;
         IndentingOStreambuf indent (s);
         for (auto&& attr : task.attributes) {
             s << attr.first << ": " << attr.second;

--- a/resource/libjobspec/jobspec.hpp
+++ b/resource/libjobspec/jobspec.hpp
@@ -131,7 +131,7 @@ public:
     Jobspec() = default;
     Jobspec(const YAML::Node&);
     Jobspec(std::istream &is);
-    Jobspec(std::string &s);
+    Jobspec(const std::string &s);
 };
 
 std::ostream& operator<<(std::ostream& s, Jobspec const& js);

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -120,8 +120,10 @@ static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST, "resource.info", info_request_cb, 0},
     { FLUX_MSGTYPE_REQUEST, "resource.stat", stat_request_cb, 0},
     { FLUX_MSGTYPE_REQUEST, "resource.next_jobid", next_jobid_request_cb, 0},
-    { FLUX_MSGTYPE_REQUEST, "resource.set_property", set_property_request_cb, 0},
-    { FLUX_MSGTYPE_REQUEST, "resource.get_property", get_property_request_cb, 0},
+    { FLUX_MSGTYPE_REQUEST, "resource.set_property", set_property_request_cb,
+      0},
+    { FLUX_MSGTYPE_REQUEST, "resource.get_property", get_property_request_cb,
+      0},
     FLUX_MSGHANDLER_TABLE_END
 };
 
@@ -880,8 +882,8 @@ static void set_property_request_cb (flux_t *h, flux_msg_handler_t *w,
     vtx_t v;
 
     if (flux_request_unpack (msg, NULL, "{s:s s:s}",
-       "sp_resource_path", &rp,
-       "sp_keyval", &kv) < 0)
+                                        "sp_resource_path", &rp,
+                                        "sp_keyval", &kv) < 0)
         goto error;
 
     resource_path = rp;
@@ -941,8 +943,8 @@ static void get_property_request_cb (flux_t *h, flux_msg_handler_t *w,
     string resp_value = "";
 
     if (flux_request_unpack (msg, NULL, "{s:s s:s}",
-        "gp_resource_path", &rp,
-        "gp_key", &gp_key) < 0)
+                                        "gp_resource_path", &rp,
+                                        "gp_key", &gp_key) < 0)
         goto error;
 
     resource_path = rp;

--- a/resource/policies/dfu_match_policy_factory.cpp
+++ b/resource/policies/dfu_match_policy_factory.cpp
@@ -38,17 +38,24 @@ bool known_match_policy (const std::string &policy)
     return rc;
 }
 
-dfu_match_cb_t *create_match_cb (const std::string &policy)
+std::shared_ptr<dfu_match_cb_t> create_match_cb (const std::string &policy)
 {
-    dfu_match_cb_t *matcher = NULL;
+    std::shared_ptr<dfu_match_cb_t> matcher = nullptr;
+
+    try {
     if (policy == HIGH_ID_FIRST)
-        matcher = (dfu_match_cb_t *)new high_first_t ();
+        matcher = std::make_shared<high_first_t> ();
     else if (policy == LOW_ID_FIRST)
-        matcher = (dfu_match_cb_t *)new low_first_t ();
+        matcher = std::make_shared<low_first_t> ();
     else if (policy == LOCALITY_AWARE)
-        matcher = (dfu_match_cb_t *)new greater_interval_first_t ();
+        matcher = std::make_shared<greater_interval_first_t> ();
     else if (policy == VAR_AWARE)
-        matcher = (dfu_match_cb_t *)new var_aware_t ();
+        matcher = std::make_shared<var_aware_t> ();
+    } catch (std::bad_alloc &e) {
+        errno = ENOMEM;
+        matcher = nullptr;
+    }
+
     return matcher;
 }
 

--- a/resource/policies/dfu_match_policy_factory.hpp
+++ b/resource/policies/dfu_match_policy_factory.hpp
@@ -26,6 +26,7 @@
 #define DFU_MATCH_POLICY_FACTORY_HPP
 
 #include <string>
+#include <memory>
 #include "resource/policies/base/dfu_match_cb.hpp"
 #include "resource/policies/dfu_match_high_id_first.hpp"
 #include "resource/policies/dfu_match_low_id_first.hpp"
@@ -45,7 +46,7 @@ bool known_match_policy (const std::string &policy);
 /*! Factory method for creating a matching callback
  *  object, representing a matching policy.
  */
-dfu_match_cb_t *create_match_cb (const std::string &policy);
+std::shared_ptr<dfu_match_cb_t> create_match_cb (const std::string &policy);
 
 } // resource_model
 } // Flux

--- a/resource/readers/resource_reader_base.cpp
+++ b/resource/readers/resource_reader_base.cpp
@@ -54,6 +54,11 @@ bool resource_reader_base_t::in_whitelist (const std::string &resource)
  *                                                                              *
  ********************************************************************************/
 
+resource_reader_base_t::~resource_reader_base_t ()
+{
+
+}
+
 int resource_reader_base_t::set_whitelist (const std::string &csl)
 {
     if (csl == "")

--- a/resource/readers/resource_reader_base.cpp
+++ b/resource/readers/resource_reader_base.cpp
@@ -31,7 +31,6 @@ extern "C" {
 #endif
 }
 
-using namespace std;
 using namespace Flux::resource_model;
 
 

--- a/resource/readers/resource_reader_base.hpp
+++ b/resource/readers/resource_reader_base.hpp
@@ -39,6 +39,9 @@ namespace resource_model {
  */
 class resource_reader_base_t {
 public:
+
+    virtual ~resource_reader_base_t ();
+
     /*! Unpack str into a resource graph.
      *
      * \param g      resource graph

--- a/resource/readers/resource_reader_grug.cpp
+++ b/resource/readers/resource_reader_grug.cpp
@@ -188,8 +188,8 @@ vtx_t dfs_emitter_t::emit_vertex (ggv_t u, gge_t e, const gg_t &recipe,
     resource_graph_t &g = *m_g_p;
     resource_graph_metadata_t &m = *m_gm_p;
     if (src_v == boost::graph_traits<resource_graph_t>::null_vertex ())
-        if (m.roots.find (recipe[u].subsystem) != m.roots.end ())
-            return m.roots[recipe[u].subsystem];
+        if (m.roots->find (recipe[u].subsystem) != m.roots->end ())
+            return (*(m.roots))[recipe[u].subsystem];
 
     vtx_t v = add_vertex (g);;
     string pref = "";
@@ -198,7 +198,7 @@ vtx_t dfs_emitter_t::emit_vertex (ggv_t u, gge_t e, const gg_t &recipe,
 
     if (src_v == boost::graph_traits<resource_graph_t>::null_vertex ()) {
         // ROOT vertex of graph
-        m.roots[recipe[u].subsystem] = v;
+        (*(m.roots))[recipe[u].subsystem] = v;
         id = 0;
     } else {
         id = gen_id (e, recipe, i, sz, j);

--- a/resource/readers/resource_reader_grug.cpp
+++ b/resource/readers/resource_reader_grug.cpp
@@ -38,7 +38,6 @@ extern "C" {
 #endif
 }
 
-using namespace std;
 using namespace Flux::resource_model;
 
 /*! Note that this class must be copy-constructible
@@ -56,7 +55,7 @@ public:
 
     void tree_edge (gge_t e, const gg_t &recipe);
     void finish_vertex (ggv_t u, const gg_t &recipe);
-    const string &err_message () const;
+    const std::string &err_message () const;
 
     void set_rank (int rank);
     int get_rank ();
@@ -72,13 +71,13 @@ private:
     int gen_id (gge_t e, const gg_t &recipe,
                 int i, int sz, int j);
 
-    map<ggv_t, vector<vtx_t>> m_gen_src_vtx;
-    deque<int> m_hier_scales;
+    std::map<ggv_t, std::vector<vtx_t>> m_gen_src_vtx;
+    std::deque<int> m_hier_scales;
     resource_graph_t *m_g_p = NULL;
     resource_graph_metadata_t *m_gm_p = NULL;
     resource_gen_spec_t *m_gspec_p = NULL;
     int m_rank = -1;
-    string m_err_msg = "";
+    std::string m_err_msg = "";
 };
 
 
@@ -88,7 +87,8 @@ private:
  *                                                                              *
  ********************************************************************************/
 
-int dfs_emitter_t::path_prefix (const string &path, int uplevel, string &prefix)
+int dfs_emitter_t::path_prefix (const std::string &path,
+                                int uplevel, std::string &prefix)
 {
     size_t pos = 0;
     unsigned int occurrence = 0;
@@ -97,12 +97,12 @@ int dfs_emitter_t::path_prefix (const string &path, int uplevel, string &prefix)
       return -1;
     while (occurrence != (num_slashes - uplevel + 1)) {
         pos = path.find ("/", pos);
-        if (pos == string::npos)
+        if (pos == std::string::npos)
             break;
         pos += 1;
         occurrence++;
     }
-    string new_prefix = path.substr (0, pos);
+    std::string new_prefix = path.substr (0, pos);
     if (new_prefix.back () != '/')
         new_prefix.push_back ('/');
     prefix = std::move (new_prefix);
@@ -133,7 +133,7 @@ int dfs_emitter_t::gen_id (gge_t e, const gg_t &recipe, int i, int sz, int j)
     if (scope > (int) m_hier_scales.size ())
         scope = m_hier_scales.size ();
     j_dim_wrap = 1;
-    deque<int>::const_iterator iter;
+    std::deque<int>::const_iterator iter;
     for (h = 0; h < scope; ++h)
         j_dim_wrap *= m_hier_scales[h];
 
@@ -192,8 +192,8 @@ vtx_t dfs_emitter_t::emit_vertex (ggv_t u, gge_t e, const gg_t &recipe,
             return (*(m.roots))[recipe[u].subsystem];
 
     vtx_t v = add_vertex (g);;
-    string pref = "";
-    string ssys = recipe[u].subsystem;
+    std::string pref = "";
+    std::string ssys = recipe[u].subsystem;
     int id = 0;
 
     if (src_v == boost::graph_traits<resource_graph_t>::null_vertex ()) {
@@ -205,7 +205,7 @@ vtx_t dfs_emitter_t::emit_vertex (ggv_t u, gge_t e, const gg_t &recipe,
         pref = g[src_v].paths[ssys];
     }
 
-    string istr = (id != -1)? to_string (id) : "";
+    std::string istr = (id != -1)? std::to_string (id) : "";
     g[v].type = recipe[u].type;
     g[v].basename = recipe[u].basename;
     g[v].size = recipe[u].size;
@@ -286,10 +286,10 @@ void dfs_emitter_t::tree_edge (gge_t e, const gg_t &recipe)
     vtx_t src_vtx, tgt_vtx;
     ggv_t src_ggv = source (e, recipe);
     ggv_t tgt_ggv = target (e, recipe);
-    vector<vtx_t>::iterator src_it, tgt_it;
+    std::vector<vtx_t>::iterator src_it, tgt_it;
     resource_graph_t &g = *m_g_p;
     resource_graph_metadata_t &m = *m_gm_p;
-    string in;
+    std::string in;
     int i = 0, j = 0;;
 
     if (recipe[src_ggv].root) {
@@ -301,7 +301,7 @@ void dfs_emitter_t::tree_edge (gge_t e, const gg_t &recipe)
         }
     }
 
-    m_gen_src_vtx[tgt_ggv] = vector<vtx_t>();
+    m_gen_src_vtx[tgt_ggv] = std::vector<vtx_t>();
 
     switch (m_gspec_p->to_gen_method_t (recipe[e].gen_method)) {
     case MULTIPLY:
@@ -347,7 +347,7 @@ void dfs_emitter_t::tree_edge (gge_t e, const gg_t &recipe)
             src_vtx = *src_it;
             for (tgt_it = m.by_type[recipe[tgt_ggv].type].begin ();
                  tgt_it != m.by_type[recipe[tgt_ggv].type].end (); tgt_it++) {
-                string comp_pth1, comp_pth2;
+                std::string comp_pth1, comp_pth2;
                 tgt_vtx = (*tgt_it);
                 path_prefix (g[tgt_vtx].paths[in],
                              recipe[e].as_tgt_uplvl, comp_pth1);
@@ -391,7 +391,7 @@ void dfs_emitter_t::finish_vertex (ggv_t u, const gg_t &recipe)
  *
  *  \return       error message
  */
-const string &dfs_emitter_t::err_message () const
+const std::string &dfs_emitter_t::err_message () const
 {
     return m_err_msg;
 }
@@ -432,7 +432,7 @@ int resource_reader_grug_t::unpack (resource_graph_t &g,
 
 {
     int rc = 0;
-    istringstream in;
+    std::istringstream in;
     in.str (str);
 
     if (m_gspec.read_graphml (in) != 0) {

--- a/resource/readers/resource_reader_grug.cpp
+++ b/resource/readers/resource_reader_grug.cpp
@@ -421,6 +421,11 @@ int dfs_emitter_t::get_rank ()
  *                                                                              *
  ********************************************************************************/
 
+resource_reader_grug_t::~resource_reader_grug_t ()
+{
+
+}
+
 int resource_reader_grug_t::unpack (resource_graph_t &g,
                                     resource_graph_metadata_t &m,
                                     const std::string &str, int rank)

--- a/resource/readers/resource_reader_grug.hpp
+++ b/resource/readers/resource_reader_grug.hpp
@@ -38,6 +38,8 @@ namespace resource_model {
  */
 class resource_reader_grug_t : public resource_reader_base_t {
 public:
+    virtual ~resource_reader_grug_t ();
+
     /*! Unpack str into a resource graph.
      *
      * \param g      resource graph

--- a/resource/readers/resource_reader_hwloc.cpp
+++ b/resource/readers/resource_reader_hwloc.cpp
@@ -336,6 +336,11 @@ done:
  *                                                                              *
  ********************************************************************************/
 
+resource_reader_hwloc_t::~resource_reader_hwloc_t ()
+{
+
+}
+
 int resource_reader_hwloc_t::unpack (resource_graph_t &g,
                                      resource_graph_metadata_t &m,
                                      const std::string &str, int rank)

--- a/resource/readers/resource_reader_hwloc.cpp
+++ b/resource/readers/resource_reader_hwloc.cpp
@@ -67,7 +67,7 @@ vtx_t resource_reader_hwloc_t::create_cluster_vertex (
                               graph_traits<resource_graph_t>::
                               null_vertex (),
                               0, subsys, "cluster", "cluster", 1);
-    m.roots[subsys] = v;
+    (*(m.roots))[subsys] = v;
 
     return v;
 }
@@ -267,7 +267,7 @@ void resource_reader_hwloc_t::walk_hwloc (resource_graph_t &g,
         // Create edge between parent/child
         if (parent == boost::graph_traits<resource_graph_t>::null_vertex ()) {
             // is root
-            m.roots[subsys] = v;
+            (*(m.roots))[subsys] = v;
         } else {
             std::string relation = "contains";
             std::string rev_relation = "in";

--- a/resource/readers/resource_reader_hwloc.hpp
+++ b/resource/readers/resource_reader_hwloc.hpp
@@ -37,6 +37,9 @@ namespace resource_model {
  */
 class resource_reader_hwloc_t : public resource_reader_base_t {
 public:
+
+    virtual ~resource_reader_hwloc_t ();
+
     /*! Unpack str into a resource graph.
      *
      * \param g      resource graph

--- a/resource/readers/resource_reader_jgf.cpp
+++ b/resource/readers/resource_reader_jgf.cpp
@@ -35,7 +35,6 @@ extern "C" {
 #endif
 }
 
-using namespace std;
 using namespace Flux;
 using namespace Flux::resource_model;
 

--- a/resource/readers/resource_reader_jgf.cpp
+++ b/resource/readers/resource_reader_jgf.cpp
@@ -279,6 +279,11 @@ done:
  *                                                                              *
  ********************************************************************************/
 
+resource_reader_jgf_t::~resource_reader_jgf_t ()
+{
+
+}
+
 int resource_reader_jgf_t::unpack (resource_graph_t &g,
                                    resource_graph_metadata_t &m,
                                    const std::string &str, int rank)

--- a/resource/readers/resource_reader_jgf.cpp
+++ b/resource/readers/resource_reader_jgf.cpp
@@ -153,7 +153,7 @@ int resource_reader_jgf_t::add_vtx (resource_graph_t &g,
         g[v].idata.member_of[kv.first] = "*";
         m.by_path[kv.second] = v;
         if (std::count(kv.second.begin (), kv.second.end (), '/') == 1)
-            m.roots[kv.first] = v;
+            (*(m.roots))[kv.first] = v;
     }
     m.by_type[g[v].type].push_back (v);
     m.by_name[g[v].name].push_back (v);

--- a/resource/readers/resource_reader_jgf.hpp
+++ b/resource/readers/resource_reader_jgf.hpp
@@ -40,6 +40,9 @@ namespace resource_model {
  */
 class resource_reader_jgf_t : public resource_reader_base_t {
 public:
+
+    virtual ~resource_reader_jgf_t ();
+
     /*! Unpack str into a resource graph.
      *
      * \param g      resource graph

--- a/resource/readers/resource_spec_grug.cpp
+++ b/resource/readers/resource_spec_grug.cpp
@@ -35,12 +35,11 @@ extern "C" {
 #endif
 }
 
-using namespace std;
 using namespace Flux::resource_model;
 
 struct str2enum_t
 {
-    string str;
+    std::string str;
     int e;
 };
 
@@ -135,7 +134,8 @@ const gg_t &resource_gen_spec_t::gen_graph ()
  *  \param s             gen_method string from graphml spec
  *  \return              0 on success; -1 otherwise
  */
-const gen_meth_t resource_gen_spec_t::to_gen_method_t (const std::string &s) const
+const gen_meth_t resource_gen_spec_t::to_gen_method_t (
+                                          const std::string &s) const
 {
     int i;
     for (i=0; str2genmeth[i].str != ""; ++i)
@@ -149,10 +149,10 @@ const gen_meth_t resource_gen_spec_t::to_gen_method_t (const std::string &s) con
  *  \param ifn           resource generator recipe file in graphml
  *  \return              0 on success; -1 otherwise
  */
-int resource_gen_spec_t::read_graphml (const string &ifn)
+int resource_gen_spec_t::read_graphml (const std::string &ifn)
 {
     int rc = 0;
-    ifstream in_file (ifn.c_str ());
+    std::ifstream in_file (ifn.c_str ());
     if (!in_file.good ())
         return -1;
     rc = read_graphml (in_file);
@@ -183,10 +183,10 @@ int resource_gen_spec_t::read_graphml (std::istream &in)
  * \param simple         if false, output will have more detailed info
  * \return               0 on success; -1 otherwise
  */
-int resource_gen_spec_t::write_graphviz (const string &ofn, bool simple)
+int resource_gen_spec_t::write_graphviz (const std::string &ofn, bool simple)
 {
     int rc = 0;
-    fstream out_file (ofn, fstream::out);
+    std::fstream out_file (ofn, std::fstream::out);
     try {
         vtx_basename_map_t v_bn_map = get (&resource_pool_gen_t::basename, g);
         vtx_size_map_t v_sz_map = get (&resource_pool_gen_t::size, g);
@@ -209,7 +209,6 @@ int resource_gen_spec_t::write_graphviz (const string &ofn, bool simple)
             boost::write_graphviz (out_file, g, vwr, ewr);
         }
     } catch (boost::graph_exception &e) {
-        cerr << e.what () << endl;
         rc = -1;
     }
     out_file.close ();

--- a/resource/store/resource_graph_store.cpp
+++ b/resource/store/resource_graph_store.cpp
@@ -28,9 +28,14 @@
 using namespace Flux;
 using namespace Flux::resource_model;
 
+resource_graph_metadata_t::resource_graph_metadata_t()
+{
+    roots = std::make_shared<std::map<subsystem_t, vtx_t>> ();
+}
+
 bool resource_graph_db_t::known_subsystem (const std::string &s)
 {
-    return (metadata.roots.find (s) != metadata.roots.end ())? true : false;
+    return (metadata.roots->find (s) != metadata.roots->end ())? true : false;
 }
 
 int resource_graph_db_t::load (const std::string &str,

--- a/resource/store/resource_graph_store.hpp
+++ b/resource/store/resource_graph_store.hpp
@@ -38,7 +38,9 @@ class resource_reader_base_t;
  *  Adjacency_list graph, roots of this graph and various indexing.
  */
 struct resource_graph_metadata_t {
-    std::map<subsystem_t, vtx_t> roots;
+    resource_graph_metadata_t ();
+
+    std::shared_ptr<std::map<subsystem_t, vtx_t>> roots;
     std::map<std::string, std::vector <vtx_t>> by_type;
     std::map<std::string, std::vector <vtx_t>> by_name;
     std::map<std::string, vtx_t> by_path;

--- a/resource/traversers/dfu.cpp
+++ b/resource/traversers/dfu.cpp
@@ -120,8 +120,10 @@ dfu_traverser_t::dfu_traverser_t ()
 
 }
 
-dfu_traverser_t::dfu_traverser_t (f_resource_graph_t *g, dfu_match_cb_t *m,
-                                  map<subsystem_t, vtx_t> *roots)
+dfu_traverser_t::dfu_traverser_t (std::shared_ptr<f_resource_graph_t> g,
+                                  std::shared_ptr<dfu_match_cb_t> m,
+                                  std::shared_ptr<std::map<subsystem_t,
+                                                           vtx_t>> roots)
     : detail::dfu_impl_t (g, m, roots)
 {
 
@@ -144,17 +146,20 @@ dfu_traverser_t::~dfu_traverser_t ()
 
 }
 
-const f_resource_graph_t *dfu_traverser_t::get_graph () const
+const std::shared_ptr<const f_resource_graph_t> dfu_traverser_t::
+                                                    get_graph () const
 {
    return detail::dfu_impl_t::get_graph ();
 }
 
-const map<subsystem_t, vtx_t> *dfu_traverser_t::get_roots () const
+const std::shared_ptr<const std::map<subsystem_t,
+                                     vtx_t>> dfu_traverser_t::get_roots () const
 {
     return detail::dfu_impl_t::get_roots ();
 }
 
-const dfu_match_cb_t *dfu_traverser_t::get_match_cb () const
+const std::shared_ptr<const dfu_match_cb_t> dfu_traverser_t::
+                                                get_match_cb () const
 {
     return detail::dfu_impl_t::get_match_cb ();
 }
@@ -164,17 +169,18 @@ const string &dfu_traverser_t::err_message () const
     return detail::dfu_impl_t::err_message ();
 }
 
-void dfu_traverser_t::set_graph (f_resource_graph_t *g)
+void dfu_traverser_t::set_graph (std::shared_ptr<f_resource_graph_t> g)
 {
     detail::dfu_impl_t::set_graph (g);
 }
 
-void dfu_traverser_t::set_roots (map<subsystem_t, vtx_t> *roots)
+void dfu_traverser_t::set_roots (std::shared_ptr<std::map<subsystem_t,
+                                                          vtx_t>> roots)
 {
     detail::dfu_impl_t::set_roots (roots);
 }
 
-void dfu_traverser_t::set_match_cb (dfu_match_cb_t *m)
+void dfu_traverser_t::set_match_cb (std::shared_ptr<dfu_match_cb_t> m)
 {
     detail::dfu_impl_t::set_match_cb (m);
 }
@@ -207,9 +213,10 @@ int dfu_traverser_t::initialize ()
     return rc;
 }
 
-int dfu_traverser_t::initialize (f_resource_graph_t *g,
-                                 map<subsystem_t, vtx_t> *roots,
-                                 dfu_match_cb_t *m)
+int dfu_traverser_t::initialize (std::shared_ptr<f_resource_graph_t> g,
+                                 std::shared_ptr<std::map<subsystem_t,
+                                                          vtx_t>> roots,
+                                 std::shared_ptr<dfu_match_cb_t> m)
 {
     set_graph (g);
     set_roots (roots);
@@ -217,7 +224,8 @@ int dfu_traverser_t::initialize (f_resource_graph_t *g,
     return initialize ();
 }
 
-int dfu_traverser_t::run (Jobspec::Jobspec &jobspec, match_writers_t *writers,
+int dfu_traverser_t::run (Jobspec::Jobspec &jobspec,
+                          std::shared_ptr<match_writers_t> writers,
                           match_op_t op, int64_t jobid, int64_t *at)
 {
     const subsystem_t &dom = get_match_cb ()->dom_subsystem ();

--- a/resource/traversers/dfu.cpp
+++ b/resource/traversers/dfu.cpp
@@ -33,7 +33,6 @@ extern "C" {
 #endif
 }
 
-using namespace std;
 using namespace Flux::resource_model;
 using namespace Flux::resource_model::detail;
 using namespace Flux::Jobspec;
@@ -47,12 +46,12 @@ using namespace Flux::Jobspec;
 int dfu_traverser_t::schedule (Jobspec::Jobspec &jobspec,
                                detail::jobmeta_t &meta, bool x, match_op_t op,
                                vtx_t root, unsigned int *needs,
-                               std::unordered_map<string, int64_t> &dfv)
+                               std::unordered_map<std::string, int64_t> &dfv)
 {
     int t = 0;
     int rc = -1;
     size_t len = 0;
-    vector<uint64_t> agg;
+    std::vector<uint64_t> agg;
     uint64_t duration = 0;
     int saved_errno = errno;
     planner_multi_t *p = NULL;
@@ -164,7 +163,7 @@ const std::shared_ptr<const dfu_match_cb_t> dfu_traverser_t::
     return detail::dfu_impl_t::get_match_cb ();
 }
 
-const string &dfu_traverser_t::err_message () const
+const std::string &dfu_traverser_t::err_message () const
 {
     return detail::dfu_impl_t::err_message ();
 }
@@ -200,7 +199,7 @@ int dfu_traverser_t::initialize ()
     }
 
     for (auto &subsystem : get_match_cb ()->subsystems ()) {
-        map<string, int64_t> from_dfv;
+        std::map<std::string, int64_t> from_dfv;
         if (get_roots ()->find (subsystem) == get_roots ()->end ()) {
             errno = ENOTSUP;
             rc = -1;
@@ -241,7 +240,7 @@ int dfu_traverser_t::run (Jobspec::Jobspec &jobspec,
     unsigned int needs = 0;
     vtx_t root = get_roots ()->at(dom);
     bool x = detail::dfu_impl_t::exclusivity (jobspec.resources, root);
-    std::unordered_map<string, int64_t> dfv;
+    std::unordered_map<std::string, int64_t> dfv;
     detail::dfu_impl_t::prime_jobspec (jobspec.resources, dfv);
     meta.build (jobspec, true, jobid, *at);
     if ( (rc = schedule (jobspec, meta, x, op, root, &needs, dfv)) ==  0) {

--- a/resource/traversers/dfu.hpp
+++ b/resource/traversers/dfu.hpp
@@ -41,20 +41,23 @@ class dfu_traverser_t : protected detail::dfu_impl_t
 {
 public:
     dfu_traverser_t ();
-    dfu_traverser_t (f_resource_graph_t *g,
-                     dfu_match_cb_t *m, std::map<subsystem_t, vtx_t> *roots);
+    dfu_traverser_t (std::shared_ptr<f_resource_graph_t> g,
+                     std::shared_ptr<dfu_match_cb_t> m,
+                     std::shared_ptr<std::map<subsystem_t, vtx_t>> roots);
     dfu_traverser_t (const dfu_traverser_t &o);
+    dfu_traverser_t (dfu_traverser_t &&o) = default;
     dfu_traverser_t &operator= (const dfu_traverser_t &o);
+    dfu_traverser_t &operator= (dfu_traverser_t &&o) = default;
     ~dfu_traverser_t ();
 
-    const f_resource_graph_t *get_graph () const;
-    const std::map<subsystem_t, vtx_t> *get_roots () const;
-    const dfu_match_cb_t *get_match_cb () const;
+    const std::shared_ptr<const f_resource_graph_t> get_graph () const;
+    const std::shared_ptr<const std::map<subsystem_t, vtx_t>> get_roots () const;
+    const std::shared_ptr<const dfu_match_cb_t> get_match_cb () const;
     const std::string &err_message () const;
 
-    void set_graph (f_resource_graph_t *g);
-    void set_roots (std::map<subsystem_t, vtx_t> *roots);
-    void set_match_cb (dfu_match_cb_t *m);
+    void set_graph (std::shared_ptr<f_resource_graph_t> g);
+    void set_roots (std::shared_ptr<std::map<subsystem_t, vtx_t>> roots);
+    void set_match_cb (std::shared_ptr<dfu_match_cb_t> m);
     void clear_err_message ();
 
     /*! Prime the resource graph with subtree plans. Assume that resource graph,
@@ -90,8 +93,9 @@ public:
      *                       ENOTSUP: roots does not contain a subsystem
      *                                the match callback uses.
      */
-    int initialize (f_resource_graph_t *g, std::map<subsystem_t, vtx_t> *roots,
-                    dfu_match_cb_t *m);
+    int initialize (std::shared_ptr<f_resource_graph_t> g,
+                    std::shared_ptr<std::map<subsystem_t, vtx_t>> roots,
+                    std::shared_ptr<dfu_match_cb_t> m);
 
     /*! Begin a graph traversal for the jobspec and either allocate or
      *  reserve the resources in the resource graph. Best-matching resources
@@ -114,7 +118,8 @@ public:
      *                       ENODEV: unsatifiable jobspec becuase no
      *                               resources/devices can satisfy the request.
      */
-    int run (Jobspec::Jobspec &jobspec, match_writers_t *writers,
+    int run (Jobspec::Jobspec &jobspec,
+             std::shared_ptr<match_writers_t> writers,
              match_op_t op, int64_t id, int64_t *at);
 
     /*! Remove the allocation/reservation referred to by jobid and update

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -30,7 +30,6 @@ extern "C" {
 #endif
 }
 
-using namespace std;
 using namespace Flux::Jobspec;
 using namespace Flux::resource_model;
 using namespace Flux::resource_model::detail;
@@ -71,7 +70,7 @@ bool dfu_impl_t::stop_explore (edg_t e, const subsystem_t &subsystem) const
             || m_color.is_black ((*m_graph)[u].idata.colors[subsystem]));
 }
 
-bool dfu_impl_t::exclusivity (const vector<Jobspec::Resource> &resources,
+bool dfu_impl_t::exclusivity (const std::vector<Jobspec::Resource> &resources,
                               vtx_t u)
 {
     // If one of the resources matches with the visiting vertex, u
@@ -170,7 +169,7 @@ int dfu_impl_t::by_subplan (const jobmeta_t &meta, const std::string &s, vtx_t u
     size_t len = 0;
     int64_t at = meta.at;
     uint64_t d = meta.duration;
-    vector<uint64_t> aggs;
+    std::vector<uint64_t> aggs;
     int saved_errno = errno;
     planner_multi_t *p = (*m_graph)[u].idata.subplans[s];
 
@@ -220,8 +219,8 @@ done:
     return rc;
 }
 
-planner_multi_t *dfu_impl_t::subtree_plan (vtx_t u, vector<uint64_t> &av,
-                                           vector<const char *> &tp)
+planner_multi_t *dfu_impl_t::subtree_plan (vtx_t u, std::vector<uint64_t> &av,
+                                           std::vector<const char *> &tp)
 {
     size_t len = av.size ();
     int64_t base_time = planner_base_time ((*m_graph)[u].schedule.plans);
@@ -229,7 +228,7 @@ planner_multi_t *dfu_impl_t::subtree_plan (vtx_t u, vector<uint64_t> &av,
     return planner_multi_new (base_time, duration, &av[0], &tp[0], len);
 }
 
-void dfu_impl_t::match (vtx_t u, const vector<Resource> &resources,
+void dfu_impl_t::match (vtx_t u, const std::vector<Resource> &resources,
                        const Resource **slot_resource,
                        const Resource **match_resource)
 {
@@ -273,9 +272,9 @@ bool dfu_impl_t::slot_match (vtx_t u, const Resource *slot_resources)
     return slot_match;
 }
 
-const vector<Resource> &dfu_impl_t::test (vtx_t u,
-                                          const vector<Resource> &resources,
-                                          bool &pristine, match_kind_t &spec)
+const std::vector<Resource> &dfu_impl_t::test (vtx_t u,
+                                 const std::vector<Resource> &resources,
+                                 bool &pristine, match_kind_t &spec)
 {
     /* Note on the purpose of pristine: we differentiate two similar but
      * distinct cases with this parameter.
@@ -292,7 +291,7 @@ const vector<Resource> &dfu_impl_t::test (vtx_t u,
      * pristine is used to detect this case.
      */
     bool slot = true;
-    const vector<Resource> *ret = &resources;
+    const std::vector<Resource> *ret = &resources;
     const Resource *slot_resources = NULL;
     const Resource *match_resources = NULL;
     match (u, resources, &slot_resources, &match_resources);
@@ -314,8 +313,9 @@ const vector<Resource> &dfu_impl_t::test (vtx_t u,
 /* Accumulate counts into accum[type] if the type is one of the pruning
  * filter type.
  */
-int dfu_impl_t::accum_if (const subsystem_t &subsystem, const string &type,
-                          unsigned int counts, map<string, int64_t> &accum)
+int dfu_impl_t::accum_if (const subsystem_t &subsystem, const std::string &type,
+                          unsigned int counts,
+                          std::map<std::string, int64_t> &accum)
 {
     int rc = -1;
     if (m_match->is_pruning_type (subsystem, type)) {
@@ -329,9 +329,9 @@ int dfu_impl_t::accum_if (const subsystem_t &subsystem, const string &type,
 }
 
 /* Same as above except that accum is unorder_map */
-int dfu_impl_t::accum_if (const subsystem_t &subsystem, const string &type,
+int dfu_impl_t::accum_if (const subsystem_t &subsystem, const std::string &type,
                           unsigned int counts,
-                          std::unordered_map<string, int64_t> &accum)
+                          std::unordered_map<std::string, int64_t> &accum)
 {
     int rc = -1;
     if (m_match->is_pruning_type (subsystem, type)) {
@@ -345,7 +345,7 @@ int dfu_impl_t::accum_if (const subsystem_t &subsystem, const string &type,
 }
 
 int dfu_impl_t::prime_exp (const subsystem_t &subsystem, vtx_t u,
-                           map<string, int64_t> &dfv)
+                           std::map<std::string, int64_t> &dfv)
 {
     int rc = 0;
     f_out_edg_iterator_t ei, ei_end;
@@ -361,7 +361,7 @@ int dfu_impl_t::prime_exp (const subsystem_t &subsystem, vtx_t u,
 
 int dfu_impl_t::explore (const jobmeta_t &meta, vtx_t u,
                          const subsystem_t &subsystem,
-                         const vector<Resource> &resources, bool pristine,
+                         const std::vector<Resource> &resources, bool pristine,
                          bool *excl, visit_t direction, scoring_api_t &dfu)
 {
     int rc = -1;
@@ -396,7 +396,7 @@ int dfu_impl_t::explore (const jobmeta_t &meta, vtx_t u,
 }
 
 int dfu_impl_t::aux_upv (const jobmeta_t &meta, vtx_t u, const subsystem_t &aux,
-                         const vector<Resource> &resources, bool pristine,
+                         const std::vector<Resource> &resources, bool pristine,
                          bool *excl, scoring_api_t &to_parent)
 {
     int rc = -1;
@@ -431,7 +431,7 @@ done:
 }
 
 int dfu_impl_t::dom_exp (const jobmeta_t &meta, vtx_t u,
-                         const vector<Resource> &resources, bool pristine,
+                         const std::vector<Resource> &resources, bool pristine,
                          bool *excl, scoring_api_t &dfu)
 {
     int rc = -1;
@@ -447,7 +447,7 @@ int dfu_impl_t::dom_exp (const jobmeta_t &meta, vtx_t u,
     return rc;
 }
 
-int dfu_impl_t::cnt_slot (const vector<Resource> &slot_shape,
+int dfu_impl_t::cnt_slot (const std::vector<Resource> &slot_shape,
                           scoring_api_t &dfu_slot)
 {
     unsigned int qc = 0;
@@ -469,7 +469,7 @@ int dfu_impl_t::cnt_slot (const vector<Resource> &slot_shape,
 }
 
 int dfu_impl_t::dom_slot (const jobmeta_t &meta, vtx_t u,
-                          const vector<Resource> &slot_shape, bool pristine,
+                          const std::vector<Resource> &slot_shape, bool pristine,
                           bool *excl, scoring_api_t &dfu)
 {
     int rc;
@@ -506,14 +506,14 @@ int dfu_impl_t::dom_slot (const jobmeta_t &meta, vtx_t u,
         edg_group.score = score;
         edg_group.count = 1;
         edg_group.exclusive = 1;
-        dfu.add (dom, string ("slot"), edg_group);
+        dfu.add (dom, std::string ("slot"), edg_group);
     }
 done:
     return (qual_num_slots)? 0 : -1;
 }
 
 int dfu_impl_t::dom_dfv (const jobmeta_t &meta, vtx_t u,
-                         const vector<Resource> &resources, bool pristine,
+                         const std::vector<Resource> &resources, bool pristine,
                          bool *excl, scoring_api_t &to_parent)
 {
     int rc = -1;
@@ -525,8 +525,8 @@ int dfu_impl_t::dom_dfv (const jobmeta_t &meta, vtx_t u,
     bool check_pres = pristine;
     scoring_api_t dfu;
     planner_t *p = NULL;
-    const string &dom = m_match->dom_subsystem ();
-    const vector<Resource> &next = test (u, resources, check_pres, sm);
+    const std::string &dom = m_match->dom_subsystem ();
+    const std::vector<Resource> &next = test (u, resources, check_pres, sm);
 
     if (sm == match_kind_t::NONE_MATCH)
         goto done;
@@ -561,7 +561,7 @@ done:
     return rc;
 }
 
-int dfu_impl_t::resolve (vtx_t root, vector<Resource> &resources,
+int dfu_impl_t::resolve (vtx_t root, std::vector<Resource> &resources,
                          scoring_api_t &dfu, bool excl, unsigned int *needs)
 {
     int rc = -1;
@@ -583,7 +583,7 @@ int dfu_impl_t::resolve (vtx_t root, vector<Resource> &resources,
 
     // resolve remaining unconstrained resource types
     for (auto &subsystem : m_match->subsystems ()) {
-        vector<string> types;
+        std::vector<std::string> types;
         dfu.resrc_types (subsystem, types);
         for (auto &type : types) {
             if (dfu.qualified_count (subsystem, type) == 0)
@@ -618,7 +618,7 @@ int dfu_impl_t::enforce (const subsystem_t &subsystem, scoring_api_t &dfu)
 {
     int rc = 0;
     try {
-        vector<string> resource_types;
+        std::vector<std::string> resource_types;
         dfu.resrc_types (subsystem, resource_types);
         for (auto &t : resource_types) {
             int best_i = dfu.best_i (subsystem, t);
@@ -633,7 +633,7 @@ int dfu_impl_t::enforce (const subsystem_t &subsystem, scoring_api_t &dfu)
                 }
             }
         }
-    } catch (const out_of_range &exception) {
+    } catch (const std::out_of_range &exception) {
         errno = ERANGE;
         rc = -1;
     }
@@ -655,7 +655,7 @@ int dfu_impl_t::emit_edg (edg_t e, std::shared_ptr<match_writers_t> w)
 
 int dfu_impl_t::upd_plan (vtx_t u, const subsystem_t &s, unsigned int needs,
                           bool excl, const jobmeta_t &meta, int &n,
-                          map<string, int64_t> &to_parent)
+                          std::map<std::string, int64_t> &to_parent)
 {
     int64_t span = 0;
     if (!excl) {
@@ -686,8 +686,8 @@ done:
 int dfu_impl_t::upd_sched (vtx_t u, std::shared_ptr<match_writers_t> writers,
                            const subsystem_t &s, unsigned int needs,
                            bool excl, int n, const jobmeta_t &meta,
-                           map<string, int64_t> &dfu,
-                           map<string, int64_t> &to_parent)
+                           std::map<std::string, int64_t> &dfu,
+                           std::map<std::string, int64_t> &to_parent)
 {
     if (upd_plan (u, s, needs, excl, meta, n, to_parent) == -1)
         goto done;
@@ -705,7 +705,7 @@ int dfu_impl_t::upd_sched (vtx_t u, std::shared_ptr<match_writers_t> writers,
         // Update subtree plan
         planner_multi_t *subtree_plan = (*m_graph)[u].idata.subplans[s];
         if (subtree_plan) {
-            vector<uint64_t> aggregate;
+            std::vector<uint64_t> aggregate;
             count_relevant_types (subtree_plan, dfu, aggregate);
             span = planner_multi_add_span (subtree_plan, meta.at, meta.duration,
                                            &(aggregate[0]), aggregate.size ());
@@ -729,7 +729,7 @@ done:
 
 int dfu_impl_t::upd_upv (vtx_t u, const subsystem_t &subsystem,
                          unsigned int needs, bool excl, const jobmeta_t &meta,
-                         map<string, int64_t> &to_parent)
+                         std::map<std::string, int64_t> &to_parent)
 {
     //NYI: update resources on the UPV direction
     return 0;
@@ -737,11 +737,11 @@ int dfu_impl_t::upd_upv (vtx_t u, const subsystem_t &subsystem,
 
 int dfu_impl_t::upd_dfv (vtx_t u, std::shared_ptr<match_writers_t> writers,
                          unsigned int needs, bool excl, const jobmeta_t &meta,
-                         std::map<string, int64_t> &to_parent)
+                         std::map<std::string, int64_t> &to_parent)
 {
     int n_plans = 0;
-    map<string, int64_t> dfu;
-    const string &dom = m_match->dom_subsystem ();
+    std::map<std::string, int64_t> dfu;
+    const std::string &dom = m_match->dom_subsystem ();
     f_out_edg_iterator_t ei, ei_end;
 
     m_trav_level++;
@@ -845,7 +845,7 @@ int dfu_impl_t::rem_x_checker (vtx_t u, int64_t jobid)
 }
 
 int dfu_impl_t::rem_subtree_plan (vtx_t u, int64_t jobid,
-                                  const string &subsystem)
+                                  const std::string &subsystem)
 {
     int rc = 0;
     int span = -1;
@@ -873,7 +873,7 @@ done:
 int dfu_impl_t::rem_dfv (vtx_t u, int64_t jobid)
 {
     int rc = 0;
-    const string &dom = m_match->dom_subsystem ();
+    const std::string &dom = m_match->dom_subsystem ();
     auto &tags = (*m_graph)[u].schedule.tags;
     f_out_edg_iterator_t ei, ei_end;
 
@@ -966,7 +966,7 @@ const std::shared_ptr<const dfu_match_cb_t> dfu_impl_t::get_match_cb () const
     return m_match;
 }
 
-const string &dfu_impl_t::err_message () const
+const std::string &dfu_impl_t::err_message () const
 {
     return m_err_msg;
 }
@@ -992,14 +992,14 @@ void dfu_impl_t::clear_err_message ()
 }
 
 int dfu_impl_t::prime_pruning_filter (const subsystem_t &s, vtx_t u,
-                                      map<string, int64_t> &to_parent)
+                                      std::map<std::string, int64_t> &to_parent)
 {
     int rc = -1;
     int saved_errno = errno;
-    vector<uint64_t> avail;
-    vector<const char *> types;
-    map<string, int64_t> dfv;
-    string type = (*m_graph)[u].type;
+    std::vector<uint64_t> avail;
+    std::vector<const char *> types;
+    std::map<std::string, int64_t> dfv;
+    std::string type = (*m_graph)[u].type;
     std::vector<std::string> out_prune_types;
 
     (*m_graph)[u].idata.colors[s] = m_color.gray ();
@@ -1038,8 +1038,9 @@ done:
     return rc;
 }
 
-void dfu_impl_t::prime_jobspec (vector<Resource> &resources,
-                                std::unordered_map<string, int64_t> &to_parent)
+void dfu_impl_t::prime_jobspec (std::vector<Resource> &resources,
+                                std::unordered_map<std::string,
+                                                   int64_t> &to_parent)
 {
     const subsystem_t &subsystem = m_match->dom_subsystem ();
     for (auto &resource : resources) {
@@ -1060,7 +1061,7 @@ int dfu_impl_t::select (Jobspec::Jobspec &j, vtx_t root, jobmeta_t &meta,
     int rc = -1;
     scoring_api_t dfu;
     bool x_in = excl;
-    const string &dom = m_match->dom_subsystem ();
+    const std::string &dom = m_match->dom_subsystem ();
 
     tick ();
     rc = dom_dfv (meta, root, j.resources, true, &x_in, dfu);
@@ -1077,7 +1078,7 @@ int dfu_impl_t::select (Jobspec::Jobspec &j, vtx_t root, jobmeta_t &meta,
 int dfu_impl_t::update (vtx_t root, std::shared_ptr<match_writers_t> writers,
                         jobmeta_t &meta, unsigned int needs, bool exclusive)
 {
-    map<string, int64_t> dfu;
+    std::map<std::string, int64_t> dfu;
     m_color.reset ();
     return (upd_dfv (root, writers, needs, exclusive, meta, dfu) > 0)? 0 : -1;
 }

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -640,14 +640,14 @@ int dfu_impl_t::enforce (const subsystem_t &subsystem, scoring_api_t &dfu)
     return rc;
 }
 
-int dfu_impl_t::emit_vtx (vtx_t u, match_writers_t *w, unsigned needs,
-                          bool exclusive)
+int dfu_impl_t::emit_vtx (vtx_t u, std::shared_ptr<match_writers_t> w,
+                          unsigned needs, bool exclusive)
 {
     w->emit_vtx (level (), (*m_graph), u, needs, exclusive);
     return 0;
 }
 
-int dfu_impl_t::emit_edg (edg_t e, match_writers_t *w)
+int dfu_impl_t::emit_edg (edg_t e, std::shared_ptr<match_writers_t> w)
  {
      w->emit_edg (level (), (*m_graph), e);
      return 0;
@@ -683,7 +683,7 @@ done:
     return (span == -1)? -1 : 0;
 }
 
-int dfu_impl_t::upd_sched (vtx_t u, match_writers_t *writers,
+int dfu_impl_t::upd_sched (vtx_t u, std::shared_ptr<match_writers_t> writers,
                            const subsystem_t &s, unsigned int needs,
                            bool excl, int n, const jobmeta_t &meta,
                            map<string, int64_t> &dfu,
@@ -735,9 +735,9 @@ int dfu_impl_t::upd_upv (vtx_t u, const subsystem_t &subsystem,
     return 0;
 }
 
-int dfu_impl_t::upd_dfv (vtx_t u, match_writers_t *writers, unsigned int needs,
-                         bool excl, const jobmeta_t &meta,
-                         map<string, int64_t> &to_parent)
+int dfu_impl_t::upd_dfv (vtx_t u, std::shared_ptr<match_writers_t> writers,
+                         unsigned int needs, bool excl, const jobmeta_t &meta,
+                         std::map<string, int64_t> &to_parent)
 {
     int n_plans = 0;
     map<string, int64_t> dfu;
@@ -914,8 +914,9 @@ dfu_impl_t::dfu_impl_t ()
 
 }
 
-dfu_impl_t::dfu_impl_t (f_resource_graph_t *g, dfu_match_cb_t *m,
-                        map<subsystem_t, vtx_t> *roots)
+dfu_impl_t::dfu_impl_t (std::shared_ptr<f_resource_graph_t> g,
+                        std::shared_ptr<dfu_match_cb_t> m,
+                        std::shared_ptr<std::map<subsystem_t, vtx_t>> roots)
     : m_roots (roots), m_graph (g), m_match (m)
 {
 
@@ -949,17 +950,18 @@ dfu_impl_t::~dfu_impl_t ()
 
 }
 
-const f_resource_graph_t *dfu_impl_t::get_graph () const
+const std::shared_ptr<const f_resource_graph_t> dfu_impl_t::get_graph () const
 {
     return m_graph;
 }
 
-const map<subsystem_t, vtx_t> *dfu_impl_t::get_roots () const
+const std::shared_ptr<const std::map<subsystem_t,
+                                     vtx_t>> dfu_impl_t::get_roots () const
 {
     return m_roots;
 }
 
-const dfu_match_cb_t *dfu_impl_t::get_match_cb () const
+const std::shared_ptr<const dfu_match_cb_t> dfu_impl_t::get_match_cb () const
 {
     return m_match;
 }
@@ -969,17 +971,17 @@ const string &dfu_impl_t::err_message () const
     return m_err_msg;
 }
 
-void dfu_impl_t::set_graph (f_resource_graph_t *g)
+void dfu_impl_t::set_graph (std::shared_ptr<f_resource_graph_t> g)
 {
     m_graph = g;
 }
 
-void dfu_impl_t::set_roots (map<subsystem_t, vtx_t> *roots)
+void dfu_impl_t::set_roots (std::shared_ptr<std::map<subsystem_t, vtx_t>> roots)
 {
     m_roots = roots;
 }
 
-void dfu_impl_t::set_match_cb (dfu_match_cb_t *m)
+void dfu_impl_t::set_match_cb (std::shared_ptr<dfu_match_cb_t> m)
 {
     m_match = m;
 }
@@ -1072,8 +1074,8 @@ int dfu_impl_t::select (Jobspec::Jobspec &j, vtx_t root, jobmeta_t &meta,
     return rc;
 }
 
-int dfu_impl_t::update (vtx_t root, match_writers_t *writers, jobmeta_t &meta,
-                        unsigned int needs, bool exclusive)
+int dfu_impl_t::update (vtx_t root, std::shared_ptr<match_writers_t> writers,
+                        jobmeta_t &meta, unsigned int needs, bool exclusive)
 {
     map<string, int64_t> dfu;
     m_color.reset ();

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -1008,7 +1008,8 @@ int dfu_impl_t::prime_pruning_filter (const subsystem_t &s, vtx_t u,
     for (auto &aggr : dfv)
         accum_if (s, aggr.first, aggr.second, to_parent);
 
-    if (m_match->get_my_pruning_types (s, (*m_graph)[u].type, out_prune_types)) {
+    if (m_match->get_my_pruning_types (s,
+                                       (*m_graph)[u].type, out_prune_types)) {
         for (auto &type : out_prune_types) {
             types.push_back (type.c_str ());
             if (dfv.find (type) != dfv.end ())

--- a/resource/utilities/command.cpp
+++ b/resource/utilities/command.cpp
@@ -53,10 +53,12 @@ command_t commands[] = {
     { "set-property", "p", cmd_set_property, "Add a property to a resource: "
 "resource-query> set-property resource PROPERTY=VALUE" },
 { "get-property", "g", cmd_get_property, "Get all properties of a resource: "
-"resource-query> get-property resource" }, /* May need to be modified to get-property resource PROPERTY*/
+"resource-query> get-property resource" },
     { "list", "l", cmd_list, "List all jobs: resource-query> list" },
-    { "info", "i", cmd_info, "Print info on a jobid: resource-query> info jobid" },
-    { "stat", "s", cmd_stat, "Print overall stats: resource-query> stat jobid" },
+    { "info", "i", cmd_info,
+"Print info on a jobid: resource-query> info jobid" },
+    { "stat", "s", cmd_stat,
+ "Print overall stats: resource-query> stat jobid" },
     { "cat", "a", cmd_cat, "Print jobspec file: resource-query> cat jobspec" },
     { "help", "h", cmd_help, "Print help message: resource-query> help" },
     { "quit", "q", cmd_quit, "Quit the session: resource-query> quit" },

--- a/resource/utilities/command.hpp
+++ b/resource/utilities/command.hpp
@@ -30,6 +30,7 @@
 #include "resource/readers/resource_reader_factory.hpp"
 #include "resource/traversers/dfu.hpp"
 #include "resource/jobinfo/jobinfo.hpp"
+#include <memory>
 #include <cerrno>
 #include <vector>
 #include <map>
@@ -65,30 +66,41 @@ struct match_perf_t {
 struct resource_context_t {
     test_params_t params;        /* Parameters for resource-query */
     uint64_t jobid_counter;      /* Hold the current jobid value */
-    dfu_match_cb_t *matcher;     /* Match callback object */
-    dfu_traverser_t *traverser;  /* Graph traverser object */
+    std::shared_ptr<dfu_match_cb_t> matcher; /* Match callback object */
+    std::shared_ptr<dfu_traverser_t> traverser; /* Graph traverser object */
     resource_graph_db_t db;      /* Resource graph data store */
-    f_resource_graph_t *fgraph;  /* Graph filtered by subsystems to use */
-    match_writers_t *writers;    /* Vertex/Edge writers for a match */
+    std::shared_ptr<f_resource_graph_t> fgraph; /* Filtered graph */
+    std::shared_ptr<match_writers_t> writers; /* Vertex/Edge writers */
     match_perf_t perf;           /* Match performance stats */
-    std::map<uint64_t, job_info_t *> jobs;     /* Jobs table */
+    std::map<uint64_t, std::shared_ptr<job_info_t>> jobs; /* Jobs table */
     std::map<uint64_t, uint64_t> allocations;  /* Allocation table */
     std::map<uint64_t, uint64_t> reservations; /* Reservation table */
 };
 
-typedef int cmd_func_f (resource_context_t *, std::vector<std::string> &);
+typedef int cmd_func_f (std::shared_ptr<resource_context_t> &,
+                        std::vector<std::string> &);
 
 cmd_func_f *find_cmd (const std::string &cmd_str);
-int cmd_match (resource_context_t *ctx, std::vector<std::string> &args);
-int cmd_cancel (resource_context_t *ctx, std::vector<std::string> &args);
-int cmd_set_property (resource_context_t *ctx, std::vector<std::string> &args);
-int cmd_get_property (resource_context_t *ctx, std::vector<std::string> &args);
-int cmd_list (resource_context_t *ctx, std::vector<std::string> &args);
-int cmd_info (resource_context_t *ctx, std::vector<std::string> &args);
-int cmd_stat (resource_context_t *ctx, std::vector<std::string> &args);
-int cmd_cat (resource_context_t *ctx, std::vector<std::string> &args);
-int cmd_quit (resource_context_t *ctx, std::vector<std::string> &args);
-int cmd_help (resource_context_t *ctx, std::vector<std::string> &args);
+int cmd_match (std::shared_ptr<resource_context_t> &ctx,
+               std::vector<std::string> &args);
+int cmd_cancel (std::shared_ptr<resource_context_t> &ctx,
+                std::vector<std::string> &args);
+int cmd_set_property (std::shared_ptr<resource_context_t> &ctx,
+                      std::vector<std::string> &args);
+int cmd_get_property (std::shared_ptr<resource_context_t> &ctx,
+                      std::vector<std::string> &args);
+int cmd_list (std::shared_ptr<resource_context_t> &ctx,
+              std::vector<std::string> &args);
+int cmd_info (std::shared_ptr<resource_context_t> &ctx,
+              std::vector<std::string> &args);
+int cmd_stat (std::shared_ptr<resource_context_t> &ctx,
+              std::vector<std::string> &args);
+int cmd_cat (std::shared_ptr<resource_context_t> &ctx,
+             std::vector<std::string> &args);
+int cmd_quit (std::shared_ptr<resource_context_t> &ctx,
+              std::vector<std::string> &args);
+int cmd_help (std::shared_ptr<resource_context_t> &ctx,
+              std::vector<std::string> &args);
 double get_elapse_time (timeval &st, timeval &et);
 
 } // namespace resource_model

--- a/resource/utilities/grug2dot.cpp
+++ b/resource/utilities/grug2dot.cpp
@@ -32,7 +32,6 @@ extern "C" {
 #endif
 }
 
-using namespace std;
 using namespace Flux::resource_model;
 
 #define OPTIONS "hm"
@@ -44,7 +43,7 @@ static const struct option longopts[] = {
 
 void usage (int code)
 {
-    cerr <<
+    std::cerr <<
 "Usage: grug2dot <genspec>.graphml\n"
 "    Convert a resource-graph generator spec (<genspec>.graphml)\n"
 "    to AT&T GraphViz format (<genspec>.dot). The output\n"
@@ -83,15 +82,15 @@ int main (int argc, char *argv[])
         usage (1);
 
     resource_gen_spec_t gspec;
-    string fn (argv[optind]);
+    std::string fn (argv[optind]);
     boost::filesystem::path path = fn;
-    string base = path.stem ().string ();
+    std::string base = path.stem ().string ();
 
     if (gspec.read_graphml (fn) != 0) {
-        cerr << "Error in reading " << fn << endl;
+        std::cerr << "Error in reading " << fn << std::endl;
         rc = -1;
     } else if (gspec.write_graphviz (base + ".dot", simple) != 0) {
-        cerr << "Error in writing " << base + ".dot" << endl;
+        std::cerr << "Error in writing " << base + ".dot" << std::endl;
         rc = -1;
     }
 

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -45,7 +45,6 @@ extern "C" {
 #endif
 }
 
-using namespace std;
 using namespace Flux::resource_model;
 
 #define OPTIONS "L:f:W:S:P:F:g:o:p:t:r:edh"
@@ -69,7 +68,7 @@ static const struct option longopts[] = {
 
 static void usage (int code)
 {
-    cerr <<
+    std::cerr <<
 "usage: resource-query [OPTIONS...]\n"
 "\n"
 "Command-line utility that takes in an HPC resource request written in\n"
@@ -209,19 +208,19 @@ static void set_default_params (std::shared_ptr<resource_context_t> &ctx)
     ctx->params.disable_prompt = false;
 }
 
-static int string_to_graph_format (string st, emit_format_t &format)
+static int string_to_graph_format (std::string st, emit_format_t &format)
 {
     int rc = 0;
-    if (boost::iequals (st, string ("dot")))
+    if (boost::iequals (st, std::string ("dot")))
         format = emit_format_t::GRAPHVIZ_DOT;
-    else if (boost::iequals (st, string ("graphml")))
+    else if (boost::iequals (st, std::string ("graphml")))
         format = emit_format_t::GRAPH_ML;
     else
         rc = -1;
     return rc;
 }
 
-static int graph_format_to_ext (emit_format_t format, string &st)
+static int graph_format_to_ext (emit_format_t format, std::string &st)
 {
     int rc = 0;
     switch (format) {
@@ -252,59 +251,59 @@ static int set_subsystems_use (std::shared_ptr<resource_context_t> &ctx,
     int rc = 0;
     ctx->matcher->set_matcher_name (n);
     dfu_match_cb_t &matcher = *(ctx->matcher);
-    const string &matcher_type = matcher.matcher_name ();
+    const std::string &matcher_type = matcher.matcher_name ();
 
-    if (boost::iequals (matcher_type, string ("CA"))) {
+    if (boost::iequals (matcher_type, std::string ("CA"))) {
         if ( (rc = subsystem_exist (ctx, "containment")) == 0)
             matcher.add_subsystem ("containment", "*");
-    } else if (boost::iequals (matcher_type, string ("IBA"))) {
+    } else if (boost::iequals (matcher_type, std::string ("IBA"))) {
         if ( (rc = subsystem_exist (ctx, "ibnet")) == 0)
             matcher.add_subsystem ("ibnet", "*");
-    } else if (boost::iequals (matcher_type, string ("IBBA"))) {
+    } else if (boost::iequals (matcher_type, std::string ("IBBA"))) {
         if ( (rc = subsystem_exist (ctx, "ibnetbw")) == 0)
             matcher.add_subsystem ("ibnetbw", "*");
-    } else if (boost::iequals (matcher_type, string ("PFS1BA"))) {
+    } else if (boost::iequals (matcher_type, std::string ("PFS1BA"))) {
         if ( (rc = subsystem_exist (ctx, "pfs1bw")) == 0)
             matcher.add_subsystem ("pfs1bw", "*");
-    } else if (boost::iequals (matcher_type, string ("PA"))) {
+    } else if (boost::iequals (matcher_type, std::string ("PA"))) {
         if ( (rc = subsystem_exist (ctx, "power")) == 0)
             matcher.add_subsystem ("power", "*");
-    } else if (boost::iequals (matcher_type, string ("C+PFS1BA"))) {
+    } else if (boost::iequals (matcher_type, std::string ("C+PFS1BA"))) {
         if ( (rc = subsystem_exist (ctx, "containment")) == 0)
             matcher.add_subsystem ("containment", "contains");
         if ( !rc && (rc = subsystem_exist (ctx, "pfs1bw")) == 0)
             matcher.add_subsystem ("pfs1bw", "*");
-    } else if (boost::iequals (matcher_type, string ("C+IBA"))) {
+    } else if (boost::iequals (matcher_type, std::string ("C+IBA"))) {
         if ( (rc = subsystem_exist (ctx, "containment")) == 0)
             matcher.add_subsystem ("containment", "contains");
         if ( !rc && (rc = subsystem_exist (ctx, "ibnet")) == 0)
             matcher.add_subsystem ("ibnet", "connected_up");
-    } else if (boost::iequals (matcher_type, string ("C+PA"))) {
+    } else if (boost::iequals (matcher_type, std::string ("C+PA"))) {
         if ( (rc = subsystem_exist (ctx, "containment")) == 0)
             matcher.add_subsystem ("containment", "*");
         if ( !rc && (rc = subsystem_exist (ctx, "power")) == 0)
             matcher.add_subsystem ("power", "draws_from");
-    } else if (boost::iequals (matcher_type, string ("IB+IBBA"))) {
+    } else if (boost::iequals (matcher_type, std::string ("IB+IBBA"))) {
         if ( (rc = subsystem_exist (ctx, "ibnet")) == 0)
             matcher.add_subsystem ("ibnet", "connected_down");
         if ( !rc && (rc = subsystem_exist (ctx, "ibnetbw")) == 0)
             matcher.add_subsystem ("ibnetbw", "*");
-    } else if (boost::iequals (matcher_type, string ("C+P+IBA"))) {
+    } else if (boost::iequals (matcher_type, std::string ("C+P+IBA"))) {
         if ( (rc = subsystem_exist (ctx, "containment")) == 0)
             matcher.add_subsystem ("containment", "contains");
         if ( (rc = subsystem_exist (ctx, "power")) == 0)
             matcher.add_subsystem ("power", "draws_from");
         if ( !rc && (rc = subsystem_exist (ctx, "ibnet")) == 0)
             matcher.add_subsystem ("ibnet", "connected_up");
-    } else if (boost::iequals (matcher_type, string ("V+PFS1BA"))) {
+    } else if (boost::iequals (matcher_type, std::string ("V+PFS1BA"))) {
         if ( (rc = subsystem_exist (ctx, "virtual1")) == 0)
             matcher.add_subsystem ("virtual1", "*");
         if ( !rc && (rc = subsystem_exist (ctx, "pfs1bw")) == 0)
             matcher.add_subsystem ("pfs1bw", "*");
-    } else if (boost::iequals (matcher_type, string ("VA"))) {
+    } else if (boost::iequals (matcher_type, std::string ("VA"))) {
         if ( (rc = subsystem_exist (ctx, "virtual1")) == 0)
             matcher.add_subsystem ("virtual1", "*");
-    } else if (boost::iequals (matcher_type, string ("ALL"))) {
+    } else if (boost::iequals (matcher_type, std::string ("ALL"))) {
         if ( (rc = subsystem_exist (ctx, "containment")) == 0)
             matcher.add_subsystem ("containment", "*");
         if ( !rc && (rc = subsystem_exist (ctx, "ibnet")) == 0)
@@ -322,7 +321,7 @@ static int set_subsystems_use (std::shared_ptr<resource_context_t> &ctx,
 }
 
 static void write_to_graphviz (f_resource_graph_t &fg, subsystem_t ss,
-                               fstream &o)
+                               std::fstream &o)
 {
     f_res_name_map_t vmap = get (&resource_pool_t::name, fg);
     f_edg_infra_map_t emap = get (&resource_relation_t::idata, fg);
@@ -331,9 +330,10 @@ static void write_to_graphviz (f_resource_graph_t &fg, subsystem_t ss,
     write_graphviz (o, fg, vwr, ewr);
 }
 
-static void flatten (f_resource_graph_t &fg, map<vtx_t, string> &paths,
-                     map<vtx_t, string> &subsystems,
-                     map<edg_t, string> &esubsystems)
+static void flatten (f_resource_graph_t &fg,
+                     std::map<vtx_t, std::string> &paths,
+                     std::map<vtx_t, std::string> &subsystems,
+                     std::map<edg_t, std::string> &esubsystems)
 {
     f_vtx_iterator_t vi, v_end;
     f_edg_iterator_t ei, e_end;
@@ -359,15 +359,19 @@ static void flatten (f_resource_graph_t &fg, map<vtx_t, string> &paths,
     }
 }
 
-static void write_to_graphml (f_resource_graph_t &fg, fstream &o)
+static void write_to_graphml (f_resource_graph_t &fg, std::fstream &o)
 {
     boost::dynamic_properties dp;
-    map<edg_t, string> esubsystems;
-    map<vtx_t, string> subsystems, properties, paths;
-    boost::associative_property_map<map<vtx_t, string>> subsystems_map (subsystems);
-    boost::associative_property_map<map<edg_t, string>> esubsystems_map (esubsystems);
-    boost::associative_property_map<map<vtx_t, string>> props_map (properties);
-    boost::associative_property_map<map<vtx_t, string>> paths_map (paths);
+    std::map<edg_t, std::string> esubsystems;
+    std::map<vtx_t, std::string> subsystems, properties, paths;
+    boost::associative_property_map<
+        std::map<vtx_t, std::string>> subsystems_map (subsystems);
+    boost::associative_property_map<
+        std::map<edg_t, std::string>> esubsystems_map (esubsystems);
+    boost::associative_property_map<
+        std::map<vtx_t, std::string>> props_map (properties);
+    boost::associative_property_map<
+        std::map<vtx_t, std::string>> paths_map (paths);
 
     flatten (fg, paths, subsystems, esubsystems);
 
@@ -390,13 +394,14 @@ static void write_to_graphml (f_resource_graph_t &fg, fstream &o)
 
 static void write_to_graph (std::shared_ptr<resource_context_t> &ctx)
 {
-    fstream o;
-    string fn, mn;
+    std::fstream o;
+    std::string fn, mn;
     mn = ctx->matcher->matcher_name ();
     fn = ctx->params.o_fname + "." + ctx->params.o_fext;
 
-    cout << "INFO: Write the target graph of the matcher..." << endl;
-    o.open (fn, fstream::out);
+    std::cout << "INFO: Write the target graph of the matcher..."
+              << std::endl;
+    o.open (fn, std::fstream::out);
 
     switch (ctx->params.o_format) {
     case emit_format_t::GRAPHVIZ_DOT:
@@ -406,11 +411,11 @@ static void write_to_graph (std::shared_ptr<resource_context_t> &ctx)
         write_to_graphml (*(ctx->fgraph), o);
         break;
     default:
-        cout << "ERROR: Unknown graph format" << endl;
+        std::cout << "ERROR: Unknown graph format" << std::endl;
         break;
     }
     if (o.bad ()) {
-        cerr << "ERROR: Failure encountered in writing" << endl;
+        std::cerr << "ERROR: Failure encountered in writing" << std::endl;
         o.clear ();
     }
     o.close ();
@@ -424,18 +429,19 @@ static void control_loop (std::shared_ptr<resource_context_t> &ctx)
                                                : readline ("resource-query> ");
         if (line == NULL)
             continue;
-        else if(*line)
+        else if (*line)
             add_history (line);
 
-        vector<string> tokens;
-        istringstream iss (line);
-        copy(istream_iterator<string>(iss), istream_iterator<string>(),
+        std::vector<std::string> tokens;
+        std::istringstream iss (line);
+        std::copy (std::istream_iterator<std::string> (iss),
+                   std::istream_iterator<std::string> (),
              back_inserter (tokens));
         free(line);
         if (tokens.empty ())
             continue;
 
-        string &cmd_str = tokens[0];
+        std::string &cmd_str = tokens[0];
         if (!(cmd = find_cmd (cmd_str)))
             continue;
         if (cmd (ctx, tokens) != 0)
@@ -447,7 +453,7 @@ static int populate_resource_db (std::shared_ptr<resource_context_t> &ctx)
 {
     int rc = -1;
     double elapse;
-    ifstream in_file;
+    std::ifstream in_file;
     struct timeval st, et;
     std::stringstream buffer{};
     std::shared_ptr<resource_reader_base_t> rd;
@@ -509,7 +515,8 @@ static std::shared_ptr<f_resource_graph_t> create_filtered_graph (
         fg = std::make_shared<f_resource_graph_t> (g, edgsel, vtxsel);
     } catch (std::bad_alloc &e) {
         errno = ENOMEM;
-        cerr << "ERROR: out of memory allocating f_resource_graph_t" << endl;
+        std::cerr << "ERROR: out of memory allocating f_resource_graph_t"
+                  << std::endl;
         fg = nullptr;
     }
 
@@ -521,15 +528,17 @@ static int init_resource_graph (std::shared_ptr<resource_context_t> &ctx)
     int rc = 0;
 
     if ( (rc = populate_resource_db (ctx)) != 0) {
-        cerr << "ERROR: can't populate graph resource database" << endl;
+        std::cerr << "ERROR: can't populate graph resource database"
+                  << std::endl;
         return rc;
     }
 
     resource_graph_t &g = ctx->db.resource_graph;
     // Configure the matcher and its subsystem selector
-    cout << "INFO: Loading a matcher: " << ctx->params.matcher_name << endl;
+    std::cout << "INFO: Loading a matcher: " << ctx->params.matcher_name
+              << std::endl;
     if ( (rc = set_subsystems_use (ctx, ctx->params.matcher_name)) != 0) {
-        cerr << "ERROR: Not all subsystems found" << endl;
+        std::cerr << "ERROR: Not all subsystems found" << std::endl;
         return rc;
     }
     if ( !(ctx->fgraph = create_filtered_graph (ctx)))
@@ -540,8 +549,9 @@ static int init_resource_graph (std::shared_ptr<resource_context_t> &ctx)
         && ctx->matcher->set_pruning_types_w_spec (ctx->matcher->dom_subsystem (),
                                                    ctx->params.prune_filters)
                                                    < 0) {
-        cerr << "ERROR: setting pruning filters with ctx->params.prune_filters: "
-             << ctx->params.prune_filters << endl;
+        std::cerr
+            << "ERROR: setting pruning filters with ctx->params.prune_filters: "
+            << ctx->params.prune_filters << std::endl;
         return -1;
     }
 
@@ -555,19 +565,20 @@ static int init_resource_graph (std::shared_ptr<resource_context_t> &ctx)
         ctx->traverser = std::make_shared<dfu_traverser_t> ();
     } catch (std::bad_alloc &e) {
         errno = ENOMEM;
-        cerr << "ERROR: out of memory allocating traverser" << endl;
+        std::cerr << "ERROR: out of memory allocating traverser" << std::endl;
         return -1;
     }
 
     if ( (rc = ctx->traverser->initialize (ctx->fgraph, ctx->db.metadata.roots,
                                            ctx->matcher)) != 0) {
-        cerr << "ERROR: initializing traverser" << endl;
+        std::cerr << "ERROR: initializing traverser" << std::endl;
         return -1;
     }
     match_format_t format = match_writers_factory_t::
                                 get_writers_type (ctx->params.match_format);
     if ( !(ctx->writers = match_writers_factory_t::create (format))) {
-        cerr << "ERROR: out of memory allocating traverser" << endl;
+        std::cerr << "ERROR: out of memory allocating traverser"
+                  << std::endl;
         return -1;
     }
 
@@ -593,7 +604,7 @@ static void process_args (std::shared_ptr<resource_context_t> &ctx,
                 ctx->params.load_format = optarg;
                 if (!known_resource_reader (ctx->params.load_format)) {
                     std::cerr << "[ERROR] unknown format for --load-format: ";
-                    std::cerr << optarg << endl;
+                    std::cerr << optarg << std::endl;
                     usage (1);
                 }
                 break;
@@ -613,16 +624,16 @@ static void process_args (std::shared_ptr<resource_context_t> &ctx,
             case 'F': /* --match-format */
                 ctx->params.match_format = optarg;
                 if (!known_match_format (ctx->params.match_format)) {
-                    cerr << "[ERROR] unknown format for --match-format: ";
-                    cerr << optarg << endl;
+                    std::cerr << "[ERROR] unknown format for --match-format: ";
+                    std::cerr << optarg << std::endl;
                     usage (1);
                 }
                 break;
             case 'g': /* --graph-format */
                 rc = string_to_graph_format (optarg, ctx->params.o_format);
                 if ( rc != 0) {
-                    cerr << "[ERROR] unknown format for --graph-format: ";
-                    cerr << optarg << endl;
+                    std::cerr << "[ERROR] unknown format for --graph-format: ";
+                    std::cerr << optarg << std::endl;
                     usage (1);
                 }
                 graph_format_to_ext (ctx->params.o_format, ctx->params.o_fext);
@@ -646,8 +657,9 @@ static void process_args (std::shared_ptr<resource_context_t> &ctx,
                 if ( (ctx->params.reserve_vtx_vec < 0)
                     || (ctx->params.reserve_vtx_vec > 2000000)) {
                     ctx->params.reserve_vtx_vec = 0;
-                    cerr << "WARN: out of range specified for --reserve-vtx-vec: ";
-                    cerr << optarg << endl;
+                    std::cerr
+                        << "WARN: out of range specified for --reserve-vtx-vec: ";
+                    std::cerr << optarg << std::endl;
                 }
                 break;
             case 'e': /* --elapse-time */
@@ -674,7 +686,8 @@ static std::shared_ptr<resource_context_t> init_resource_query (int c,
     try {
         ctx = std::make_shared<resource_context_t> ();
     } catch (std::bad_alloc &e) {
-        cerr << "ERROR: out of memory allocating resource context" << endl;
+        std::cerr << "ERROR: out of memory allocating resource context"
+                  << std::endl;
         errno = ENOMEM;
         goto done;
     }
@@ -685,12 +698,12 @@ static std::shared_ptr<resource_context_t> init_resource_query (int c,
     ctx->perf.max = 0.0f;
     ctx->perf.accum = 0.0f;
     if ( !(ctx->matcher = create_match_cb (ctx->params.matcher_policy))) {
-        cerr << "ERROR: unknown match policy " << endl;
-        cerr << "ERROR: " << ctx->params.matcher_policy << endl;
+        std::cerr << "ERROR: unknown match policy " << std::endl;
+        std::cerr << "ERROR: " << ctx->params.matcher_policy << std::endl;
         ctx = nullptr;
     }
     if (init_resource_graph (ctx) != 0) {
-        cerr << "ERROR: resource graph initialization" << endl;
+        std::cerr << "ERROR: resource graph initialization" << std::endl;
         ctx = nullptr;
     }
 
@@ -710,7 +723,7 @@ int main (int argc, char *argv[])
 {
     std::shared_ptr<resource_context_t> ctx = nullptr;
     if ( !(ctx = init_resource_query (argc, argv))) {
-        cerr << "ERROR: resource query initialization" << endl;
+        std::cerr << "ERROR: resource query initialization" << std::endl;
         return EXIT_FAILURE;
     }
 

--- a/resource/writers/match_writers.cpp
+++ b/resource/writers/match_writers.cpp
@@ -195,9 +195,7 @@ rlite_match_writers_t::rlite_match_writers_t()
 {
     m_reducer["core"] = set<int64_t> ();
     m_reducer["gpu"] = set<int64_t> ();
-    // Note: GCC 4.8 doesn't support move constructor for stringstream
-    // we use a pointer type although it is not ideal.
-    m_gatherer["node"] = new stringstream ();
+    m_gatherer["node"] = std::make_shared<std::stringstream> ();
 }
 
 rlite_match_writers_t::~rlite_match_writers_t ()

--- a/resource/writers/match_writers.cpp
+++ b/resource/writers/match_writers.cpp
@@ -31,7 +31,6 @@
 namespace Flux {
 namespace resource_model {
 
-using namespace std;
 
 /****************************************************************************
  *                                                                          *
@@ -39,7 +38,8 @@ using namespace std;
  *                                                                          *
  ****************************************************************************/
 
-void match_writers_t::compress (stringstream &o, const set<int64_t> &ids)
+void match_writers_t::compress (std::stringstream &o,
+                                const std::set<int64_t> &ids)
 {
     int64_t base = INT64_MIN;
     int64_t runlen = 0;
@@ -49,7 +49,7 @@ void match_writers_t::compress (stringstream &o, const set<int64_t> &ids)
             runlen++;
         } else {
             if (runlen != 0)
-                o << "-" + to_string (base + runlen) + ",";
+                o << "-" + std::to_string (base + runlen) + ",";
             else if (base != INT64_MIN)
                 o << ",";
             o << id;
@@ -68,7 +68,7 @@ void match_writers_t::compress (stringstream &o, const set<int64_t> &ids)
  *                                                                          *
  ****************************************************************************/
 
-void sim_match_writers_t::emit (stringstream &out)
+void sim_match_writers_t::emit (std::stringstream &out)
 {
     out << m_out.str ();
 }
@@ -79,12 +79,13 @@ void sim_match_writers_t::reset ()
     m_out.clear ();
 }
 
-void sim_match_writers_t::emit_vtx (const string &prefix,
+void sim_match_writers_t::emit_vtx (const std::string &prefix,
                                     const f_resource_graph_t &g, const vtx_t &u,
                                     unsigned int needs, bool exclusive)
 {
-    string mode = (exclusive)? "x" : "s";
-    m_out << prefix << g[u].name << "[" << needs << ":" << mode  << "]" << endl;
+    std::string mode = (exclusive)? "x" : "s";
+    m_out << prefix << g[u].name << "[" << needs << ":" << mode  << "]"
+          << std::endl;
 }
 
 
@@ -94,7 +95,7 @@ void sim_match_writers_t::emit_vtx (const string &prefix,
  *                                                                          *
  ****************************************************************************/
 
-void jgf_match_writers_t::emit (stringstream &out, bool newline)
+void jgf_match_writers_t::emit (std::stringstream &out, bool newline)
 {
     size_t vout_size = m_vout.str ().size ();
     size_t eout_size = m_eout.str ().size ();
@@ -106,11 +107,11 @@ void jgf_match_writers_t::emit (stringstream &out, bool newline)
         out << m_eout.str ().substr (0, eout_size - 1);
         out << "]}}";
         if (newline)
-           out << endl;
+           out << std::endl;
     }
 }
 
-void jgf_match_writers_t::emit (stringstream &out)
+void jgf_match_writers_t::emit (std::stringstream &out)
 {
     emit (out, true);
 }
@@ -123,11 +124,11 @@ void jgf_match_writers_t::reset ()
     m_eout.clear ();
 }
 
-void jgf_match_writers_t::emit_vtx (const string &prefix,
+void jgf_match_writers_t::emit_vtx (const std::string &prefix,
                                     const f_resource_graph_t &g, const vtx_t &u,
                                     unsigned int needs, bool exclusive)
 {
-    string x = (exclusive)? "true" : "false";
+    std::string x = (exclusive)? "true" : "false";
     m_vout << "{";
     m_vout <<     "\"id\":\"" << g[u].uniq_id << "\",";
     m_vout <<     "\"metadata\":{";
@@ -141,7 +142,7 @@ void jgf_match_writers_t::emit_vtx (const string &prefix,
     m_vout <<         "\"unit\":\"" << g[u].unit << "\",";
     m_vout <<         "\"size\":" << needs;
     if (!g[u].properties.empty ()) {
-        stringstream props;
+        std::stringstream props;
         m_vout <<                         ", ";
         m_vout <<     "\"properties\":{";
         for (auto &kv : g[u].properties)
@@ -150,7 +151,7 @@ void jgf_match_writers_t::emit_vtx (const string &prefix,
         m_vout <<      "}";
     }
     if (!g[u].paths.empty ()) {
-        stringstream paths;
+        std::stringstream paths;
         m_vout <<                         ", ";
         m_vout <<     "\"paths\":{";
         for (auto &kv : g[u].paths)
@@ -163,7 +164,7 @@ void jgf_match_writers_t::emit_vtx (const string &prefix,
     m_vout << "},";
 }
 
-void jgf_match_writers_t::emit_edg (const string &prefix,
+void jgf_match_writers_t::emit_edg (const std::string &prefix,
                                     const f_resource_graph_t &g, const edg_t &e)
 {
     m_eout << "{";
@@ -172,7 +173,7 @@ void jgf_match_writers_t::emit_edg (const string &prefix,
     m_eout <<     "\"metadata\":{";
 
     if (!g[e].name.empty ()) {
-        stringstream names;
+        std::stringstream names;
         m_eout <<     "\"name\":{";
         for (auto &kv : g[e].name)
             names << "\"" << kv.first << "\":\"" << kv.second << "\",";
@@ -193,8 +194,8 @@ void jgf_match_writers_t::emit_edg (const string &prefix,
 
 rlite_match_writers_t::rlite_match_writers_t()
 {
-    m_reducer["core"] = set<int64_t> ();
-    m_reducer["gpu"] = set<int64_t> ();
+    m_reducer["core"] = std::set<int64_t> ();
+    m_reducer["gpu"] = std::set<int64_t> ();
     m_gatherer["node"] = std::make_shared<std::stringstream> ();
 }
 
@@ -209,17 +210,17 @@ void rlite_match_writers_t::reset ()
     m_out.clear ();
 }
 
-void rlite_match_writers_t::emit (stringstream &out, bool newline)
+void rlite_match_writers_t::emit (std::stringstream &out, bool newline)
 {
     size_t size = m_out.str ().size ();
     if (size > 1) {
         out << "{\"R_lite\":[" << m_out.str ().substr (0, size - 1) << "]}";
         if (newline)
-            out << endl;
+            out << std::endl;
     }
 }
 
-void rlite_match_writers_t::emit (stringstream &out)
+void rlite_match_writers_t::emit (std::stringstream &out)
 {
     emit (out, true);
 }
@@ -236,7 +237,7 @@ bool rlite_match_writers_t::m_reducer_set ()
     return set;
 }
 
-void rlite_match_writers_t::emit_vtx (const string &prefix,
+void rlite_match_writers_t::emit_vtx (const std::string &prefix,
                                       const f_resource_graph_t &g,
                                       const vtx_t &u,
                                       unsigned int needs,
@@ -246,7 +247,7 @@ void rlite_match_writers_t::emit_vtx (const string &prefix,
         m_reducer[g[u].type].insert (g[u].id);
     } else if (m_gatherer.find (g[u].type) != m_gatherer.end ()) {
         if (m_reducer_set ()) {
-            stringstream &gout = *(m_gatherer[g[u].type]);
+            std::stringstream &gout = *(m_gatherer[g[u].type]);
             gout << "{";
             gout << "\"rank\":\"" << g[u].rank << "\",";
             gout << "\"node\":\"" << g[u].name << "\",";
@@ -280,24 +281,24 @@ void rv1_match_writers_t::reset ()
     jgf.reset ();
 }
 
-void rv1_match_writers_t::emit (stringstream &out)
+void rv1_match_writers_t::emit (std::stringstream &out)
 {
-    string ver = "\"version\":1";
-    string exec_key = "\"execution\":";
-    string sched_key = "\"scheduling\":";
+    std::string ver = "\"version\":1";
+    std::string exec_key = "\"execution\":";
+    std::string sched_key = "\"scheduling\":";
     size_t base = out.str ().size ();
     out << "{" << ver;
     out << "," << exec_key;
     rlite.emit (out, false);
     out << "," << sched_key;
     jgf.emit (out, false);
-    out << "}" << endl;
+    out << "}" << std::endl;
     if (out.str ().size () <= (base + ver.size () + exec_key.size ()
                                     + sched_key.size () + 5))
         out.str (out.str ().substr (0, base));
 }
 
-void rv1_match_writers_t::emit_vtx (const string &prefix,
+void rv1_match_writers_t::emit_vtx (const std::string &prefix,
                                     const f_resource_graph_t &g,
                                     const vtx_t &u,
                                     unsigned int needs,
@@ -307,7 +308,7 @@ void rv1_match_writers_t::emit_vtx (const string &prefix,
     jgf.emit_vtx (prefix, g, u, needs, exclusive);
 }
 
-void rv1_match_writers_t::emit_edg (const string &prefix,
+void rv1_match_writers_t::emit_edg (const std::string &prefix,
                                     const f_resource_graph_t &g,
                                     const edg_t &e)
 {
@@ -327,20 +328,20 @@ void rv1_nosched_match_writers_t::reset ()
     rlite.reset ();
 }
 
-void rv1_nosched_match_writers_t::emit (stringstream &out)
+void rv1_nosched_match_writers_t::emit (std::stringstream &out)
 {
-    string ver = "\"version\":1";
-    string exec_key = "\"execution\":";
+    std::string ver = "\"version\":1";
+    std::string exec_key = "\"execution\":";
     size_t base = out.str ().size ();
     out << "{" << ver;
     out << "," << exec_key;
     rlite.emit (out, false);
-    out << "}" << endl;
+    out << "}" << std::endl;
     if (out.str ().size () <= (base + ver.size () + exec_key.size () + 4))
         out.str (out.str ().substr (0, base));
 }
 
-void rv1_nosched_match_writers_t::emit_vtx (const string &prefix,
+void rv1_nosched_match_writers_t::emit_vtx (const std::string &prefix,
                                             const f_resource_graph_t &g,
                                             const vtx_t &u,
                                             unsigned int needs,
@@ -356,7 +357,7 @@ void rv1_nosched_match_writers_t::emit_vtx (const string &prefix,
  *                                                                          *
  ****************************************************************************/
 
-void pretty_sim_match_writers_t::emit (stringstream &out)
+void pretty_sim_match_writers_t::emit (std::stringstream &out)
 {
     for (auto &s: m_out)
         out << s;
@@ -367,14 +368,15 @@ void pretty_sim_match_writers_t::reset ()
     m_out.clear ();
 }
 
-void pretty_sim_match_writers_t::emit_vtx (const string &prefix,
+void pretty_sim_match_writers_t::emit_vtx (const std::string &prefix,
                                            const f_resource_graph_t &g,
                                            const vtx_t &u,
                                            unsigned int needs, bool exclusive)
 {
-    stringstream out;
-    string mode = (exclusive)? "exclusive" : "shared";
-    out << prefix << g[u].name << "[" << needs << ":" << mode  << "]" << endl;
+    std::stringstream out;
+    std::string mode = (exclusive)? "exclusive" : "shared";
+    out << prefix << g[u].name << "[" << needs << ":" << mode  << "]"
+        << std::endl;
     m_out.push_front (out.str ());
 }
 
@@ -420,7 +422,7 @@ std::shared_ptr<match_writers_t> match_writers_factory_t::
     return w;
 }
 
-match_format_t match_writers_factory_t::get_writers_type (const string &n)
+match_format_t match_writers_factory_t::get_writers_type (const std::string &n)
 {
     match_format_t format = match_format_t::SIMPLE;
     if (n == "jgf")
@@ -436,7 +438,7 @@ match_format_t match_writers_factory_t::get_writers_type (const string &n)
     return format;
 }
 
-bool known_match_format (const string &format)
+bool known_match_format (const std::string &format)
 {
    return (format == "simple"
            || format == "jgf"

--- a/resource/writers/match_writers.cpp
+++ b/resource/writers/match_writers.cpp
@@ -200,8 +200,7 @@ rlite_match_writers_t::rlite_match_writers_t()
 
 rlite_match_writers_t::~rlite_match_writers_t ()
 {
-    for (auto kv : m_gatherer)
-        delete kv.second;
+
 }
 
 void rlite_match_writers_t::reset ()
@@ -386,34 +385,37 @@ void pretty_sim_match_writers_t::emit_vtx (const string &prefix,
  *                                                                          *
  ****************************************************************************/
 
-match_writers_t *match_writers_factory_t::create (match_format_t f)
+std::shared_ptr<match_writers_t> match_writers_factory_t::
+                                     create (match_format_t f)
 {
-    match_writers_t *w = NULL;
+    std::shared_ptr<match_writers_t> w = nullptr;
 
-    switch (f) {
-    case match_format_t::SIMPLE:
-        w = new (nothrow)sim_match_writers_t ();
-        break;
-    case match_format_t::JGF:
-        w = new (nothrow)jgf_match_writers_t ();
-        break;
-    case match_format_t::RLITE:
-        w = new (nothrow)rlite_match_writers_t ();
-        break;
-    case match_format_t::RV1_NOSCHED:
-        w = new (nothrow)rv1_nosched_match_writers_t ();
-        break;
-    case match_format_t::PRETTY_SIMPLE:
-        w = new (nothrow)pretty_sim_match_writers_t ();
-        break;
-    case match_format_t::RV1:
-    default:
-        w = new (nothrow)rv1_match_writers_t ();
-        break;
-    }
-
-    if (!w)
+    try {
+        switch (f) {
+        case match_format_t::SIMPLE:
+            w = std::make_shared<sim_match_writers_t> ();
+            break;
+        case match_format_t::JGF:
+            w = std::make_shared<jgf_match_writers_t> ();
+            break;
+        case match_format_t::RLITE:
+            w = std::make_shared<rlite_match_writers_t> ();
+            break;
+        case match_format_t::RV1_NOSCHED:
+            w = std::make_shared<rv1_nosched_match_writers_t> ();
+            break;
+        case match_format_t::PRETTY_SIMPLE:
+            w = std::make_shared<pretty_sim_match_writers_t> ();
+            break;
+        case match_format_t::RV1:
+        default:
+            w = std::make_shared<rv1_match_writers_t> ();
+            break;
+        }
+    } catch (std::bad_alloc &e) {
         errno = ENOMEM;
+        w = nullptr;
+    }
 
     return w;
 }

--- a/resource/writers/match_writers.hpp
+++ b/resource/writers/match_writers.hpp
@@ -25,6 +25,7 @@
 #ifndef MATCH_WRITERS_HPP
 #define MATCH_WRITERS_HPP
 
+#include <memory>
 #include <string>
 #include <sstream>
 #include <set>
@@ -108,7 +109,7 @@ public:
 private:
     bool m_reducer_set ();
     std::map<std::string, std::set<int64_t>> m_reducer;
-    std::map<std::string, std::stringstream *> m_gatherer;
+    std::map<std::string, std::shared_ptr<std::stringstream>> m_gatherer;
     std::stringstream m_out;
 };
 

--- a/resource/writers/match_writers.hpp
+++ b/resource/writers/match_writers.hpp
@@ -167,7 +167,7 @@ private:
 class match_writers_factory_t {
 public:
     static match_format_t get_writers_type (const std::string &n);
-    static match_writers_t *create (match_format_t f);
+    static std::shared_ptr<match_writers_t> create (match_format_t f);
 };
 
 bool known_match_format (const std::string &format);


### PR DESCRIPTION
This PR adds smart pointer support using `std::shared_ptr` to:

- Improve memory management by disallowing memory leaks in general;
- Allow the traverser code to use shared pointers on a few key member variables: filtered graph, metadata and match policy callback members. The traverser does not solely "own" these objects (in fact they are being passed from outside), and this means using raw pointers requires a careful manual coordination between the owners of these objects. Sharing the ownership of these objects using std::shared_ptr should be safer and far more elegant.

This PR also adds a few other cleanups:
- Use fully qualified `std` namespace paths for all of the symbols in this namespace;
- Change log messages within the `resource` module to include the function name in the message, which contains that log message statement;
- Other misc. style changes including enforcing 80 character per line limit and improving indentations for readability.