### PR TITLE
Flux tree helper

### DIFF
--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -1,2 +1,3 @@
 dist_fluxcmd_SCRIPTS = \
-    flux-tree
+	flux-tree \
+	flux-tree-helper.py

--- a/src/cmd/flux-tree
+++ b/src/cmd/flux-tree
@@ -165,11 +165,11 @@ Options:\n\
                                    (default=${FT_NJOBS})\n\
  -o, --perf-out=FILENAME       Dump the performance data into\n\
                                    the given file (default: don't print)\n\
- --perf-format=FORMAT          Dump the performance data with the given\n\
+     --perf-format=FORMAT      Dump the performance data with the given\n\
                                    format. Uses the python format\n\
                                    specification mini-language.\n\
                                    Example: \"{treeid:<15s},{elapse:>20f}\"\n\
- --job-name=NAME               Name to use when submitting child jobs\n\
+     --job-name=NAME           Name to use when submitting child jobs\n\
      --                        Stop parsing options after this\n\
 "
 

--- a/src/cmd/flux-tree
+++ b/src/cmd/flux-tree
@@ -33,6 +33,9 @@ FT_QUEUE='default'             # store arg to --queue-policy (e.g., fcfs:easy)
 FT_PARAMS='default'            # store arg to --queue-params
 FT_MATCH='default'             # store arg to --match-policy (e.g., low:high)
 FT_PERF_OUT='%^+_no'           # store perf-out filename given by --perf-out
+FT_PERF_FORMAT='{treeid:<15s} {elapse:>20f} {begin:>20f} {end:>20f} {match:>15f} '\
+'{njobs:>15d} {my_nodes:>5d} {my_cores:>4d} {my_gpus:>4d}'
+                               # store perf-out with format given by --perf-format
 FT_FXLOGS='%^+_no'             # dir in which flux logs are produced
 FT_LEAF='no'                   # is this a leaf instance (given by --leaf)?
 FT_G_PREFIX='tree'             # store hierarchical path given by --prefix
@@ -56,10 +59,6 @@ declare -r top_prefix='tree'   # prefix name to identify the top Flux instance
 declare -r t_delim='x'         # topology delimiter
 declare -r p_delim=':'         # match policy delimiter
 declare -r perf_format='%-15s %20s %20s %20s %15s %15s %5s %4s %4s'
-declare -r perf_keys=' .treeid, .perf.elapse, .perf.begin, .perf.end,'\
-' .perf.match, .njobs, .my_nodes, .my_cores, .my_gpus '
-declare -r perf_heading=' TreeID Elapse(sec) Begin(Epoch) End(Epoch) Match(usec)'\
-' NJobs NNodes CPN GPN '
 declare -A mp_policies=(       # make sure to update this when match
     [low]=1                    # policies are updated.
     [high]=1
@@ -83,7 +82,7 @@ declare -a jobids             # array to store a set of submitted job IDs
 
 declare -r long_opts='help,leaf,flux-logs:,nnodes:,ncores-per-node:'\
 ',ngpus-per-node:,topology:,queue-policy:,queue-params:,match-policy:'\
-',njobs:,perf-out:,prefix:,dry-run'
+',njobs:,perf-out:,perf-format:,prefix:,dry-run'
 
 declare -r short_opts='hlf:N:c:g:T:Q:P:M:J:o:X:d'
 declare -r prog=${0##*/}
@@ -165,42 +164,16 @@ Options:\n\
                                    (default=${FT_NJOBS})\n\
  -o, --perf-out=FILENAME       Dump the performance data into\n\
                                    the given file (default: don't print)\n\
+ --perf-format=FORMAT          Dump the performance data with the given\n\
+                                   format. Uses the python format\n\
+                                   specification mini-language.\n\
+                                   Example: \"{treeid:<15s},{elapse:>20f}\"\n\
      --                        Stop parsing options after this\n\
 "
 
 die() { echo -e "${prog}:" "$@"; exit 1; }
 warn() { echo -e "${prog}: warning:" "$@"; }
 dr_print() { echo -e "${prog}: dry-run:" "$@"; }
-
-#
-# Write the performance data into the given file.  Should be called
-# by the upper layer when the performance data record for each and every
-# Flux instance has been aggregated. Then, this is recursively invoked.
-#
-dump_perf() {
-    local blurb="${1}"
-    local out="${2}"
-
-    [[ "x${blurb}" = "x" ]] && die "empty json"
-
-    # Parse perf json for the given level into a record
-    local tuple=''
-    local length=0
-    tuple=$(echo "${blurb}" | jq "${perf_keys}") || die "invalid json"
-    length=$(echo "${blurb}" | jq ' .child | length ') || die "invalid json"
-
-    # Print the record for this level Didn't quote $tuple to remove new lines
-    printf "${perf_format}\n" ${tuple} >> "${out}"
-
-    # Recurse down to parse the record for each child Flux instance
-    for i in $(seq 0 $(( length - 1 )))
-    do
-        local new_o=''
-        new_o=$(echo "${blurb}" | jq " .child[${i}] ")
-        dump_perf "${new_o}" "${out}"
-    done
-}
-
 
 #
 # Roll up the performance records for each Flux instance to the KVS
@@ -210,23 +183,14 @@ rollup() {
     local prefix="${1}"
     local blurb="${2}"
     local out="${3}"
+    local num_children="${4}"
+    local format="${5}"
 
-    if [[ "${out}" != "%^+_no" ]]
-    then
-        # If output filename is given (e.g., top-level), dump the data
-        # to the file. Didn't quote $perf_heanding on purpose below.
-        rm -f "${out}"
-        printf "${perf_format}\n" ${perf_heading} > "${out}"
-        dump_perf "${blurb}" "${out}"
+    if [[ "${prefix}" == "${top_prefix}" &&  "${out}" != "%^+_no" ]]; then
+        flux tree-helper --perf-out="${out}" --perf-format="${format}" \
+             ${num_children} "tree-perf" <<< "${blurb}"
     else
-        if [[ "${prefix}" != "${top_prefix}" ]]
-        then
-            if [[ "x${FT_DRY_RUN}" = "xno" ]]
-            then
-                # Put it to KVS parent namespace except when we are at top level
-                flux --parent kvs put --raw "tree-perf=-" <<< "${blurb}" || warn "KVS error"
-            fi
-        fi
+        flux tree-helper ${num_children} "tree-perf" <<< "${blurb}"
     fi
 }
 
@@ -563,6 +527,7 @@ leaf() {
     local njobs="${5}"
     local cl="${6}"
     local perfout="${7}"
+    local format="${8}"
 
     # Begin Time Stamp
     local B=''
@@ -578,7 +543,7 @@ leaf() {
 
     o=$(jsonify "${prefix}" "${njobs}" "${nnodes}" "${ncores}" \
 "${ngpus}" "${B}" "${E}")
-    rollup "${prefix}" "${o}" "${perfout}"
+    rollup "${prefix}" "${o}" "${perfout}" "0" "${format}"
 }
 
 
@@ -605,8 +570,9 @@ rollup_exit_code() {
 }
 
 #
-# Submit the specified number of Flux instances at the next level
-# of the calling instance. Use flux-tree recursively.
+# Submit the specified number of Flux instances at the next level of the calling
+# instance. Use flux-tree recursively. Instances that have 0 jobs assigned are
+# not launched.
 #
 submit() {
     local prefix="${1}"
@@ -700,23 +666,15 @@ coll_perf() {
     local begin="${6}"
     local end="${7}"
     local perfout="${8}"
+    local nchildren="${9}"
+    local format="${10}"
 
     #
     # Make a JSON string from the performance data
     #
     local blurb=''
     blurb=$(jsonify "${prefix}" "${njobs}" "${nnodes}" "${ncores}" "${ngpus}" "${begin}" "${end}")
-    local child=''
-    local rank=0
-
-    for rank in $(seq 1 "${njobs}");
-    do
-        [[ "x${jobids[${rank}]}" = "x" || "x${FT_DRY_RUN}" = "xyes" ]] && break
-        child=$(flux job info ${jobids[${rank}]} guest.tree-perf)
-        blurb=$(echo "${blurb}" | jq " .child += [${child}]")
-    done
-
-    rollup "${prefix}" "${blurb}" "${perfout}"
+    rollup "${prefix}" "${blurb}" "${perfout}" "${nchildren}" "${format}"
 }
 
 
@@ -732,6 +690,7 @@ internal() {
     local ngpus="${8}"
     local njobs="${10}"
     local perfout="${13}"
+    local format="${14}"
 
     # Begin Time Stamp
     local B=''
@@ -743,8 +702,13 @@ internal() {
     local E=''
     E=$(date +%s.%N)
 
+    if [[ "x${FT_DRY_RUN}" = "xyes" ]]; then
+        nchildren=0
+    else
+        nchildren=${#jobids[@]}
+    fi
     coll_perf "${prefix}" "${nnodes}" "${ncores}" "${ngpus}" \
-"${njobs}" "${B}" "${E}" "${perfout}"
+"${njobs}" "${B}" "${E}" "${perfout}" "${nchildren}" "${format}"
 }
 
 
@@ -768,6 +732,7 @@ main() {
     local cl="${11}"           # jobscript commandline
     local flogs="${12}"        # flux log output option
     local out="${13}"          # perf output filename
+    local format="${14}"      # perf output format
     local size=0
 
     if [[ ${leaf} = "yes" ]]
@@ -778,7 +743,7 @@ main() {
         # be executed on the last-level Flux instance. 
         #
         leaf "${prefix}" "${nnodes}" "${ncores}" "${ngpus}" "${njobs}" \
-             "${cl}" "${out}"
+             "${cl}" "${out}" "${format}"
     else
         #
         # flux-tree is invoked to instantate ${size} internal Flux instances
@@ -787,7 +752,7 @@ main() {
         size=${topo%%${t_delim}*}
         internal "${prefix}" "${topo}" "${queue}" "${param}" "${match}" \
                  "${nnodes}" "${ncores}" "${ngpus}" "${size}" "${njobs}" \
-                 "${cl}" "${flogs}" "${out}"
+                 "${cl}" "${flogs}" "${out}" "${format}"
     fi
 
     exit ${FT_MAX_EXIT_CODE}
@@ -819,6 +784,7 @@ while true; do
       -M|--match-policy)           FT_MATCH="${2}"; FT_INTER="yes";    shift 2 ;;
       -J|--njobs)                  FT_NJOBS=${2};                shift 2 ;;
       -o|--perf-out)               FT_PERF_OUT="${2}";           shift 2 ;;
+      --perf-format)               FT_PERF_FORMAT="${2}";        shift 2 ;;
       -X|--prefix)                 FT_G_PREFIX="${2}";           shift 2 ;;
       --)                          shift; break;                         ;;
       *)                           die "Invalid option '${1}'\n${usage}" ;;
@@ -858,7 +824,7 @@ fi
 
 main "${FT_LEAF}" "${FT_G_PREFIX}" "${FT_TOPO}" "${FT_QUEUE}" "${FT_PARAMS}" \
      "${FT_MATCH}" "${FT_NNODES}" "${FT_NCORES}" "${FT_NGPUS}" "${FT_NJOBS}" \
-     "${FT_CL}" "${FT_FXLOGS}" "${FT_PERF_OUT}"
+     "${FT_CL}" "${FT_FXLOGS}" "${FT_PERF_OUT}" "${FT_PERF_FORMAT}"
 
 #
 # vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/cmd/flux-tree
+++ b/src/cmd/flux-tree
@@ -46,7 +46,8 @@ FT_MAX_FLUX_JOBID=0            # maximum flux jobid that reports max exit code
 FT_MAX_TREE_ID=""              # FLUX_TREE_ID that reports max exit code
 FT_MAX_JOBSCRIPT_IX=""         # FLUX_TREE_JOBSCRIPT_INDEX reporting max code
                                # --prefix is an internal-use-only option
-ORIG_FLUX_QMANAGER_OPTIONS=''  # 
+FT_JOB_NAME='%^+_no'           # job name to use when submitting children
+ORIG_FLUX_QMANAGER_OPTIONS=''  #
 ORIG_FLUX_RESOURCE_OPTIONS=''  # to apply and unapply QMANAGER and RESOURCE
 ORIG_FLUX_QMANAGER_RC_NOOP=''  # module load options.
 ORIG_FLUX_RESOURCE_RC_NOOP=''  #
@@ -82,7 +83,7 @@ declare -a jobids             # array to store a set of submitted job IDs
 
 declare -r long_opts='help,leaf,flux-logs:,nnodes:,ncores-per-node:'\
 ',ngpus-per-node:,topology:,queue-policy:,queue-params:,match-policy:'\
-',njobs:,perf-out:,perf-format:,prefix:,dry-run'
+',njobs:,perf-out:,perf-format:,prefix:,job-name:,dry-run'
 
 declare -r short_opts='hlf:N:c:g:T:Q:P:M:J:o:X:d'
 declare -r prog=${0##*/}
@@ -168,6 +169,7 @@ Options:\n\
                                    format. Uses the python format\n\
                                    specification mini-language.\n\
                                    Example: \"{treeid:<15s},{elapse:>20f}\"\n\
+ --job-name=NAME               Name to use when submitting child jobs\n\
      --                        Stop parsing options after this\n\
 "
 
@@ -188,9 +190,10 @@ rollup() {
 
     if [[ "${prefix}" == "${top_prefix}" &&  "${out}" != "%^+_no" ]]; then
         flux tree-helper --perf-out="${out}" --perf-format="${format}" \
-             ${num_children} "tree-perf" <<< "${blurb}"
+             ${num_children} "tree-perf" "${FT_JOB_NAME}" <<< "${blurb}"
     else
-        flux tree-helper ${num_children} "tree-perf" <<< "${blurb}"
+        flux tree-helper ${num_children} "tree-perf" "${FT_JOB_NAME}" \
+             <<< "${blurb}"
     fi
 }
 
@@ -641,8 +644,9 @@ submit() {
             continue
         fi
         jobid=$(\
-flux mini submit -N${N} -n${N} -c${c} ${G} flux start ${o} \
-flux tree -N${N} -c${c} ${G} ${T} ${Q} ${P} ${M} ${F} ${X} ${J} -- ${S})
+flux mini submit --job-name=${FT_JOB_NAME} -N${N} -n${N} -c${c} ${G} \
+     flux start ${o} \
+     flux tree -N${N} -c${c} ${G} ${T} ${Q} ${P} ${M} ${F} ${X} ${J} -- ${S})
         jobids["${rank}"]="${jobid}"
     done
 
@@ -786,6 +790,7 @@ while true; do
       -o|--perf-out)               FT_PERF_OUT="${2}";           shift 2 ;;
       --perf-format)               FT_PERF_FORMAT="${2}";        shift 2 ;;
       -X|--prefix)                 FT_G_PREFIX="${2}";           shift 2 ;;
+      --job-name)                  FT_JOB_NAME="${2}";           shift 2 ;;
       --)                          shift; break;                         ;;
       *)                           die "Invalid option '${1}'\n${usage}" ;;
     esac
