### PR TITLE
qmanager: add exception safety for schedutil callbacks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -155,6 +155,8 @@ AC_CONFIG_FILES([Makefile
   src/common/libtap/Makefile
   src/common/libutil/Makefile
   src/common/librbtree/Makefile
+  src/common/c++wrappers/Makefile
+  src/common/c++wrappers/test/Makefile
   src/cmd/Makefile
   resource/Makefile
   resource/planner/Makefile

--- a/qmanager/modules/Makefile.am
+++ b/qmanager/modules/Makefile.am
@@ -19,6 +19,8 @@ qmanager_la_SOURCES = \
     qmanager.cpp \
     qmanager_opts.cpp \
     qmanager_opts.hpp \
+    qmanager_callbacks.cpp \
+    qmanager_callbacks.hpp \
     $(top_srcdir)/src/common/liboptmgr/optmgr.hpp \
     $(top_srcdir)/src/common/liboptmgr/optmgr_impl.hpp \
     $(top_srcdir)/resource/hlapi/bindings/c++/reapi.hpp \

--- a/qmanager/modules/Makefile.am
+++ b/qmanager/modules/Makefile.am
@@ -40,7 +40,8 @@ qmanager_la_SOURCES = \
     $(top_srcdir)/qmanager/policies/queue_policy_conservative.hpp \
     $(top_srcdir)/qmanager/policies/queue_policy_conservative_impl.hpp \
     $(top_srcdir)/qmanager/policies/queue_policy_factory.hpp \
-    $(top_srcdir)/qmanager/policies/queue_policy_factory_impl.hpp
+    $(top_srcdir)/qmanager/policies/queue_policy_factory_impl.hpp \
+    $(top_srcdir)/src/common/c++wrappers/eh_wrapper.hpp
 
 qmanager_la_CXXFLAGS = \
     $(AM_CXXFLAGS) \

--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -31,6 +31,7 @@ extern "C" {
 #include <jansson.h>
 }
 
+#include "qmanager/modules/qmanager_callbacks.hpp"
 #include "qmanager/policies/base/queue_policy_base.hpp"
 #include "qmanager/policies/base/queue_policy_base_impl.hpp"
 #include "qmanager/policies/queue_policy_factory_impl.hpp"
@@ -50,157 +51,10 @@ using namespace Flux::cplusplus_wrappers;
  *                                                                            *
  ******************************************************************************/
 
-struct qmanager_ctx_t {
+struct qmanager_ctx_t : public qmanager_cb_ctx_t {
     flux_t *h;
-    schedutil_t *schedutil;
     optmgr_composer_t<qmanager_opts_t> opts;
-    std::shared_ptr<queue_policy_base_t> queue;
 };
-
-
-/******************************************************************************
- *                                                                            *
- *                     Internal Queue Manager APIs                            *
- *                                                                            *
- ******************************************************************************/
-
-static int post_sched_loop (std::shared_ptr<qmanager_ctx_t> &ctx)
-{
-    int rc = -1;
-    std::shared_ptr<job_t> job = nullptr;
-
-    while ((job = ctx->queue->alloced_pop ()) != nullptr) {
-        if (schedutil_alloc_respond_R (ctx->schedutil, job->msg,
-                                       job->schedule.R.c_str (), NULL) < 0) {
-            flux_log_error (ctx->h, "%s: schedutil_alloc_respond_R",
-                            __FUNCTION__);
-            goto out;
-        }
-        flux_log (ctx->h, LOG_DEBUG,
-                  "alloc success (id=%jd)", (intmax_t)job->id);
-    }
-    while ((job = ctx->queue->rejected_pop ()) != nullptr) {
-        std::string note = "alloc denied due to type=\"" + job->note + "\"";
-        if (schedutil_alloc_respond_denied (ctx->schedutil,
-                                            job->msg,
-                                            note.c_str ()) < 0) {
-            flux_log_error (ctx->h, "%s: schedutil_alloc_respond_denied",
-                            __FUNCTION__);
-            goto out;
-        }
-        flux_log (ctx->h, LOG_DEBUG,
-                  "%s (id=%jd)", note.c_str (), (intmax_t)job->id);
-    }
-    rc = 0;
-
-out:
-    return rc;
-}
-
-// FIXME: This will be expanded when we implement full scheduler
-// resilency schemes: Issue #470.
-extern "C" int jobmanager_hello_cb (flux_t *h,
-                                    flux_jobid_t id, int prio, uint32_t uid,
-                                    double ts, const char *R, void *arg)
-
-{
-    int rc = -1;
-    std::shared_ptr<qmanager_ctx_t> ctx = nullptr;
-    ctx = *(static_cast<std::shared_ptr<qmanager_ctx_t> *>(arg));
-    std::shared_ptr<job_t> running_job
-        = std::make_shared<job_t> (job_state_kind_t::
-                                   RUNNING, id, uid, prio, ts, R);
-
-    if (ctx->queue->reconstruct (running_job) < 0) {
-        flux_log_error (h, "%s: reconstruct (id=%jd)", __FUNCTION__, (intmax_t)id);
-        goto out;
-    }
-    rc = 0;
-
-out:
-    return rc;
-}
-
-extern "C" void jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
-                                     const char *jobspec, void *arg)
-{
-    std::shared_ptr<qmanager_ctx_t> ctx = nullptr;
-    ctx = *(static_cast<std::shared_ptr<qmanager_ctx_t> *>(arg));
-    std::shared_ptr<job_t> job = std::make_shared<job_t> ();
-
-    if (schedutil_alloc_request_decode (msg, &job->id, &job->priority,
-                                        &job->userid, &job->t_submit) < 0) {
-        flux_log_error (h, "%s: schedutil_alloc_request_decode", __FUNCTION__);
-        return;
-    }
-    job->jobspec = jobspec;
-    job->msg = flux_msg_copy (msg, true);
-    if (ctx->queue->insert (job) < 0) {
-        flux_log_error (h, "%s: queue insert (id=%jd)",
-                        __FUNCTION__, (intmax_t)job->id);
-        return;
-    }
-    if (ctx->queue->run_sched_loop ((void *)ctx->h, true) < 0
-        || post_sched_loop (ctx) < 0) {
-        flux_log_error (ctx->h, "%s: schedule loop", __FUNCTION__);
-        return;
-    }
-}
-
-extern "C" void jobmanager_free_cb (flux_t *h, const flux_msg_t *msg,
-                                    const char *R, void *arg)
-{
-    flux_jobid_t id;
-    std::shared_ptr<qmanager_ctx_t> ctx = nullptr;
-    ctx = *(static_cast<std::shared_ptr<qmanager_ctx_t> *>(arg));
-
-    if (schedutil_free_request_decode (msg, &id) < 0) {
-        flux_log_error (h, "%s: schedutil_free_request_decode", __FUNCTION__);
-        return;
-    }
-    if ((ctx->queue->remove (id)) < 0) {
-        flux_log_error (h, "%s: remove (id=%jd)", __FUNCTION__, (intmax_t)id);
-        return;
-    }
-    if (ctx->queue->run_sched_loop ((void *)ctx->h, true) < 0) {
-        flux_log_error (ctx->h, "%s: run_sched_loop", __FUNCTION__);
-        return;
-    }
-    if (schedutil_free_respond (ctx->schedutil, msg) < 0) {
-        flux_log_error (h, "%s: schedutil_free_respond", __FUNCTION__);
-        return;
-    }
-    flux_log (ctx->h, LOG_DEBUG, "free succeeded (id=%jd)", (intmax_t)id);
-    if (post_sched_loop (ctx) < 0) {
-        flux_log_error (ctx->h, "%s: post_sched_loop", __FUNCTION__);
-        return;
-    }
-}
-
-static void jobmanager_exception_cb (flux_t *h, flux_jobid_t id,
-                                     const char *type, int severity, void *arg)
-{
-    std::shared_ptr<job_t> job;
-    std::shared_ptr<qmanager_ctx_t> ctx = nullptr;
-    ctx = *(static_cast<std::shared_ptr<qmanager_ctx_t> *>(arg));
-
-    if (severity > 0 || (job = ctx->queue->lookup (id)) == nullptr
-        || !job->is_pending ())
-        return;
-    if (ctx->queue->remove (id) < 0) {
-        flux_log_error (h, "%s: remove job (%jd)", __FUNCTION__, (intmax_t)id);
-        return;
-    }
-    std::string note = std::string ("alloc aborted due to exception type=")
-                       + type;
-    if (schedutil_alloc_respond_denied (ctx->schedutil,
-                                        job->msg,
-                                        note.c_str ()) < 0) {
-        flux_log_error (h, "%s: schedutil_alloc_respond_denied", __FUNCTION__);
-        return;
-    }
-    flux_log (h, LOG_DEBUG, "%s (id=%jd)", note.c_str (), (intmax_t)id);
-}
 
 static int process_args (std::shared_ptr<qmanager_ctx_t> &ctx,
                          int argc, char **argv)
@@ -281,15 +135,20 @@ static int handshake_jobmanager (std::shared_ptr<qmanager_ctx_t> &ctx)
     const qmanager_opts_t &opt = ctx->opts.get_opt ();
     const char *mode = (opt.get_queue_policy () == "fcfs")? "single"
                                                           : "unlimited";
-    if (!(ctx->schedutil = schedutil_create (ctx->h,
-                                             jobmanager_alloc_cb,
-                                             jobmanager_free_cb,
-                                             jobmanager_exception_cb,
-                                             &ctx))) {
+    if (!(ctx->schedutil = schedutil_create (
+                               ctx->h,
+                               &qmanager_safe_cb_t::jobmanager_alloc_cb,
+                               &qmanager_safe_cb_t::jobmanager_free_cb,
+                               &qmanager_safe_cb_t::jobmanager_exception_cb,
+                               std::static_pointer_cast<
+                                   qmanager_cb_ctx_t> (ctx).get ()))) {
         flux_log_error (ctx->h, "%s: schedutil_create", __FUNCTION__);
         goto out;
     }
-    if (schedutil_hello (ctx->schedutil, jobmanager_hello_cb, &ctx) < 0) {
+    if (schedutil_hello (ctx->schedutil,
+                         &qmanager_safe_cb_t::jobmanager_hello_cb,
+                         std::static_pointer_cast<
+			     qmanager_cb_ctx_t> (ctx).get ()) < 0) {
         flux_log_error (ctx->h, "%s: schedutil_hello", __FUNCTION__);
         goto out;
     }

--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -48,7 +48,8 @@ int qmanager_cb_t::post_sched_loop (flux_t *h, schedutil_t *schedutil,
             flux_log_error (h, "%s: schedutil_alloc_respond_R", __FUNCTION__);
             goto out;
         }
-        flux_log (h, LOG_DEBUG, "alloc success (id=%jd)", (intmax_t)job->id);
+        flux_log (h, LOG_DEBUG, "alloc success (id=%jd)",
+                 static_cast<intmax_t> (job->id));
     }
     while ((job = queue->rejected_pop ()) != nullptr) {
         std::string note = "alloc denied due to type=\"" + job->note + "\"";
@@ -59,8 +60,8 @@ int qmanager_cb_t::post_sched_loop (flux_t *h, schedutil_t *schedutil,
                             __FUNCTION__);
             goto out;
         }
-        flux_log (h, LOG_DEBUG,
-                  "%s (id=%jd)", note.c_str (), (intmax_t)job->id);
+        flux_log (h, LOG_DEBUG, "%s (id=%jd)", note.c_str (),
+                 static_cast<intmax_t> (job->id));
     }
     rc = 0;
 
@@ -83,7 +84,8 @@ int qmanager_cb_t::jobmanager_hello_cb (flux_t *h,
                                    RUNNING, id, uid, prio, ts, R);
 
     if (ctx->queue->reconstruct (running_job) < 0) {
-        flux_log_error (h, "%s: reconstruct (id=%jd)", __FUNCTION__, (intmax_t)id);
+        flux_log_error (h, "%s: reconstruct (id=%jd)", __FUNCTION__,
+                       static_cast<intmax_t> (id));
         goto out;
     }
     rc = 0;
@@ -107,11 +109,11 @@ void qmanager_cb_t::jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
     job->jobspec = jobspec;
     job->msg = flux_msg_copy (msg, true);
     if (ctx->queue->insert (job) < 0) {
-        flux_log_error (h, "%s: queue insert (id=%jd)",
-                        __FUNCTION__, (intmax_t)job->id);
+        flux_log_error (h, "%s: queue insert (id=%jd)", __FUNCTION__,
+                       static_cast<intmax_t> (job->id));
         return;
     }
-    if (ctx->queue->run_sched_loop ((void *)h, true) < 0
+    if (ctx->queue->run_sched_loop (static_cast<void *> (h), true) < 0
         || post_sched_loop (h, ctx->schedutil, ctx->queue) < 0) {
         flux_log_error (h, "%s: schedule loop", __FUNCTION__);
         return;
@@ -130,7 +132,8 @@ void qmanager_cb_t::jobmanager_free_cb (flux_t *h, const flux_msg_t *msg,
         return;
     }
     if ((ctx->queue->remove (id)) < 0) {
-        flux_log_error (h, "%s: remove (id=%jd)", __FUNCTION__, (intmax_t)id);
+        flux_log_error (h, "%s: remove (id=%jd)", __FUNCTION__,
+                       static_cast<intmax_t> (id));
         return;
     }
     if (ctx->queue->run_sched_loop ((void *)h, true) < 0) {
@@ -141,7 +144,8 @@ void qmanager_cb_t::jobmanager_free_cb (flux_t *h, const flux_msg_t *msg,
         flux_log_error (h, "%s: schedutil_free_respond", __FUNCTION__);
         return;
     }
-    flux_log (h, LOG_DEBUG, "free succeeded (id=%jd)", (intmax_t)id);
+    flux_log (h, LOG_DEBUG, "free succeeded (id=%jd)",
+             static_cast<intmax_t> (id));
     if (post_sched_loop (h, ctx->schedutil, ctx->queue) < 0) {
         flux_log_error (h, "%s: post_sched_loop", __FUNCTION__);
         return;
@@ -160,7 +164,8 @@ void qmanager_cb_t::jobmanager_exception_cb (flux_t *h, flux_jobid_t id,
         || !job->is_pending ())
         return;
     if (ctx->queue->remove (id) < 0) {
-        flux_log_error (h, "%s: remove job (%jd)", __FUNCTION__, (intmax_t)id);
+        flux_log_error (h, "%s: remove job (%jd)", __FUNCTION__,
+                       static_cast<intmax_t> (id));
         return;
     }
     std::string note = std::string ("alloc aborted due to exception type=")
@@ -171,7 +176,8 @@ void qmanager_cb_t::jobmanager_exception_cb (flux_t *h, flux_jobid_t id,
         flux_log_error (h, "%s: schedutil_alloc_respond_denied", __FUNCTION__);
         return;
     }
-    flux_log (h, LOG_DEBUG, "%s (id=%jd)", note.c_str (), (intmax_t)id);
+    flux_log (h, LOG_DEBUG, "%s (id=%jd)", note.c_str (),
+             static_cast<intmax_t> (id));
 }
 
 int qmanager_safe_cb_t::jobmanager_hello_cb (flux_t *h,

--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -1,0 +1,226 @@
+/*****************************************************************************\
+ *  Copyright (c) 2019 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+}
+
+#include "qmanager/modules/qmanager_callbacks.hpp"
+#include "src/common/c++wrappers/eh_wrapper.hpp"
+
+using namespace Flux;
+using namespace Flux::queue_manager;
+using namespace Flux::queue_manager::detail;
+using namespace Flux::cplusplus_wrappers;
+
+int qmanager_cb_t::post_sched_loop (flux_t *h, schedutil_t *schedutil,
+                                    std::shared_ptr<queue_policy_base_t> &queue)
+{
+    int rc = -1;
+    std::shared_ptr<job_t> job = nullptr;
+
+    while ((job = queue->alloced_pop ()) != nullptr) {
+        if (schedutil_alloc_respond_R (schedutil, job->msg,
+                                       job->schedule.R.c_str (), NULL) < 0) {
+            flux_log_error (h, "%s: schedutil_alloc_respond_R", __FUNCTION__);
+            goto out;
+        }
+        flux_log (h, LOG_DEBUG, "alloc success (id=%jd)", (intmax_t)job->id);
+    }
+    while ((job = queue->rejected_pop ()) != nullptr) {
+        std::string note = "alloc denied due to type=\"" + job->note + "\"";
+        if (schedutil_alloc_respond_denied (schedutil,
+                                            job->msg,
+                                            note.c_str ()) < 0) {
+            flux_log_error (h, "%s: schedutil_alloc_respond_denied",
+                            __FUNCTION__);
+            goto out;
+        }
+        flux_log (h, LOG_DEBUG,
+                  "%s (id=%jd)", note.c_str (), (intmax_t)job->id);
+    }
+    rc = 0;
+
+out:
+    return rc;
+}
+
+// FIXME: This will be expanded when we implement full scheduler
+// resilency schemes: Issue #470.
+int qmanager_cb_t::jobmanager_hello_cb (flux_t *h,
+                                        flux_jobid_t id, int prio, uint32_t uid,
+                                        double ts, const char *R, void *arg)
+
+{
+    int rc = -1;
+    qmanager_cb_ctx_t *ctx = nullptr;
+    ctx = static_cast<qmanager_cb_ctx_t *> (arg);
+    std::shared_ptr<job_t> running_job
+        = std::make_shared<job_t> (job_state_kind_t::
+                                   RUNNING, id, uid, prio, ts, R);
+
+    if (ctx->queue->reconstruct (running_job) < 0) {
+        flux_log_error (h, "%s: reconstruct (id=%jd)", __FUNCTION__, (intmax_t)id);
+        goto out;
+    }
+    rc = 0;
+
+out:
+    return rc;
+}
+
+void qmanager_cb_t::jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
+                                         const char *jobspec, void *arg)
+{
+    qmanager_cb_ctx_t *ctx = nullptr;
+    ctx = static_cast<qmanager_cb_ctx_t *> (arg);
+    std::shared_ptr<job_t> job = std::make_shared<job_t> ();
+
+    if (schedutil_alloc_request_decode (msg, &job->id, &job->priority,
+                                        &job->userid, &job->t_submit) < 0) {
+        flux_log_error (h, "%s: schedutil_alloc_request_decode", __FUNCTION__);
+        return;
+    }
+    job->jobspec = jobspec;
+    job->msg = flux_msg_copy (msg, true);
+    if (ctx->queue->insert (job) < 0) {
+        flux_log_error (h, "%s: queue insert (id=%jd)",
+                        __FUNCTION__, (intmax_t)job->id);
+        return;
+    }
+    if (ctx->queue->run_sched_loop ((void *)h, true) < 0
+        || post_sched_loop (h, ctx->schedutil, ctx->queue) < 0) {
+        flux_log_error (h, "%s: schedule loop", __FUNCTION__);
+        return;
+    }
+}
+
+void qmanager_cb_t::jobmanager_free_cb (flux_t *h, const flux_msg_t *msg,
+                                        const char *R, void *arg)
+{
+    flux_jobid_t id;
+    qmanager_cb_ctx_t *ctx = nullptr;
+    ctx = static_cast<qmanager_cb_ctx_t *> (arg);
+
+    if (schedutil_free_request_decode (msg, &id) < 0) {
+        flux_log_error (h, "%s: schedutil_free_request_decode", __FUNCTION__);
+        return;
+    }
+    if ((ctx->queue->remove (id)) < 0) {
+        flux_log_error (h, "%s: remove (id=%jd)", __FUNCTION__, (intmax_t)id);
+        return;
+    }
+    if (ctx->queue->run_sched_loop ((void *)h, true) < 0) {
+        flux_log_error (h, "%s: run_sched_loop", __FUNCTION__);
+        return;
+    }
+    if (schedutil_free_respond (ctx->schedutil, msg) < 0) {
+        flux_log_error (h, "%s: schedutil_free_respond", __FUNCTION__);
+        return;
+    }
+    flux_log (h, LOG_DEBUG, "free succeeded (id=%jd)", (intmax_t)id);
+    if (post_sched_loop (h, ctx->schedutil, ctx->queue) < 0) {
+        flux_log_error (h, "%s: post_sched_loop", __FUNCTION__);
+        return;
+    }
+}
+
+void qmanager_cb_t::jobmanager_exception_cb (flux_t *h, flux_jobid_t id,
+                                             const char *type,
+                                             int severity, void *arg)
+{
+    std::shared_ptr<job_t> job;
+    qmanager_cb_ctx_t *ctx = nullptr;
+    ctx = static_cast<qmanager_cb_ctx_t *> (arg);
+
+    if (severity > 0 || (job = ctx->queue->lookup (id)) == nullptr
+        || !job->is_pending ())
+        return;
+    if (ctx->queue->remove (id) < 0) {
+        flux_log_error (h, "%s: remove job (%jd)", __FUNCTION__, (intmax_t)id);
+        return;
+    }
+    std::string note = std::string ("alloc aborted due to exception type=")
+                       + type;
+    if (schedutil_alloc_respond_denied (ctx->schedutil,
+                                        job->msg,
+                                        note.c_str ()) < 0) {
+        flux_log_error (h, "%s: schedutil_alloc_respond_denied", __FUNCTION__);
+        return;
+    }
+    flux_log (h, LOG_DEBUG, "%s (id=%jd)", note.c_str (), (intmax_t)id);
+}
+
+int qmanager_safe_cb_t::jobmanager_hello_cb (flux_t *h,
+                                             flux_jobid_t id, int prio,
+                                             uint32_t uid, double ts,
+                                             const char *R, void *arg)
+{
+    eh_wrapper_t exception_safe_wrapper;
+    int rc = exception_safe_wrapper (qmanager_cb_t::jobmanager_hello_cb,
+                                     h, id, prio, uid, ts, R, arg);
+    if (exception_safe_wrapper.bad ())
+        flux_log_error (h, "%s: %s", __FUNCTION__,
+                        exception_safe_wrapper.get_err_message ());
+    return rc;
+}
+
+void qmanager_safe_cb_t::jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
+                                              const char *jobspec, void *arg)
+{
+    eh_wrapper_t exception_safe_wrapper;
+    exception_safe_wrapper (qmanager_cb_t::jobmanager_alloc_cb,
+                            h, msg, jobspec, arg);
+    if (exception_safe_wrapper.bad ())
+        flux_log_error (h, "%s: %s", __FUNCTION__,
+                        exception_safe_wrapper.get_err_message ());
+}
+
+void qmanager_safe_cb_t::jobmanager_free_cb (flux_t *h, const flux_msg_t *msg,
+                                             const char *R, void *arg)
+{
+    eh_wrapper_t exception_safe_wrapper;
+    exception_safe_wrapper (qmanager_cb_t::jobmanager_free_cb, h, msg, R, arg);
+    if (exception_safe_wrapper.bad ())
+        flux_log_error (h, "%s: %s", __FUNCTION__,
+                        exception_safe_wrapper.get_err_message ());
+}
+
+void qmanager_safe_cb_t::jobmanager_exception_cb (flux_t *h, flux_jobid_t id,
+                                                  const char *type, int severity,
+                                                  void *arg)
+{
+    eh_wrapper_t exception_safe_wrapper;
+    exception_safe_wrapper (qmanager_cb_t::jobmanager_exception_cb,
+                            h, id, type, severity, arg);
+    if (exception_safe_wrapper.bad ())
+        flux_log_error (h, "%s: %s", __FUNCTION__,
+                        exception_safe_wrapper.get_err_message ());
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/qmanager/modules/qmanager_callbacks.hpp
+++ b/qmanager/modules/qmanager_callbacks.hpp
@@ -1,0 +1,73 @@
+/*****************************************************************************\
+ *  Copyright (c) 2020 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#ifndef QMANAGER_CALLBACKS_HPP
+#define QMANAGER_CALLBACKS_HPP
+
+extern "C" {
+#include <flux/core.h>
+#include <flux/schedutil.h>
+}
+
+#include "qmanager/policies/base/queue_policy_base.hpp"
+
+struct qmanager_cb_ctx_t {
+    schedutil_t *schedutil;
+    std::shared_ptr<Flux::queue_manager::queue_policy_base_t> queue;
+};
+
+class qmanager_cb_t {
+protected:
+    static int jobmanager_hello_cb (flux_t *h,
+                                    flux_jobid_t id, int prio, uint32_t uid,
+                                    double ts, const char *R, void *arg);
+    static void jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
+                                     const char *jobspec, void *arg);
+    static void jobmanager_free_cb (flux_t *h, const flux_msg_t *msg,
+                                    const char *R, void *arg);
+    static void jobmanager_exception_cb (flux_t *h, flux_jobid_t id,
+                                         const char *type, int severity,
+                                         void *arg);
+    static int post_sched_loop (flux_t *h, schedutil_t *schedutil, std::shared_ptr<
+                                    Flux::queue_manager::queue_policy_base_t> &queue);
+};
+
+struct qmanager_safe_cb_t : public qmanager_cb_t {
+    static int jobmanager_hello_cb (flux_t *h,
+                                    flux_jobid_t id, int prio, uint32_t uid,
+                                    double ts, const char *R, void *arg);
+    static void jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
+                                     const char *jobspec, void *arg);
+    static void jobmanager_free_cb (flux_t *h, const flux_msg_t *msg,
+                                    const char *R, void *arg);
+    static void jobmanager_exception_cb (flux_t *h, flux_jobid_t id,
+                                         const char *type, int severity,
+                                         void *arg);
+};
+
+#endif // #define QMANAGER_CALLBACKS_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = libtap libutil librbtree
+SUBDIRS = libtap libutil librbtree c++wrappers

--- a/src/common/c++wrappers/Makefile.am
+++ b/src/common/c++wrappers/Makefile.am
@@ -1,0 +1,2 @@
+SUBDIRS = test
+

--- a/src/common/c++wrappers/eh_wrapper.hpp
+++ b/src/common/c++wrappers/eh_wrapper.hpp
@@ -1,0 +1,121 @@
+/*****************************************************************************\
+ *  Copyright (c) 2020 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#include <cerrno>
+#include <cstring>
+#include <utility>
+#include <exception>
+#include <stdexcept>
+
+namespace Flux {
+namespace cplusplus_wrappers {
+
+/*! Exception handling wrapper functor class.
+ *  Use perfect forwarding to wrap the target functor of many different types
+ *  in order to add an exception handling semantics: mapping certain C++
+ *  exception classes to errnos as they are caught.
+ */
+class eh_wrapper_t {
+public:
+    /*! Templated operator() method: An object of eh_wrapper_t *can invoke
+     *  its wrapping function using the function invocation convention.
+     *  "functor_object()". Different numbers and types of function parameters
+     *  are handled with template parameter pack/unpack (i.e. "..." keyword).
+     *  Transparent forwarding of function arguments is handled with
+     *  the so-called "universal" or "forwarding" reference (Args&&) in
+     *  combination with the std::forward method.  Introductory examples
+     *  for perfect forwarding can be found in the following:
+     *  https://www.modernescpp.com/index.php/perfect-forwarding
+     *
+     * \param f        functor (function, function pointer or function object)
+     * \param args     variadic arguments list that is transparently
+     *                 forwarded to f.
+     */
+    template <typename Functor, typename ... Args>
+    auto operator() (Functor f, Args && ... args)
+        -> decltype(f (std::forward<Args> (args) ... )) {
+        int rc = -1;
+        exception_raised = false;
+        memset (err_message, '\0', 4096);
+        try {
+            return f (std::forward<Args> (args) ... );
+        }
+        catch (std::bad_alloc &e) {
+            errno = ENOMEM;
+            snprintf (err_message, 4096, "ENOMEM: %s", e.what ());
+        }
+        catch (std::length_error &e) {
+            errno = ERANGE;
+            snprintf (err_message, 4096, "ERANGE: %s", e.what ());
+        }
+        catch (std::out_of_range &e) {
+            errno = ENOENT;
+            snprintf (err_message, 4096, "ENOENT: %s", e.what ());
+        }
+        catch (std::exception &e) {
+            errno = ENOSYS;
+            snprintf (err_message, 4096, "ENOSYS: %s", e.what ());
+        }
+        catch (...) {
+            errno = ENOSYS;
+            snprintf (err_message, 4096, "ENOSYS: Caught unknown exception");
+        }
+        exception_raised = true;
+        return return_<decltype(f (std::forward<Args> (args) ...))> (rc);
+    }
+
+    /*! Has a C++ exception been raised from the last invocation of operator()?
+     */
+    bool bad () {
+        return exception_raised;
+    }
+
+    /*! Return the exception error message associated from the last invocation
+     *  of operator().
+     */
+    const char *get_err_message () {
+        return exception_raised ? err_message : NULL;
+    }
+
+private:
+    template <typename T>
+    T return_ (int i) {
+        return T(i);
+    }
+
+    bool exception_raised = false;
+    char err_message[4096]; // to avoid a bad_alloc exception with std::string
+};
+
+template <>
+void eh_wrapper_t::return_<void> (int i) {
+    return;
+}
+
+} // namespace c++wrappers
+} // namespace Flux
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/c++wrappers/eh_wrapper.hpp
+++ b/src/common/c++wrappers/eh_wrapper.hpp
@@ -109,7 +109,7 @@ private:
 };
 
 template <>
-void eh_wrapper_t::return_<void> (int i) {
+inline void eh_wrapper_t::return_<void> (int i) {
     return;
 }
 

--- a/src/common/c++wrappers/test/Makefile.am
+++ b/src/common/c++wrappers/test/Makefile.am
@@ -1,0 +1,17 @@
+AM_CXXFLAGS = \
+	$(WARNING_CXXFLAGS) \
+	$(CODE_COVERAGE_CXXFLAGS)
+
+AM_LDFLAGS = $(CODE_COVERAGE_LDFLAGS)
+
+AM_CPPFLAGS = -I$(top_srcdir)
+
+TESTS = exception_safe_wrapper_test01
+
+check_PROGRAMS = $(TESTS)
+exception_safe_wrapper_test01_SOURCES = exception_safe_wrapper_test01.cpp
+exception_safe_wrapper_test01_CXXFLAGS = \
+	$(AM_CXXFLAGS) -I$(top_srcdir)/src/common/c++wrappers
+exception_safe_wrapper_test01_LDADD = \
+	$(top_builddir)/src/common/libtap/libtap.la
+

--- a/src/common/c++wrappers/test/exception_safe_wrapper_test01.cpp
+++ b/src/common/c++wrappers/test/exception_safe_wrapper_test01.cpp
@@ -1,0 +1,277 @@
+/*****************************************************************************\
+ *  Copyright (c) 2020 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include <cstdlib>
+#include <cerrno>
+#include <string>
+#include <exception>
+#include <stdexcept>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/c++wrappers/eh_wrapper.hpp"
+
+using namespace Flux::cplusplus_wrappers;
+
+
+static void throw_exception (int en)
+{
+    switch (en) {
+    case ENOMEM:
+        throw std::bad_alloc ();
+        break;
+    case ERANGE:
+        throw std::length_error (__FUNCTION__);
+        break;
+    case ENOENT:
+        throw std::out_of_range (__FUNCTION__);
+        break;
+    case ENOSYS:
+        throw std::exception ();
+        break;
+    case ENOTSUP:
+        throw "Unknown exception";
+        break;
+    }
+}
+
+struct foo_functor_t {
+    int operator() (int en) {
+        throw_exception (en);
+        return 0;
+    }
+};
+
+struct foo_functor_eh_wrapper_t {
+    int operator() (int en) {
+        eh_wrapper_t exception_safe_wrapper;
+        foo_functor_t functor;
+        return exception_safe_wrapper (functor, en);
+    }
+};
+
+int foo1 (int en)
+{
+    throw_exception (en);
+    return 0;
+}
+
+int foo2 (int en, double p1, float p2, long p3, long long p4)
+{
+    int rc =  (int) (p1 + p2 + p3 + p4);
+    p1 = p2 = p3 = p4 = 0;
+    return rc;
+}
+
+int foo3 (int en, double &p1, float &p2, long &p3, long long &p4)
+{
+    int rc = (int) (p1 + p2 + p3 + p4);
+    p1 = p2 = p3 = p4 = 0;
+    return rc;
+}
+
+void foo4 (int en)
+{
+    throw_exception (en);
+}
+
+
+static void test_functor_wrapper ()
+{
+    int rc = 0;
+    foo_functor_eh_wrapper_t func;
+
+    errno = 0;
+    rc = func (-1);
+    ok (rc == 0 && errno == 0,
+        "eh_wrapper_t works with functor (no exception)");
+
+    errno = 0;
+    rc = func (ENOMEM);
+    ok (rc == -1 && errno == ENOMEM,
+        "eh_wrapper_t works with functor (bad_alloc exception)");
+
+    errno = 0;
+    rc = func (ERANGE);
+    ok (rc == -1 && errno == ERANGE,
+        "eh_wrapper_t works with functor (length_error exception)");
+
+    errno = 0;
+    rc = func (ENOENT);
+    ok (rc == -1 && errno == ENOENT,
+        "eh_wrapper_t works with functor (out_of_range exception)");
+
+    errno = 0;
+    rc = func (ENOSYS);
+    ok (rc == -1 && errno == ENOSYS,
+        "eh_wrapper_t works with functor (std::exception)");
+
+    errno = 0;
+    rc = func (ENOTSUP);
+    ok (rc == -1 && errno == ENOSYS,
+        "eh_wrapper_t works with functor (unknown exception)");
+}
+
+static void test_function_wrapper ()
+{
+    int rc = 0;
+    const char *msg = NULL;
+    eh_wrapper_t exception_safe_wrapper;
+
+    errno = 0;
+    rc = exception_safe_wrapper (foo1, -1);
+    ok (rc == 0 && errno == 0,
+        "eh_wrapper_t works with simple function (no exception)");
+    ok (!exception_safe_wrapper.bad (),
+        "eh_wrapper_t::bad() works with simple function (no exception)");
+    msg = exception_safe_wrapper.get_err_message ();
+    ok (msg == NULL, "eh_wrapper_t::get_err_message () works (no exception)");
+
+    errno = 0;
+    rc = exception_safe_wrapper (foo1, ENOENT);
+    ok (rc == -1 && errno == ENOENT,
+        "eh_wrapper_t works with simple function (out_of_range)");
+    ok (exception_safe_wrapper.bad (),
+        "eh_wrapper_t::bad() works with simple function (out_of_range)");
+    msg = exception_safe_wrapper.get_err_message ();
+    ok (msg != NULL, "eh_wrapper_t::get_err_message () reports: %s", msg);
+}
+
+static void test_function_wrapper2 ()
+{
+    int rc = 0;
+    double p1 = 1.0f;
+    float p2 = 2.0f;
+    long p3 = 3;
+    long long p4 = 4;
+    eh_wrapper_t exception_safe_wrapper;
+
+    errno = 0;
+    int sum1 = static_cast<int> (p1 + p2 + p3 + p4);
+    rc = exception_safe_wrapper (foo2, -1, p1, p2, p3, p4);
+    int sum2 = static_cast<int> (p1 + p2 + p3 + p4);
+    ok (rc == sum1 && sum1 == sum2 && errno == 0,
+        "eh_wrapper_t forwards args by value works");
+}
+
+static void test_function_wrapper3 ()
+{
+    int rc = 0;
+    double p1 = 1.0f;
+    float p2 = 2.0f;
+    long p3 = 3;
+    long long p4 = 4;
+    eh_wrapper_t exception_safe_wrapper;
+
+    errno = 0;
+    int sum1 = static_cast<int> (p1 + p2 + p3 + p4);
+    rc = exception_safe_wrapper (foo3, -1, p1, p2, p3, p4);
+    int sum2 = static_cast<int> (p1 + p2 + p3 + p4);
+    ok (rc == sum1 && sum2 == 0 && errno == 0,
+        "eh_wrapper_t forwards args by reference works");
+}
+
+static void test_lambda_wrapper ()
+{
+    int rc = 0;
+    const char *msg = NULL;
+    eh_wrapper_t exception_safe_wrapper;
+
+    errno = 0;
+    rc = exception_safe_wrapper ([](int en) {
+                                     throw_exception (en);
+                                     return 0; },
+                                -1);
+
+    ok (rc == 0 && errno == 0,
+        "eh_wrapper_t works with lambda function (no exception)");
+    ok (!exception_safe_wrapper.bad (),
+        "eh_wrapper_t::bad() works with simple function (no exception)");
+    msg = exception_safe_wrapper.get_err_message ();
+    ok (msg == NULL, "eh_wrapper_t::get_err_message () works (no exception)");
+
+    errno = 0;
+    rc = exception_safe_wrapper ([](int en) {
+                                     throw_exception (en);
+                                     return 0; },
+                                ENOENT);
+    ok (rc == -1 && errno == ENOENT,
+        "eh_wrapper_t works with simple function (out_of_range)");
+    ok (exception_safe_wrapper.bad (),
+        "eh_wrapper_t::bad() works with simple function (out_of_range)");
+    msg = exception_safe_wrapper.get_err_message ();
+    ok (msg != NULL, "eh_wrapper_t::get_err_message () reports: %s", msg);
+}
+
+static void test_function_wrapper4 ()
+{
+    const char *msg = NULL;
+    eh_wrapper_t exception_safe_wrapper;
+
+    errno = 0;
+    exception_safe_wrapper (foo4, -1);
+    ok (errno == 0,
+        "eh_wrapper_t works with void function (no exception)");
+    ok (!exception_safe_wrapper.bad (),
+        "eh_wrapper_t::bad() works with void function (no exception)");
+    msg = exception_safe_wrapper.get_err_message ();
+    ok (msg == NULL, "eh_wrapper_t::get_err_message () works void function");
+
+    errno = 0;
+    exception_safe_wrapper (foo4, ENOENT);
+    ok (errno == ENOENT,
+        "eh_wrapper_t works with void function (out_of_range)");
+    ok (exception_safe_wrapper.bad (),
+        "eh_wrapper_t::bad() works with void function (out_of_range)");
+    msg = exception_safe_wrapper.get_err_message ();
+    ok (msg != NULL, "eh_wrapper_t::get_err_message () reports: %s", msg);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (26);
+
+    test_functor_wrapper ();
+
+    test_function_wrapper ();
+
+    test_function_wrapper2 ();
+
+    test_function_wrapper3 ();
+
+    test_lambda_wrapper ();
+
+    test_function_wrapper4 ();
+
+    done_testing ();
+
+    return EXIT_SUCCESS;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */


### PR DESCRIPTION
This PR uses the `eh_wrapper_t` class to add
exception safety for schedutil callbacks.

- Refactor callbacks for `schedutil` into two classes
   in new header and source files:
   `qmanager_cb_t` contains the existing code;
   `qmanager_safe_cb_t` wraps it with `eh_wrapper_t`.

-  Avoid interdepedency between `qmanager` and
    the classes in `qmanager_callbacks.hpp` by
    introducing `qmanager_cb_ctx_t` to make
    it easy for the `qmanager` module to
    pass its state to these new classes.

- Update `qmanager` code and build rules to add
   the new files.