### PR TITLE
docker: add ENTRYPOINT to start munged by default

### DIFF
--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -143,8 +143,8 @@ if test -n "$TAG"; then
     docker commit \
 	--change 'ENTRYPOINT [ "/usr/local/sbin/entrypoint.sh" ]' \
 	--change 'CMD [ "/usr/bin/flux", "start", "/bin/bash" ]' \
-	--change 'USER flux' \
-	--change 'WORKDIR /home/flux' \
+	--change 'USER fluxuser' \
+	--change 'WORKDIR /home/fluxuser' \
 	tmp.$$ $TAG \
 	|| die "docker commit failed"
     docker rm tmp.$$

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -136,11 +136,13 @@ if test -n "$TAG"; then
         --volume=$TOP:/usr/src \
         --user="root" \
 	travis-builder:${IMAGE} \
-	sh -c "make install && \
+	sh -c "cd ${BUILD_DIR:-.} && \
+	       make install && \
                userdel $USER" \
 	|| (docker rm tmp.$$; die "docker run of 'make install' failed")
     docker commit \
-	--change 'CMD "/usr/bin/flux"' \
+	--change 'ENTRYPOINT [ "/usr/local/sbin/entrypoint.sh" ]' \
+	--change 'CMD [ "/usr/bin/flux", "start", "/bin/bash" ]' \
 	--change 'USER flux' \
 	--change 'WORKDIR /home/flux' \
 	tmp.$$ $TAG \

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -16,8 +16,8 @@ declare -r prog=${0##*/}
 die() { echo -e "$prog: $@"; exit 1; }
 
 #
-declare -r long_opts="help,quiet,interactive,image:,jobs:,no-cache,no-home,distcheck,tag:"
-declare -r short_opts="hqIdi:j:t:"
+declare -r long_opts="help,quiet,interactive,image:,jobs:,no-cache,no-home,distcheck,tag:,build-directory:"
+declare -r short_opts="hqIdi:j:t:D:"
 declare -r usage="
 Usage: $prog [OPTIONS] -- [CONFIGURE_ARGS...]\n\
 Build docker image for travis builds, then run tests inside the new\n\
@@ -34,6 +34,7 @@ Options:\n\
  -i, --image=NAME              Use base docker image NAME (default=$IMAGE)\n\
  -j, --jobs=N                  Value for make -j (default=$JOBS)\n
  -d, --distcheck               Run 'make distcheck' instead of 'make check'\n\
+ -D, --build-directory=DIRNAME Name of a subdir to build in, will be made\n\
  -I, --interactive             Instead of running travis build, run docker\n\
                                 image with interactive shell.\n\
 "
@@ -58,6 +59,7 @@ while true; do
       -j|--jobs)                   JOBS="$2";                  shift 2 ;;
       -I|--interactive)            INTERACTIVE="/bin/bash";    shift   ;;
       -d|--distcheck)              DISTCHECK=t;                shift   ;;
+      -D|--build-directory)        BUILD_DIR="$2";             shift 2 ;;
       --no-cache)                  NO_CACHE="--no-cache";      shift   ;;
       --no-home)                   MOUNT_HOME_ARGS="";         shift   ;;
       -t|--tag)                    TAG="$2";                   shift 2 ;;
@@ -94,6 +96,7 @@ echo "mounting $TOP as /usr/src"
 
 export JOBS
 export DISTCHECK
+export BUILD_DIR
 export chain_lint
 
 docker run --rm \
@@ -112,6 +115,7 @@ docker run --rm \
     -e TEST_INSTALL \
     -e CPPCHECK \
     -e DISTCHECK \
+    -e BUILD_DIR \
     -e chain_lint \
     -e JOBS \
     -e USER \

--- a/src/test/travis_run.sh
+++ b/src/test/travis_run.sh
@@ -97,7 +97,12 @@ echo "Starting MUNGE"
 sudo /sbin/runuser -u munge /usr/sbin/munged
 
 travis_fold "autogen.sh" "./autogen.sh..." ./autogen.sh
-travis_fold "configure"  "./configure ${ARGS}..." ./configure ${ARGS}
+
+if test -n "$BUILD_DIR"; then
+  mkdir -p "$BUILD_DIR"
+  cd "$BUILD_DIR"
+fi
+travis_fold "configure"  "configure ${ARGS}..." /usr/src/configure ${ARGS}
 travis_fold "make_clean" "make clean..." make clean
 
 eval ${MAKECMDS}


### PR DESCRIPTION
Use the `entrypoint.sh` from flux-core by default in published flux-sched docker images, so that `docker run -ti fluxrm/flux-sched` works the same as `docker run -ti fluxrm/flux-core`, i.e. munged is started and user is dropped into an instance of size=1.

Also, pull in @trws' `--build-directory` option for `docker-run-checks.sh` since this has been useful.
