### PR TITLE
github: add workflow action to validate PR commits

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,12 @@
+on: pull_request
+jobs:
+  check-pr:
+    name: validate commits
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+    - run: git fetch origin master
+    - uses: flux-framework/pr-validator@master


### PR DESCRIPTION
Copy workflow config from flux-core which validates that no commits in a PR are not valid for merging (i.e. have "fixup" or "squash" in the subject, or are merge commits)