### PR TITLE
Update jobspec command to be list instead of list or string

### DIFF
--- a/resource/libjobspec/jobspec.cpp
+++ b/resource/libjobspec/jobspec.cpp
@@ -228,11 +228,9 @@ Task::Task (const YAML::Node &tasknode)
     }
     if (tasknode["command"].IsSequence()) {
         command = tasknode["command"].as<std::vector<std::string>>();
-    } else if (tasknode["command"].IsScalar()) {
-        command.push_back(tasknode["command"].as<std::string>());
     } else {
         throw parse_error (tasknode["command"],
-                           "\"command\" value must be a scalar or a sequence");
+                           "\"command\" value must be a sequence");
     }
 
     /* Import slot */

--- a/t/data/resource/jobspecs/advanced/test001.yaml
+++ b/t/data/resource/jobspecs/advanced/test001.yaml
@@ -22,7 +22,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/advanced/test002.yaml
+++ b/t/data/resource/jobspecs/advanced/test002.yaml
@@ -41,11 +41,11 @@ resources:
                       - type: core
                         count: 8
 tasks:
-  - command: app1
+  - command: [ "app1" ]
     slot: gpunode
     count:
       per_slot: 1
-  - command: app2
+  - command: [ "app2" ]
     slot: octcorenode
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/advanced/test003.yaml
+++ b/t/data/resource/jobspecs/advanced/test003.yaml
@@ -71,7 +71,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/advanced/test004.yaml
+++ b/t/data/resource/jobspecs/advanced/test004.yaml
@@ -59,7 +59,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/advanced/test005.yaml
+++ b/t/data/resource/jobspecs/advanced/test005.yaml
@@ -27,7 +27,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/basics/bad.yaml
+++ b/t/data/resource/jobspecs/basics/bad.yaml
@@ -23,7 +23,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/basics/test001.yaml
+++ b/t/data/resource/jobspecs/basics/test001.yaml
@@ -23,7 +23,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/basics/test002.yaml
+++ b/t/data/resource/jobspecs/basics/test002.yaml
@@ -22,7 +22,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/basics/test003.yaml
+++ b/t/data/resource/jobspecs/basics/test003.yaml
@@ -22,7 +22,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/basics/test004.yaml
+++ b/t/data/resource/jobspecs/basics/test004.yaml
@@ -14,7 +14,7 @@ attributes:
   system:
     duration: 7200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/basics/test005.yaml
