### PR TITLE
rc: use reload -f to load qmanager/resource

### DIFF
--- a/etc/qmanager-start
+++ b/etc/qmanager-start
@@ -10,9 +10,16 @@
 # Finally, if FLUX_QMANAGER_RC_NOOP=1, flux-core
 # won't load in or remove qmanager as part of runlevel 1 and 3.
 #
+# Note that we use "flux reload -f qmanager" instead of "flux load qmanager"
+# to ease our testing.
+# Without this, some of the in-tree tests can fail when flux-sched is already
+# installed with flux-core. These installed rc1 scripts are
+# executed first and disallow the "in-tree" modules from loading.
+# We now use "flux reload -f qmanager" so that when these failing tests
+# load it via FLUX_RC_EXTRA, the in-tree version can be loaded.
 
 if [ -z ${FLUX_QMANAGER_RC_NOOP} ]; then
-    flux module remove sched-simple
-    flux module load qmanager ${FLUX_QMANAGER_OPTIONS}
+    flux module remove -f sched-simple
+    flux module reload -f qmanager ${FLUX_QMANAGER_OPTIONS}
 fi
 

--- a/etc/resource-start
+++ b/etc/resource-start
@@ -10,9 +10,16 @@
 # Finally, if FLUX_RESOURCE_RC_NOOP=1, flux-core
 # won't load in or remove resource as part of runlevel 1 and 3.
 #
+# Note that we use "flux reload -f resource" instead of "flux load resource"
+# to ease our testing.
+# Without this, some of the in-tree tests can fail when flux-sched is already
+# installed with flux-core. These installed rc1 scripts are
+# executed first and disallow the "in-tree" modules from loading.
+# We now use "flux reload -f resource" so that when these failing tests
+# load it via FLUX_RC_EXTRA, the in-tree version can be loaded.
 
 if [ -z ${FLUX_RESOURCE_RC_NOOP} ]; then
     FLUX_RESOURCE_OPTIONS=${FLUX_RESOURCE_OPTIONS:-"load-whitelist=node,core,gpu"}
-    flux module load resource ${FLUX_RESOURCE_OPTIONS}
+    flux module reload -f resource ${FLUX_RESOURCE_OPTIONS}
 fi
 

--- a/t/t1005-qmanager-conf.t
+++ b/t/t1005-qmanager-conf.t
@@ -24,7 +24,9 @@ conf_base=${SHARNESS_TEST_SRCDIR}/conf.d
 test_expect_success 'qmanager: load qmanager works with valid qmanager.toml' '
     conf_name="01-default" &&
     export FLUX_CONF_DIR=${conf_base}/${conf_name} &&
-    flux broker flux dmesg > ${conf_name}.out &&
+    flux broker bash -c \
+"flux dmesg -C && flux module reload -f qmanager && "\
+"flux dmesg" > ${conf_name}.out &&
     p=$(cat ${conf_name}.out | grep "enforced policy" | awk "{ print \$5}") &&
     qp=$(cat ${conf_name}.out | grep "queue params" | awk "{ print \$6}") &&
     pp=$(cat ${conf_name}.out | grep "policy params" | awk "{ print \$6}") &&
@@ -34,35 +36,28 @@ test_expect_success 'qmanager: load qmanager works with valid qmanager.toml' '
     unset FLUX_CONF_DIR
 '
 
-set_rc1_option() {
-    local s="queue-policy=easy queue-params=max-queue-depth=20000 "\
-"policy-params=max-reservation-depth=64"
-    export FLUX_QMANAGER_OPTIONS="${s}"
-}
-
-unset_rc1_option() {
-    unset FLUX_QMANAGER_OPTIONS
-}
-
 test_expect_success 'qmanager: module load options takes precedence' '
     conf_name="01-default" &&
     export FLUX_CONF_DIR=${conf_base}/${conf_name} &&
-    set_rc1_option &&
-    flux broker flux dmesg > ${conf_name}2.out &&
+    flux broker bash -c \
+"flux dmesg -C && flux module reload -f qmanager "\
+"queue-policy=easy queue-params=max-queue-depth=20000 "\
+"policy-params=max-reservation-depth=64 && flux dmesg" > ${conf_name}2.out &&
     p=$(cat ${conf_name}2.out | grep "enforced policy" | awk "{ print \$5}") &&
     qp=$(cat ${conf_name}2.out | grep "queue params" | awk "{ print \$6}") &&
     pp=$(cat ${conf_name}2.out | grep "policy params" | awk "{ print \$6}") &&
     test "${p}" = "easy" &&
     test "${qp}" = "max-queue-depth=20000,queue-depth=8192" &&
     test "${pp}" = "max-reservation-depth=64,reservation-depth=64" &&
-    unset_rc1_option &&
     unset FLUX_CONF_DIR
 '
 
 test_expect_success 'qmanager: load qmanager works with no keys' '
     conf_name="02-no-keys" &&
     export FLUX_CONF_DIR=${conf_base}/${conf_name} &&
-    flux broker flux dmesg > ${conf_name}.out &&
+    flux broker bash -c \
+"flux dmesg -C && flux module reload -f qmanager && flux dmesg" \
+> ${conf_name}.out &&
     qp=$(cat ${conf_name}.out | grep "queue params" | awk "{ print \$6}") &&
     pp=$(cat ${conf_name}.out | grep "policy params" | awk "{ print \$6}") &&
     test "${qp}" = "default" &&
@@ -73,7 +68,9 @@ test_expect_success 'qmanager: load qmanager works with no keys' '
 test_expect_success 'qmanager: load qmanager works with extra keys' '
     conf_name="03-extra-keys" &&
     export FLUX_CONF_DIR=${conf_base}/${conf_name} &&