@@ -813,6 +818,15 @@ qparams_check "${FT_PARAMS}" || die "invalid queue params!"
 if [[ "${FT_INTER}" = "yes" && "${FT_LEAF}" = "yes" ]]
 then
     die "--leaf must not be used together with internal tree-node options!"
+fi
+
+# if the user did not set a name, then use a partially random string to prevent
+# conflicts with other flux-tree instances during performance data collection
+# via flux-tree-helper
+if [[ "$FT_JOB_NAME" == '%^+_no' ]]; then
+    # code copied from:
+    # https://unix.stackexchange.com/questions/230673/how-to-generate-a-random-string
+    FT_JOB_NAME="flux-tree-$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32)"
 fi
 
 

--- a/src/cmd/flux-tree-helper.py
+++ b/src/cmd/flux-tree-helper.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+
+##############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+import os
+import sys
+import time
+import json
+import argparse
+import logging
+
+import flux
+import flux.util
+import flux.kvs
+import flux.job
+
+logger = logging.getLogger("flux-tree-helper")
+
+
+def get_child_jobids(flux_handle, num_children):
+    """
+    Get the jobids of num_children instances.  Will repeatedly query the
+    job-info module until num_children jobids are collected, with sleeps
+    inbetween queries.
+    """
+    jobids = set()
+    since = 0.0
+    logger.debug("Getting inactive children's IDs")
+    while True:
+        for job in flux.job.job_list_inactive(
+            flux_handle, max_entries=num_children, since=since, attrs=["t_inactive"]
+        ).get_jobs():
+            jobid = job["id"]
+            since = max(since, job["t_inactive"])
+            jobids.add(jobid)
+        if len(jobids) >= num_children:
+            break
+        logger.debug(
+            "Only %d out of %d children are inactive, sleeping before trying again",
+            len(jobids),
+            num_children,
+        )
+        time.sleep(1)
+    return jobids
+
+
+def get_this_instance_data():
+    data = json.load(sys.stdin)
+    return data
+
+
+def get_child_data(flux_handle, num_children, kvs_key):
+    child_data = []
+    jobids = get_child_jobids(flux_handle, num_children)
+    for jobid in jobids:
+        kvs_dir = flux.job.job_kvs_guest(flux_handle, jobid)
+        child_data.append(kvs_dir[kvs_key])
+    return child_data
+
+
+def combine_data(this_instance_data, child_data):
+    this_instance_data["child"] = child_data
+    return this_instance_data
+
+
+class PerfOutputFormat(flux.util.OutputFormat):
+    """
+    Store a parsed version of the program's output format,
+    allowing the fields to iterated without modifiers, building
+    a new format suitable for headers display, etc...
+    """
+
+    #  List of legal format fields and their header names
+    headings = dict(
+        treeid="TreeID",
+        elapse="Elapsed(sec)",
+        begin="Begin(Epoch)",
+        end="End(Epoch)",
+        match="Match(usec)",
+        njobs="NJobs",
+        my_nodes="NNodes",
+        my_cores="CPN",
+        my_gpus="GPN",
+    )
+
+    def __init__(self, fmt):
+        """
+        Parse the input format fmt with string.Formatter.
+        Save off the fields and list of format tokens for later use,
+        (converting None to "" in the process)
+
+        Throws an exception if any format fields do not match the allowed
+        list of headings above.
+        """
+        super().__init__(PerfOutputFormat.headings, fmt)
+
+
+def write_data_to_file(output_filename, output_format, data):
+    def json_traverser(data):
+        fieldnames = PerfOutputFormat.headings.keys()
+        output = {k: v for k, v in data.items() if k in fieldnames}
+        output.update(data["perf"])
+        yield output
+        for child in data["child"]:
+            yield from json_traverser(child)
+
+    formatter = PerfOutputFormat(output_format)
+    with open(output_filename, "w") as outfile:
+        header = formatter.header() + "\n"
+        outfile.write(header)
+        fmt = formatter.get_format() + "\n"
+        for data_row in json_traverser(data):
+            # newline = formatter.format(data_row)
+            newline = fmt.format(**data_row)
+            outfile.write(newline)
+
+
+def write_data_to_parent(flux_handle, kvs_key, data):
+    try:
+        parent_uri = flux_handle.flux_attr_get("parent-uri")
+    except FileNotFoundError:
+        return
+    parent_handle = flux.Flux(parent_uri)
+
+    try:
+        parent_kvs_namespace = flux_handle.flux_attr_get("parent-kvs-namespace").decode(
+            "utf-8"
+        )
+    except FileNotFoundError:
+        return
+    env_name = "FLUX_KVS_NAMESPACE"
+    os.environ[env_name] = parent_kvs_namespace
+
+    flux.kvs.put(parent_handle, kvs_key, data)
+    flux.kvs.commit(parent_handle)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog="flux-tree-helper", formatter_class=flux.util.help_formatter()
+    )
+    parser.add_argument(
+        "num_children",
+        type=int,
+        help="number of children to collect data from.  Should be 0 at leaves.",
+    )
+    parser.add_argument(
+        "kvs_key", type=str, help="key to use when propagating data up through the tree"
+    )
+    parser.add_argument(
+        "--perf-out",
+        type=str,
+        help="Dump the performance data into the given file. Assumed to be given at the root instance.",
+    )
+    parser.add_argument(
+        "--perf-format",
+        type=str,
+        help="Dump the performance data with the given format string.",
+    )
+    return parser.parse_args()
+
+
+@flux.util.CLIMain(logger)
+def main():
+    args = parse_args()
+    flux_handle = flux.Flux()
+
+    logger.debug("Getting this instance's data")
+    this_data = get_this_instance_data()
+    if args.num_children > 0:
+        logger.debug("Getting children's data")
+        child_data = get_child_data(flux_handle, args.num_children, args.kvs_key)
+    else:
+        child_data = []
+    logger.debug("Combining data")
+    combined_data = combine_data(this_data, child_data)
+    logger.debug("Writing data to parent's KVS")
+    write_data_to_parent(flux_handle, args.kvs_key, combined_data)
+    if args.perf_out:
+        logger.debug("Writing data to file")
+        write_data_to_file(args.perf_out, args.perf_format, combined_data)
+
+
+if __name__ == "__main__":
+    main()

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -75,6 +75,7 @@ test_under_flux() {
     fi
     if test "$debug" = "t" -o -n "$FLUX_TESTS_DEBUG" ; then
         flags="${flags} --debug"
+        export FLUX_PYCLI_LOGLEVEL=10
     fi
     if test "$chain_lint" = "t"; then
         flags="${flags} --chain-lint"

--- a/t/t2000-tree-basic.t
+++ b/t/t2000-tree-basic.t
@@ -301,6 +301,17 @@ test_expect_success 'flux-tree: --perf-out generates a perf output file' '
     test ${wcount} -eq 18
 '
 
+test_expect_success 'flux-tree: --perf-format works with custom format' '
+    flux tree --dry-run -T 2 -N 2 -c 4 -J 2 -o perf.out \
+         --perf-format="{treeid}\ {elapse:f}\ {my_nodes:d}" \
+         /bin/hostname &&
+    test -f perf.out &&
+    lcount=$(wc -l perf.out | awk "{print \$1}") &&
+    test ${lcount} -eq 2 && 
+    wcount=$(wc -w perf.out | awk "{print \$1}") &&
+    test ${wcount} -eq 6
+'
+
 test_expect_success 'flux-tree: -T4x2 on 4 nodes/4 cores work' '
     cat >cmp.11 <<-EOF &&
 	FLUX_QMANAGER_OPTIONS:

--- a/t/t2000-tree-basic.t
+++ b/t/t2000-tree-basic.t
@@ -739,6 +739,29 @@ EOF
     test_cmp cmp.23 out.23
 '
 
+PERF_FORMAT="{treeid}"
+PERF_BLOB='{"treeid":"tree", "perf": {}}'
+JOB_NAME="foobar"
+test_expect_success 'flux-tree: successfully runs alongside other jobs' '
+    flux tree -T 1 -N 1 -c 1 -J 1 -o p.out5 --perf-format="$PERF_FORMAT" \
+         --job-name="${JOB_NAME}" -- hostname &&
+    flux mini run -N1 -c1 hostname &&
+    echo "$PERF_BLOB" | run_timeout 5 flux tree-helper --perf-out=p.out6 \
+         --perf-format="$PERF_FORMAT" 1 "tree-perf" "${JOB_NAME}" &&
+    test_cmp p.out5 p.out6
+'
+
+JOB_NAME="foobar2"
+test_expect_success 'flux-tree: successfully runs alongside other flux-trees' '
+    run_timeout 20 \
+    flux tree -T 1x1 -N 1 -c 1 -J 1 -o p.out7 --perf-format="$PERF_FORMAT" \
+         --job-name="${JOB_NAME}" -- hostname &&
+    flux tree -T 1 -N 1 -c 1 -J 1 -- hostname &&
+    echo "$PERF_BLOB" | run_timeout 5 flux tree-helper --perf-out=p.out8 \
+         --perf-format="$PERF_FORMAT" 1 "tree-perf" "${JOB_NAME}" &&
+    test_cmp p.out7 p.out8
+'
+
 test_expect_success 'flux-tree: removing qmanager/resource works' '
      flux module remove resource &&
      flux module remove qmanager


### PR DESCRIPTION
Problem: constructing and manipulating JSON blobs via the command line
has a high overhead and quickly exceeds the limit for command line
argument length set in the linux kernel.

Solution: Add a helper written in python that performs the same
action but using python's standard library utilities and the flux python
bindings.  This reduces the number of processes launched, eliminates the
need for using command line arguments to pass JSON blobs between
programs, and reduces the total number of times the JSON needs to
be (de-)serialized.

Results:
Before the helper, for a tree topology of 32x36, the perf
results record a runtime of 45 seconds, but the `time` utility used on
the flux-tree command directly reports a runtime of 3 minutes 45
seconds.  After the introduction of the helper, for the same tree
topology, the perf results record a runtime of 34 seconds, and the
`time` utility reports a runtime of 47 seconds.  So the helper not only
speeds up the post-processing time, but it also has a measurable impact
on the reported results as well.

Before the helper, for a tree topology of 1x32x36, the root instance in
the tree topology (i.e., not the instance that flux-tree is directly run
inside of), would hit the linux kernel limit for command line argument
length whilst processing the JSON performance data. This would cause the
script to error out when collecting performance results and fails to
write any performance data out to the filesystem. After the helper, the
same tree topology runs to completion, successfully saves out the
performance data, and does so with a total runtime (as reported by
`time`) of 53 seconds.

Depends on https://github.com/flux-framework/flux-core/pull/2804
