### PR TITLE
drop flux module -r option

### DIFF
--- a/etc/qmanager-start
+++ b/etc/qmanager-start
@@ -13,6 +13,6 @@
 
 if [ -z ${FLUX_QMANAGER_RC_NOOP} ]; then
     flux module remove sched-simple
-    flux module load -r 0 qmanager ${FLUX_QMANAGER_OPTIONS}
+    flux module load qmanager ${FLUX_QMANAGER_OPTIONS}
 fi
 

--- a/etc/resource-start
+++ b/etc/resource-start
@@ -13,6 +13,6 @@
 
 if [ -z ${FLUX_RESOURCE_RC_NOOP} ]; then
     FLUX_RESOURCE_OPTIONS=${FLUX_RESOURCE_OPTIONS:-"load-whitelist=node,core,gpu"}
-    flux module load -r 0 resource ${FLUX_RESOURCE_OPTIONS}
+    flux module load resource ${FLUX_RESOURCE_OPTIONS}
 fi
 

--- a/t/t1001-qmanager-basic.t
+++ b/t/t1001-qmanager-basic.t
@@ -87,8 +87,8 @@ test_expect_success 'qmanager: exception during run is supported' '
 '
 
 test_expect_success 'removing resource and qmanager modules' '
-    flux module remove -r 0 qmanager &&
-    flux module remove -r 0 resource
+    flux module remove qmanager &&
+    flux module remove resource
 '
 
 test_done

--- a/t/t1002-qmanager-reload.t
+++ b/t/t1002-qmanager-reload.t
@@ -76,8 +76,8 @@ test_expect_success 'qmanager: canceling a pending job works' '
 '
 
 test_expect_success 'removing resource and qmanager modules' '
-    flux module remove -r 0 qmanager &&
-    flux module remove -r 0 resource
+    flux module remove qmanager &&
+    flux module remove resource
 '
 
 test_done

--- a/t/t1003-qmanager-policy.t
+++ b/t/t1003-qmanager-policy.t
@@ -131,8 +131,8 @@ test_expect_success 'qmanager: CONSERVATIVE correctly schedules jobs' '
 '
 
 test_expect_success 'removing resource and qmanager modules' '
-    flux module remove -r 0 qmanager &&
-    flux module remove -r 0 resource
+    flux module remove qmanager &&
+    flux module remove resource
 '
 
 test_done

--- a/t/t1004-qmanager-optimize.t
+++ b/t/t1004-qmanager-optimize.t
@@ -123,8 +123,8 @@ test_expect_success 'qmanager: CONSERVATIVE policy conforms to queue-depth=5' '
 '
 
 test_expect_success 'removing resource and qmanager modules' '
-    flux module remove -r 0 qmanager &&
-    flux module remove -r 0 resource
+    flux module remove qmanager &&
+    flux module remove resource
 '
 
 test_done

--- a/t/t4000-match-params.t
+++ b/t/t4000-match-params.t
@@ -34,45 +34,45 @@ test_debug '
 
 test_expect_success 'loading resource module with a tiny machine GRUG works' '
     flux module remove resource &&
-    flux module load -r 0 resource load-file=${grug} \
+    flux module load resource load-file=${grug} \
 load-format=grug prune-filters=ALL:core
 '
 
 test_expect_success 'loading resource module with an XML works' '
     flux module remove resource &&
-    flux module load -r 0 resource load-file=${xml} \
+    flux module load resource load-file=${xml} \
 load-format=hwloc prune-filters=ALL:core
 '
 
 test_expect_success 'loading resource module with no option works' '
     flux module remove resource &&
-    flux module load -r 0 resource prune-filters=ALL:core
+    flux module load resource prune-filters=ALL:core
 '
 
 test_expect_success 'loading resource module with a nonexistent GRUG fails' '
     flux module remove resource &&
-    test_expect_code 1 flux module load -r 0 resource load-file=${ne_grug} \
+    test_expect_code 1 flux module load resource load-file=${ne_grug} \
 load-format=grug prune-filters=ALL:core
 '
 
 test_expect_success 'loading resource module with a nonexistent XML fails' '
-    test_expect_code 1 flux module load -r 0 resource load-file=${ne_xml} \
+    test_expect_code 1 flux module load resource load-file=${ne_xml} \
 load-format=hwloc prune-filters=ALL:core
 '
 
 test_expect_success 'loading resource module with known policies works' '
-    flux module load -r 0 resource policy=high &&
+    flux module load resource policy=high &&
     flux module remove resource &&
-    flux module load -r 0 resource policy=low &&
+    flux module load resource policy=low &&
     flux module remove resource &&
-    flux module load -r 0 resource policy=locality
+    flux module load resource policy=locality
 '
 
 test_expect_success 'loading resource module with unknown policies is tolerated' '
     flux module remove resource &&
-    flux module load -r 0 resource policy=foo &&
+    flux module load resource policy=foo &&
     flux module remove resource &&
-    flux module load -r 0 resource policy=bar
+    flux module load resource policy=bar
 '
 
 test_expect_success 'removing resource works' '

--- a/t/t4004-match-hwloc.t
+++ b/t/t4004-match-hwloc.t
@@ -93,7 +93,7 @@ test_expect_success 'resource-query works with whitelist' '
 
 # Test using the full resource matching service
 test_expect_success 'loading resource module with a tiny hwloc xml file works' '
-    flux module load -r 0 resource load-file=${hwloc_4core}
+    flux module load resource load-file=${hwloc_4core}
 '
 
 test_expect_success 'match-allocate works with four one-core jobspecs' '
@@ -119,7 +119,7 @@ test_expect_success 'reloading session/hwloc information with test data' '
 '
 
 test_expect_success 'loading resource module with default resource info source' '
-    flux module load -r 0 resource subsystems=containment policy=high
+    flux module load resource subsystems=containment policy=high
 '
 
 test_expect_success 'match-allocate works with four two-socket jobspecs' '
@@ -139,7 +139,7 @@ test_expect_success 'match-allocate fails when all resources are allocated' '
 test_expect_success 'reloading sierra xml and match allocate' '
     flux module remove resource &&
     flux hwloc reload ${excl_4N4B_sierra2} &&
-    flux module load -r 0 resource subsystems=containment \
+    flux module load resource subsystems=containment \
 policy=high load-whitelist=node,socket,core,gpu &&
     flux resource match allocate ${jobspec_1socket_2gpu} &&
     flux resource match allocate ${jobspec_1socket_2gpu} &&

--- a/t/t4008-match-jgf.t
+++ b/t/t4008-match-jgf.t
@@ -35,7 +35,7 @@ test_debug '
 
 # Test using the full resource matching service
 test_expect_success 'loading resource module with a tiny jgf file works' '
-    flux module load -r 0 resource load-file=${jgf_4core} load-format=jgf
+    flux module load resource load-file=${jgf_4core} load-format=jgf
 '
 
 test_expect_success 'JGF: allocate works with four one-core jobspecs' '


### PR DESCRIPTION
This PR makes some minor changes to the the way `flux module` is called, preparing for flux-framework/flux-core#2612 to be merged.  This PR should go in first or sched will no longer work with the flux-core master once the core PR is merged.