### PR TITLE
Fix build/test issues and enable travis on CentOS 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,12 @@ matrix:
        - ARGS="--prefix=/usr"
        - IMG=centos7
        - DOCKER_TAG=t
+    - name: "Centos 8: docker-deploy"
+      compiler: gcc
+      env:
+       - ARGS="--prefix=/usr"
+       - IMG=centos8
+       - DOCKER_TAG=t
 
 env:
   global:

--- a/configure.ac
+++ b/configure.ac
@@ -48,19 +48,6 @@ PKG_CHECK_MODULES([HWLOC], [hwloc >= 1.11.1], [], [])
 PKG_CHECK_MODULES([JANSSON], [jansson >= 2.6], [], [])
 PKG_CHECK_MODULES([XML2], [libxml-2.0])
 AX_VALGRIND_H
-AX_PROG_LUA([5.1],[5.3])
-AX_LUA_HEADERS
-AX_LUA_LIBS
-#  Glean liblua name from LUA_LIB set by AX_LUA_LIBS
-LIBLUA_SONAME=`echo $LUA_LIB | sed 's/.*-l\(lua[[0-9.-]]*\).*/lib\1.so/'`
-AC_MSG_CHECKING([for liblua DSO name])
-AS_IF([test "x$LIBLUA_SONAME" != "x"],
-      [AC_MSG_RESULT([$LIBLUA_SONAME])],
-      [AC_MSG_RESULT([no])
-       AC_MSG_ERROR([Unable to determine name of the liblua shared library])
-      ])
-AC_DEFINE_UNQUOTED([LIBLUA_SO], ["$LIBLUA_SONAME"],
-                   [Define the liblua DSO filename])
 
 PKG_CHECK_MODULES([UUID], [uuid], [], [])
 AX_FLUX_CORE

--- a/src/test/docker/centos8/Dockerfile
+++ b/src/test/docker/centos8/Dockerfile
@@ -1,0 +1,30 @@
+FROM fluxrm/flux-core:centos8
+
+ARG USER=flux
+ARG UID=1000
+
+# Install extra buildrequires for flux-sched:
+RUN sudo yum -y install \
+	boost-devel \
+	boost-graph \
+	boost-system \
+	boost-filesystem \
+	boost-regex \
+	libxml2-devel \
+	readline-devel \
+	python3-pyyaml \
+	yaml-cpp-devel
+
+# Add configured user to image with sudo access:
+#
+RUN \
+ if test "$USER" != "flux"; then  \
+      sudo groupadd -g $UID $USER \
+   && sudo useradd -g $USER -u $UID -d /home/$USER -m $USER \
+   && sudo sh -c "printf \"$USER ALL= NOPASSWD: ALL\\n\" >> /etc/sudoers" \
+   && sudo usermod -G wheel $USER; \
+ fi
+
+USER $USER
+WORKDIR /home/$USER
+RUN flux keygen

--- a/t/scripts/flux-jsonschemalint
+++ b/t/scripts/flux-jsonschemalint
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import argparse
 import errno
 import json
@@ -9,16 +11,16 @@ import jsonschema
     Print json document and schema as a verbose option
 """
 def print_verbose (doc, schema):
-    print "=============================================="
-    print " Jsonschema "
-    print "=============================================="
-    print (json.dumps (schema, indent=4, sort_keys=True))
-    print ""
-    print "=============================================="
-    print " Json document "
-    print "=============================================="
-    print (json.dumps (doc, indent=4, sort_keys=True))
-    print ""
+    print("==============================================")
+    print(" Jsonschema ")
+    print("==============================================")
+    print(json.dumps (schema, indent=4, sort_keys=True))
+    print("")
+    print("==============================================")
+    print(" Json document ")
+    print("==============================================")
+    print(json.dumps (doc, indent=4, sort_keys=True))
+    print("")
 
 
 """
@@ -44,22 +46,22 @@ def main ():
 
         jsonschema.validate (doc, schema)
         valstr = "Document(\"{0}\") validates against schema (\"{1}\")"
-        print valstr.format (args.json, args.schema)
+        print (valstr.format (args.json, args.schema))
 
     except IOError as e:
-        print "I/O error({0}): {1}".format (e.errno, e.strerror)
+        print ("I/O error({0}): {1}".format (e.errno, e.strerror))
         exit (1)
     except EnvironmentError as e:
-        print "Environment error({0}): {1}".format (e.errno, e.strerror)
+        print ("Environment error({0}): {1}".format (e.errno, e.strerror))
         exit (1)
     except ValueError as estr:
-        print "Value error: {0}".format (str (estr))
+        print ("Value error: {0}".format (str (estr)))
         exit (1)
     except jsonschema.exceptions.ValidationError as e:
-        print "Jsonschema validation error: {0}".format (e.message)
+        print ("Jsonschema validation error: {0}".format (e.message))
         exit (1)
     except jsonschema.exceptions.SchemaError as e:
-        print "Jsonschema schema error: {0}".format (e.message)
+        print ("Jsonschema schema error: {0}".format (e.message))
         exit (1)
 
 if __name__ == "__main__":

--- a/t/scripts/flux-resource
+++ b/t/scripts/flux-resource
@@ -271,12 +271,11 @@ def main ():
         args = parser.parse_args ()
         args.func (args)
 
-    except IOError as e:
-        print ("I/O error({0}): {1}".format (e.errno, e.strerror))
-        exit (3)
-
-    except EnvironmentError as e:
-        print ("Environment error({0}): {1}".format (e.errno, e.strerror))
+    except (IOError,EnvironmentError) as e:
+        name = e.__class__.__name__
+        print ("{}: error({}): {}".format (name, e.errno, e.strerror))
+        if e.errno == errno.ENOENT:
+            exit (3)
         if e.errno == errno.EBUSY:  # resource currently unavailable
             exit (16)
         if e.errno == errno.ENODEV: # unsatisfiable jobspec

--- a/t/scripts/flux-resource
+++ b/t/scripts/flux-resource
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import argparse
 import errno
 import yaml
@@ -72,11 +73,11 @@ def match_alloc_action (args):
         jobspec_str = yaml.dump (yaml.load (stream))
         r = ResourceModuleInterface ()
         resp = r.rpc_allocate (r.rpc_next_jobid (), jobspec_str)
-        print heading ()
-        print body (resp['jobid'], resp['status'], resp['at'], resp['overhead'])
+        print (heading ())
+        print (body (resp['jobid'], resp['status'], resp['at'], resp['overhead']))
         print ("=" * width ())
-        print "MATCHED RESOURCES:"
-        print resp['R']
+        print ("MATCHED RESOURCES:")
+        print (resp['R'])
 
 """
     Action for match allocate_with_satisfiability sub-command
@@ -87,11 +88,11 @@ def match_alloc_sat_action (args):
         r = ResourceModuleInterface ()
         resp = r.rpc_allocate_with_satisfiability (r.rpc_next_jobid (),
                                                    jobspec_str)
-        print heading ()
-        print body (resp['jobid'], resp['status'], resp['at'], resp['overhead'])
+        print (heading ())
+        print (body (resp['jobid'], resp['status'], resp['at'], resp['overhead']))
         print ("=" * width ())
-        print "MATCHED RESOURCES:"
-        print resp['R']
+        print ("MATCHED RESOURCES:")
+        print (resp['R'])
 
 """
     Action for match allocate_orelse_reserve sub-command
@@ -101,11 +102,11 @@ def match_reserve_action (args):
         jobspec_str = yaml.dump (yaml.load (stream))
         r = ResourceModuleInterface ()
         resp = r.rpc_reserve (r.rpc_next_jobid (), jobspec_str)
-        print heading ()
-        print body (resp['jobid'], resp['status'], resp['at'], resp['overhead'])
+        print (heading ())
+        print (body (resp['jobid'], resp['status'], resp['at'], resp['overhead']))
         print ("=" * width ())
-        print "MATCHED RESOURCES:"
-        print resp['R']
+        print ("MATCHED RESOURCES:")
+        print (resp['R'])
 
 """
     Action for cancel sub-command
@@ -122,8 +123,8 @@ def info_action (args):
     r = ResourceModuleInterface ()
     jobid = args.jobid
     resp = r.rpc_info (jobid)
-    print heading ()
-    print body (resp['jobid'], resp['status'], resp['at'], resp['overhead'])
+    print (heading ())
+    print (body (resp['jobid'], resp['status'], resp['at'], resp['overhead']))
 
 """
     Action for stat sub-command
@@ -131,13 +132,13 @@ def info_action (args):
 def stat_action (args):
     r = ResourceModuleInterface ()
     resp = r.rpc_stat ()
