### PR TITLE
New metadata for elastic jobs

### DIFF
--- a/resource/readers/resource_reader_jgf.cpp
+++ b/resource/readers/resource_reader_jgf.cpp
@@ -373,6 +373,7 @@ int resource_reader_jgf_t::update_vtx_plan (vtx_t v, resource_graph_t &g,
     int64_t span = -1;
     int64_t avail = -1;
     planner_t *plans = NULL;
+    std::string jobtype = "static";
 
     if ( (plans = g[v].schedule.plans) == NULL) {
         errno = EINVAL;
@@ -396,10 +397,14 @@ int resource_reader_jgf_t::update_vtx_plan (vtx_t v, resource_graph_t &g,
             m_err_msg += ": can't add span into " + g[v].name + ".\n";
             goto done;
         }
-        if (rsv)
-            g[v].schedule.reservations[jobid] = span;
-        else
-            g[v].schedule.allocations[jobid] = span;
+        if (rsv) {
+            g[v].schedule.reservations.spantype[jobid].span = span;
+            g[v].schedule.reservations.spantype[jobid].jobtype = jobtype;
+       }
+        else {
+            g[v].schedule.allocations.spantype[jobid].span = span;
+            g[v].schedule.allocations.spantype[jobid].jobtype = jobtype;
+       }
     } else {
         if (avail < g[v].size) {
             // if g[v] has already been allocated/reserved, this is an error
@@ -468,10 +473,10 @@ int resource_reader_jgf_t::undo_vertices (resource_graph_t &g,
         try {
             v = kv.second.v;
             if (rsv) {
-                span = g[v].schedule.reservations.at (jobid);
+                span = g[v].schedule.reservations.spantype.at (jobid).span;
                 g[v].schedule.reservations.erase (jobid);
             } else {
-                span = g[v].schedule.allocations.at (jobid);
+                span = g[v].schedule.allocations.spantype.at (jobid).span;
                 g[v].schedule.allocations.erase (jobid);
             }
 

--- a/resource/schema/sched_data.cpp
+++ b/resource/schema/sched_data.cpp
@@ -25,6 +25,34 @@
 namespace Flux {
 namespace resource_model {
 
+allotment_t::allotment_t ()
+{
+
+}
+
+void allotment_t::insert (const int64_t jobid, const int64_t span,
+                         const std::string &jobtype)
+{
+    id2spantype[jobid].span = span;
+    id2spantype[jobid].jobtype = jobtype;
+
+    type2id[jobtype].insert (jobid);
+
+}
+
+void allotment_t::erase (const int64_t jobid)
+{
+    std::string jtype = id2spantype[jobid].jobtype;
+
+    type2id[jtype].erase (jobid);
+    id2spantype.erase (jobid);
+}
+
+allotment_t::~allotment_t ()
+{
+
+}
+
 schedule_t::schedule_t ()
 {
 
@@ -50,7 +78,6 @@ schedule_t &schedule_t::operator= (const schedule_t &o)
 {
     int64_t base_time = 0;
     uint64_t duration = 0;
-    size_t len = 0;
 
     // assign operator does not copy the contents
     // of the schedule tables and of the planner objects.

--- a/resource/schema/sched_data.hpp
+++ b/resource/schema/sched_data.hpp
@@ -30,6 +30,22 @@
 namespace Flux {
 namespace resource_model {
 
+struct spantype_t {
+    int64_t span;
+    std::string jobtype;
+};
+
+struct allotment_t {
+    void erase (const int64_t jobid) {
+    	if (spantype[jobid].jobtype == "elastic")
+    	    --elasticcount;
+        spantype.erase(jobid);
+    }
+
+    std::map<int64_t, spantype_t> spantype;
+    int64_t elasticcount = 0;
+};
+
 //! Type to keep track of current schedule state
 struct schedule_t {
     schedule_t ();
@@ -37,8 +53,8 @@ struct schedule_t {
     schedule_t &operator= (const schedule_t &o);
     ~schedule_t ();
 
-    std::map<int64_t, int64_t> allocations;
-    std::map<int64_t, int64_t> reservations;
+    allotment_t allocations;
+    allotment_t reservations;
     planner_t *plans = NULL;
 };
 

--- a/resource/schema/sched_data.hpp
+++ b/resource/schema/sched_data.hpp
@@ -24,6 +24,7 @@
 #define SCHED_DATA_H
 
 #include <map>
+#include <set>
 #include <cstdint>
 #include "resource/planner/planner.h"
 
@@ -36,14 +37,14 @@ struct spantype_t {
 };
 
 struct allotment_t {
-    void erase (const int64_t jobid) {
-    	if (spantype[jobid].jobtype == "elastic")
-    	    --elasticcount;
-        spantype.erase(jobid);
-    }
+    allotment_t ();
+    void insert (const int64_t jobid, const int64_t span,
+                 const std::string &jobtype);
+    void erase (const int64_t jobid);
+    ~allotment_t ();
 
-    std::map<int64_t, spantype_t> spantype;
-    int64_t elasticcount = 0;
+    std::map<int64_t, spantype_t> id2spantype;
+    std::map<std::string, std::set<int64_t>> type2id;
 };
 
 //! Type to keep track of current schedule state

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -57,6 +57,7 @@ struct jobmeta_t {
     int64_t jobid = -1;
     int64_t at = -1;
     uint64_t duration = SYSTEM_DEFAULT_DURATION; // will need config ultimately
+    std::string jobtype = "static";
 
     void build (Jobspec::Jobspec &jobspec, bool alloc, int64_t id, int64_t t)
     {
@@ -68,6 +69,11 @@ struct jobmeta_t {
             duration = SYSTEM_MAX_DURATION; // need config support ultimately
         else
             duration = (int64_t)jobspec.attributes.system.duration;
+
+        std::unordered_map<std::string, YAML::Node>::const_iterator jtype =
+                jobspec.attributes.system.optional.find ("jobtype");
+        if (jtype != jobspec.attributes.system.optional.end ())
+            jobtype = jtype->second.as<std::string> ();
     }
 };
 

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -57,7 +57,7 @@ struct jobmeta_t {
     int64_t jobid = -1;
     int64_t at = -1;
     uint64_t duration = SYSTEM_DEFAULT_DURATION; // will need config ultimately
-    std::string jobtype = "static";
+    std::string jobtype = "rigid";
 
     void build (Jobspec::Jobspec &jobspec, bool alloc, int64_t id, int64_t t)
     {

--- a/resource/traversers/dfu_impl_update.cpp
+++ b/resource/traversers/dfu_impl_update.cpp
@@ -148,17 +148,11 @@ int dfu_impl_t::upd_plan (vtx_t u, const subsystem_t &s, unsigned int needs,
             }
             return -1;
         }
-        if (jobmeta.allocate) {
-            (*m_graph)[u].schedule.allocations.spantype[jobmeta.jobid].span = span;
-            (*m_graph)[u].schedule.allocations.spantype[jobmeta.jobid].jobtype = jobmeta.jobtype;
+        if (jobmeta.allocate) 
+            (*m_graph)[u].schedule.allocations.insert (jobmeta.jobid, span, jobmeta.jobtype);
 
-            if (jobmeta.jobtype == "elastic")
-                ++(*m_graph)[u].schedule.allocations.elasticcount;
-       }
-        else {
-            (*m_graph)[u].schedule.reservations.spantype[jobmeta.jobid].span = span;
-            (*m_graph)[u].schedule.reservations.spantype[jobmeta.jobid].jobtype = jobmeta.jobtype;
-        }
+        else
+            (*m_graph)[u].schedule.reservations.insert (jobmeta.jobid, span, jobmeta.jobtype);
     }
     return 0;
 }
@@ -359,13 +353,13 @@ int dfu_impl_t::rem_plan (vtx_t u, int64_t jobid)
     int64_t span = -1;
     planner_t *plans = NULL;
 
-    if ((*m_graph)[u].schedule.allocations.spantype.find (jobid)
-        != (*m_graph)[u].schedule.allocations.spantype.end ()) {
-        span = (*m_graph)[u].schedule.allocations.spantype[jobid].span;
+    if ((*m_graph)[u].schedule.allocations.id2spantype.find (jobid)
+        != (*m_graph)[u].schedule.allocations.id2spantype.end ()) {
+        span = (*m_graph)[u].schedule.allocations.id2spantype[jobid].span;
         (*m_graph)[u].schedule.allocations.erase (jobid);
-    } else if ((*m_graph)[u].schedule.reservations.spantype.find (jobid)
-               != (*m_graph)[u].schedule.reservations.spantype.end ()) {
-        span = (*m_graph)[u].schedule.reservations.spantype[jobid].span;
+    } else if ((*m_graph)[u].schedule.reservations.id2spantype.find (jobid)
+               != (*m_graph)[u].schedule.reservations.id2spantype.end ()) {
+        span = (*m_graph)[u].schedule.reservations.id2spantype[jobid].span;
         (*m_graph)[u].schedule.reservations.erase (jobid);
     } else {
         goto done;
@@ -433,13 +427,13 @@ int dfu_impl_t::rem_exv (int64_t jobid)
     // In this case, you can't find allocated resources from an accelerated
     // depth first visit (dfv). There won't be no idata for that allocation.
     for (boost::tie (vi, v_end) = boost::vertices (g); vi != v_end; ++vi) {
-        if (g[*vi].schedule.allocations.spantype.find (jobid)
-            != g[*vi].schedule.allocations.spantype.end ()) {
-            span = g[*vi].schedule.allocations.spantype[jobid].span;
+        if (g[*vi].schedule.allocations.id2spantype.find (jobid)
+            != g[*vi].schedule.allocations.id2spantype.end ()) {
+            span = g[*vi].schedule.allocations.id2spantype[jobid].span;
             g[*vi].schedule.allocations.erase (jobid);
-        } else if (g[*vi].schedule.reservations.spantype.find (jobid)
-                   != g[*vi].schedule.reservations.spantype.end ()) {
-            span = g[*vi].schedule.reservations.spantype[jobid].span;
+        } else if (g[*vi].schedule.reservations.id2spantype.find (jobid)
+                   != g[*vi].schedule.reservations.id2spantype.end ()) {
+            span = g[*vi].schedule.reservations.id2spantype[jobid].span;
             g[*vi].schedule.reservations.erase (jobid);
         } else {
             continue;

--- a/resource/traversers/dfu_impl_update.cpp
+++ b/resource/traversers/dfu_impl_update.cpp
@@ -148,10 +148,17 @@ int dfu_impl_t::upd_plan (vtx_t u, const subsystem_t &s, unsigned int needs,
             }
             return -1;
         }
-        if (jobmeta.allocate)
-            (*m_graph)[u].schedule.allocations[jobmeta.jobid] = span;
-        else
-            (*m_graph)[u].schedule.reservations[jobmeta.jobid] = span;
+        if (jobmeta.allocate) {
+            (*m_graph)[u].schedule.allocations.spantype[jobmeta.jobid].span = span;
+            (*m_graph)[u].schedule.allocations.spantype[jobmeta.jobid].jobtype = jobmeta.jobtype;
+
+            if (jobmeta.jobtype == "elastic")
+                ++(*m_graph)[u].schedule.allocations.elasticcount;
+       }
+        else {
+            (*m_graph)[u].schedule.reservations.spantype[jobmeta.jobid].span = span;
+            (*m_graph)[u].schedule.reservations.spantype[jobmeta.jobid].jobtype = jobmeta.jobtype;
+        }
     }
     return 0;
 }
@@ -352,13 +359,13 @@ int dfu_impl_t::rem_plan (vtx_t u, int64_t jobid)
     int64_t span = -1;
     planner_t *plans = NULL;
 
-    if ((*m_graph)[u].schedule.allocations.find (jobid)
-        != (*m_graph)[u].schedule.allocations.end ()) {
-        span = (*m_graph)[u].schedule.allocations[jobid];
+    if ((*m_graph)[u].schedule.allocations.spantype.find (jobid)
+        != (*m_graph)[u].schedule.allocations.spantype.end ()) {
+        span = (*m_graph)[u].schedule.allocations.spantype[jobid].span;
         (*m_graph)[u].schedule.allocations.erase (jobid);
-    } else if ((*m_graph)[u].schedule.reservations.find (jobid)
-               != (*m_graph)[u].schedule.reservations.end ()) {
-        span = (*m_graph)[u].schedule.reservations[jobid];
+    } else if ((*m_graph)[u].schedule.reservations.spantype.find (jobid)
+               != (*m_graph)[u].schedule.reservations.spantype.end ()) {
+        span = (*m_graph)[u].schedule.reservations.spantype[jobid].span;
         (*m_graph)[u].schedule.reservations.erase (jobid);
     } else {
         goto done;
@@ -426,13 +433,13 @@ int dfu_impl_t::rem_exv (int64_t jobid)
     // In this case, you can't find allocated resources from an accelerated
     // depth first visit (dfv). There won't be no idata for that allocation.
     for (boost::tie (vi, v_end) = boost::vertices (g); vi != v_end; ++vi) {
-        if (g[*vi].schedule.allocations.find (jobid)
-            != g[*vi].schedule.allocations.end ()) {
-            span = g[*vi].schedule.allocations[jobid];
+        if (g[*vi].schedule.allocations.spantype.find (jobid)
+            != g[*vi].schedule.allocations.spantype.end ()) {
+            span = g[*vi].schedule.allocations.spantype[jobid].span;
             g[*vi].schedule.allocations.erase (jobid);
-        } else if (g[*vi].schedule.reservations.find (jobid)
-                   != g[*vi].schedule.reservations.end ()) {
-            span = g[*vi].schedule.reservations[jobid];
+        } else if (g[*vi].schedule.reservations.spantype.find (jobid)
+                   != g[*vi].schedule.reservations.spantype.end ()) {
+            span = g[*vi].schedule.reservations.spantype[jobid].span;
             g[*vi].schedule.reservations.erase (jobid);
         } else {
             continue;


### PR DESCRIPTION
This PR adds necessary metadata to enable elastic jobs.  It defines an attribute `jobtype` that is attached to each resource vertex and mapped by `jobid`.  Furthermore, since a vertex can have multiple jobs allocated, job shrink will need a count of the number of elastic jobs scheduled on the vertex.

The PR also includes logic to read the jobtype attribute from a jobspec and attach it to `jobmeta`.