### PR TITLE
Add new option-set management support

### DIFF
--- a/etc/qmanager.toml
+++ b/etc/qmanager.toml
@@ -4,13 +4,16 @@
 
 [qmanager]
 
-policy = "fcfs"                    # queueing policy type
+# queueing policy type
+queue-policy = "fcfs"
 
-    [qmanager.queue-params]        # general queue parameters
-    max-queue-depth = 1000000      # max queue depth (applied to all policies)
-    queue-depth = 8192             # queue-depth (applied to all policies)
+# general queue parameters
+    # queue-depth (applied to all policies)
+    # max queue depth (applied to all policies)
+queue-params = "queue-depth=8192,max-queue-depth=1000000"
 
-    [qmanager.policy-params]       # queue policy parameters
-    max-reservation-depth = 100000 # max depth for "conservative" and "hybrid"
-    reservation-depth = 64         # reservation depth for HYBRID
+# queue policy parameters
+    # max depth for "conservative" and "hybrid"
+    # reservation depth for HYBRID
+policy-params = "reservation-depth=64,max-reservation-depth=100000"
 

--- a/qmanager/modules/Makefile.am
+++ b/qmanager/modules/Makefile.am
@@ -17,6 +17,10 @@ fluxmod_LTLIBRARIES = qmanager.la
 #
 qmanager_la_SOURCES = \
     qmanager.cpp \
+    qmanager_opts.cpp \
+    qmanager_opts.hpp \
+    $(top_srcdir)/src/common/liboptmgr/optmgr.hpp \
+    $(top_srcdir)/src/common/liboptmgr/optmgr_impl.hpp \
     $(top_srcdir)/resource/hlapi/bindings/c++/reapi.hpp \
     $(top_srcdir)/resource/hlapi/bindings/c++/reapi_cli.hpp \
     $(top_srcdir)/resource/hlapi/bindings/c++/reapi_cli_impl.hpp \