-    print "Num. of Vertices: ", resp['V']
-    print "Num. of Edges: ", resp['E']
-    print "Graph Load Time: ", resp['load-time'], "Secs"
-    print "Num. of Jobs Matched: ", resp['njobs']
-    print "Min. Match Time: ", resp['min-match'], "Secs"
-    print "Max. Match Time: ", resp['max-match'], "Secs"
-    print "Avg. Match Time: ", resp['avg-match'], "Secs"
+    print ("Num. of Vertices: ", resp['V'])
+    print ("Num. of Edges: ", resp['E'])
+    print ("Graph Load Time: ", resp['load-time'], "Secs")
+    print ("Num. of Jobs Matched: ", resp['njobs'])
+    print ("Min. Match Time: ", resp['min-match'], "Secs")
+    print ("Max. Match Time: ", resp['max-match'], "Secs")
+    print ("Avg. Match Time: ", resp['avg-match'], "Secs")
 
 """
     Action for set-property sub-command
@@ -156,7 +157,7 @@ def get_property_action (args):
     gp_resource_path = args.gp_resource_path
     gp_key = args.gp_key
     resp = r.rpc_get_property (gp_resource_path, gp_key)
-    print args.gp_key, "=", resp['value']
+    print (args.gp_key, "=", resp['value'])
 
 """
     Main entry point
@@ -271,11 +272,11 @@ def main ():
         args.func (args)
 
     except IOError as e:
-        print "I/O error({0}): {1}".format (e.errno, e.strerror)
+        print ("I/O error({0}): {1}".format (e.errno, e.strerror))
         exit (3)
 
     except EnvironmentError as e:
-        print "Environment error({0}): {1}".format (e.errno, e.strerror)
+        print ("Environment error({0}): {1}".format (e.errno, e.strerror))
         if e.errno == errno.EBUSY:  # resource currently unavailable
             exit (16)
         if e.errno == errno.ENODEV: # unsatisfiable jobspec
@@ -284,7 +285,7 @@ def main ():
             exit (1)
 
     except yaml.YAMLError as e:
-        print "Parsing error: ", e
+        print ("Parsing error: ", e)
         exit (2)
 
 if __name__ == "__main__":

--- a/t/t4003-cancel-info.t
+++ b/t/t4003-cancel-info.t
@@ -71,7 +71,7 @@ test_expect_success 'resource-info on allocated jobs works' '
 '
 
 test_expect_success 'cancel on nonexistent jobid is handled gracefully' '
-    test_expect_code 1 flux resource cancel 100000
+    test_expect_code 3 flux resource cancel 100000
 '
 
 test_expect_success 'removing resource works' '

--- a/t/t4006-properties.t
+++ b/t/t4006-properties.t
@@ -80,22 +80,22 @@ test_expect_success 'set/get property multiple properties works' '
 '
 
 test_expect_success 'test with no path works' '
-	test_expect_code 1 flux resource set-property /dont/exist random=1
+	test_expect_code 3 flux resource set-property /dont/exist random=1
 '
 
 test_expect_success 'test with no property works' '
-	test_expect_code 1 flux resource get-property /tiny0/rack0/node0 dontexist
+	test_expect_code 3 flux resource get-property /tiny0/rack0/node0 dontexist
 '
 
 test_expect_success 'test with malformed inputs works' '
 	test_expect_code 1 flux resource set-property /tiny0/rack0/node0 badprop &&
-	test_expect_code 1 flux resource get-property /tiny0/rack0/node0 badprop &&
+	test_expect_code 3 flux resource get-property /tiny0/rack0/node0 badprop &&
 	test_expect_code 1 flux resource set-property /tiny0/rack0/node0 badprop= &&
-	test_expect_code 1 flux resource get-property /tiny0/rack0/node0 badprop &&
+	test_expect_code 3 flux resource get-property /tiny0/rack0/node0 badprop &&
 	test_expect_code 1 flux resource set-property /tiny0/rack0/node0 =badprop &&
-	test_expect_code 1 flux resource get-property /tiny0/rack0/node0 badprop &&
+	test_expect_code 3 flux resource get-property /tiny0/rack0/node0 badprop &&
 	test_expect_code 1 flux resource set-property /tiny0/rack0/node0 = && 
-	test_expect_code 1 flux resource get-property /tiny0/rack0/node0 badprop
+	test_expect_code 3 flux resource get-property /tiny0/rack0/node0 badprop
 '
 
 test_expect_success 'test with complex inputs works' '


### PR DESCRIPTION
This PR enables a CentOS 8 build for flux-sched and fixes associated errors.

Many of the changes here were required due to the fact that Python 3.6 is the default /usr/bin/python in the centos8 docker image. I have no idea if I made the right fixes there, so feedback welcome!

Fixes #563