### PR TITLE
Use Jansson for JSON-based writers + time keys in RV1

### DIFF
--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -686,7 +686,11 @@ static int run_match (std::shared_ptr<resource_ctx_t> &ctx, int64_t jobid,
     if ((rc = run (ctx, jobid, cmd, jstr, at)) < 0)
         goto done;
 
-    ctx->writers->emit (o);
+    if ((rc = ctx->writers->emit (o)) < 0) {
+        flux_log_error (ctx->h, "%s: writer can't emit", __FUNCTION__);
+        goto done;
+    }
+
     gettimeofday (&end, NULL);
     *ov = get_elapse_time (start, end);
     update_match_perf (ctx, *ov);

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -672,7 +672,6 @@ static int run_match (std::shared_ptr<resource_ctx_t> &ctx, int64_t jobid,
     struct timeval end;
 
     gettimeofday (&start, NULL);
-    ctx->writers->reset ();
 
     if (strcmp ("allocate", cmd) != 0
         && strcmp ("allocate_orelse_reserve", cmd) != 0

--- a/resource/readers/resource_reader_jgf.cpp
+++ b/resource/readers/resource_reader_jgf.cpp
@@ -142,7 +142,7 @@ int resource_reader_jgf_t::unpack_vtx (json_t *element, fetch_helper_t &f)
     if ( (json_unpack (element, "{ s:s }", "id", &f.vertex_id) < 0)) {
         errno = EPROTO;
         m_err_msg += __FUNCTION__;
-        m_err_msg += ": JGF vertex id key is not found in an node.\n";
+        m_err_msg += ": JGF vertex id key is not found in a node.\n";
         goto done;
     }
     if ( (metadata = json_object_get (element, "metadata")) == NULL) {

--- a/resource/traversers/dfu_impl_update.cpp
+++ b/resource/traversers/dfu_impl_update.cpp
@@ -477,7 +477,15 @@ int dfu_impl_t::update (vtx_t root, std::shared_ptr<match_writers_t> &writers,
     unsigned int needs = m_graph_db->metadata.v_rt_edges[dom].get_needs ();
     m_color.reset ();
 
-    rc = upd_dfv (root, writers, needs, x, jobmeta, true, dfu);
+    if ((rc = upd_dfv (root, writers, needs, x, jobmeta, true, dfu)) > 0) {
+         uint64_t starttime = jobmeta.at;
+         uint64_t endtime = jobmeta.at + jobmeta.duration;
+         if (writers->emit_tm (starttime, endtime) == -1) {
+             m_err_msg += __FUNCTION__;
+             m_err_msg += ": emit_tm returned -1.\n";
+         }
+     }
+
     return (rc > 0)? 0 : -1;
 }
 

--- a/resource/utilities/command.cpp
+++ b/resource/utilities/command.cpp
@@ -185,7 +185,13 @@ int cmd_match (std::shared_ptr<resource_context_t> &ctx,
         if ((rc != 0) && (errno == ENODEV))
             sat = false;
 
-        ctx->writers->emit (o);
+        if (ctx->traverser->err_message () != "") {
+            std::cerr << "ERROR: " << ctx->traverser->err_message ();
+            ctx->traverser->clear_err_message ();
+        }
+        if (ctx->writers->emit (o) < 0)
+            std::cerr << "ERROR: match writer emit: " << strerror (errno) << std::endl;
+
         std::ostream &out = (ctx->params.r_fname != "")? ctx->params.r_out
                                                        : std::cout;
         out << o.str ();

--- a/resource/utilities/command.cpp
+++ b/resource/utilities/command.cpp
@@ -168,7 +168,6 @@ int cmd_match (std::shared_ptr<resource_context_t> &ctx,
         struct timeval st, et;
 
         gettimeofday (&st, NULL);
-        ctx->writers->reset ();
 
         if (args[1] == "allocate")
             rc = ctx->traverser->run (job, ctx->writers, match_op_t::
@@ -282,7 +281,6 @@ static int update (std::shared_ptr<resource_context_t> &ctx,
     }
 
     buffer << jgf_file.rdbuf ();
-    ctx->writers->reset ();
     jgf_file.close ();
 
     return update_run (ctx, args[2], buffer.str (), jobid, at, d);

--- a/resource/writers/match_writers.cpp
+++ b/resource/writers/match_writers.cpp
@@ -690,6 +690,13 @@ int rv1_match_writers_t::emit_edg (const std::string &prefix,
     return rc;
 }
 
+int rv1_match_writers_t::emit_tm (uint64_t start_tm, uint64_t end_tm)
+{
+    m_starttime = start_tm;
+    m_expiration = end_tm;
+    return 0;
+}
+
 
 /****************************************************************************
  *                                                                          *
@@ -744,6 +751,13 @@ int rv1_nosched_match_writers_t::emit_vtx (const std::string &prefix,
                                            bool exclusive)
 {
     return rlite.emit_vtx (prefix, g, u, needs, exclusive);
+}
+
+int rv1_nosched_match_writers_t::emit_tm (uint64_t start_tm, uint64_t end_tm)
+{
+    m_starttime = start_tm;
+    m_expiration = end_tm;
+    return 0;
 }
 
 

--- a/resource/writers/match_writers.cpp
+++ b/resource/writers/match_writers.cpp
@@ -642,10 +642,12 @@ int rv1_match_writers_t::emit (std::stringstream &out)
         json_decref (rlite_o);
         goto ret;
     }
-    if (!(o = json_pack ("{s:i s:{s:o s:o}}",
+    if (!(o = json_pack ("{s:i s:{s:o s:I s:I} s:o}",
                              "version", 1,
                              "execution",
                              "R_lite", rlite_o,
+                             "starttime", m_starttime,
+                             "expiration", m_expiration,
                              "scheduling", jgf_o))) {
         json_decref (rlite_o);
         json_decref (jgf_o);
@@ -720,10 +722,12 @@ int rv1_nosched_match_writers_t::emit (std::stringstream &out)
         goto ret;
     if ((rc = rlite.emit_json (&rlite_o)) < 0)
         goto ret;
-    if (!(o = json_pack ("{s:i s:{s:o}}",
+    if (!(o = json_pack ("{s:i s:{s:o s:I s:I}}",
                              "version", 1,
                              "execution",
-                             "R_lite",  rlite_o))) {
+                             "R_lite",  rlite_o,
+                             "starttime", m_starttime,
+                             "expiration", m_expiration))) {
         json_decref (rlite_o);
         rc = -1;
         errno = ENOMEM;

--- a/resource/writers/match_writers.cpp
+++ b/resource/writers/match_writers.cpp
@@ -68,6 +68,11 @@ void match_writers_t::compress (std::stringstream &o,
  *                                                                          *
  ****************************************************************************/
 
+bool sim_match_writers_t::empty ()
+{
+    return m_out.str ().empty ();
+}
+
 int sim_match_writers_t::emit (std::stringstream &out)
 {
     out << m_out.str ();
@@ -770,6 +775,18 @@ int rv1_nosched_match_writers_t::emit_tm (uint64_t start_tm, uint64_t end_tm)
  *         PRETTY Simple Writers Class Public Method Definitions            *
  *                                                                          *
  ****************************************************************************/
+
+bool pretty_sim_match_writers_t::empty ()
+{
+    bool empty = true;
+    for (auto &s: m_out) {
+        if (!s.empty ()) {
+            empty = false;
+            break;
+        }
+    }
+    return empty;
+}
 
 int pretty_sim_match_writers_t::emit (std::stringstream &out)
 {

--- a/resource/writers/match_writers.cpp
+++ b/resource/writers/match_writers.cpp
@@ -193,43 +193,125 @@ int jgf_match_writers_t::emit_edg (const std::string &prefix,
 
 /****************************************************************************
  *                                                                          *
- *                 RLITE Writers Class Method Definitions                   *
+ *            RLITE Writers Class Public Method Definitions                 *
  *                                                                          *
  ****************************************************************************/
 
-rlite_match_writers_t::rlite_match_writers_t()
+rlite_match_writers_t::rlite_match_writers_t ()
 {
     m_reducer["core"] = std::set<int64_t> ();
     m_reducer["gpu"] = std::set<int64_t> ();
-    m_gatherer["node"] = std::make_shared<std::stringstream> ();
+    m_gatherer.insert ("node");
+    if (!(m_out = json_array ()))
+        throw std::bad_alloc ();
+}
+
+rlite_match_writers_t::rlite_match_writers_t (const rlite_match_writers_t &w)
+{
+    m_reducer = w.m_reducer;
+    m_gatherer = w.m_gatherer;
+    if (!(m_out = json_deep_copy (w.m_out)))
+        throw std::bad_alloc ();
+}
+
+rlite_match_writers_t &rlite_match_writers_t::operator=(
+                                                 const rlite_match_writers_t &w)
+{
+    m_reducer = w.m_reducer;
+    m_gatherer = w.m_gatherer;
+    if (!(m_out = json_deep_copy (w.m_out)))
+        throw std::bad_alloc ();
+    return *this;
 }
 
 rlite_match_writers_t::~rlite_match_writers_t ()
 {
-
+    json_decref (m_out);
 }
 
-void rlite_match_writers_t::reset ()
+bool rlite_match_writers_t::empty ()
 {
-    m_out.str ("");
-    m_out.clear ();
+    return (json_array_size (m_out) == 0)? true : false;
+}
+
+int rlite_match_writers_t::emit_json (json_t **o)
+{
+    int rc = 0;
+    if (!m_out) {
+        errno = EINVAL;
+        rc = -1;
+        goto ret;
+    }
+    if ((rc = json_array_size (m_out)) != 0) {
+        *o = m_out;
+        if (!(m_out = json_array ())) {
+            json_decref (*o);
+            *o = NULL;
+            rc = -1;
+            errno = ENOMEM;
+            goto ret;
+        }
+    }
+ret:
+    return rc;
 }
 
 int rlite_match_writers_t::emit (std::stringstream &out, bool newline)
 {
-    size_t size = m_out.str ().size ();
-    if (size > 1) {
-        out << "{\"R_lite\":[" << m_out.str ().substr (0, size - 1) << "]}";
+    int rc = 0;
+    json_t *o = NULL;
+    if ((rc = emit_json (&o)) > 0) {
+        char *json_str = NULL;
+        if (!(json_str = json_dumps (o, JSON_INDENT (0)))) {
+            json_decref (o);
+            rc = -1;
+            errno = ENOMEM;
+            goto ret;
+        }
+        out << json_str;
         if (newline)
             out << std::endl;
-    }
-    return 0;
+        free (json_str);
+        json_decref (o);
+     }
+ret:
+    return (rc == -1)? -1 : 0;
 }
 
 int rlite_match_writers_t::emit (std::stringstream &out)
 {
     return emit (out, true);
 }
+
+int rlite_match_writers_t::emit_vtx (const std::string &prefix,
+                                     const f_resource_graph_t &g,
+                                     const vtx_t &u,
+                                     unsigned int needs,
+                                     bool exclusive)
+{
+    int rc = 0;
+
+    if (!m_out) {
+        rc = -1;
+        errno = EINVAL;
+        goto ret;
+    }
+    if (m_reducer.find (g[u].type) != m_reducer.end ()) {
+        m_reducer[g[u].type].insert (g[u].id);
+    } else if (m_gatherer.find (g[u].type) != m_gatherer.end ()) {
+        if ((rc = emit_gatherer (g, u)) < 0)
+            goto ret;
+    }
+ret:
+    return rc;
+}
+
+
+/****************************************************************************
+ *                                                                          *
+ *            RLITE Writers Class Private Method Definitions                *
+ *                                                                          *
+ ****************************************************************************/
 
 bool rlite_match_writers_t::m_reducer_set ()
 {
@@ -243,36 +325,55 @@ bool rlite_match_writers_t::m_reducer_set ()
     return set;
 }
 
-int rlite_match_writers_t::emit_vtx (const std::string &prefix,
-                                     const f_resource_graph_t &g,
-                                     const vtx_t &u,
-                                     unsigned int needs,
-                                     bool exclusive)
+int rlite_match_writers_t::emit_gatherer (const f_resource_graph_t &g,
+                                          const vtx_t &u)
 {
-    if (m_reducer.find (g[u].type) != m_reducer.end ()) {
-        m_reducer[g[u].type].insert (g[u].id);
-    } else if (m_gatherer.find (g[u].type) != m_gatherer.end ()) {
-        if (m_reducer_set ()) {
-            std::stringstream &gout = *(m_gatherer[g[u].type]);
-            gout << "{";
-            gout << "\"rank\":\"" << g[u].rank << "\",";
-            gout << "\"node\":\"" << g[u].name << "\",";
-            gout << "\"children\":{";
-            for (auto &kv : m_reducer) {
-                if (kv.second.empty ())
-                    continue;
-                gout << "\"" << kv.first << "\":\"";
-                compress (gout, kv.second);
-                gout << "\",";
-                kv.second.clear ();
-            }
-            size_t size = gout.str ().size ();
-            m_out << gout.str ().substr (0, size - 1) << "}},";
-            gout.clear ();
-            gout.str ("");
-        }
+    int rc = 0;
+    json_t *o = NULL;
+    json_t *co = NULL;
+
+    if (!m_reducer_set ())
+        goto ret;
+    if (!(co = json_object ())) {
+        rc = -1;
+        errno = ENOMEM;
+        goto ret;
     }
-    return 0;
+    for (auto &kv : m_reducer) {
+        if (kv.second.empty ())
+            continue;
+        std::stringstream s;
+        compress (s, kv.second);
+        json_t *vo = NULL;
+        if (!(vo = json_string (s.str ().c_str ()))) {
+            json_decref (co);
+            rc = -1;
+            errno = ENOMEM;
+            goto ret;
+        }
+        if ((rc = json_object_set_new (co, kv.first.c_str (), vo)) < 0) {
+            json_decref (co);
+            errno = ENOMEM;
+            goto ret;
+        }
+        kv.second.clear ();
+    }
+    if (!(o = json_pack ("{s:s s:s s:o}",
+                             "rank", std::to_string (g[u].rank).c_str (),
+                             "node", g[u].name.c_str (),
+                             "children", co))) {
+        json_decref (co);
+        rc = -1;
+        errno = ENOMEM;
+        goto ret;
+    }
+    if ((rc = json_array_append_new (m_out, o)) != 0) {
+        errno = ENOMEM;
+        goto ret;
+    }
+
+ret:
+    return rc;
 }
 
 
@@ -292,16 +393,19 @@ int rv1_match_writers_t::emit (std::stringstream &out)
 {
     std::string ver = "\"version\":1";
     std::string exec_key = "\"execution\":";
+    std::string rlite_key = "\"R_lite\":";
     std::string sched_key = "\"scheduling\":";
     size_t base = out.str ().size ();
     out << "{" << ver;
     out << "," << exec_key;
+    out << "{" << rlite_key;
     rlite.emit (out, false);
+    out << "}";
     out << "," << sched_key;
     jgf.emit (out, false);
     out << "}" << std::endl;
     if (out.str ().size () <= (base + ver.size () + exec_key.size ()
-                                    + sched_key.size () + 5))
+                                    + rlite_key.size () + sched_key.size () + 7))
         out.str (out.str ().substr (0, base));
     return 0;
 }
@@ -340,16 +444,20 @@ void rv1_nosched_match_writers_t::reset ()
 
 int rv1_nosched_match_writers_t::emit (std::stringstream &out)
 {
+    int rc = 0;
     std::string ver = "\"version\":1";
     std::string exec_key = "\"execution\":";
+    std::string rlite_key = "\"R_lite\":";
     size_t base = out.str ().size ();
     out << "{" << ver;
     out << "," << exec_key;
-    rlite.emit (out, false);
-    out << "}" << std::endl;
-    if (out.str ().size () <= (base + ver.size () + exec_key.size () + 4))
+    out << "{" << rlite_key;
+    rc = rlite.emit (out);
+    out << "}}" << std::endl;
+    if (out.str ().size () <= (base + ver.size ()
+                               + exec_key.size () + rlite_key.size () + 6))
         out.str (out.str ().substr (0, base));
-    return 0;
+    return rc;
 }
 
 int rv1_nosched_match_writers_t::emit_vtx (const std::string &prefix,

--- a/resource/writers/match_writers.cpp
+++ b/resource/writers/match_writers.cpp
@@ -76,13 +76,9 @@ bool sim_match_writers_t::empty ()
 int sim_match_writers_t::emit (std::stringstream &out)
 {
     out << m_out.str ();
-    return 0;
-}
-
-void sim_match_writers_t::reset ()
-{
     m_out.str ("");
     m_out.clear ();
+    return 0;
 }
 
 int sim_match_writers_t::emit_vtx (const std::string &prefix,
@@ -792,12 +788,8 @@ int pretty_sim_match_writers_t::emit (std::stringstream &out)
 {
     for (auto &s: m_out)
         out << s;
-    return 0;
-}
-
-void pretty_sim_match_writers_t::reset ()
-{
     m_out.clear ();
+    return 0;
 }
 
 int pretty_sim_match_writers_t::emit_vtx (const std::string &prefix,

--- a/resource/writers/match_writers.hpp
+++ b/resource/writers/match_writers.hpp
@@ -149,7 +149,8 @@ private:
 class rv1_match_writers_t : public match_writers_t
 {
 public:
-    virtual void reset ();
+    virtual void reset () { }
+    virtual bool empty ();
     virtual int emit (std::stringstream &out);
     virtual int emit_vtx (const std::string &prefix,
                           const f_resource_graph_t &g, const vtx_t &u,

--- a/resource/writers/match_writers.hpp
+++ b/resource/writers/match_writers.hpp
@@ -52,7 +52,6 @@ public:
     virtual ~match_writers_t () {}
     virtual bool empty () = 0;
     virtual int emit (std::stringstream &out) = 0;
-    virtual void reset () = 0;
     virtual int emit_vtx (const std::string &prefix,
                           const f_resource_graph_t &g, const vtx_t &u,
                           unsigned int needs, bool exclusive) = 0;
@@ -75,7 +74,6 @@ public:
     virtual ~sim_match_writers_t () {}
     virtual bool empty ();
     virtual int emit (std::stringstream &out);
-    virtual void reset ();
     virtual int emit_vtx (const std::string &prefix,
                           const f_resource_graph_t &g, const vtx_t &u,
                           unsigned int needs, bool exclusive);
@@ -94,7 +92,6 @@ public:
     jgf_match_writers_t &operator=(const jgf_match_writers_t &w);
     virtual ~jgf_match_writers_t ();
 
-    virtual void reset () { }
     virtual bool empty ();
     int emit_json (json_t **o);
     virtual int emit (std::stringstream &out);
@@ -131,7 +128,6 @@ public:
     rlite_match_writers_t &operator=(const rlite_match_writers_t &w);
     virtual ~rlite_match_writers_t ();
 
-    virtual void reset () { }
     virtual bool empty ();
     int emit_json (json_t **o);
     virtual int emit (std::stringstream &out, bool newline);
@@ -154,7 +150,6 @@ private:
 class rv1_match_writers_t : public match_writers_t
 {
 public:
-    virtual void reset () { }
     virtual bool empty ();
     virtual int emit (std::stringstream &out);
     virtual int emit_vtx (const std::string &prefix,
@@ -176,7 +171,6 @@ private:
 class rv1_nosched_match_writers_t : public match_writers_t
 {
 public:
-    virtual void reset () { }
     virtual bool empty ();
     virtual int emit (std::stringstream &out);
     virtual int emit_vtx (const std::string &prefix,
@@ -197,7 +191,6 @@ class pretty_sim_match_writers_t : public match_writers_t
 public:
     virtual bool empty ();
     virtual int emit (std::stringstream &out);
-    virtual void reset ();
     virtual int emit_vtx (const std::string &prefix,
                           const f_resource_graph_t &g, const vtx_t &u,
                           unsigned int needs, bool exclusive);

--- a/resource/writers/match_writers.hpp
+++ b/resource/writers/match_writers.hpp
@@ -50,6 +50,7 @@ enum class match_format_t { SIMPLE,
 class match_writers_t {
 public:
     virtual ~match_writers_t () {}
+    virtual bool empty () = 0;
     virtual int emit (std::stringstream &out) = 0;
     virtual void reset () = 0;
     virtual int emit_vtx (const std::string &prefix,
@@ -72,6 +73,7 @@ class sim_match_writers_t : public match_writers_t
 {
 public:
     virtual ~sim_match_writers_t () {}
+    virtual bool empty ();
     virtual int emit (std::stringstream &out);
     virtual void reset ();
     virtual int emit_vtx (const std::string &prefix,
@@ -193,6 +195,7 @@ private:
 class pretty_sim_match_writers_t : public match_writers_t
 {
 public:
+    virtual bool empty ();
     virtual int emit (std::stringstream &out);
     virtual void reset ();
     virtual int emit_vtx (const std::string &prefix,

--- a/resource/writers/match_writers.hpp
+++ b/resource/writers/match_writers.hpp
@@ -59,6 +59,9 @@ public:
                           const f_resource_graph_t &g, const edg_t &e) {
         return 0;
     }
+    virtual int emit_tm (uint64_t starttime, uint64_t expiration) {
+        return 0;
+    }
     void compress (std::stringstream &o, const std::set<int64_t> &ids);
 };
 
@@ -157,8 +160,11 @@ public:
                           unsigned int needs, bool exclusive);
     virtual int emit_edg (const std::string &prefix,
                           const f_resource_graph_t &g, const edg_t &e);
+    virtual int emit_tm (uint64_t start_tm, uint64_t end_tm);
 private:
     rlite_match_writers_t rlite;
+    int64_t m_starttime = 0;
+    int64_t m_expiration = 0;
     jgf_match_writers_t jgf;
 };
 
@@ -174,8 +180,11 @@ public:
     virtual int emit_vtx (const std::string &prefix,
                           const f_resource_graph_t &g, const vtx_t &u,
                           unsigned int needs, bool exclusive);
+    virtual int emit_tm (uint64_t start_tm, uint64_t end_tm);
 private:
     rlite_match_writers_t rlite;
+    int64_t m_starttime = 0;
+    int64_t m_expiration = 0;
 };
 
 

--- a/resource/writers/match_writers.hpp
+++ b/resource/writers/match_writers.hpp
@@ -167,7 +167,8 @@ private:
 class rv1_nosched_match_writers_t : public match_writers_t
 {
 public:
-    virtual void reset ();
+    virtual void reset () { }
+    virtual bool empty ();
     virtual int emit (std::stringstream &out);
     virtual int emit_vtx (const std::string &prefix,
                           const f_resource_graph_t &g, const vtx_t &u,

--- a/resource/writers/match_writers.hpp
+++ b/resource/writers/match_writers.hpp
@@ -84,9 +84,14 @@ private:
 class jgf_match_writers_t : public match_writers_t
 {
 public:
-    virtual ~jgf_match_writers_t () {}
-    virtual void reset ();
-    virtual int emit (std::stringstream &out, bool newline);
+    jgf_match_writers_t ();
+    jgf_match_writers_t (const jgf_match_writers_t &w);
+    jgf_match_writers_t &operator=(const jgf_match_writers_t &w);
+    virtual ~jgf_match_writers_t ();
+
+    virtual void reset () { }
+    virtual bool empty ();
+    int emit_json (json_t **o);
     virtual int emit (std::stringstream &out);
     virtual int emit_vtx (const std::string &prefix,
                           const f_resource_graph_t &g, const vtx_t &u,
@@ -94,8 +99,20 @@ public:
     virtual int emit_edg (const std::string &prefix,
                           const f_resource_graph_t &g, const edg_t &e);
 private:
-    std::stringstream m_vout;
-    std::stringstream m_eout;
+    json_t *emit_vtx_base (const f_resource_graph_t &g, const vtx_t &u,
+                           unsigned int needs, bool exclusive);
+    int emit_vtx_prop (json_t *o, const f_resource_graph_t &g,
+                       const vtx_t &u, unsigned int needs, bool exclusive);
+    int emit_vtx_path (json_t *o, const f_resource_graph_t &g,
+                       const vtx_t &u, unsigned int needs, bool exclusive);
+    int map2json (json_t *o, const std::map<std::string, std::string> &mp,
+                  const char *key);
+    int emit_edg_meta (json_t *o, const f_resource_graph_t &g, const edg_t &e);
+    int alloc_json_arrays ();
+    int check_array_sizes ();
+
+    json_t *m_vout = NULL;
+    json_t *m_eout = NULL;
 };
 
 

--- a/resource/writers/match_writers.hpp
+++ b/resource/writers/match_writers.hpp
@@ -30,6 +30,10 @@
 #include <sstream>
 #include <set>
 
+extern "C" {
+#include <jansson.h>
+}
+
 namespace Flux {
 namespace resource_model {
 
@@ -101,8 +105,13 @@ class rlite_match_writers_t : public match_writers_t
 {
 public:
     rlite_match_writers_t ();
+    rlite_match_writers_t (const rlite_match_writers_t &w);
+    rlite_match_writers_t &operator=(const rlite_match_writers_t &w);
     virtual ~rlite_match_writers_t ();
-    virtual void reset ();
+
+    virtual void reset () { }
+    virtual bool empty ();
+    int emit_json (json_t **o);
     virtual int emit (std::stringstream &out, bool newline);
     virtual int emit (std::stringstream &out);
     virtual int emit_vtx (const std::string &prefix,
@@ -110,9 +119,11 @@ public:
                           unsigned int needs, bool exclusive);
 private:
     bool m_reducer_set ();
+    int emit_gatherer (const f_resource_graph_t &g, const vtx_t &u);
+
     std::map<std::string, std::set<int64_t>> m_reducer;
-    std::map<std::string, std::shared_ptr<std::stringstream>> m_gatherer;
-    std::stringstream m_out;
+    std::set<std::string> m_gatherer;
+    json_t *m_out = NULL;
 };
 
 

--- a/t/t6001-match-formats.t
+++ b/t/t6001-match-formats.t
@@ -54,11 +54,11 @@ test_expect_success "--match-format=rv1_nosched and =rlite works" '
 '
 
 test_expect_success "--match-format=pretty_simple works" '
-    echo "match allocate ${jobspec}" > in8.txt &&
-    echo "quit" >> in8.txt &&
-    ${query} -L ${tiny_grug} -F pretty_simple -d -t o8 < in8.txt &&
-    cat o8 | grep -v "INFO:" > o8.simple &&
-    test -s o8.simple
+    echo "match allocate ${jobspec}" > in9.txt &&
+    echo "quit" >> in9.txt &&
+    ${query} -L ${tiny_grug} -F pretty_simple -d -t o9 < in9.txt &&
+    cat o9 | grep -v "INFO:" > o9.simple &&
+    test -s o9.simple
 '
 
 test_done

--- a/t/t6001-match-formats.t
+++ b/t/t6001-match-formats.t
@@ -61,4 +61,24 @@ test_expect_success "--match-format=pretty_simple works" '
     test -s o9.simple
 '
 
+test_expect_success "rv1 contains starttime and expiration keys" '
+    echo "match allocate ${jobspec}" > in10.txt &&
+    echo "quit" >> in10.txt &&
+    ${query} -L ${tiny_grug} -F rv1_nosched -d -t o10 < in10.txt &&
+    starttime=$(cat o10 | grep -v "INFO:" | jq ".execution.starttime") &&
+    expiration=$(cat o10 | grep -v "INFO:" | jq ".execution.expiration") &&
+    test ${starttime} -eq 0 &&
+    test ${expiration} -eq 3600
+'
+
+test_expect_success "rv1_nosched contains starttime and expiration keys" '
+    echo "match allocate ${jobspec}" > in11.txt &&
+    echo "quit" >> in11.txt &&
+    ${query} -L ${tiny_grug} -F rv1 -d -t o11 < in11.txt &&
+    starttime=$(cat o11 | grep -v "INFO:" | jq ".execution.starttime") &&
+    expiration=$(cat o11 | grep -v "INFO:" | jq ".execution.expiration") &&
+    test ${starttime} -eq 0 &&
+    test ${expiration} -eq 3600
+'
+
 test_done

--- a/t/t6001-match-formats.t
+++ b/t/t6001-match-formats.t
@@ -35,14 +35,6 @@ test_expect_success LONGTEST "Large R emitted with -F jgf validates" '
     flux jsonschemalint -v ${schema} o3.json
 '
 
-test_expect_success LONGTEST "Large R emitted with -F pretty_jgf validates" '
-    echo "match allocate ${jobspec2}" > in4.txt &&
-    echo "quit" >> in4.txt &&
-    ${query} -L ${large_grug} -r 400000 -F pretty_jgf -d -t o4 < in4.txt &&
-    cat o4 | grep -v "INFO:" > o4.json &&
-    flux jsonschemalint -v ${schema} o4.json
-'
-
 test_expect_success "--match-format=rv1 works" '
     echo "match allocate ${jobspec}" > in5.txt &&
     echo "quit" >> in5.txt &&

--- a/t/t6001-match-formats.t
+++ b/t/t6001-match-formats.t
@@ -48,7 +48,7 @@ test_expect_success "--match-format=rv1_nosched and =rlite works" '
     echo "quit" >> in7.txt &&
     ${query} -L ${tiny_grug} -F rv1_nosched -d -t o7 < in7.txt &&
     ${query} -L ${tiny_grug} -F rlite -d -t o8 < in7.txt &&
-    cat o7 | grep -v "INFO:" | jq ".execution" > o7.json &&
+    cat o7 | grep -v "INFO:" | jq ".execution.R_lite" > o7.json &&
     cat o8 | grep -v "INFO:" | jq "" > o8.json &&
     diff o7.json o8.json
 '


### PR DESCRIPTION
This PR reworks the match writers to use Jansson for emitting JSON-based writers.

Currently, the match writers commonly use C++ `std::stringstream` to emit resource set information regardless of emitting formats: i.e., plain-text formats or JSON-based formats alike. For a JSON-based format, however, this approach is becoming increasingly more complex to modify when we change the format.

Use Jansson to emit all of the JSON-based resource set information including `rlite`, `jgf`, `rv1` and `rv1_nosched` formats.

This should address the issues identified from my previous attempt: #613.

Fix #610 and #383.