--- a/qmanager/modules/qmanager_opts.cpp
+++ b/qmanager/modules/qmanager_opts.cpp
@@ -1,0 +1,184 @@
+/*****************************************************************************\
+ *  Copyright (c) 2020 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include "qmanager_opts.hpp"
+
+using namespace Flux;
+using namespace Flux::opts_manager;
+
+
+/******************************************************************************
+ *                                                                            *
+ *              Private API for Queue Manager Option Class                    *
+ *                                                                            *
+ ******************************************************************************/
+
+qmanager_opts_t &qmanager_opts_t::canonicalize ()
+{
+    // Placeholder: If there are options whose default values are
+    // determined by another option, this method must
+    // cannoicalize the state.
+    return *this;
+}
+
+bool qmanager_opts_t::known_queue_policy (const std::string &policy)
+{
+    bool rc = false;
+    if (policy == "fcfs" || policy == "easy"
+        || policy == "hybrid" || policy == "conservative")
+        rc = true;
+    return rc;
+}
+
+
+/******************************************************************************
+ *                                                                            *
+ *              Public API for Queue Manager Option Class                     *
+ *                                                                            *
+ ******************************************************************************/
+
+qmanager_opts_t::qmanager_opts_t ()
+{
+    // Note: std::pair<>() is guaranteed to throw only an exception
+    // from its arguments which in this case std::bad_alloc -- i.e.,
+    // from std::string (const char *).
+    // map<>::insert() can also throw std::bad_alloc.
+
+    bool inserted = true;
+
+    auto ret = m_tab.insert (std::pair<std::string, int> (
+                   "queue-policy",
+                   static_cast<int> (qmanager_opts_key_t::QUEUE_POLICY)));
+    inserted &= ret.second;
+    ret = m_tab.insert (std::pair<std::string, int> (
+              "queue-params",
+              static_cast<int> (qmanager_opts_key_t::QUEUE_PARAMS)));
+    inserted &= ret.second;
+    ret= m_tab.insert (std::pair<std::string, int> (
+              "policy-params",
+              static_cast<int> (qmanager_opts_key_t::POLICY_PARAMS)));
+    inserted &= ret.second;
+
+    if (!inserted)
+        throw std::bad_alloc ();
+}
+
+void qmanager_opts_t::set_queue_policy (const std::string &o)
+{
+    m_queue_prop.queue_policy = o;
+}
+
+void qmanager_opts_t::set_queue_params (const std::string &o)
+{
+    m_queue_prop.queue_params = o;
+}
+
+void qmanager_opts_t::set_policy_params (const std::string &o)
+{
+    m_queue_prop.policy_params = o;
+}
+
+const std::string &qmanager_opts_t::get_queue_policy () const
+{
+    return m_queue_prop.queue_policy;
+}
+
+const std::string &qmanager_opts_t::get_queue_params () const
+{
+    return m_queue_prop.queue_params;
+}
+
+const std::string &qmanager_opts_t::get_policy_params () const
+{
+    return m_queue_prop.policy_params;
+}
+
+bool qmanager_opts_t::is_queue_policy_set () const
+{
+    return m_queue_prop.queue_policy != QMANAGER_OPTS_UNSET_STR;
+}
+
+bool qmanager_opts_t::is_queue_params_set () const
+{
+    return m_queue_prop.queue_params != QMANAGER_OPTS_UNSET_STR;
+}
+
+bool qmanager_opts_t::is_policy_params_set () const
+{
+    return m_queue_prop.policy_params != QMANAGER_OPTS_UNSET_STR;
+}
+
+qmanager_opts_t &qmanager_opts_t::operator+= (const qmanager_opts_t &src)
+{
+    if (src.m_queue_prop.queue_policy != QMANAGER_OPTS_UNSET_STR)
+        m_queue_prop.queue_policy = src.m_queue_prop.queue_policy;
+    if (src.m_queue_prop.queue_params != QMANAGER_OPTS_UNSET_STR)
+        m_queue_prop.queue_params = src.m_queue_prop.queue_params;
+    if (src.m_queue_prop.policy_params != QMANAGER_OPTS_UNSET_STR)
+        m_queue_prop.policy_params = src.m_queue_prop.policy_params;
+    return canonicalize ();
+}
+
+int qmanager_opts_t::parse (const std::string &k, const std::string &v,
+                            std::string &info)
+{
+    int rc = 0;
+    std::string dflt;
+    int key = static_cast<int> (qmanager_opts_key_t::UNKNOWN);
+
+    if (m_tab.find (k) != m_tab.end ())
+        key = m_tab[k];
+
+    switch (key) {
+    case static_cast<int> (qmanager_opts_key_t::QUEUE_POLICY):
+        dflt = m_queue_prop.queue_policy;
+        m_queue_prop.queue_policy = v;
+        if (!known_queue_policy (m_queue_prop.queue_policy)) {
+            info += "Unknown queuing policy (" + v + ")! ";
+            info += "Use default.";
+            m_queue_prop.queue_policy = dflt;
+        }
+        break;
+
+    case static_cast<int> (qmanager_opts_key_t::QUEUE_PARAMS):
+        m_queue_prop.queue_params = v;
+        break;
+
+    case static_cast<int> (qmanager_opts_key_t::POLICY_PARAMS):
+        m_queue_prop.policy_params = v;
+        break;
+
+    default:
+        info += "Unknown option (" + k + ").";
+        errno = EINVAL;
+        rc = -1;
+        break;
+    }
+
+    return rc;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/qmanager/modules/qmanager_opts.hpp
+++ b/qmanager/modules/qmanager_opts.hpp
@@ -1,0 +1,112 @@
+/*****************************************************************************\
+ *  Copyright (c) 2020 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef QMANAGER_OPTS_HPP
+#define QMANAGER_OPTS_HPP
+
+#include <string>
+#include <vector>
+#include <map>
+#include "src/common/liboptmgr/optmgr.hpp"
+
+namespace Flux {
+namespace opts_manager {
+
+const std::string QMANAGER_OPTS_UNSET_STR = "0xdeadbeef";
+
+struct queue_prop_t {
+    std::string queue_policy = QMANAGER_OPTS_UNSET_STR;
+    std::string queue_params = QMANAGER_OPTS_UNSET_STR;
+    std::string policy_params = QMANAGER_OPTS_UNSET_STR;
+};
+
+/*! qmanager option set class
+ *
+ */
+class qmanager_opts_t : public optmgr_parse_t {
+public:
+    enum class qmanager_opts_key_t : int {
+        QUEUE_POLICY              = 10, // queue-policy
+        QUEUE_PARAMS              = 20, // queue-params
+        POLICY_PARAMS             = 30, // policy-params
+        UNKNOWN                   = 5000
+    };
+
+    // These constructors can throw std::bad_alloc exception
+    qmanager_opts_t ();
+    qmanager_opts_t (const qmanager_opts_t &o) = default;
+    qmanager_opts_t &operator= (const qmanager_opts_t &o) = default;
+    // No exception is thrown from move constructor and move assignment
+    qmanager_opts_t (qmanager_opts_t &&o) = default;
+    qmanager_opts_t &operator= (qmanager_opts_t &&o) = default;
+
+    void set_queue_policy (const std::string &o);
+    void set_queue_params (const std::string &o);
+    void set_policy_params (const std::string &o);
+
+    const std::string &get_queue_policy () const;
+    const std::string &get_queue_params () const;
+    const std::string &get_policy_params () const;
+
+    bool is_queue_policy_set () const;
+    bool is_queue_params_set () const;
+    bool is_policy_params_set () const;
+
+    /*! Add an option with a higher precendence than "this" object.
+     *  Modify this object according to the following "add" semantics
+     *  and return the modified object:
+     *  For each option key in o which has a non-default value,
+     *  override the same key in this object.
+     *
+     *  \param o         an option set object with a higher precendence.
+     *  \return          the composed qmanager_opts_t object.
+     */
+    qmanager_opts_t &operator+= (const qmanager_opts_t &o);
+
+    /*! Parse the value string (v) according to the key string (k).
+     *  The parsed results are stored in "this" object.
+     *
+     *  \param k         key string
+     *  \param v         value string
+     *  \param info      parsing info and warning string to return.
+     *  \return          0 on success; -1 on error.
+     */
+    int parse (const std::string &k, const std::string &v, std::string &info);
+
+private:
+    qmanager_opts_t &canonicalize ();
+    bool known_queue_policy (const std::string &policy);
+
+    queue_prop_t m_queue_prop;
+    std::map<std::string, int> m_tab;
+};
+
+} // namespace Flux
+} // namespace opts_manager
+
+#endif // QMANAGER_OPTS_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/qmanager/policies/base/queue_policy_base_impl.hpp
+++ b/qmanager/policies/base/queue_policy_base_impl.hpp
@@ -106,20 +106,29 @@ int queue_policy_base_t::set_policy_params (const std::string &params)
 int queue_policy_base_t::apply_params ()
 {
     int rc = 0;
+    int depth = 0;
     try {
         std::unordered_map<std::string, std::string>::const_iterator i;
         if ((i = queue_policy_base_impl_t::m_qparams.find ("max-queue-depth"))
              != queue_policy_base_impl_t::m_qparams.end ()) {
-            unsigned int depth = std::stoi (i->second);
+            if ( (depth = std::stoi (i->second)) < 1) {
+                errno = ERANGE;
+                rc += -1;
+            }
             queue_policy_base_impl_t::m_max_queue_depth = depth;
-            if (depth < queue_policy_base_impl_t::m_queue_depth) {
+            if (static_cast<unsigned> (depth)
+                    < queue_policy_base_impl_t::m_queue_depth) {
                 queue_policy_base_impl_t::m_queue_depth = depth;
             }
         }
         if ((i = queue_policy_base_impl_t::m_qparams.find ("queue-depth"))
              != queue_policy_base_impl_t::m_qparams.end ()) {
-            unsigned int depth = std::stoi (i->second);
-            if (depth < m_max_queue_depth) {
+            int depth = std::stoi (i->second);
+            if ( (depth = std::stoi (i->second)) < 1) {
+                errno = ERANGE;
+                rc += -1;
+            }
+            if (static_cast<unsigned> (depth) < m_max_queue_depth) {
                 queue_policy_base_impl_t::m_queue_depth = depth;
             } else {
                 queue_policy_base_impl_t::m_queue_depth

--- a/qmanager/policies/queue_policy_conservative_impl.hpp
+++ b/qmanager/policies/queue_policy_conservative_impl.hpp
@@ -53,10 +53,14 @@ int queue_policy_conservative_t<reapi_type>::apply_params ()
         if ((i = queue_policy_base_impl_t
                      ::m_pparams.find ("max-reservation-depth"))
              != queue_policy_base_impl_t::m_pparams.end ()) {
-            unsigned int depth = std::stoi (i->second);
+            int depth = 0;
+            if ( (depth = std::stoi (i->second)) < 1) {
+                errno = ERANGE;
+                rc = -1;
+            }
             queue_policy_bf_base_t<reapi_type>::m_max_reservation_depth = depth;
-            if (depth < queue_policy_bf_base_t<reapi_type>
-                            ::m_reservation_depth) {
+            if (static_cast<unsigned> (depth)
+                    < queue_policy_bf_base_t<reapi_type>::m_reservation_depth) {
                 queue_policy_bf_base_t<reapi_type>::m_reservation_depth = depth;
             }
         }

--- a/qmanager/policies/queue_policy_factory.hpp
+++ b/qmanager/policies/queue_policy_factory.hpp
@@ -27,11 +27,11 @@
 
 #include <memory>
 #include <string>
+#include "qmanager/policies/base/queue_policy_base.hpp"
 
 namespace Flux {
 namespace queue_manager {
 
-bool known_queue_policy (const std::string &policy);
 std::shared_ptr<queue_policy_base_t> create_queue_policy (
                                          const std::string &policy,
                                          const std::string &reapi);

--- a/qmanager/policies/queue_policy_factory_impl.hpp
+++ b/qmanager/policies/queue_policy_factory_impl.hpp
@@ -49,15 +49,6 @@ namespace detail {
 using namespace resource_model;
 using namespace resource_model::detail;
 
-bool known_queue_policy (const std::string &policy)
-{
-    bool rc = false;
-    if (policy == "fcfs" || policy == "easy"
-        || policy == "hybrid" || policy == "conservative")
-        rc = true;
-    return rc;
-}
-
 std::shared_ptr<queue_policy_base_t> create_queue_policy (
                                          const std::string &policy,
                                          const std::string &reapi)

--- a/qmanager/policies/queue_policy_hybrid_impl.hpp
+++ b/qmanager/policies/queue_policy_hybrid_impl.hpp
@@ -48,19 +48,26 @@ template<class reapi_type>
 int queue_policy_hybrid_t<reapi_type>::apply_params ()
 {
     int rc = queue_policy_base_t::apply_params ();
+    int depth = 0;
     try {
         std::unordered_map<std::string, std::string>::const_iterator i;
         if ((i = queue_policy_base_impl_t
                      ::m_pparams.find ("max-reservation-depth"))
              != queue_policy_base_impl_t::m_pparams.end ()) {
-            unsigned int depth = std::stoi (i->second);
+            if ( (depth = std::stoi (i->second)) < 1) {
+                errno = ERANGE;
+                rc += -1;
+            }
             queue_policy_bf_base_t<reapi_type>::m_max_reservation_depth = depth;
         }
         if ((i = queue_policy_base_impl_t
                      ::m_pparams.find ("reservation-depth"))
              != queue_policy_base_impl_t::m_pparams.end ()) {
-            unsigned int depth = std::stoi (i->second);
-            if (depth < queue_policy_bf_base_t<reapi_type>
+            if ( (depth = std::stoi (i->second)) < 1) {
+                errno = ERANGE;
+                rc += -1;
+            }
+            if (static_cast<unsigned> (depth) < queue_policy_bf_base_t<reapi_type>
                             ::m_max_reservation_depth) {
                 queue_policy_bf_base_t<reapi_type>::m_reservation_depth = depth;
             } else {

--- a/src/common/liboptmgr/optmgr.hpp
+++ b/src/common/liboptmgr/optmgr.hpp
@@ -1,0 +1,217 @@
+/*****************************************************************************\
+ *  Copyright (c) 2020 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/ 
+#ifndef OPTMGR_HPP
+#define OPTMGR_HPP
+
+#include <map>
+#include <string>
+#include <vector>
+#include "src/common/liboptmgr/optmgr_impl.hpp"
+
+namespace Flux {
+namespace opts_manager {
+
+
+/*! Flux module option composer class: Module options can come
+ *  from multiple sources (e.g., through compile-time default,
+ *  configuration file and module load options). This simple templated
+ *  class helps compose the options from those multiple sources
+ *  with specific precedences.
+ *
+ *  T is a Flux module option-set data type, representing an option
+ *  set from a single source. optmgr_composer_t requires the T to
+ *  provide the operator+=() method that implements how "this" T
+ *  object must be composed with another T object with a higher precedence.
+ *
+ *  Expectation: operator+=() would newly add an option from the option
+ *  set managed by the passed T object if "this" object does not already
+ *  have it; otherwise override it. However, this wrapper class simply
+ *  delegates the composition rule down to the template T class.
+ */
+template <class T>
+class optmgr_composer_t {
+public:
+
+    /*!
+     * Compose the option-set state managed by "this" object
+     * with the option-set state from another object with
+     * a higher precedence.
+     * If T doesn't have operator+=(), a compilation error
+     * will ensue.
+     *
+     * \param o        option-set object of T type 
+     * \return         the option set object of type T of "this"
+     *                 after composed with o.
+     */
+    T &operator+= (const T &o) {
+        return m_opt += o;
+    }
+
+    /*!
+     * Getter
+     *
+     * \return         Option set object of type T
+     */
+    const T &get_opt () const {
+        return m_opt;
+    }
+
+private:
+    T m_opt;
+};
+
+
+/*! A key value store class that helps parsing and holding
+ *  the option set from a single source (e.g., an option set passed from
+ *  module-load time).
+ *  Template class T should be a module option-set management class
+ *  that provides a "parse" method. This method must take in an option
+ *  key-value pair from the optmgr_kv_t class and update its state.
+ */
+template <class T>
+struct optmgr_kv_t : public detail::optmgr_kv_impl_t<T> {
+
+    /*! Getter
+     *
+     * \return         Option set object of type T of "this" object.
+     */
+    const T &get_opt () const {
+        return detail::optmgr_kv_impl_t<T>::get_opt ();
+    }
+
+    /*! Put
+     *
+     * \param k        Key string
+     * \param v        Value string
+     *
+     * \return         0 on success; -1 on error.
+     */
+    int put (const std::string &k, const std::string &v) {
+        return detail::optmgr_kv_impl_t<T>::put (k, v);
+    }
+
+    /*! Put
+     *
+     * \param kv       Key=Value string
+     *
+     * \return         0 on success; -1 on error.
+     */
+    int put (const std::string &kv) {
+        return detail::optmgr_kv_impl_t<T>::put (kv);
+    }
+
+    /*! Get
+     *
+     * \param k        Key string
+     * \param v        Returning value string associated with the key
+     *
+     * \return         0 on success; -1 on error.
+     */
+    int get (const std::string &k, std::string &v) const {
+        return detail::optmgr_kv_impl_t<T>::get (k, v);
+    }
+
+    /*! Parse key=value option pairs and update the state of
+     *  the option-set of T type. If T doesn't have parse() method,
+     *  compilation error will ensue.
+     *
+     * \param info     parse warning or error string.
+     * \return         0 on success; -1 on error.
+     */
+    int parse (std::string &info) {
+        return detail::optmgr_kv_impl_t<T>::parse (info);
+    }
+};
+
+
+/*! Parsing utilities.
+ *
+ */
+struct optmgr_parse_t : public detail::optmgr_parse_impl_t {
+
+    /*! Parse a string that contains key and value delimited with token.
+     *  The parsed key and value are passed through k and v respectively.
+     *
+     * \param str      String that contains key and value.
+     * \param token    Token string.
+     * \param k        Key string to return.
+     * \param v        Value string to return.
+     *
+     * \return         0 on success; -1 on error.
+     *                 errno: EINVAL and EPROTO
+     */
+    int parse_single (const std::string &str, const std::string &token,
+                      std::string &k, std::string &v) {
+        return detail::optmgr_parse_impl_t::parse_single (str, token, k, v);
+    }
+
+    /*! Parse multi_value string: each value is delimited with the
+     *  delim character and return the parsed results to entries.
+     *  (e.g., "foo1=bar1 foo2=bar2" whereby ' ' is the delim character
+     *  then each of foo*=bar* pairs is parsed into the entries vector).
+     *
+     * \param multi_value
+     *                 Multi-value string.
+     * \param delim    Delim character.
+     * \param entries  Parsed results are returned to vector of strings.
+     *
+     * \return         0 on success; -1 on error.
+     *                 errno: ENOMEM
+     */
+    int parse_multi (const std::string multi_value, const char delim,
+                     std::vector<std::string> &entries) {
+        return detail::optmgr_parse_impl_t::parse_multi (multi_value,
+                                                         delim, entries);
+    }
+
+    /*! Parse the m_opts string that contains multiple options delimited
+     *  with odelim.
+     *  (e.g., "foo1=bar1 foo2=bar2" whereby ' ' is the option delimiter
+     *  and '=' is the key-value delimiter, the parsed result
+     *  will be returned to std::map accordingly.
+     *
+     * \param m_opts   Multi-option string.
+     * \param odelim   Option delimiter character.
+     * \param kdelim   Key-value delimiter character.
+     * \param opt_mp   std::map object that contains the parsed result.
+     *
+     * \return         0 on success; -1 on error.
+     *                 errno: ENOMEM, EEXIST, EINVAL and EPROTO.
+     */
+    int parse_multi_options (const std::string &m_opts, const char odelim,
+                             const char kdelim, std::map<std::string,
+                                                         std::string> &opt_mp) {
+        return detail::optmgr_parse_impl_t::parse_multi_options (m_opts, odelim,
+                                                                 kdelim, opt_mp);
+    }
+};
+
+} // namespace Flux::opts_manager
+} // namespace Flux
+
+#endif // OPTMGR_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/liboptmgr/optmgr_impl.hpp
+++ b/src/common/liboptmgr/optmgr_impl.hpp
@@ -1,0 +1,179 @@
+/*****************************************************************************\
+ *  Copyright (c) 2020 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef OPTMGR_IMPL_HPP
+#define OPTMGR_IMPL_HPP
+
+#include <map>
+#include <string>
+#include <sstream>
+#include <vector>
+
+namespace Flux {
+namespace opts_manager {
+namespace detail {
+
+template <class T>
+class optmgr_kv_impl_t {
+protected:
+
+    const T &get_opt () const {
+        return m_opt;
+    }
+
+    int put (const std::string &k, const std::string &v) {
+        int rc = 0;
+        try {
+            auto ret = m_kv.insert (std::pair<std::string, std::string> (k, v));
+            if (!ret.second) {
+                errno = EEXIST;
+                rc = -1;
+            }
+        }
+        catch (std::bad_alloc &) {
+            errno = ENOMEM;
+            rc = -1;
+        }
+        return rc;
+    }
+
+    int put (const std::string &kv) {
+        size_t found = std::string::npos;
+        if ( (found = kv.find_first_of ("=")) == std::string::npos) {
+            errno = EPROTO;
+            return -1;
+        }
+        return put (kv.substr (0, found), kv.substr (found + 1));
+    }
+
+    int get (const std::string &k, std::string &v) const {
+        int rc = 0;
+        try {
+            v = m_kv.at (k);
+        }
+        catch (std::bad_alloc &) {
+            errno = ENOMEM;
+            rc = -1;
+        }
+        catch (std::out_of_range &) {
+            errno = ENOENT;
+            rc = -1;
+        }
+        return rc;
+    }
+
+    int parse (std::string &info) {
+        int rc = 0;
+        for (const auto &kv : m_kv) {
+            // If T doesn't have parse method, this produces an compiler error
+            if ( (rc = m_opt.parse (kv.first, kv.second, info)) < 0) {
+                return rc;
+            }
+        }
+        return rc;
+    }
+
+private:
+    T m_opt;
+    std::map<std::string, std::string> m_kv;
+};
+
+
+class optmgr_parse_impl_t {
+protected:
+    int parse_single (const std::string &str, const std::string &token,
+                      std::string &k, std::string &v) {
+        size_t found;
+        if (str == "" || token == "") {
+            errno = EINVAL;
+            return -1;
+        }
+        if ( (found = str.find_first_of (token)) == std::string::npos) {
+            errno = EPROTO;
+            return -1;
+        }
+        k = str.substr (0, found);
+        v = str.substr (found + 1);
+        return 0;
+    }
+
+    int parse_multi (const std::string multi_value, const char delim,
+                     std::vector<std::string> &entries) {
+        int rc = 0;
+        try {
+            std::stringstream ss;
+            std::string entry;
+            ss << multi_value;
+            while (getline (ss, entry, delim))
+                entries.push_back (entry);
+        }
+        catch (std::bad_alloc &) {
+            errno = ENOMEM;
+            rc = -1;
+        }
+        return rc;
+    }
+
+    int parse_multi_options (const std::string &m_opts, const char odelim,
+                             const char kdelim, std::map<std::string,
+                                                         std::string> &opt_mp) {
+        int rc = 0;
+        try {
+            std::vector<std::string> entries;
+            if ( (rc = parse_multi (m_opts, odelim, entries)) < 0)
+                goto done;
+            for (const auto &entry : entries) {
+                std::string n = "";
+                std::string v = "";
+                if ( (rc = parse_single (entry, std::string (1, kdelim), n, v)) < 0)
+                    goto done;
+                auto ret = opt_mp.insert (std::pair<std::string,
+                                                    std::string> (n, v));
+                if (!ret.second) {
+                    errno = EEXIST;
+                    rc = -1;
+                    goto done;
+                }
+            }
+        }
+        catch (std::bad_alloc &) {
+            errno = ENOMEM;
+            rc = -1;
+        }
+    done:
+        return rc;
+    
+        }
+};
+
+
+} // detail
+} // opts_manager
+} // Flux
+
+#endif // OPTMGR_IMPL_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/conf.d/01-default/qmanager.toml
+++ b/t/conf.d/01-default/qmanager.toml
@@ -4,13 +4,15 @@
 
 [qmanager]
 
-policy = "fcfs"                    # queueing policy type
+# queueing policy type
+queue-policy = "fcfs"
 
-    [qmanager.queue-params]        # general queue parameters
-    max-queue-depth = 1000000      # max queue depth (applied to all policies)
-    queue-depth = 8192             # queue-depth (applied to all policies)
+# general queue parameters
+    # max queue depth (applied to all policies)
+    # queue-depth (applied to all policies)
+queue-params = "max-queue-depth=1000000,queue-depth=8192"
 
-    [qmanager.policy-params]       # queue policy parameters
-    max-reservation-depth = 100000 # max depth for "conservative" and "hybrid"
-    reservation-depth = 64         # reservation depth for HYBRID
-
+# queue policy parameters
+    # max depth for "conservative" and "hybrid"
+    # reservation depth for HYBRID
+policy-params = "max-reservation-depth=100000,reservation-depth=64"

--- a/t/conf.d/02-no-keys/qmanager.toml
+++ b/t/conf.d/02-no-keys/qmanager.toml
@@ -4,7 +4,3 @@
 
 [qmanager]
 
-    [qmanager.queue-params]        # general queue parameters
-
-    [qmanager.policy-params]       # queue policy parameters
-

--- a/t/conf.d/03-extra-keys/qmanager.toml
+++ b/t/conf.d/03-extra-keys/qmanager.toml
@@ -4,14 +4,16 @@
 
 [qmanager]
 
-policy = "fcfs"                # queueing policy type
+queue-policy = "fcfs"              # queueing policy type
 
-    [qmanager.queue-params]        # general queue parameters
-    max-queue-depth = 1000000      # max queue depth (applied to all policies)
-    queue-depth = 8192             # queue-depth (applied to all policies)
-    foo = 1234                     # unknown key (this should be okay)
+# general queue parameters
+    # max queue depth (applied to all policies)
+    # queue-depth (applied to all policies)
+    # unknown key should be tolerated
+queue-params = "max-queue-depth=1000000,queue-depth=8192,foo=1234"
 
-    [qmanager.policy-params]       # queue policy parameters
-    max-reservation-depth = 100000 # max depth for "conservative" and "hybrid"
-    reservation-depth = 64         # reservation depth for HYBRID
+# queue policy parameters
+    # max depth for "conservative" and "hybrid"
+    # reservation depth for HYBRID
+policy-params = "max-reservation-depth=100000,reservation-depth=64"
 

--- a/t/conf.d/04-conservative/qmanager.toml
+++ b/t/conf.d/04-conservative/qmanager.toml
@@ -4,12 +4,15 @@
 
 [qmanager]
 
-policy = "conservative"        # queueing policy type
+queue-policy = "conservative"        # queueing policy type
 
-    [qmanager.queue-params]        # general queue parameters
-    max-queue-depth = 1000000      # max queue depth (applied to all policies)
-    queue-depth = 8192             # queue-depth (applied to all policies)
+# general queue parameters
+    # max queue depth (applied to all policies)
+    # queue-depth (applied to all policies)
+    # unknown key should be tolerated
+queue-params = "max-queue-depth=1000000,queue-depth=8192"
 
-    [qmanager.policy-params]       # queue policy parameters
-    max-reservation-depth = 64     # max depth for "conservative" and "hybrid"
+# queue policy parameters
+    # max depth for "conservative" and "hybrid"
+policy-params = "max-reservation-depth=64"
 

--- a/t/conf.d/05-small-queue-depth/qmanager.toml
+++ b/t/conf.d/05-small-queue-depth/qmanager.toml
@@ -4,13 +4,16 @@
 
 [qmanager]
 
-policy = "fcfs"                 # queueing policy type
+queue-policy = "fcfs"                 # queueing policy type
 
-    [qmanager.queue-params]        # general queue parameters
-    max-queue-depth = 1000         # max queue depth (applied to all policies)
-    queue-depth = 10               # queue-depth (applied to all policies)
+# general queue parameters
+    # max queue depth (applied to all policies)
+    # queue-depth (applied to all policies)
+    # unknown key should be tolerated
+queue-params = "max-queue-depth=1000,queue-depth=10"
 
-    [qmanager.policy-params]       # queue policy parameters
-    max-reservation-depth = 100000 # max depth for "conservative" and "hybrid"
-    reservation-depth = 64         # reservation depth for HYBRID
+# queue policy parameters
+    # max depth for "conservative" and "hybrid"
+    # reservation depth for HYBRID
+policy-params = "max-reservation-depth=100000,reservation-depth=64"
 

--- a/t/conf.d/06-hybrid/qmanager.toml
+++ b/t/conf.d/06-hybrid/qmanager.toml
@@ -4,13 +4,16 @@
 
 [qmanager]
 
-policy = "hybrid"              # queueing policy type
+queue-policy = "hybrid"              # queueing policy type
 
-    [qmanager.queue-params]        # general queue parameters
-    max-queue-depth = 1000000      # max queue depth (applied to all policies)
-    queue-depth = 8192             # queue-depth (applied to all policies)
+# general queue parameters
+    # max queue depth (applied to all policies)
+    # queue-depth (applied to all policies)
+    # unknown key should be tolerated
+queue-params = "max-queue-depth=1000000,queue-depth=8192"
 
-    [qmanager.policy-params]       # queue policy parameters
-    max-reservation-depth = 128    # max depth for "conservative" and "hybrid"
-    reservation-depth = 64         # reservation depth for HYBRID
+# queue policy parameters
+    # max depth for "conservative" and "hybrid"
+    # reservation depth for HYBRID
+policy-params = "max-reservation-depth=128,reservation-depth=64"
 

--- a/t/conf.d/07-hybrid2/qmanager.toml
+++ b/t/conf.d/07-hybrid2/qmanager.toml
@@ -4,13 +4,16 @@
 
 [qmanager]
 
-policy = "hybrid"              # queueing policy type
+queue-policy = "hybrid"              # queueing policy type
 
-    [qmanager.queue-params]        # general queue parameters
-    max-queue-depth = 1000000      # max queue depth (applied to all policies)
-    queue-depth = 8192             # queue-depth (applied to all policies)
+# general queue parameters
+    # max queue depth (applied to all policies)
+    # queue-depth (applied to all policies)
+    # unknown key should be tolerated
+queue-params = "max-queue-depth=1000000,queue-depth=8192"
 
-    [qmanager.policy-params]       # queue policy parameters
-    max-reservation-depth = 64     # max depth for "conservative" and "hybrid"
-    reservation-depth = 128        # reservation depth for HYBRID
+# queue policy parameters
+    # max depth for "conservative" and "hybrid"
+    # reservation depth for HYBRID
+policy-params = "max-reservation-depth=64,reservation-depth=128"
 

--- a/t/conf.d/08-no-queue-depth/qmanager.toml
+++ b/t/conf.d/08-no-queue-depth/qmanager.toml
@@ -4,12 +4,15 @@
 
 [qmanager]
 
-policy = "fcfs"                 # queueing policy type
+queue-policy = "fcfs"                 # queueing policy type
 
-    [qmanager.queue-params]        # general queue parameters
-    max-queue-depth = 1000         # max queue depth (applied to all policies)
+# general queue parameters
+    # max queue depth (applied to all policies)
+    # queue-depth (applied to all policies)
+    # unknown key should be tolerated
+queue-params = "max-queue-depth=1000"
 
-    [qmanager.policy-params]       # queue policy parameters
-    max-reservation-depth = 100000 # max depth for "conservative" and "hybrid"
-    reservation-depth = 64         # reservation depth for HYBRID
-
+# queue policy parameters
+    # max depth for "conservative" and "hybrid"
+    # reservation depth for HYBRID
+policy-params = "max-reservation-depth=100000,reservation-depth=64"

--- a/t/conf.d/09-invalid-policy/qmanager.toml
+++ b/t/conf.d/09-invalid-policy/qmanager.toml
@@ -4,13 +4,14 @@
 
 [qmanager]
 
-policy = "invalid"             # queueing policy type
+queue-policy = "invalid"             # queueing policy type
 
-    [qmanager.queue-params]        # general queue parameters
-    max-queue-depth = 1000000      # max queue depth (applied to all policies)
-    queue-depth = 8192             # queue-depth (applied to all policies)
+# general queue parameters
+    # max queue depth (applied to all policies)
+    # queue-depth (applied to all policies)
+queue-params = "max-queue-depth=1000000,queue-depth=8192"
 
-    [qmanager.policy-params]       # queue policy parameters
-    max-reservation-depth = 100000 # max depth for "conservative" and "hybrid"
-    reservation-depth = 64         # reservation depth for HYBRID
-
+# queue policy parameters
+    # max depth for "conservative" and "hybrid"
+    # reservation depth for HYBRID
+policy-params = "max-reservation-depth=100000,reservation-depth=64"

--- a/t/conf.d/10-neg-value/qmanager.toml
+++ b/t/conf.d/10-neg-value/qmanager.toml
@@ -4,13 +4,15 @@
 
 [qmanager]
 
-policy = "easy"                # queueing policy type
+queue-policy = "easy"                # queueing policy type
 
-    [qmanager.queue-params]        # general queue parameters
-    max-queue-depth = -1           # max queue depth (applied to all policies)
-    queue-depth = 8192             # queue-depth (applied to all policies)
+# general queue parameters
+    # max queue depth (applied to all policies)
+    # queue-depth (applied to all policies)
+queue-params = "max-queue-depth=-1,queue-depth=8192"
 
-    [qmanager.policy-params]       # queue policy parameters
-    max-reservation-depth = 100000 # max depth for "conservative" and "hybrid"
-    reservation-depth = 64         # reservation depth for HYBRID
+# queue policy parameters
+    # max depth for "conservative" and "hybrid"
+    # reservation depth for HYBRID
+policy-params = "max-reservation-depth=100000,reservation-depth=64"
 

--- a/t/conf.d/11-no-params/qmanager.toml
+++ b/t/conf.d/11-no-params/qmanager.toml
@@ -4,5 +4,5 @@
 
 [qmanager]
 
-policy = "fcfs"                 # queueing policy type
+queue-policy = "fcfs"                 # queueing policy type
 

--- a/t/conf.d/12-no-policy-params/qmanager.toml
+++ b/t/conf.d/12-no-policy-params/qmanager.toml
@@ -4,9 +4,9 @@
 
 [qmanager]
 
-policy = "fcfs"                    # queueing policy type
+queue-policy = "fcfs"                    # queueing policy type
 
-    [qmanager.queue-params]        # general queue parameters
-    max-queue-depth = 1000000      # max queue depth (applied to all policies)
-    queue-depth = 8192             # queue-depth (applied to all policies)
-
+# general queue parameters
+    # max queue depth (applied to all policies)
+    # queue-depth (applied to all policies)
+queue-params = "max-queue-depth=1000000,queue-depth=8192"

--- a/t/conf.d/13-bad-value/qmanager.toml
+++ b/t/conf.d/13-bad-value/qmanager.toml
@@ -4,13 +4,15 @@
 
 [qmanager]
 
-policy = "easy"                # queueing policy type
+queue-policy = "easy"                # queueing policy type
 
-    [qmanager.queue-params]        # general queue parameters
-    max-queue-depth = "foo"        # max queue depth (applied to all policies)
-    queue-depth = 8192             # queue-depth (applied to all policies)
+# general queue parameters
+    # max queue depth (applied to all policies)
+    # queue-depth (applied to all policies)
+queue-params = "max-queue-depth=foo,queue-depth=8192"
 
-    [qmanager.policy-params]       # queue policy parameters
-    max-reservation-depth = 100000 # max depth for "conservative" and "hybrid"
-    reservation-depth = 64         # reservation depth for HYBRID
+# queue policy parameters
+    # max depth for "conservative" and "hybrid"
+    # reservation depth for HYBRID
+policy-params = "max-reservation-depth=100000,reservation-depth=64"
 

--- a/t/conf.d/14-no-queue-params/qmanager.toml
+++ b/t/conf.d/14-no-queue-params/qmanager.toml
@@ -4,9 +4,10 @@
 
 [qmanager]
 
-policy = "fcfs"                    # queueing policy type
+queue-policy = "fcfs"                    # queueing policy type
 
-    [qmanager.policy-params]       # queue policy parameters
-    max-reservation-depth = 100000 # max depth for "conservative" and "hybrid"
-    reservation-depth = 64         # reservation depth for HYBRID
+# queue policy parameters
+    # max depth for "conservative" and "hybrid"
+    # reservation depth for HYBRID
+policy-params = "max-reservation-depth=100000,reservation-depth=64"
 

--- a/t/conf.d/15-no-qmanager/qmanager.toml
+++ b/t/conf.d/15-no-qmanager/qmanager.toml
@@ -2,12 +2,14 @@
 # Configuration for the qmanager module
 #
 
+# general queue parameters
+    # max queue depth (applied to all policies)
+    # queue-depth (applied to all policies)
+queue-params = "max-queue-depth=1000000,queue-depth=8192"
 
-[qmanager.queue-params]        # general queue parameters
-max-queue-depth = 1000000      # max queue depth (applied to all policies)
-queue-depth = 8192             # queue-depth (applied to all policies)
+# queue policy parameters
+    # max depth for "conservative" and "hybrid"
+    # reservation depth for HYBRID
+policy-params = "max-reservation-depth=100000,reservation-depth=64"
 
-[qmanager.policy-params]       # queue policy parameters
-max-reservation-depth = 100000 # max depth for "conservative" and "hybrid"
-reservation-depth = 64         # reservation depth for HYBRID
 


### PR DESCRIPTION
This PR adds a better module option-set management support and update `qmanager` on top of it.

- Add generic module option management helper classes into `src/common/liboptmgr`: `optmgr_composer_t`, `optmgr_kv_t` and `optmgr_parse_t`;
- Add a `qmanager`-specific option-set class that uses and conforms to the generic management class (`qmanager_opts_t`);
- Integrate `qmanager_opts_t` into `qmanager` to reduce the complexity of option-set management. This will be particularly essential as I will add multi-queue support into `qmanager` soon with more complex set of options;
- Adjust test cases and `qmanager` configuration files.