-    flux broker flux dmesg > ${conf_name}.out &&
+    flux broker bash -c \
+"flux dmesg -C && flux module reload -f qmanager && flux dmesg" \
+> ${conf_name}.out &&
     qp=$(cat ${conf_name}.out | grep "queue params" | awk "{ print \$6}") &&
     pp=$(cat ${conf_name}.out | grep "policy params" | awk "{ print \$6}") &&
     test "${qp}" = "queue-depth=8192,max-queue-depth=1000000" &&
@@ -84,7 +81,9 @@ test_expect_success 'qmanager: load qmanager works with extra keys' '
 test_expect_success 'qmanager: load works with no reservation-depth key' '
     conf_name="04-conservative" &&
     export FLUX_CONF_DIR=${conf_base}/${conf_name} &&
-    flux broker flux dmesg > ${conf_name}.out &&
+    flux broker bash -c \
+"flux dmesg -C && flux module reload -f qmanager && flux dmesg" \
+> ${conf_name}.out &&
     p=$(cat ${conf_name}.out | grep "enforced policy" | awk "{ print \$5}") &&
     qp=$(cat ${conf_name}.out | grep "queue params" | awk "{ print \$6}") &&
     pp=$(cat ${conf_name}.out | grep "policy params" | awk "{ print \$6}") &&
@@ -97,7 +96,9 @@ test_expect_success 'qmanager: load works with no reservation-depth key' '
 test_expect_success 'qmanager: load works with small queue-depth' '
     conf_name="05-small-queue-depth" &&
     export FLUX_CONF_DIR=${conf_base}/${conf_name} &&
-    flux broker flux dmesg > ${conf_name}.out &&
+    flux broker bash -c \
+"flux dmesg -C &&  flux module reload -f qmanager && flux dmesg" \
+> ${conf_name}.out &&
     qp=$(cat ${conf_name}.out | grep "queue params" | awk "{ print \$6}") &&
     pp=$(cat ${conf_name}.out | grep "policy params" | awk "{ print \$6}") &&
     test "${qp}" = "queue-depth=10,max-queue-depth=1000" &&
@@ -108,7 +109,9 @@ test_expect_success 'qmanager: load works with small queue-depth' '
 test_expect_success 'qmanager: load works with hybrid params 1' '
     conf_name="06-hybrid" &&
     export FLUX_CONF_DIR=${conf_base}/${conf_name} &&
-    flux broker flux dmesg > ${conf_name}.out &&
+    flux broker bash -c \
+"flux dmesg -C && flux module reload -f qmanager && flux dmesg" \
+> ${conf_name}.out &&
     qp=$(cat ${conf_name}.out | grep "queue params" | awk "{ print \$6}") &&
     pp=$(cat ${conf_name}.out | grep "policy params" | awk "{ print \$6}") &&
     test "${qp}" = "queue-depth=8192,max-queue-depth=1000000" &&
@@ -119,7 +122,9 @@ test_expect_success 'qmanager: load works with hybrid params 1' '
 test_expect_success 'qmanager: load works with hybrid params 2' '
     conf_name="07-hybrid2" &&
     export FLUX_CONF_DIR=${conf_base}/${conf_name} &&
-    flux broker flux dmesg > ${conf_name}.out &&
+    flux broker bash -c \
+"flux dmesg -C && flux module reload -f qmanager && flux dmesg" \
+> ${conf_name}.out &&
     qp=$(cat ${conf_name}.out | grep "queue params" | awk "{ print \$6}") &&
     pp=$(cat ${conf_name}.out | grep "policy params" | awk "{ print \$6}") &&
     test "${qp}" = "queue-depth=8192,max-queue-depth=1000000" &&
@@ -130,7 +135,9 @@ test_expect_success 'qmanager: load works with hybrid params 2' '
 test_expect_success 'qmanager: load works with no queue-depth key' '
     conf_name="08-no-queue-depth" &&
     export FLUX_CONF_DIR=${conf_base}/${conf_name} &&
-    flux broker flux dmesg > ${conf_name}.out &&
+    flux broker bash -c \
+"flux dmesg -C && flux module reload -f qmanager && flux dmesg" \
+> ${conf_name}.out &&
     qp=$(cat ${conf_name}.out | grep "queue params" | awk "{ print \$6}") &&
     pp=$(cat ${conf_name}.out | grep "policy params" | awk "{ print \$6}") &&
     test "${qp}" = "max-queue-depth=1000" &&
@@ -178,7 +185,9 @@ test_expect_success 'qmanager: load must fail on no queue-params category' '
 test_expect_success 'qmanager: load succeeds on no qmanager category' '
     conf_name="15-no-qmanager" &&
     export FLUX_CONF_DIR=${conf_base}/${conf_name} &&
-    flux broker flux dmesg > ${conf_name}.out &&
+    flux broker bash -c \
+"flux dmesg -C &&  flux module reload -f qmanager && flux dmesg" \
+> ${conf_name}.out &&
     qp=$(cat ${conf_name}.out | grep "queue params" | awk "{ print \$6}") &&
     pp=$(cat ${conf_name}.out | grep "policy params" | awk "{ print \$6}") &&
     test "${qp}" = "queue-depth=8192,max-queue-depth=1000000" &&


### PR DESCRIPTION
This PR changes the behavior of the rc1 scripts of flux-sched modules. 

Currently, some of the in-tree tests are failing when flux-sched is  already installed within flux-core. Their rc1 scripts are executed and load those "installed" modules instead of "in-tree" modules.

Use "flux reload -f <qmanager|resource>" so that when these failing tests load them via the FLUX_RC_EXTRA environment variable, the in-tree versions are loaded.

Discussed at https://github.com/flux-framework/flux-core/issues/2788#issuecomment-593131902. 

Fix #607 and #604 .