+++ b/t/data/resource/jobspecs/basics/test005.yaml
@@ -22,7 +22,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/basics/test006.yaml
+++ b/t/data/resource/jobspecs/basics/test006.yaml
@@ -23,7 +23,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/basics/test007.yaml
+++ b/t/data/resource/jobspecs/basics/test007.yaml
@@ -23,7 +23,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/basics/test008.yaml
+++ b/t/data/resource/jobspecs/basics/test008.yaml
@@ -12,7 +12,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/basics/test009.yaml
+++ b/t/data/resource/jobspecs/basics/test009.yaml
@@ -18,7 +18,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/basics/test010.yaml
+++ b/t/data/resource/jobspecs/basics/test010.yaml
@@ -12,7 +12,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/basics/test011.yaml
+++ b/t/data/resource/jobspecs/basics/test011.yaml
@@ -17,7 +17,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/basics/test012.yaml
+++ b/t/data/resource/jobspecs/basics/test012.yaml
@@ -15,7 +15,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/basics/test013.yaml
+++ b/t/data/resource/jobspecs/basics/test013.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/cancel/test001.yaml
+++ b/t/data/resource/jobspecs/cancel/test001.yaml
@@ -18,7 +18,7 @@ attributes:
   system:
     duration: 600
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/cancel/test002.yaml
+++ b/t/data/resource/jobspecs/cancel/test002.yaml
@@ -18,7 +18,7 @@ attributes:
   system:
     duration: 57600
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/cancel/test003.yaml
+++ b/t/data/resource/jobspecs/cancel/test003.yaml
@@ -18,7 +18,7 @@ attributes:
   system:
     duration: 57600
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/cancel/test004.yaml
+++ b/t/data/resource/jobspecs/cancel/test004.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 57600
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/cancel/test005.yaml
+++ b/t/data/resource/jobspecs/cancel/test005.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 57600
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/cancel/test006.yaml
+++ b/t/data/resource/jobspecs/cancel/test006.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 9000
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/cancel/test007.yaml
+++ b/t/data/resource/jobspecs/cancel/test007.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/cancel/test008.yaml
+++ b/t/data/resource/jobspecs/cancel/test008.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 32400
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/cancel/test009.yaml
+++ b/t/data/resource/jobspecs/cancel/test009.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 32400
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/cancel/test010.yaml
+++ b/t/data/resource/jobspecs/cancel/test010.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 9000
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/cancel/test011.yaml
+++ b/t/data/resource/jobspecs/cancel/test011.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/cancel/test012.yaml
+++ b/t/data/resource/jobspecs/cancel/test012.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 57600
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/cancel/test013.yaml
+++ b/t/data/resource/jobspecs/cancel/test013.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 13800
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/cancel/test014.yaml
+++ b/t/data/resource/jobspecs/cancel/test014.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 13800
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/cancel/test015.yaml
+++ b/t/data/resource/jobspecs/cancel/test015.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 14401
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/cancel/test016.yaml
+++ b/t/data/resource/jobspecs/cancel/test016.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 14400
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/cancel/test017.yaml
+++ b/t/data/resource/jobspecs/cancel/test017.yaml
@@ -23,7 +23,7 @@ attributes:
   system:
     duration: 118800
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/coarse_iobw/test001.yaml
+++ b/t/data/resource/jobspecs/coarse_iobw/test001.yaml
@@ -25,7 +25,7 @@ attributes:
   system:
     duration: 57600
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/coarse_iobw/test002.yaml
+++ b/t/data/resource/jobspecs/coarse_iobw/test002.yaml
@@ -34,7 +34,7 @@ attributes:
   system:
     duration: 57600
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/exclusive/test001.yaml
+++ b/t/data/resource/jobspecs/exclusive/test001.yaml
@@ -26,7 +26,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/exclusive/test002.yaml
+++ b/t/data/resource/jobspecs/exclusive/test002.yaml
@@ -27,7 +27,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: corelevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/exclusive/test003.yaml
+++ b/t/data/resource/jobspecs/exclusive/test003.yaml
@@ -27,7 +27,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: corelevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/exclusive/test004.yaml
+++ b/t/data/resource/jobspecs/exclusive/test004.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: nodelevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/exclusive/test005.yaml
+++ b/t/data/resource/jobspecs/exclusive/test005.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: nodelevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/exclusive/test006.yaml
+++ b/t/data/resource/jobspecs/exclusive/test006.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: nodelevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/exclusive/test007.yaml
+++ b/t/data/resource/jobspecs/exclusive/test007.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: corelevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/exclusive/test008.yaml
+++ b/t/data/resource/jobspecs/exclusive/test008.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: corelevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/exclusive/test009.yaml
+++ b/t/data/resource/jobspecs/exclusive/test009.yaml
@@ -18,7 +18,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/exclusive/test010.yaml
+++ b/t/data/resource/jobspecs/exclusive/test010.yaml
@@ -12,7 +12,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: nodelevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/global_constraints/test001.yaml
+++ b/t/data/resource/jobspecs/global_constraints/test001.yaml
@@ -24,7 +24,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: myslot
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/global_constraints/test002.yaml
+++ b/t/data/resource/jobspecs/global_constraints/test002.yaml
@@ -24,7 +24,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: myslot
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/global_constraints/test003.yaml
+++ b/t/data/resource/jobspecs/global_constraints/test003.yaml
@@ -24,7 +24,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: myslot
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/granule/test001.yaml
+++ b/t/data/resource/jobspecs/granule/test001.yaml
@@ -20,7 +20,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/min_max/test001.yaml
+++ b/t/data/resource/jobspecs/min_max/test001.yaml
@@ -18,7 +18,7 @@ attributes:
   system:
     duration: 57600
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/min_max/test002.yaml
+++ b/t/data/resource/jobspecs/min_max/test002.yaml
@@ -22,7 +22,7 @@ attributes:
   system:
     duration: 57600
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/min_max/test003.yaml
+++ b/t/data/resource/jobspecs/min_max/test003.yaml
@@ -22,7 +22,7 @@ attributes:
   system:
     duration: 57600
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/min_max/test004.yaml
+++ b/t/data/resource/jobspecs/min_max/test004.yaml
@@ -23,7 +23,7 @@ attributes:
   system:
     duration: 57600
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/min_max/test005.yaml
+++ b/t/data/resource/jobspecs/min_max/test005.yaml
@@ -23,7 +23,7 @@ attributes:
   system:
     duration: 57600
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/min_max/test006.yaml
+++ b/t/data/resource/jobspecs/min_max/test006.yaml
@@ -23,7 +23,7 @@ attributes:
   system:
     duration: 57600
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test001.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test001.yaml
@@ -28,7 +28,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test002.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test002.yaml
@@ -28,7 +28,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test003.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test003.yaml
@@ -28,7 +28,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test004.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test004.yaml
@@ -28,7 +28,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test005.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test005.yaml
@@ -28,7 +28,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test006.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test006.yaml
@@ -28,7 +28,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test007.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test007.yaml
@@ -28,7 +28,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test008.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test008.yaml
@@ -27,7 +27,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test009.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test009.yaml
@@ -28,7 +28,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test010.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test010.yaml
@@ -25,7 +25,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test011.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test011.yaml
@@ -25,7 +25,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test012.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test012.yaml
@@ -25,7 +25,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test013.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test013.yaml
@@ -25,7 +25,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test014.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test014.yaml
@@ -24,7 +24,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test015.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test015.yaml
@@ -25,7 +25,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test016.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test016.yaml
@@ -25,7 +25,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test017.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test017.yaml
@@ -25,7 +25,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test018.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test018.yaml
@@ -25,7 +25,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test019.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test019.yaml
@@ -22,7 +22,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test020.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test020.yaml
@@ -22,7 +22,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test021.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test021.yaml
@@ -22,7 +22,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test022.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test022.yaml
@@ -22,7 +22,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test023.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test023.yaml
@@ -21,7 +21,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test024.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test024.yaml
@@ -22,7 +22,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test025.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test025.yaml
@@ -22,7 +22,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test026.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test026.yaml
@@ -22,7 +22,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/omit_prefix/test027.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test027.yaml
@@ -22,7 +22,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/power/test001.yaml
+++ b/t/data/resource/jobspecs/power/test001.yaml
@@ -29,7 +29,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/power/test002.yaml
+++ b/t/data/resource/jobspecs/power/test002.yaml
@@ -20,7 +20,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/reservation/test001.yaml
+++ b/t/data/resource/jobspecs/reservation/test001.yaml
@@ -18,7 +18,7 @@ attributes:
   system:
     duration: 600
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/reservation/test002.yaml
+++ b/t/data/resource/jobspecs/reservation/test002.yaml
@@ -18,7 +18,7 @@ attributes:
   system:
     duration: 57600
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/reservation/test003.yaml
+++ b/t/data/resource/jobspecs/reservation/test003.yaml
@@ -18,7 +18,7 @@ attributes:
   system:
     duration: 57600
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/reservation/test004.yaml
+++ b/t/data/resource/jobspecs/reservation/test004.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 57600
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/reservation/test005.yaml
+++ b/t/data/resource/jobspecs/reservation/test005.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 57600
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/reservation/test006.yaml
+++ b/t/data/resource/jobspecs/reservation/test006.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 9000
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/reservation/test007.yaml
+++ b/t/data/resource/jobspecs/reservation/test007.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/reservation/test008.yaml
+++ b/t/data/resource/jobspecs/reservation/test008.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 32400
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/reservation/test009.yaml
+++ b/t/data/resource/jobspecs/reservation/test009.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 32400
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/reservation/test010.yaml
+++ b/t/data/resource/jobspecs/reservation/test010.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 9000
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/reservation/test011.yaml
+++ b/t/data/resource/jobspecs/reservation/test011.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 43200
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/reservation/test012.yaml
+++ b/t/data/resource/jobspecs/reservation/test012.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 57600
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/reservation/test013.yaml
+++ b/t/data/resource/jobspecs/reservation/test013.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 13800
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/reservation/test014.yaml
+++ b/t/data/resource/jobspecs/reservation/test014.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 13800
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/reservation/test015.yaml
+++ b/t/data/resource/jobspecs/reservation/test015.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 14401
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/reservation/test016.yaml
+++ b/t/data/resource/jobspecs/reservation/test016.yaml
@@ -19,7 +19,7 @@ attributes:
   system:
     duration: 14400
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/reservation/test017.yaml
+++ b/t/data/resource/jobspecs/reservation/test017.yaml
@@ -23,7 +23,7 @@ attributes:
   system:
     duration: 118800
 tasks:
-  - command: default
+  - command: [ "default" ]
     slot: socketlevel
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/satisfiability/test001.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test001.yaml
@@ -23,7 +23,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/satisfiability/test002.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test002.yaml
@@ -14,7 +14,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/satisfiability/test003.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test003.yaml
@@ -14,7 +14,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/satisfiability/test004.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test004.yaml
@@ -17,7 +17,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/satisfiability/test005.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test005.yaml
@@ -17,7 +17,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/satisfiability/test006.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test006.yaml
@@ -23,7 +23,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/satisfiability/test007.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test007.yaml
@@ -23,7 +23,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/satisfiability/test008.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test008.yaml
@@ -20,7 +20,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/satisfiability/test009.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test009.yaml
@@ -26,7 +26,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/satisfiability/test010.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test010.yaml
@@ -23,7 +23,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/satisfiability/test011.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test011.yaml
@@ -24,7 +24,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/satisfiability/test012.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test012.yaml
@@ -11,7 +11,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/satisfiability/test013.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test013.yaml
@@ -14,7 +14,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/satisfiability/test014.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test014.yaml
@@ -14,7 +14,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/satisfiability/test015.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test015.yaml
@@ -14,7 +14,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/satisfiability/test016.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test016.yaml
@@ -14,7 +14,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/update/test001.yaml
+++ b/t/data/resource/jobspecs/update/test001.yaml
@@ -23,7 +23,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/update/test002.yaml
+++ b/t/data/resource/jobspecs/update/test002.yaml
@@ -23,7 +23,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/update/test003.yaml
+++ b/t/data/resource/jobspecs/update/test003.yaml
@@ -24,7 +24,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/update/test004.yaml
+++ b/t/data/resource/jobspecs/update/test004.yaml
@@ -22,7 +22,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/update/test005.yaml
+++ b/t/data/resource/jobspecs/update/test005.yaml
@@ -20,7 +20,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/update/test006.yaml
+++ b/t/data/resource/jobspecs/update/test006.yaml
@@ -17,7 +17,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/attributes_bad_entry.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/attributes_bad_entry.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/attributes_not_mapping.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/attributes_not_mapping.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/missing_attributes.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/missing_attributes.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/missing_resources.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/missing_resources.yaml
@@ -1,6 +1,6 @@
 version: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/missing_version.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/missing_version.yaml
