### PR TITLE
testsuite: break a race in a qmgr reload test

### DIFF
--- a/t/t1002-qmanager-reload.t
+++ b/t/t1002-qmanager-reload.t
@@ -29,7 +29,7 @@ submit_jobs()   {
 }
 
 test_expect_success 'qmanager: generate jobspec for a simple test job' '
-    flux jobspec srun -n1 -t 1 hostname | exec_test > basic.json
+    flux jobspec srun -n1 -t 100 hostname | exec_test > basic.json
 '
 
 test_expect_success 'qmanager: hwloc reload works' '


### PR DESCRIPTION
Problem: A qmanager reload test is randomly
failing in Travis CI, which tests jobs in
the job-manager queue aren't lost during
the reload. This test enqueues a few jobs
and removes/reloads qmanager before checking
if those jobs are still in the queue.
But because this test only gives
1 second walltime for those jobs, there is
a chance that a job can complete before
the reload is done.

Use 100 seconds as the walltime for
those jobs to break those jobs "effectively".