### PR TITLE
testsuite: update flux-job list usage

### DIFF
--- a/t/t1003-qmanager-policy.t
+++ b/t/t1003-qmanager-policy.t
@@ -64,9 +64,9 @@ test_expect_success 'qmanager: EASY policy correctly schedules jobs' '
     flux job cancel ${jobid6} &&
     flux job wait-event -t 2 ${jobid7} start &&
     flux job wait-event -t 2 ${jobid9} start &&
-    test $(flux job list | wc -l) -eq 11 &&
-    test $(flux job list | grep -v USERID | grep R | wc -l) -eq 4 &&
-    flux job list | grep -v USERID | xargs -L 1 flux job cancel &&
+    test $(flux job list --states=active | wc -l) -eq 10 &&
+    test $(flux job list --states=running| wc -l) -eq 4 &&
+    flux job list --states=active | jq .id | xargs -L 1 flux job cancel &&
     flux job wait-event -t 2 ${jobid10} clean
 '
 
@@ -94,9 +94,9 @@ test_expect_success 'qmanager: HYBRID policy correctly schedules jobs' '
     flux job wait-event -t 2 ${jobid11} start &&
     flux job cancel ${jobid7} &&
     flux job wait-event -t 2 ${jobid9} start &&
-    test $(flux job list | wc -l) -eq 11 &&
-    test $(flux job list | grep -v USERID | grep R | wc -l) -eq 3 &&
-    flux job list | grep -v USERID | xargs -L 1 flux job cancel &&
+    test $(flux job list --states=active | wc -l) -eq 10 &&
+    test $(flux job list --states=running| wc -l) -eq 3 &&
+    flux job list --states=active | jq .id | xargs -L 1 flux job cancel &&
     flux job wait-event -t 2 ${jobid11} clean
 '
 
@@ -124,9 +124,9 @@ test_expect_success 'qmanager: CONSERVATIVE correctly schedules jobs' '
     flux job wait-event -t 2 ${jobid11} start &&
     flux job cancel ${jobid7} &&
     flux job wait-event -t 2 ${jobid7} clean &&
-    test $(flux job list | wc -l) -eq 11 &&
-    test $(flux job list | grep -v USERID | grep R | wc -l) -eq 2 &&
-    flux job list | grep -v USERID | xargs -L 1 flux job cancel &&
+    test $(flux job list --states=active | wc -l) -eq 10 &&
+    test $(flux job list --states=running| wc -l) -eq 2 &&
+    flux job list --states=active | jq .id | xargs -L 1 flux job cancel &&
     flux job wait-event -t 2 ${jobid11} clean
 '
 

--- a/t/t1004-qmanager-optimize.t
+++ b/t/t1004-qmanager-optimize.t
@@ -64,9 +64,9 @@ test_expect_success 'qmanager: EASY policy conforms to queue-depth=5' '
     flux job wait-event -t 2 ${jobid7} start &&
     flux job cancel ${jobid7} &&
     flux job wait-event -t 2 ${jobid8} start &&
-    test $(flux job list | wc -l) -eq 10 &&
-    test $(flux job list | grep -v USERID | grep R | wc -l) -eq 2 &&
-    flux job list | grep -v USERID | xargs -L 1 flux job cancel &&
+    test $(flux job list --states=active | wc -l) -eq 9 &&
+    test $(flux job list --states=running | wc -l) -eq 2 &&
+    flux job list --states=active | jq .id | xargs -L 1 flux job cancel &&
     flux job wait-event -t 2 ${jobid11} clean
 '
 
@@ -90,9 +90,9 @@ test_expect_success 'qmanager: HYBRID policy conforms to queue-depth=5' '
     jobid11=$(flux job submit C02.T3600.json) &&
 
     flux job wait-event -t 2 ${jobid1} start &&
-    test $(flux job list | wc -l) -eq 12 &&
-    test $(flux job list | grep -v USERID | grep R | wc -l) -eq 1 &&
-    flux job list | grep -v USERID | xargs -L 1 flux job cancel &&
+    test $(flux job list --states=active | wc -l) -eq 11 &&
+    test $(flux job list --states=running| wc -l) -eq 1 &&
+    flux job list --states=active | jq .id | xargs -L 1 flux job cancel &&
     flux job wait-event -t 2 ${jobid11} clean
 '
 
@@ -116,9 +116,9 @@ test_expect_success 'qmanager: CONSERVATIVE policy conforms to queue-depth=5' '
     jobid11=$(flux job submit C02.T3600.json) &&
 
     flux job wait-event -t 2 ${jobid1} start &&
-    test $(flux job list | wc -l) -eq 12 &&
-    test $(flux job list | grep -v USERID | grep R | wc -l) -eq 1 &&
-    flux job list | grep -v USERID | xargs -L 1 flux job cancel &&
+    test $(flux job list --states=active | wc -l) -eq 11 &&
+    test $(flux job list --states=running | wc -l) -eq 1 &&
+    flux job list | jq .id | xargs -L 1 flux job cancel &&
     flux job wait-event -t 2 ${jobid11} clean
 '
 


### PR DESCRIPTION
Problem: In upstream flux-core the `flux job list` plumbing tool
was changed to only output JSON, which breaks some of the flux-sched
tests which use this tool to count active and running jobs.

Update flux-job list usage in the qmanager tests to prevent failures.

Note: although `flux job list` and `flux job list --states=active`
are currently equivalent, use the latter form in tests to be
explicit as well as protect the tests from potential changes
in the default output of `flux job list.

Fixes #570