### PR TITLE
flux-tree: add rundir support

### DIFF
--- a/src/cmd/flux-tree
+++ b/src/cmd/flux-tree
@@ -37,6 +37,7 @@ FT_PERF_FORMAT='{treeid:<15s} {elapse:>20f} {begin:>20f} {end:>20f} {match:>15f}
 '{njobs:>15d} {my_nodes:>5d} {my_cores:>4d} {my_gpus:>4d}'
                                # store perf-out with format given by --perf-format
 FT_FXLOGS='%^+_no'             # dir in which flux logs are produced
+FT_FXRDIR='%^+_no'             # flux rundir attribute to pass
 FT_LEAF='no'                   # is this a leaf instance (given by --leaf)?
 FT_G_PREFIX='tree'             # store hierarchical path given by --prefix
 FT_DRY_RUN='no'                # --dry-run for testing?
@@ -81,11 +82,10 @@ declare -A q_params=(          # make sure to update this when
 )
 declare -a jobids             # array to store a set of submitted job IDs
 
-declare -r long_opts='help,leaf,flux-logs:,nnodes:,ncores-per-node:'\
-',ngpus-per-node:,topology:,queue-policy:,queue-params:,match-policy:'\
-',njobs:,perf-out:,perf-format:,prefix:,job-name:,dry-run'
-
-declare -r short_opts='hlf:N:c:g:T:Q:P:M:J:o:X:d'
+declare -r long_opts='help,leaf,flux-logs:,flux-rundir:,nnodes:'\
+',ncores-per-node:,ngpus-per-node:,topology:,queue-policy:,queue-params:'\
+',match-policy:,njobs:,perf-out:,perf-format:,prefix:,job-name:,dry-run'
+declare -r short_opts='hlf:r:N:c:g:T:Q:P:M:J:o:X:d'
 declare -r prog=${0##*/}
 declare -r usage="
 Usage: ${prog} [OPTIONS] -- Jobscript\n\
@@ -146,6 +146,9 @@ Options:\n\
                                with internal tree-node options like -T.\n\
                                    (default=${FT_LEAF})\n\
  -f, --flux-logs=DIR           Dump Flux logs for all instances into DIR\n\
+ -r, --flux-rundir=DIR         Set the rundir attribute of each Flux tree instance\n\
+                                   into a subdirectory within DIR. The content\n\
+                                   stores will be redirected to them as well\n\
  -N, --nnodes=NNODES           Total num of nodes to use\n\
                                    (default=${FT_NNODES})\n\
  -c, --ncores-per-node=NCORES  Total num of cores per node to use\n\
@@ -590,7 +593,7 @@ submit() {
     local njobs="${10}"
     local cl="${11}"
     local log="${12}"
-    local out="${13}"
+    local rdir="${13}"
 
     # Flux instance rank-agnostic command-line options for the next level
     local T="${nx_topo:+--topology=${nx_topo}}"
@@ -601,6 +604,8 @@ submit() {
     local F=''
     [[ "x${log}" != "x%^+_no" ]] && F="--flux-logs=${log}"
     local S="${cl}"
+    local R=''
+    [[ "x${rdir}" != "x%^+_no" ]] && R="--flux-rundir=${rdir}"
     local rank=0
 
     # Main Loop to Submit the Next-Level Flux Instances
@@ -621,8 +626,20 @@ submit() {
         local o=''
         if [[ x"${log}" != "x%^+_no" ]]
         then
-            mkdir -p "${log}"
-            o="-o,-S,log-filename=${log}/${prefix}.${rank}.log"
+            if [[ "x${FT_DRY_RUN}" != "xyes" ]]
+            then
+                mkdir -p "${log}"
+            fi
+            o="-o,-Slog-filename=${log}/${prefix}.${rank}.log"
+        fi
+        if [[ x"${rdir}" != "x%^+_no" ]]
+        then
+            if [[ "x${FT_DRY_RUN}" != "xyes" ]]
+            then
+                rm -rf "${rdir}/${prefix}.${rank}.pfs"
+                mkdir -p "${rdir}/${prefix}.${rank}.pfs"
+            fi
+            o="${o:+${o} }-o,-Srundir=${rdir}/${prefix}.${rank}.pfs"
         fi
         local N=0
         N=$(get_my_nodes "${ncores}" "${my_cores}")
@@ -646,7 +663,7 @@ submit() {
         jobid=$(\
 flux mini submit --job-name=${FT_JOB_NAME} -N${N} -n${N} -c${c} ${G} \
      flux start ${o} \
-     flux tree -N${N} -c${c} ${G} ${T} ${Q} ${P} ${M} ${F} ${X} ${J} -- ${S})
+     flux tree -N${N} -c${c} ${G} ${T} ${Q} ${P} ${M} ${F} ${R} ${X} ${J} -- ${S})
         jobids["${rank}"]="${jobid}"
     done
 
@@ -693,8 +710,8 @@ internal() {
     local ncores="${7}"
     local ngpus="${8}"
     local njobs="${10}"
-    local perfout="${13}"
-    local format="${14}"
+    local perfout="${14}"
+    local format="${15}"
 
     # Begin Time Stamp
     local B=''
@@ -735,8 +752,9 @@ main() {
     local njobs="${10}"        # num of jobs assigned to this Flux instance
     local cl="${11}"           # jobscript commandline
     local flogs="${12}"        # flux log output option
-    local out="${13}"          # perf output filename
-    local format="${14}"      # perf output format
+    local frdir="${13}"        # flux rundir attribute
+    local out="${14}"          # perf output filename
+    local format="${15}"      # perf output format
     local size=0
 
     if [[ ${leaf} = "yes" ]]
@@ -756,7 +774,7 @@ main() {
         size=${topo%%${t_delim}*}
         internal "${prefix}" "${topo}" "${queue}" "${param}" "${match}" \
                  "${nnodes}" "${ncores}" "${ngpus}" "${size}" "${njobs}" \
-                 "${cl}" "${flogs}" "${out}" "${format}"
+                 "${cl}" "${flogs}" "${frdir}" "${out}" "${format}"
     fi
 
     exit ${FT_MAX_EXIT_CODE}
@@ -779,6 +797,7 @@ while true; do
       -l|--leaf)                   FT_LEAF="yes";                shift 1 ;;
       -d|--dry-run)                FT_DRY_RUN="yes";             shift 1 ;;
       -f|--flux-logs)              FT_FXLOGS="${2}";             shift 2 ;;
+      -r|--flux-rundir)            FT_FXRDIR="${2}";             shift 2 ;;
       -N|--nnodes)                 FT_NNODES=${2};               shift 2 ;;
       -c|--ncores-per-node)        FT_NCORES=${2};               shift 2 ;;
       -g|--ngpus-per-node)         FT_NGPUS=${2};                shift 2 ;;