@@ -6,7 +6,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/resource_count_bad_type.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_count_bad_type.yaml
@@ -9,7 +9,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/resource_count_missing_max.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_count_missing_max.yaml
@@ -10,7 +10,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/resource_count_missing_min.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_count_missing_min.yaml
@@ -10,7 +10,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/resource_count_missing_operand.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_count_missing_operand.yaml
@@ -10,7 +10,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/resource_count_missing_operator.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_count_missing_operator.yaml
@@ -10,7 +10,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/resource_count_scalar_bad_value.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_count_scalar_bad_value.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/resource_exclusive_invalid.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_exclusive_invalid.yaml
@@ -8,7 +8,7 @@ resources:
         count: 1
         exclusive: blah
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/resource_exclusive_not_scalar.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_exclusive_not_scalar.yaml
@@ -10,7 +10,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/resource_id_not_scalar.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_id_not_scalar.yaml
@@ -10,7 +10,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/resource_label_not_scalar.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_label_not_scalar.yaml
@@ -9,7 +9,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/resource_missing_count.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_missing_count.yaml
@@ -6,7 +6,7 @@ resources:
     with:
       - type: node
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/resource_missing_type.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_missing_type.yaml
@@ -6,7 +6,7 @@ resources:
     with:
       - count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/resource_not_mapping.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_not_mapping.yaml
