### PR TITLE
cmd/flux-tree: Remove -j option to kvs put

### DIFF
--- a/src/cmd/flux-tree
+++ b/src/cmd/flux-tree
@@ -224,7 +224,7 @@ rollup() {
             if [[ "x${FT_DRY_RUN}" = "xno" ]]
             then
                 # Put it to KVS parent namespace except when we are at top level
-                flux --parent kvs put -j "tree-perf=${blurb}" || warn "KVS error"
+                flux --parent kvs put --raw "tree-perf=-" <<< "${blurb}" || warn "KVS error"
             fi
         fi
     fi


### PR DESCRIPTION
Option has been removed in flux-core issue #2796 (PR https://github.com/flux-framework/flux-core/pull/2807)

Credit to @SteVwonder for patch.