@@ -838,7 +857,7 @@ fi
 
 main "${FT_LEAF}" "${FT_G_PREFIX}" "${FT_TOPO}" "${FT_QUEUE}" "${FT_PARAMS}" \
      "${FT_MATCH}" "${FT_NNODES}" "${FT_NCORES}" "${FT_NGPUS}" "${FT_NJOBS}" \
-     "${FT_CL}" "${FT_FXLOGS}" "${FT_PERF_OUT}" "${FT_PERF_FORMAT}"
+     "${FT_CL}" "${FT_FXLOGS}" "${FT_FXRDIR}" "${FT_PERF_OUT}" "${FT_PERF_FORMAT}"
 
 #
 # vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/cmd/flux-tree
+++ b/src/cmd/flux-tree
@@ -61,6 +61,7 @@ declare -r top_prefix='tree'   # prefix name to identify the top Flux instance
 declare -r t_delim='x'         # topology delimiter
 declare -r p_delim=':'         # match policy delimiter
 declare -r perf_format='%-15s %20s %20s %20s %15s %15s %5s %4s %4s'
+declare -a FT_CL=()            # save the jobscript command into an array
 declare -A mp_policies=(       # make sure to update this when match
     [low]=1                    # policies are updated.
     [high]=1
@@ -472,7 +473,6 @@ execute() {
     local ncores="${3}"
     local ngpus="${4}"
     local njobs="${5}"
-    local jobscript_cl="${6}"
     local rc=0
 
     for job in $(seq 1 "${njobs}");
@@ -490,11 +490,11 @@ execute() {
             dr_print "FLUX_TREE_NCORES_PER_NODE=${FLUX_TREE_NCORES_PER_NODE}"
             dr_print "FLUX_TREE_NGPUS_PER_NODE=${FLUX_TREE_NGPUS_PER_NODE}"
             dr_print "FLUX_TREE_NNODES=${FLUX_TREE_NNODES}"
-            dr_print "eval ${jobscript_cl}"
+            dr_print "eval ${FT_CL[@]}"
             continue
         else
             rc=0
-            eval ${jobscript_cl} || rc=$?
+            "${FT_CL[@]}" || rc=$?
             if [[ ${rc} -gt ${FT_MAX_EXIT_CODE} ]]
             then
                 FT_MAX_EXIT_CODE=${rc}
@@ -508,7 +508,7 @@ execute() {
 
     if [[ "x${FT_MAX_TREE_ID}" != "x" ]]
     then
-        warn "${jobscript_cl}: exited with exit code (${FT_MAX_EXIT_CODE})"
+        warn "${FT_CL[@]}: exited with exit code (${FT_MAX_EXIT_CODE})"
         warn "invocation id: ${FT_MAX_TREE_ID}@index[${FT_MAX_JOBSCRIPT_IX}]"
         warn "output displayed above, if any"
     fi
@@ -531,9 +531,8 @@ leaf() {
     local ncores="${3}"
     local ngpus="${4}"
     local njobs="${5}"
-    local cl="${6}"
-    local perfout="${7}"
-    local format="${8}"
+    local perfout="${6}"
+    local format="${7}"
 
     # Begin Time Stamp
     local B=''
@@ -591,9 +590,8 @@ submit() {
     local ngpus="${8}"
     local size="${9}"
     local njobs="${10}"
-    local cl="${11}"
-    local log="${12}"
-    local rdir="${13}"
+    local log="${11}"
+    local rdir="${12}"
 
     # Flux instance rank-agnostic command-line options for the next level
     local T="${nx_topo:+--topology=${nx_topo}}"
@@ -603,7 +601,6 @@ submit() {
     local M="${nx_match:+--match-policy=${nx_match}}"
     local F=''
     [[ "x${log}" != "x%^+_no" ]] && F="--flux-logs=${log}"
-    local S="${cl}"
     local R=''
     [[ "x${rdir}" != "x%^+_no" ]] && R="--flux-rundir=${rdir}"
     local rank=0
@@ -656,14 +653,15 @@ submit() {
             dr_print "Rank=${rank}: N=${N} c=${c} ${G:+g=${G}} ${o:+o=${o}}"
             dr_print "Rank=${rank}: ${T:+T=${T}}"
             dr_print "Rank=${rank}: ${Q:+Q=${Q}} ${P:+P=${P}} ${M:+M=${M}}" 
-            dr_print "Rank=${rank}: ${X:+X=${X}} ${J:+J=${J}} ${S:+S=${S}}"
+            dr_print "Rank=${rank}: ${X:+X=${X}} ${J:+J=${J}} ${FT_CL:+S=${FT_CL[@]}}"
             dr_print ""
             continue
         fi
         jobid=$(\
 flux mini submit --job-name=${FT_JOB_NAME} -N${N} -n${N} -c${c} ${G} \
      flux start ${o} \
-     flux tree -N${N} -c${c} ${G} ${T} ${Q} ${P} ${M} ${F} ${R} ${X} ${J} -- ${S})
+     flux tree -N${N} -c${c} ${G} ${T} ${Q} ${P} ${M} ${F} ${R} ${X} ${J} \
+     -- "${FT_CL[@]}")
         jobids["${rank}"]="${jobid}"
     done
 
@@ -710,8 +708,8 @@ internal() {
     local ncores="${7}"
     local ngpus="${8}"
     local njobs="${10}"
-    local perfout="${14}"
-    local format="${15}"
+    local perfout="${13}"
+    local format="${14}"
 
     # Begin Time Stamp
     local B=''
@@ -750,11 +748,10 @@ main() {
     local ncores="${8}"        # num of cores per node
     local ngpus="${9}"         # num of gpus per node
     local njobs="${10}"        # num of jobs assigned to this Flux instance
-    local cl="${11}"           # jobscript commandline
-    local flogs="${12}"        # flux log output option
-    local frdir="${13}"        # flux rundir attribute
-    local out="${14}"          # perf output filename
-    local format="${15}"      # perf output format
+    local flogs="${11}"        # flux log output option
+    local frdir="${12}"        # flux rundir attribute
+    local out="${13}"          # perf output filename
+    local format="${14}"      # perf output format
     local size=0
 
     if [[ ${leaf} = "yes" ]]
@@ -765,7 +762,7 @@ main() {
         # be executed on the last-level Flux instance. 
         #
         leaf "${prefix}" "${nnodes}" "${ncores}" "${ngpus}" "${njobs}" \
-             "${cl}" "${out}" "${format}"
+             "${out}" "${format}"
     else
         #
         # flux-tree is invoked to instantate ${size} internal Flux instances
@@ -774,7 +771,7 @@ main() {
         size=${topo%%${t_delim}*}
         internal "${prefix}" "${topo}" "${queue}" "${param}" "${match}" \
                  "${nnodes}" "${ncores}" "${ngpus}" "${size}" "${njobs}" \
-                 "${cl}" "${flogs}" "${frdir}" "${out}" "${format}"
+                 "${flogs}" "${frdir}" "${out}" "${format}"
     fi
 
     exit ${FT_MAX_EXIT_CODE}
@@ -787,7 +784,7 @@ main() {
 #                                                                              #
 ################################################################################
 
-GETOPTS=$(/usr/bin/getopt -u -o ${short_opts} -l ${long_opts} -n "${prog}" -- "${@}")
+GETOPTS=$(/usr/bin/getopt -o ${short_opts} -l ${long_opts} -n "${prog}" -- "${@}")
 eval set -- "${GETOPTS}"
 rcopt=$?
 
@@ -816,7 +813,7 @@ while true; do
 done
 
 FT_SCRIPT="${1}"
-FT_CL="${@}"
+FT_CL=( "${@}" )
 
 [[ "$#" -lt 1 || "${rcopt}" -ne 0 ]] && die "${usage}"
 
@@ -857,7 +854,7 @@ fi
 
 main "${FT_LEAF}" "${FT_G_PREFIX}" "${FT_TOPO}" "${FT_QUEUE}" "${FT_PARAMS}" \
      "${FT_MATCH}" "${FT_NNODES}" "${FT_NCORES}" "${FT_NGPUS}" "${FT_NJOBS}" \
-     "${FT_CL}" "${FT_FXLOGS}" "${FT_FXRDIR}" "${FT_PERF_OUT}" "${FT_PERF_FORMAT}"
+     "${FT_FXLOGS}" "${FT_FXRDIR}" "${FT_PERF_OUT}" "${FT_PERF_FORMAT}"
 
 #
 # vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/cmd/flux-tree-helper.py
+++ b/src/cmd/flux-tree-helper.py
@@ -180,11 +180,15 @@ def parse_args():
 @flux.util.CLIMain(logger)
 def main():
     args = parse_args()
-    flux_handle = flux.Flux()
+    flux_handle = None
+    try:
+        flux_handle = flux.Flux()
+    except FileNotFoundError:
+        flux_handle = None
 
     logger.debug("Getting this instance's data")
     this_data = get_this_instance_data()
-    if args.num_children > 0:
+    if flux_handle != None and args.num_children > 0:
         logger.debug("Getting children's data")
         child_data = get_child_data(
             flux_handle, args.num_children, args.job_name, args.kvs_key
@@ -193,8 +197,9 @@ def main():
         child_data = []
     logger.debug("Combining data")
     combined_data = combine_data(this_data, child_data)
-    logger.debug("Writing data to parent's KVS")
-    write_data_to_parent(flux_handle, args.kvs_key, combined_data)
+    if flux_handle != None:
+        logger.debug("Writing data to parent's KVS")
+        write_data_to_parent(flux_handle, args.kvs_key, combined_data)
     if args.perf_out:
         logger.debug("Writing data to file")
         write_data_to_file(args.perf_out, args.perf_format, combined_data)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -28,6 +28,7 @@ TESTS = \
     t1004-qmanager-optimize.t \
     t1005-qmanager-conf.t \
     t2000-tree-basic.t \
+    t2001-tree-real.t \
     t3000-jobspec.t \
     t3001-resource-basic.t \
     t3002-resource-prefix.t \

--- a/t/t2000-tree-basic.t
+++ b/t/t2000-tree-basic.t
@@ -137,7 +137,7 @@ test_expect_success 'flux-tree: --topology=1 works' '
 EOF
     flux tree --dry-run --topology=1 /bin/hostname > out.04 &&
     remove_prefix out.04 out.04.2 &&
-    sed -i "s/[ \t]*$//g" out.04.2 && 
+    sed -i "s/[ \t]*$//g" out.04.2 &&
     test_cmp cmp.04 out.04.2
 '
 
@@ -296,7 +296,7 @@ test_expect_success 'flux-tree: --perf-out generates a perf output file' '
     flux tree --dry-run -T 4 -N 4 -c 4 -J 10 -o p.out /bin/hostname &&
     test -f p.out &&
     lcount=$(wc -l p.out | awk "{print \$1}") &&
-    test ${lcount} -eq 2 && 
+    test ${lcount} -eq 2 &&
     wcount=$(wc -w p.out | awk "{print \$1}") &&
     test ${wcount} -eq 18
 '
@@ -307,7 +307,7 @@ test_expect_success 'flux-tree: --perf-format works with custom format' '
          /bin/hostname &&
     test -f perf.out &&
     lcount=$(wc -l perf.out | awk "{print \$1}") &&
-    test ${lcount} -eq 2 && 
+    test ${lcount} -eq 2 &&
     wcount=$(wc -w perf.out | awk "{print \$1}") &&
     test ${wcount} -eq 6
 '
@@ -569,7 +569,7 @@ EOF
     unset FLUX_RESOURCE_OPTIONS &&
     remove_prefix out.18 out.18.2 &&
     sed -i "s/[ \t]*$//g" out.18.2 &&
-    test_cmp cmp.18 out.18.2 
+    test_cmp cmp.18 out.18.2
 '
 
 test_expect_success 'flux-tree: -T4 on 4 nodes/4 cores/4 GPUs work' '

--- a/t/t2000-tree-basic.t
+++ b/t/t2000-tree-basic.t
@@ -679,4 +679,56 @@ EOF
     test_cmp cmp.22 out.22.2
 '
 
+test_expect_success 'flux-tree: --flux-rundir=DIR works in dry-run' '
+    cat >cmp.23 <<-EOF &&
+	FLUX_QMANAGER_OPTIONS:
+	FLUX_RESOURCE_OPTIONS:
+	Rank=1: N=1 c=2 o=-o,-Srundir=DIR/tree.1.pfs
+	Rank=1: T=--leaf
+	Rank=1:
+	Rank=1: X=--prefix=tree.1 J=--njobs=5 S=/bin/hostname
+	
+	Rank=2: N=1 c=2 o=-o,-Srundir=DIR/tree.2.pfs
+	Rank=2: T=--leaf
+	Rank=2:
+	Rank=2: X=--prefix=tree.2 J=--njobs=5 S=/bin/hostname
+	
+	FLUX_QMANAGER_OPTIONS:
+	FLUX_RESOURCE_OPTIONS:
+	FLUX_QMANAGER_RC_NOOP:1
+	FLUX_RESOURCE_RC_NOOP:1
+EOF
+    flux tree --dry-run --topology=2 -N 2 -c 2 -J 10 -r DIR \
+/bin/hostname > out.23 &&
+    remove_prefix out.23 out.23.2 &&
+    sed -i "s/[ \t]*$//g" out.23.2 &&
+    test_cmp cmp.23 out.23.2
+'
+
+test_expect_success 'flux-tree: --flux-rundir=DIR works along with -f' '
+    cat >cmp.24 <<-EOF &&
+	FLUX_QMANAGER_OPTIONS:
+	FLUX_RESOURCE_OPTIONS:
+	Rank=1: N=1 c=2 o=-o,-Slog-filename=DIR2/tree.1.log -o,-Srundir=DIR/tree.1.pfs
+	Rank=1: T=--leaf
+	Rank=1:
+	Rank=1: X=--prefix=tree.1 J=--njobs=5 S=/bin/hostname
+	
+	Rank=2: N=1 c=2 o=-o,-Slog-filename=DIR2/tree.2.log -o,-Srundir=DIR/tree.2.pfs
+	Rank=2: T=--leaf
+	Rank=2:
+	Rank=2: X=--prefix=tree.2 J=--njobs=5 S=/bin/hostname
+	
+	FLUX_QMANAGER_OPTIONS:
+	FLUX_RESOURCE_OPTIONS:
+	FLUX_QMANAGER_RC_NOOP:1
+	FLUX_RESOURCE_RC_NOOP:1
+EOF
+    flux tree --dry-run --topology=2 -N 2 -c 2 -J 10 -r DIR -f DIR2 \
+/bin/hostname > out.24 &&
+    remove_prefix out.24 out.24.2 &&
+    sed -i "s/[ \t]*$//g" out.24.2 &&
+    test_cmp cmp.24 out.24.2
+'
+
 test_done

--- a/t/t2000-tree-basic.t
+++ b/t/t2000-tree-basic.t
@@ -12,8 +12,6 @@ ORIG_HOME=${HOME}
 #
 HOME=${ORIG_HOME}
 
-test_under_flux 1
-
 if test -z "${FLUX_SCHED_TEST_INSTALLED}" || test -z "${FLUX_SCHED_CO_INST}"
  then
      export FLUX_RC_EXTRA="${SHARNESS_TEST_SRCDIR}/rc"
@@ -679,92 +677,6 @@ EOF
     remove_prefix out.22 out.22.2 &&
     sed -i "s/[ \t]*$//g" out.22.2 &&
     test_cmp cmp.22 out.22.2
-'
-
-test_expect_success 'flux-tree: prep for testing in real mode works' '
-    flux module remove sched-simple &&
-    flux module load resource prune-filters=ALL:core \
-subsystems=containment policy=low load-whitelist=node,core,gpu &&
-    flux module load qmanager
-'
-
-test_expect_success 'flux-tree: --leaf in real mode' '
-    flux tree --leaf -N 1 -c 1 -J 1 -o p.out2 hostname &&
-    test -f p.out2 &&
-    lcount=$(wc -l p.out2 | awk "{print \$1}") &&
-    test ${lcount} -eq 2 &&
-    wcount=$(wc -w p.out2 | awk "{print \$1}") &&
-    test ${wcount} -eq 18
-'
-
-test_expect_success 'flux-tree: -T1 in real mode' '
-    flux tree -T1 -N 1 -c 1 -J 1 -o p.out3 hostname &&
-    test -f p.out3 &&
-    lcount=$(wc -l p.out3 | awk "{print \$1}") &&
-    test ${lcount} -eq 3 &&
-    wcount=$(wc -w p.out3 | awk "{print \$1}") &&
-    test ${wcount} -eq 27
-'
-
-test_expect_success 'flux-tree: -T1x1 in real mode' '
-    flux tree -T1x1 -N 1 -c 1 -J 1 -o p.out4 hostname &&
-    test -f p.out4 &&
-    lcount=$(wc -l p.out4 | awk "{print \$1}") &&
-    test ${lcount} -eq 4 &&
-    wcount=$(wc -w p.out4 | awk "{print \$1}") &&
-    test ${wcount} -eq 36
-'
-
-test_expect_success 'flux-tree: -T2 with exit code rollup works' '
-    cat >jobscript.sh <<EOF &&
-#! /bin/bash
-echo \${FLUX_TREE_ID}
-if [[ \${FLUX_TREE_ID} = "tree.2" ]]
-then
-	exit 4
-else
-	exit 1
-fi
-EOF
-
-    cat >cmp.23 <<EOF &&
-tree.2
-flux-tree: warning: ./jobscript.sh: exited with exit code (4)
-flux-tree: warning: invocation id: tree.2@index[1]
-flux-tree: warning: output displayed above, if any
-EOF
-    chmod u+x jobscript.sh &&
-    test_expect_code 4 flux tree -T2 -N 1 -c 2 -J 2 \
-./jobscript.sh > out.23 &&
-    test_cmp cmp.23 out.23
-'
-
-PERF_FORMAT="{treeid}"
-PERF_BLOB='{"treeid":"tree", "perf": {}}'
-JOB_NAME="foobar"
-test_expect_success 'flux-tree: successfully runs alongside other jobs' '
-    flux tree -T 1 -N 1 -c 1 -J 1 -o p.out5 --perf-format="$PERF_FORMAT" \
-         --job-name="${JOB_NAME}" -- hostname &&
-    flux mini run -N1 -c1 hostname &&
-    echo "$PERF_BLOB" | run_timeout 5 flux tree-helper --perf-out=p.out6 \
-         --perf-format="$PERF_FORMAT" 1 "tree-perf" "${JOB_NAME}" &&
-    test_cmp p.out5 p.out6
-'
-
-JOB_NAME="foobar2"
-test_expect_success 'flux-tree: successfully runs alongside other flux-trees' '
-    run_timeout 20 \
-    flux tree -T 1x1 -N 1 -c 1 -J 1 -o p.out7 --perf-format="$PERF_FORMAT" \
-         --job-name="${JOB_NAME}" -- hostname &&
-    flux tree -T 1 -N 1 -c 1 -J 1 -- hostname &&
-    echo "$PERF_BLOB" | run_timeout 5 flux tree-helper --perf-out=p.out8 \
-         --perf-format="$PERF_FORMAT" 1 "tree-perf" "${JOB_NAME}" &&
-    test_cmp p.out7 p.out8
-'
-
-test_expect_success 'flux-tree: removing qmanager/resource works' '
-     flux module remove resource &&
-     flux module remove qmanager
 '
 
 test_done

--- a/t/t2001-tree-real.t
+++ b/t/t2001-tree-real.t
@@ -105,6 +105,16 @@ test_expect_success 'flux-tree: works with pre-existing rundir subdirectories' '
     flux tree -T 1 -N 1 -c 1 -r DIR -- hostname
 '
 
+test_expect_success 'flux-tree: rundir is propagated to nest instances' '
+    run_timeout 20 \
+    flux tree -T 1x1 -N 1 -c 1 -r DIR -- \
+    bash -c "flux lsattr -v | grep ^rundir > test.out" &&
+    p=$(cat test.out | awk "{print \$2}") &&
+    p2=${p%/*} &&
+    rundir=${p2##/*} &&
+    test ${rundir} = DIR
+'
+
 test_expect_success 'flux-tree: works with quoted jobscript argument' '
     flux tree -T 1 -N 1 -c 1 -- bash -c "touch touch-me" &&
     test -f touch-me

--- a/t/t2001-tree-real.t
+++ b/t/t2001-tree-real.t
@@ -100,6 +100,11 @@ test_expect_success 'flux-tree: successfully runs alongside other flux-trees' '
     test_cmp p.out6 p.out7
 '
 
+test_expect_success 'flux-tree: works with pre-existing rundir subdirectories' '
+    flux tree -T 1 -N 1 -c 1 -r DIR -- hostname &&
+    flux tree -T 1 -N 1 -c 1 -r DIR -- hostname
+'
+
 test_expect_success 'flux-tree: removing qmanager/resource works' '
      flux module remove resource &&
      flux module remove qmanager

--- a/t/t2001-tree-real.t
+++ b/t/t2001-tree-real.t
@@ -1,0 +1,108 @@
+#!/bin/sh
+
+test_description='Test flux-tree correctness in real running mode'
+
+ORIG_HOME=${HOME}
+
+. `dirname $0`/sharness.sh
+
+#
+# sharness modifies $HOME environment variable, but this interferes
+# with python's package search path, in particular its user site package.
+#
+HOME=${ORIG_HOME}
+
+test_under_flux 1
+
+if test -z "${FLUX_SCHED_TEST_INSTALLED}" || test -z "${FLUX_SCHED_CO_INST}"
+ then
+     export FLUX_RC_EXTRA="${SHARNESS_TEST_SRCDIR}/rc"
+fi
+
+test_expect_success 'flux-tree: prep for testing in real mode works' '
+    flux module remove sched-simple &&
+    flux module load resource prune-filters=ALL:core \
+subsystems=containment policy=low load-whitelist=node,core,gpu &&
+    flux module load qmanager
+'
+
+test_expect_success 'flux-tree: --leaf in real mode' '
+    flux tree --leaf -N 1 -c 1 -J 1 -o p.out2 hostname &&
+    test -f p.out2 &&
+    lcount=$(wc -l p.out2 | awk "{print \$1}") &&
+    test ${lcount} -eq 2 &&
+    wcount=$(wc -w p.out2 | awk "{print \$1}") &&
+    test ${wcount} -eq 18
+'
+
+test_expect_success 'flux-tree: -T1 in real mode' '
+    flux tree -T1 -N 1 -c 1 -J 1 -o p.out3 hostname &&
+    test -f p.out3 &&
+    lcount=$(wc -l p.out3 | awk "{print \$1}") &&
+    test ${lcount} -eq 3 &&
+    wcount=$(wc -w p.out3 | awk "{print \$1}") &&
+    test ${wcount} -eq 27
+'
+
+test_expect_success 'flux-tree: -T1x1 in real mode' '
+    flux tree -T1x1 -N 1 -c 1 -J 1 -o p.out4 hostname &&
+    test -f p.out4 &&
+    lcount=$(wc -l p.out4 | awk "{print \$1}") &&
+    test ${lcount} -eq 4 &&
+    wcount=$(wc -w p.out4 | awk "{print \$1}") &&
+    test ${wcount} -eq 36
+'
+
+test_expect_success 'flux-tree: -T2 with exit code rollup works' '
+    cat >jobscript.sh <<EOF &&
+#! /bin/bash
+echo \${FLUX_TREE_ID}
+if [[ \${FLUX_TREE_ID} = "tree.2" ]]
+then
+	exit 4
+else
+	exit 1
+fi
+EOF
+
+    cat >cmp.01 <<EOF &&
+tree.2
+flux-tree: warning: ./jobscript.sh: exited with exit code (4)
+flux-tree: warning: invocation id: tree.2@index[1]
+flux-tree: warning: output displayed above, if any
+EOF
+    chmod u+x jobscript.sh &&
+    test_expect_code 4 flux tree -T2 -N 1 -c 2 -J 2 \
+./jobscript.sh > out.01 &&
+    test_cmp cmp.01 out.01
+'
+
+PERF_FORMAT="{treeid}"
+PERF_BLOB='{"treeid":"tree", "perf": {}}'
+JOB_NAME="foobar"
+test_expect_success 'flux-tree: successfully runs alongside other jobs' '
+    flux tree -T 1 -N 1 -c 1 -J 1 -o p.out5 --perf-format="$PERF_FORMAT" \
+         --job-name="${JOB_NAME}" -- hostname &&
+    flux mini run -N1 -c1 hostname &&
+    echo "$PERF_BLOB" | run_timeout 5 flux tree-helper --perf-out=p.out6 \
+         --perf-format="$PERF_FORMAT" 1 "tree-perf" "${JOB_NAME}" &&
+    test_cmp p.out5 p.out6
+'
+
+JOB_NAME="foobar2"
+test_expect_success 'flux-tree: successfully runs alongside other flux-trees' '
+    run_timeout 20 \
+    flux tree -T 1x1 -N 1 -c 1 -J 1 -o p.out6 --perf-format="$PERF_FORMAT" \
+         --job-name="${JOB_NAME}" -- hostname &&
+    flux tree -T 1 -N 1 -c 1 -J 1 -- hostname &&
+    echo "$PERF_BLOB" | run_timeout 5 flux tree-helper --perf-out=p.out7 \
+         --perf-format="$PERF_FORMAT" 1 "tree-perf" "${JOB_NAME}" &&
+    test_cmp p.out6 p.out7
+'
+
+test_expect_success 'flux-tree: removing qmanager/resource works' '
+     flux module remove resource &&
+     flux module remove qmanager
+'
+
+test_done

--- a/t/t2001-tree-real.t
+++ b/t/t2001-tree-real.t
@@ -105,6 +105,11 @@ test_expect_success 'flux-tree: works with pre-existing rundir subdirectories' '
     flux tree -T 1 -N 1 -c 1 -r DIR -- hostname
 '
 
+test_expect_success 'flux-tree: works with quoted jobscript argument' '
+    flux tree -T 1 -N 1 -c 1 -- bash -c "touch touch-me" &&
+    test -f touch-me
+'
+
 test_expect_success 'flux-tree: removing qmanager/resource works' '
      flux module remove resource &&
      flux module remove qmanager


### PR DESCRIPTION
This PR adds `--flux-rundir` support to `flux-tree`.

Problem: For a large flux-tree test where lots of flux instances are used, the content store back-ends can use lots of memory leading to OOM.

Provide `--flux-rundir=DIR` option which sets the rundir to DIR so that the content stores can be redirected to a subdirectory in DIR for this case. Use the rundir attribute because upon the exit of each Flux instance, its content store sqlite file is removed.

Add two test cases that uses `--dry-run`