@@ -7,7 +7,7 @@ resources:
        - type: node
          count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/resource_slot_not_labelled.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_slot_not_labelled.yaml
@@ -6,7 +6,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/resource_unit_not_scalar.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_unit_not_scalar.yaml
@@ -10,7 +10,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/resources_not_sequence.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resources_not_sequence.yaml
@@ -7,7 +7,7 @@ resources:
     - type: node
       count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/task_command_not_array.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/task_command_not_array.yaml
@@ -1,0 +1,14 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/data/resource/jobspecs/validation/invalid/task_count_not_mapping.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/task_count_not_mapping.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count: 1
 attributes:

--- a/t/data/resource/jobspecs/validation/invalid/task_missing_count.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/task_missing_count.yaml
@@ -7,6 +7,6 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
 attributes:

--- a/t/data/resource/jobspecs/validation/invalid/task_missing_slot.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/task_missing_slot.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     count:
       per_slot: 1
 attributes:

--- a/t/data/resource/jobspecs/validation/invalid/tasks_not_sequence.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/tasks_not_sequence.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  command: app
+  command: [ "app" ]
   slot: foo
   count:
     per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/version_bad_number.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/version_bad_number.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/invalid/version_not_scalar.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/version_not_scalar.yaml
@@ -8,7 +8,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/valid/basic.yaml
+++ b/t/data/resource/jobspecs/validation/valid/basic.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/valid/example1.yaml
+++ b/t/data/resource/jobspecs/validation/valid/example1.yaml
@@ -10,7 +10,7 @@ resources:
           - type: core
             count: 2
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/valid/example2.yaml
+++ b/t/data/resource/jobspecs/validation/valid/example2.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: hostname
+  - command: [ "hostname" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/valid/use_case_2.1.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_2.1.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: hostname
+  - command: [ "hostname" ]
     slot: default
     count:
       per_slot: 5

--- a/t/data/resource/jobspecs/validation/valid/use_case_2.2.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_2.2.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: hostname
+  - command: [ "hostname" ]
     slot: myslot
     count:
       total: 5

--- a/t/data/resource/jobspecs/validation/valid/use_case_2.3.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_2.3.yaml
@@ -7,7 +7,7 @@ resources:
       - type: core
         count: 2
 tasks:
-  - command: myapp
+  - command: [ "myapp" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/valid/use_case_2.4.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_2.4.yaml
@@ -22,11 +22,11 @@ resources:
             count: 24
             unit: GB
 tasks:
-  - command: read-db
+  - command: [ "read-db" ]
     slot: read-db
     count:
       per_slot: 1
-  - command: db
+  - command: [ "db" ]
     slot: db
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/valid/use_case_2.5.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_2.5.yaml
@@ -10,7 +10,7 @@ resources:
     - type: core
       count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/valid/use_case_2.6.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_2.6.yaml
@@ -11,7 +11,7 @@ resources:
           count: 4
           unit: GB
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: 4GB-node
     count:
       total: 10

--- a/t/data/resource/jobspecs/var_aware/job_1N.yaml
+++ b/t/data/resource/jobspecs/var_aware/job_1N.yaml
@@ -17,7 +17,7 @@ attributes:
   system:
     duration: 7200
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/var_aware/job_2N.yaml
+++ b/t/data/resource/jobspecs/var_aware/job_2N.yaml
@@ -17,7 +17,7 @@ attributes:
   system:
     duration: 5400
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/var_aware/job_4N.yaml
+++ b/t/data/resource/jobspecs/var_aware/job_4N.yaml
@@ -17,7 +17,7 @@ attributes:
   system:
     duration: 4800
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1


### PR DESCRIPTION
Per RFC PR https://github.com/flux-framework/rfc/pull/215, and follow up in `flux-core` of https://github.com/flux-framework/flux-core/pull/2564, the command in a jobspec shall be a list and not a list OR string.

The work in this PR is "done", but I've labeled it as "WIP" until the RFC change is approved.  This was initially done mostly to see "how much do we have to change".  Ends up not too much.  Some parsing in `libjobspec` had to be tweaked, but that was it code wise.  Update jobspecs throughout the tests and added an extra test for a bad jobspec with command as a string.