### PR TITLE
Introduce generic exception handling wrapper support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -155,6 +155,8 @@ AC_CONFIG_FILES([Makefile
   src/common/libtap/Makefile
   src/common/libutil/Makefile
   src/common/librbtree/Makefile
+  src/common/c++wrappers/Makefile
+  src/common/c++wrappers/test/Makefile
   src/cmd/Makefile
   resource/Makefile
   resource/planner/Makefile

--- a/qmanager/modules/Makefile.am
+++ b/qmanager/modules/Makefile.am
@@ -36,7 +36,8 @@ qmanager_la_SOURCES = \
     $(top_srcdir)/qmanager/policies/queue_policy_conservative.hpp \
     $(top_srcdir)/qmanager/policies/queue_policy_conservative_impl.hpp \
     $(top_srcdir)/qmanager/policies/queue_policy_factory.hpp \
-    $(top_srcdir)/qmanager/policies/queue_policy_factory_impl.hpp
+    $(top_srcdir)/qmanager/policies/queue_policy_factory_impl.hpp \
+    $(top_srcdir)/src/common/c++wrappers/eh_wrapper.hpp
 
 qmanager_la_CXXFLAGS = \
     $(AM_CXXFLAGS) \

--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -33,11 +33,12 @@ extern "C" {
 #include "qmanager/policies/base/queue_policy_base.hpp"
 #include "qmanager/policies/base/queue_policy_base_impl.hpp"
 #include "qmanager/policies/queue_policy_factory_impl.hpp"
-
+#include "src/common/c++wrappers/eh_wrapper.hpp"
 
 using namespace Flux;
 using namespace Flux::queue_manager;
 using namespace Flux::queue_manager::detail;
+using namespace Flux::cplusplus_wrappers;
 
 /******************************************************************************
  *                                                                            *
@@ -522,39 +523,42 @@ static int process_config_file (std::shared_ptr<qmanager_ctx_t> &ctx)
  *                                                                            *
  ******************************************************************************/
 
-extern "C" int mod_main (flux_t *h, int argc, char **argv)
+int mod_start (flux_t *h, int argc, char **argv)
 {
     int rc = -1;
-    try {
-        std::shared_ptr<qmanager_ctx_t> ctx = nullptr;
-        if (!(ctx = qmanager_new (h))) {
-            flux_log_error (h, "%s: qmanager_new", __FUNCTION__);
-            return rc;
-        }
-        if ((rc = process_config_file (ctx)) < 0) {
-            flux_log_error (h, "%s: config file parsing", __FUNCTION__);
-            qmanager_destroy (ctx);
-            return rc;
-        }
-        if ((rc = process_args (ctx, argc, argv)) < 0) {
-            flux_log_error (h, "%s: load line argument parsing", __FUNCTION__);
-            qmanager_destroy (ctx);
-            return rc;
-        }
-        if ((rc = enforce_queue_policy (ctx)) < 0) {
-            flux_log_error (h, "%s: enforce_queue_policy", __FUNCTION__);
-            qmanager_destroy (ctx);
-            return rc;
-        }
-        if ((rc = process_args (ctx, argc, argv)) < 0)
-            flux_log_error (h, "%s: load line argument parsing", __FUNCTION__);
-        if ((rc = flux_reactor_run (flux_get_reactor (h), 0)) < 0)
-            flux_log_error (h, "%s: flux_reactor_run", __FUNCTION__);
+    std::shared_ptr<qmanager_ctx_t> ctx = nullptr;
+    if ( !(ctx = qmanager_new (h))) {
+        flux_log_error (h, "%s: qmanager_new", __FUNCTION__);
+        return rc;
+    }
+    if ( (rc = process_config_file (ctx)) < 0) {
+        flux_log_error (h, "%s: config file parsing", __FUNCTION__);
         qmanager_destroy (ctx);
+        return rc;
     }
-    catch (std::exception &e) {
-        flux_log_error (h, "%s: %s", __FUNCTION__, e.what ());
+    if ( (rc = process_args (ctx, argc, argv)) < 0) {
+        flux_log_error (h, "%s: load line argument parsing", __FUNCTION__);
+        qmanager_destroy (ctx);
+        return rc;
     }
+    if ( (rc = enforce_queue_policy (ctx)) < 0) {
+        flux_log_error (h, "%s: enforce_queue_policy", __FUNCTION__);
+        qmanager_destroy (ctx);
+        return rc;
+    }
+    if ( (rc = flux_reactor_run (flux_get_reactor (h), 0)) < 0)
+        flux_log_error (h, "%s: flux_reactor_run", __FUNCTION__);
+    qmanager_destroy (ctx);
+    return rc;
+}
+
+extern "C" int mod_main (flux_t *h, int argc, char **argv)
+{
+    eh_wrapper_t exception_safe_main;
+    int rc = exception_safe_main (mod_start, h, argc, argv);
+    if (exception_safe_main.bad ())
+        flux_log_error (h, "%s: %s", __FUNCTION__,
+                            exception_safe_main.get_err_message ());
     return rc;
 }
 

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = libtap libutil librbtree
+SUBDIRS = libtap libutil librbtree c++wrappers

--- a/src/common/c++wrappers/Makefile.am
+++ b/src/common/c++wrappers/Makefile.am
@@ -1,0 +1,2 @@
+SUBDIRS = test
+

--- a/src/common/c++wrappers/eh_wrapper.hpp
+++ b/src/common/c++wrappers/eh_wrapper.hpp
@@ -1,0 +1,121 @@
+/*****************************************************************************\
+ *  Copyright (c) 2020 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include <cerrno>
+#include <cstring>
+#include <utility>
+#include <exception>
+#include <stdexcept>
+
+namespace Flux {
+namespace cplusplus_wrappers {
+
+/*! Exception handling wrapper functor class.
+ *  Use perfect forwarding to wrap the target functor of many different types
+ *  in order to add an exception handling semantics: mapping certain C++
+ *  exception classes to errnos as they are caught.
+ */
+class eh_wrapper_t {
+public:
+    /*! Templated operator() method: An object of eh_wrapper_t *can invoke
+     *  its wrapping function using the function invocation convention.
+     *  "functor_object()". Different numbers and types of function parameters
+     *  are handled with template parameter pack/unpack (i.e. "..." keyword).
+     *  Transparent forwarding of function arguments is handled with
+     *  the so-called "universal" or "forwarding" reference (Args&&) in
+     *  combination with the std::forward method.  Introductory examples
+     *  for perfect forwarding can be found in the following:
+     *  https://www.modernescpp.com/index.php/perfect-forwarding
+     *
+     * \param f        functor (function, function pointer or function object)
+     * \param args     variadic arguments list that is transparently
+     *                 forwarded to f.
+     */
+    template <typename Functor, typename ... Args>
+    auto operator() (Functor f, Args && ... args)
+        -> decltype(f (std::forward<Args> (args) ... )) {
+        int rc = -1;
+        exception_raised = false;
+        memset (err_message, '\0', 4096);
+        try {
+            return f (std::forward<Args> (args) ... );
+        }
+        catch (std::bad_alloc &e) {
+            errno = ENOMEM;
+            snprintf (err_message, 4096, "ENOMEM: %s", e.what ());
+        }
+        catch (std::length_error &e) {
+            errno = ERANGE;
+            snprintf (err_message, 4096, "ERANGE: %s", e.what ());
+        }
+        catch (std::out_of_range &e) {
+            errno = ENOENT;
+            snprintf (err_message, 4096, "ENOENT: %s", e.what ());
+        }
+        catch (std::exception &e) {
+            errno = ENOSYS;
+            snprintf (err_message, 4096, "ENOSYS: %s", e.what ());
+        }
+        catch (...) {
+            errno = ENOSYS;
+            snprintf (err_message, 4096, "ENOSYS: Caught unknown exception");
+        }
+        exception_raised = true;
+        return return_<decltype(f (std::forward<Args> (args) ...))> (rc);
+    }
+
+    /*! Has a C++ exception been raised from the last invocation of operator()?
+     */
+    bool bad () {
+        return exception_raised;
+    }
+
+    /*! Return the exception error message associated from the last invocation
+     *  of operator().
+     */
+    const char *get_err_message () {
+        return exception_raised ? err_message : NULL;
+    }
+
+private:
+    template <typename T>
+    T return_ (int i) {
+        return T(i);
+    }
+
+    bool exception_raised = false;
+    char err_message[4096]; // to avoid a bad_alloc exception with std::string
+};
+
+template <>
+void eh_wrapper_t::return_<void> (int i) {
+    return;
+}
+
+} // namespace c++wrappers
+} // namespace Flux
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/c++wrappers/test/Makefile.am
+++ b/src/common/c++wrappers/test/Makefile.am
@@ -1,0 +1,17 @@
+AM_CXXFLAGS = \
+	$(WARNING_CXXFLAGS) \
+	$(CODE_COVERAGE_CXXFLAGS)
+
+AM_LDFLAGS = $(CODE_COVERAGE_LDFLAGS)
+
+AM_CPPFLAGS = -I$(top_srcdir)
+
+TESTS = exception_safe_wrapper_test01
+
+check_PROGRAMS = $(TESTS)
+exception_safe_wrapper_test01_SOURCES = exception_safe_wrapper_test01.cpp
+exception_safe_wrapper_test01_CXXFLAGS = \
+	$(AM_CXXFLAGS) -I$(top_srcdir)/src/common/c++wrappers
+exception_safe_wrapper_test01_LDADD = \
+	$(top_builddir)/src/common/libtap/libtap.la
+

--- a/src/common/c++wrappers/test/exception_safe_wrapper_test01.cpp
+++ b/src/common/c++wrappers/test/exception_safe_wrapper_test01.cpp
@@ -1,0 +1,277 @@
+/*****************************************************************************\
+ *  Copyright (c) 2020 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include <cstdlib>
+#include <cerrno>
+#include <string>
+#include <exception>
+#include <stdexcept>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/c++wrappers/eh_wrapper.hpp"
+
+using namespace Flux::cplusplus_wrappers;
+
+
+static void throw_exception (int en)
+{
+    switch (en) {
+    case ENOMEM:
+        throw std::bad_alloc ();
+        break;
+    case ERANGE:
+        throw std::length_error (__FUNCTION__);
+        break;
+    case ENOENT:
+        throw std::out_of_range (__FUNCTION__);
+        break;
+    case ENOSYS:
+        throw std::exception ();
+        break;
+    case ENOTSUP:
+        throw "Unknown exception";
+        break;
+    }
+}
+
+struct foo_functor_t {
+    int operator() (int en) {
+        throw_exception (en);
+        return 0;
+    }
+};
+
+struct foo_functor_eh_wrapper_t {
+    int operator() (int en) {
+        eh_wrapper_t exception_safe_wrapper;
+        foo_functor_t functor;
+        return exception_safe_wrapper (functor, en);
+    }
+};
+
+int foo1 (int en)
+{
+    throw_exception (en);
+    return 0;
+}
+
+int foo2 (int en, double p1, float p2, long p3, long long p4)
+{
+    int rc =  (int) (p1 + p2 + p3 + p4);
+    p1 = p2 = p3 = p4 = 0;
+    return rc;
+}
+
+int foo3 (int en, double &p1, float &p2, long &p3, long long &p4)
+{
+    int rc = (int) (p1 + p2 + p3 + p4);
+    p1 = p2 = p3 = p4 = 0;
+    return rc;
+}
+
+void foo4 (int en)
+{
+    throw_exception (en);
+}
+
+
+static void test_functor_wrapper ()
+{
+    int rc = 0;
+    foo_functor_eh_wrapper_t func;
+
+    errno = 0;
+    rc = func (-1);
+    ok (rc == 0 && errno == 0,
+        "eh_wrapper_t works with functor (no exception)");
+
+    errno = 0;
+    rc = func (ENOMEM);
+    ok (rc == -1 && errno == ENOMEM,
+        "eh_wrapper_t works with functor (bad_alloc exception)");
+
+    errno = 0;
+    rc = func (ERANGE);
+    ok (rc == -1 && errno == ERANGE,
+        "eh_wrapper_t works with functor (length_error exception)");
+
+    errno = 0;
+    rc = func (ENOENT);
+    ok (rc == -1 && errno == ENOENT,
+        "eh_wrapper_t works with functor (out_of_range exception)");
+
+    errno = 0;
+    rc = func (ENOSYS);
+    ok (rc == -1 && errno == ENOSYS,
+        "eh_wrapper_t works with functor (std::exception)");
+
+    errno = 0;
+    rc = func (ENOTSUP);
+    ok (rc == -1 && errno == ENOSYS,
+        "eh_wrapper_t works with functor (unknown exception)");
+}
+
+static void test_function_wrapper ()
+{
+    int rc = 0;
+    const char *msg = NULL;
+    eh_wrapper_t exception_safe_wrapper;
+
+    errno = 0;
+    rc = exception_safe_wrapper (foo1, -1);
+    ok (rc == 0 && errno == 0,
+        "eh_wrapper_t works with simple function (no exception)");
+    ok (!exception_safe_wrapper.bad (),
+        "eh_wrapper_t::bad() works with simple function (no exception)");
+    msg = exception_safe_wrapper.get_err_message ();
+    ok (msg == NULL, "eh_wrapper_t::get_err_message () works (no exception)");
+
+    errno = 0;
+    rc = exception_safe_wrapper (foo1, ENOENT);
+    ok (rc == -1 && errno == ENOENT,
+        "eh_wrapper_t works with simple function (out_of_range)");
+    ok (exception_safe_wrapper.bad (),
+        "eh_wrapper_t::bad() works with simple function (out_of_range)");
+    msg = exception_safe_wrapper.get_err_message ();
+    ok (msg != NULL, "eh_wrapper_t::get_err_message () reports: %s", msg);
+}
+
+static void test_function_wrapper2 ()
+{
+    int rc = 0;
+    double p1 = 1.0f;
+    float p2 = 2.0f;
+    long p3 = 3;
+    long long p4 = 4;
+    eh_wrapper_t exception_safe_wrapper;
+
+    errno = 0;
+    int sum1 = static_cast<int> (p1 + p2 + p3 + p4);
+    rc = exception_safe_wrapper (foo2, -1, p1, p2, p3, p4);
+    int sum2 = static_cast<int> (p1 + p2 + p3 + p4);
+    ok (rc == sum1 && sum1 == sum2 && errno == 0,
+        "eh_wrapper_t forwards args by value works");
+}
+
+static void test_function_wrapper3 ()
+{
+    int rc = 0;
+    double p1 = 1.0f;
+    float p2 = 2.0f;
+    long p3 = 3;
+    long long p4 = 4;
+    eh_wrapper_t exception_safe_wrapper;
+
+    errno = 0;
+    int sum1 = static_cast<int> (p1 + p2 + p3 + p4);
+    rc = exception_safe_wrapper (foo3, -1, p1, p2, p3, p4);
+    int sum2 = static_cast<int> (p1 + p2 + p3 + p4);
+    ok (rc == sum1 && sum2 == 0 && errno == 0,
+        "eh_wrapper_t forwards args by reference works");
+}
+
+static void test_lambda_wrapper ()
+{
+    int rc = 0;
+    const char *msg = NULL;
+    eh_wrapper_t exception_safe_wrapper;
+
+    errno = 0;
+    rc = exception_safe_wrapper ([](int en) {
+                                     throw_exception (en);
+                                     return 0; },
+                                -1);
+
+    ok (rc == 0 && errno == 0,
+        "eh_wrapper_t works with lambda function (no exception)");
+    ok (!exception_safe_wrapper.bad (),
+        "eh_wrapper_t::bad() works with simple function (no exception)");
+    msg = exception_safe_wrapper.get_err_message ();
+    ok (msg == NULL, "eh_wrapper_t::get_err_message () works (no exception)");
+
+    errno = 0;
+    rc = exception_safe_wrapper ([](int en) {
+                                     throw_exception (en);
+                                     return 0; },
+                                ENOENT);
+    ok (rc == -1 && errno == ENOENT,
+        "eh_wrapper_t works with simple function (out_of_range)");
+    ok (exception_safe_wrapper.bad (),
+        "eh_wrapper_t::bad() works with simple function (out_of_range)");
+    msg = exception_safe_wrapper.get_err_message ();
+    ok (msg != NULL, "eh_wrapper_t::get_err_message () reports: %s", msg);
+}
+
+static void test_function_wrapper4 ()
+{
+    const char *msg = NULL;
+    eh_wrapper_t exception_safe_wrapper;
+
+    errno = 0;
+    exception_safe_wrapper (foo4, -1);
+    ok (errno == 0,
+        "eh_wrapper_t works with void function (no exception)");
+    ok (!exception_safe_wrapper.bad (),
+        "eh_wrapper_t::bad() works with void function (no exception)");
+    msg = exception_safe_wrapper.get_err_message ();
+    ok (msg == NULL, "eh_wrapper_t::get_err_message () works void function");
+
+    errno = 0;
+    exception_safe_wrapper (foo4, ENOENT);
+    ok (errno == ENOENT,
+        "eh_wrapper_t works with void function (out_of_range)");
+    ok (exception_safe_wrapper.bad (),
+        "eh_wrapper_t::bad() works with void function (out_of_range)");
+    msg = exception_safe_wrapper.get_err_message ();
+    ok (msg != NULL, "eh_wrapper_t::get_err_message () reports: %s", msg);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (26);
+
+    test_functor_wrapper ();
+
+    test_function_wrapper ();
+
+    test_function_wrapper2 ();
+
+    test_function_wrapper3 ();
+
+    test_lambda_wrapper ();
+
+    test_function_wrapper4 ();
+
+    done_testing ();
+
+    return EXIT_SUCCESS;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */


### PR DESCRIPTION
This PR adds generic C++ exception handling wrapper support.

This is generic in that this will enable us to wrap functions of many types
and provide exception safety to those functions with minor efforts.
Specifically, this is needed to wrap `mod_main` of `qmanager`,
which is a part of this PR, and more importantly the schedutil
callbacks within `qmanager`, which will be a part of a future PR.

The wrappers uses perfect forwarding to wrap the target functor
of many different types and add an exception
handling semantics common for Flux. Essentially, map
certain C++ exceptions classes to `errno`s as they are caught.

Note that this won't be used to wrap "native" request handlers as
it doesn't do flux respond epilogues like what @trws's PR #542 does.
Wrapping native request handlers will need an interface like #542.
In fact, I will continue to grow `c++wrappers` directory to have
a more specialized wrapper like it. 



