### PR TITLE
testsuite: avoid rc3 hang in qmanager-reload test

### DIFF
--- a/t/t1002-qmanager-reload.t
+++ b/t/t1002-qmanager-reload.t
@@ -80,4 +80,10 @@ test_expect_success 'removing resource and qmanager modules' '
     flux module remove resource
 '
 
+# Reload the core scheduler so that rc3 won't hang waiting for
+# queue to become idle after jobs are canceled.
+test_expect_success 'load sched-simple module' '
+    flux module load sched-simple
+'
+
 test_done


### PR DESCRIPTION
In flux-framework/flux-core#2733, the github workflow build against flux-sched is hanging in teardown of the qmanager-reload test.

Recently we added cleanup of running jobs to rc3 with `flux job cancelall --states=RUN`, and a call to `flux  queue idle` which blocks until jobs in RUNNING or CLEANUP states transition to INACTIVE.  Since the qmanager-reload test leaves jobs running and exits wtihout a scheduler loaded, this cleanup hangs because the job manager can't free the resources of those jobs, so they are stuck in CLEANUP.

Before the above PR, rc3 just timed out and the rc3 failure was ignored.

After the PR, rc3 doesn't run under the timeout, so the test hangs running `flux queue idle`.

The tools like `flux job cancelall` that make cleaning up the running jobs within the test easy are recent additions to core, so I thought the simplest solution would be to just reload `sched-simple` at the end of the test.