### PR TITLE
qmanager: add multi-queue support

### DIFF
--- a/qmanager/modules/Makefile.am
+++ b/qmanager/modules/Makefile.am
@@ -23,6 +23,7 @@ qmanager_la_SOURCES = \
     qmanager_callbacks.hpp \
     $(top_srcdir)/src/common/liboptmgr/optmgr.hpp \
     $(top_srcdir)/src/common/liboptmgr/optmgr_impl.hpp \
+    $(top_srcdir)/resource/libjobspec/jobspec.hpp \
     $(top_srcdir)/resource/hlapi/bindings/c++/reapi.hpp \
     $(top_srcdir)/resource/hlapi/bindings/c++/reapi_cli.hpp \
     $(top_srcdir)/resource/hlapi/bindings/c++/reapi_cli_impl.hpp \
@@ -51,6 +52,7 @@ qmanager_la_CXXFLAGS = \
     $(FLUX_SCHEDUTIL_CFLAGS)
 
 qmanager_la_LIBADD = \
+    $(top_builddir)/resource/libjobspec/libjobspec_conv.la \
     $(FLUX_CORE_LIBS) \
     $(FLUX_SCHEDUTIL_LIBS) \
     $(CZMQ_LIBS) \

--- a/qmanager/modules/qmanager_callbacks.hpp
+++ b/qmanager/modules/qmanager_callbacks.hpp
@@ -30,11 +30,19 @@ extern "C" {
 #include <flux/schedutil.h>
 }
 
+#include "qmanager/modules/qmanager_opts.hpp"
 #include "qmanager/policies/base/queue_policy_base.hpp"
 
 struct qmanager_cb_ctx_t {
-    schedutil_t *schedutil;
-    std::shared_ptr<Flux::queue_manager::queue_policy_base_t> queue;
+    schedutil_t *schedutil{nullptr};
+    Flux::opts_manager::optmgr_composer_t<
+        Flux::opts_manager::qmanager_opts_t> opts;
+    std::map<std::string, std::shared_ptr<
+        Flux::queue_manager::queue_policy_base_t>> queues;
+
+    int find_queue (
+            flux_jobid_t id, std::string &queue_name,
+            std::shared_ptr<Flux::queue_manager::queue_policy_base_t> &queue);
 };
 
 class qmanager_cb_t {
@@ -49,8 +57,10 @@ protected:
     static void jobmanager_exception_cb (flux_t *h, flux_jobid_t id,
                                          const char *type, int severity,
                                          void *arg);
-    static int post_sched_loop (flux_t *h, schedutil_t *schedutil, std::shared_ptr<
-                                    Flux::queue_manager::queue_policy_base_t> &queue);
+    static int post_sched_loop (flux_t *h,
+        schedutil_t *schedutil,
+        std::map<std::string, std::shared_ptr<
+            Flux::queue_manager::queue_policy_base_t>> &queues);
 };
 
 struct qmanager_safe_cb_t : public qmanager_cb_t {

--- a/qmanager/modules/qmanager_opts.cpp
+++ b/qmanager/modules/qmanager_opts.cpp
@@ -204,6 +204,15 @@ qmanager_opts_t &qmanager_opts_t::operator+= (const qmanager_opts_t &src)
     return canonicalize ();
 }
 
+bool qmanager_opts_t::operator ()(const std::string &k1,
+                                  const std::string &k2) const
+{
+    if (m_tab.find (k1) == m_tab.end ()
+        || m_tab.find (k2) == m_tab.end ())
+        return k1 < k2;
+    return m_tab.at (k1) < m_tab.at (k2);
+}
+
 int qmanager_opts_t::parse (const std::string &k, const std::string &v,
                             std::string &info)
 {

--- a/qmanager/modules/qmanager_opts.cpp
+++ b/qmanager/modules/qmanager_opts.cpp
@@ -151,8 +151,16 @@ qmanager_opts_t::qmanager_opts_t ()
     bool inserted = true;
 
     auto ret = m_tab.insert (std::pair<std::string, int> (
-                   "queue-policy",
-                   static_cast<int> (qmanager_opts_key_t::QUEUE_POLICY)));
+              "queues",
+              static_cast<int> (qmanager_opts_key_t::QUEUES)));
+    inserted &= ret.second;
+    ret = m_tab.insert (std::pair<std::string, int> (
+              "default-queue",
+              static_cast<int> (qmanager_opts_key_t::DEFAULT_QUEUE)));
+    inserted &= ret.second;
+    ret = m_tab.insert (std::pair<std::string, int> (
+              "queue-policy",
+              static_cast<int> (qmanager_opts_key_t::QUEUE_POLICY)));
     inserted &= ret.second;
     ret = m_tab.insert (std::pair<std::string, int> (
               "queue-params",
@@ -161,6 +169,18 @@ qmanager_opts_t::qmanager_opts_t ()
     ret= m_tab.insert (std::pair<std::string, int> (
               "policy-params",
               static_cast<int> (qmanager_opts_key_t::POLICY_PARAMS)));
+    inserted &= ret.second;
+    ret= m_tab.insert (std::pair<std::string, int> (
+              "queue-policy-per-queue",
+              static_cast<int> (qmanager_opts_key_t::QUEUE_POLICY_PER_QUEUE)));
+    inserted &= ret.second;
+    ret= m_tab.insert (std::pair<std::string, int> (
+              "queue-params-per-queue",
+              static_cast<int> (qmanager_opts_key_t::QUEUE_PARAMS_PER_QUEUE)));
+    inserted &= ret.second;
+    ret= m_tab.insert (std::pair<std::string, int> (
+              "policy-params-per-queue",
+              static_cast<int> (qmanager_opts_key_t::POLICY_PARAMS_PER_QUEUE)));
     inserted &= ret.second;
 
     if (!inserted)

--- a/qmanager/modules/qmanager_opts.cpp
+++ b/qmanager/modules/qmanager_opts.cpp
@@ -58,6 +58,52 @@ bool qmanager_opts_t::known_queue_policy (const std::string &policy)
  *                                                                            *
  ******************************************************************************/
 
+const std::string &queue_prop_t::get_queue_policy () const
+{
+    return queue_policy;
+}
+
+const std::string &queue_prop_t::get_queue_params () const
+{
+    return queue_params;
+}
+
+const std::string &queue_prop_t::get_policy_params () const
+{
+    return policy_params;
+}
+
+bool queue_prop_t::set_queue_policy (const std::string &p)
+{
+    queue_policy = p;
+    return true;
+}
+
+void queue_prop_t::set_queue_params (const std::string &p)
+{
+    queue_params = p;
+}
+
+void queue_prop_t::set_policy_params (const std::string &p)
+{
+    policy_params = p;
+}
+
+bool queue_prop_t::is_queue_policy_set () const
+{
+    return queue_policy != QMANAGER_OPTS_UNSET_STR;
+}
+
+bool queue_prop_t::is_queue_params_set () const
+{
+    return queue_params != QMANAGER_OPTS_UNSET_STR;
+}
+
+bool queue_prop_t::is_policy_params_set () const
+{
+    return policy_params != QMANAGER_OPTS_UNSET_STR;
+}
+
 qmanager_opts_t::qmanager_opts_t ()
 {
     // Note: std::pair<>() is guaranteed to throw only an exception

--- a/qmanager/modules/qmanager_opts.cpp
+++ b/qmanager/modules/qmanager_opts.cpp
@@ -54,6 +54,22 @@ bool qmanager_opts_t::known_queue_policy (const std::string &policy)
 
 /******************************************************************************
  *                                                                            *
+ *                Private API for Queue Property Class                        *
+ *                                                                            *
+ ******************************************************************************/
+
+bool queue_prop_t::known_queue_policy (const std::string &policy)
+{
+    bool rc = false;
+    if (policy == "fcfs" || policy == "easy"
+        || policy == "hybrid" || policy == "conservative")
+        rc = true;
+    return rc;
+}
+
+
+/******************************************************************************
+ *                                                                            *
  *              Public API for Queue Manager Option Class                     *
  *                                                                            *
  ******************************************************************************/
@@ -75,6 +91,8 @@ const std::string &queue_prop_t::get_policy_params () const
 
 bool queue_prop_t::set_queue_policy (const std::string &p)
 {
+    if (!known_queue_policy (p))
+        return false;
     queue_policy = p;
     return true;
 }

--- a/qmanager/modules/qmanager_opts.cpp
+++ b/qmanager/modules/qmanager_opts.cpp
@@ -324,7 +324,7 @@ int qmanager_opts_t::parse (const std::string &k, const std::string &v,
         if (!m_per_queue_prop.empty ()
             && m_per_queue_prop.find (v) == m_per_queue_prop.end ()) {
             info += "Unknown default queue (" + v + ")! ";
-            info += "Use default.";
+            info += "Using default.";
             m_default_queue = dflt;
         }
         break;
@@ -332,7 +332,7 @@ int qmanager_opts_t::parse (const std::string &k, const std::string &v,
     case static_cast<int> (qmanager_opts_key_t::QUEUE_POLICY):
         if (!m_queue_prop.set_queue_policy (v)) {
             info += "Unknown queuing policy (" + v + ")! ";
-            info += "Use default.";
+            info += "Using default.";
         }
         break;
 
@@ -358,7 +358,7 @@ int qmanager_opts_t::parse (const std::string &k, const std::string &v,
             if (!m_per_queue_prop[kv.first].set_queue_policy (kv.second)) {
                 info += "Unknown queuing policy (" + v + ") for queue ("
                         + kv.second + ")! ";
-                info += "Use default. ";
+                info += "Using default. ";
             }
         }
         break;

--- a/qmanager/modules/qmanager_opts.hpp
+++ b/qmanager/modules/qmanager_opts.hpp
@@ -63,9 +63,14 @@ private:
 class qmanager_opts_t : public optmgr_parse_t {
 public:
     enum class qmanager_opts_key_t : int {
+        QUEUES                    = 0,  // queues
+        DEFAULT_QUEUE             = 1,  // default-queue
         QUEUE_POLICY              = 10, // queue-policy
         QUEUE_PARAMS              = 20, // queue-params
         POLICY_PARAMS             = 30, // policy-params
+        QUEUE_POLICY_PER_QUEUE    = 40, // queue-policy-per_queue
+        QUEUE_PARAMS_PER_QUEUE    = 50, // queue-params-per_queue
+        POLICY_PARAMS_PER_QUEUE   = 60, // policy-params-per_queue
         UNKNOWN                   = 5000
     };
 

--- a/qmanager/modules/qmanager_opts.hpp
+++ b/qmanager/modules/qmanager_opts.hpp
@@ -39,6 +39,18 @@ struct queue_prop_t {
     std::string queue_policy = QMANAGER_OPTS_UNSET_STR;
     std::string queue_params = QMANAGER_OPTS_UNSET_STR;
     std::string policy_params = QMANAGER_OPTS_UNSET_STR;
+
+    const std::string &get_queue_policy () const;
+    const std::string &get_queue_params () const;
+    const std::string &get_policy_params () const;
+
+    bool set_queue_policy (const std::string &p);
+    void set_queue_params (const std::string &p);
+    void set_policy_params (const std::string &p);
+
+    bool is_queue_policy_set () const;
+    bool is_queue_params_set () const;
+    bool is_policy_params_set () const;
 };
 
 /*! qmanager option set class

--- a/qmanager/modules/qmanager_opts.hpp
+++ b/qmanager/modules/qmanager_opts.hpp
@@ -140,8 +140,14 @@ private:
 
     const std::string m_default_queue_name = "default";
     std::string m_default_queue = QMANAGER_OPTS_UNSET_STR;
+
+    // default queue properties
     queue_prop_t m_queue_prop;
+
+    // properties of each queue
     std::map<std::string, queue_prop_t> m_per_queue_prop;
+
+    // mapping each option to an integer
     std::map<std::string, int> m_tab;
 };
 

--- a/qmanager/modules/qmanager_opts.hpp
+++ b/qmanager/modules/qmanager_opts.hpp
@@ -82,14 +82,20 @@ public:
     qmanager_opts_t (qmanager_opts_t &&o) = default;
     qmanager_opts_t &operator= (qmanager_opts_t &&o) = default;
 
-    void set_queue_policy (const std::string &o);
+    void set_default_queue (const std::string &o);
+    bool set_queue_policy (const std::string &o);
     void set_queue_params (const std::string &o);
     void set_policy_params (const std::string &o);
 
+    const std::string &get_default_queue_name () const;
+    const std::string &get_default_queue () const;
+    const queue_prop_t &get_queue_prop () const;
     const std::string &get_queue_policy () const;
     const std::string &get_queue_params () const;
     const std::string &get_policy_params () const;
+    const std::map<std::string, queue_prop_t> &get_per_queue_prop () const;
 
+    bool is_default_queue_set () const;
     bool is_queue_policy_set () const;
     bool is_queue_params_set () const;
     bool is_policy_params_set () const;
@@ -131,7 +137,6 @@ public:
 
 private:
     int parse_queues (const std::string &queues);
-    bool known_queue_policy (const std::string &policy);
 
     const std::string m_default_queue_name = "default";
     std::string m_default_queue = QMANAGER_OPTS_UNSET_STR;

--- a/qmanager/modules/qmanager_opts.hpp
+++ b/qmanager/modules/qmanager_opts.hpp
@@ -100,6 +100,15 @@ public:
      */
     qmanager_opts_t &operator+= (const qmanager_opts_t &o);
 
+    /*! Comparator function to make this whole class be used
+     *  as a functor -- allowing an upper class to call parse()
+     *  with a specific iteration order among key-value pairs.
+     *  \param k1        reference key
+     *  \param k2        comparing key
+     *  \return          true if k1 should precede k2 during iteration.
+     */
+    bool operator ()(const std::string &k1, const std::string &k2) const;
+
     /*! Parse the value string (v) according to the key string (k).
      *  The parsed results are stored in "this" object.
      *

--- a/qmanager/modules/qmanager_opts.hpp
+++ b/qmanager/modules/qmanager_opts.hpp
@@ -94,6 +94,11 @@ public:
     bool is_queue_params_set () const;
     bool is_policy_params_set () const;
 
+    /*! Canonicalize the option set -- apply the general queue properities
+     *  to per_queue queue properities if the latters are not explictly set.
+     */
+    qmanager_opts_t &canonicalize ();
+
     /*! Add an option with a higher precendence than "this" object.
      *  Modify this object according to the following "add" semantics
      *  and return the modified object:

--- a/qmanager/modules/qmanager_opts.hpp
+++ b/qmanager/modules/qmanager_opts.hpp
@@ -123,7 +123,10 @@ private:
     qmanager_opts_t &canonicalize ();
     bool known_queue_policy (const std::string &policy);
 
+    const std::string m_default_queue_name = "default";
+    std::string m_default_queue = QMANAGER_OPTS_UNSET_STR;
     queue_prop_t m_queue_prop;
+    std::map<std::string, queue_prop_t> m_per_queue_prop;
     std::map<std::string, int> m_tab;
 };
 

--- a/qmanager/modules/qmanager_opts.hpp
+++ b/qmanager/modules/qmanager_opts.hpp
@@ -37,10 +37,6 @@ const std::string QMANAGER_OPTS_UNSET_STR = "0xdeadbeef";
 
 class queue_prop_t {
 public:
-    std::string queue_policy = QMANAGER_OPTS_UNSET_STR;
-    std::string queue_params = QMANAGER_OPTS_UNSET_STR;
-    std::string policy_params = QMANAGER_OPTS_UNSET_STR;
-
     const std::string &get_queue_policy () const;
     const std::string &get_queue_params () const;
     const std::string &get_policy_params () const;
@@ -55,6 +51,10 @@ public:
 
 private:
     bool known_queue_policy (const std::string &policy);
+
+    std::string queue_policy = QMANAGER_OPTS_UNSET_STR;
+    std::string queue_params = QMANAGER_OPTS_UNSET_STR;
+    std::string policy_params = QMANAGER_OPTS_UNSET_STR;
 };
 
 /*! qmanager option set class

--- a/qmanager/modules/qmanager_opts.hpp
+++ b/qmanager/modules/qmanager_opts.hpp
@@ -120,7 +120,7 @@ public:
     int parse (const std::string &k, const std::string &v, std::string &info);
 
 private:
-    qmanager_opts_t &canonicalize ();
+    int parse_queues (const std::string &queues);
     bool known_queue_policy (const std::string &policy);
 
     const std::string m_default_queue_name = "default";

--- a/qmanager/modules/qmanager_opts.hpp
+++ b/qmanager/modules/qmanager_opts.hpp
@@ -35,7 +35,8 @@ namespace opts_manager {
 
 const std::string QMANAGER_OPTS_UNSET_STR = "0xdeadbeef";
 
-struct queue_prop_t {
+class queue_prop_t {
+public:
     std::string queue_policy = QMANAGER_OPTS_UNSET_STR;
     std::string queue_params = QMANAGER_OPTS_UNSET_STR;
     std::string policy_params = QMANAGER_OPTS_UNSET_STR;
@@ -51,6 +52,9 @@ struct queue_prop_t {
     bool is_queue_policy_set () const;
     bool is_queue_params_set () const;
     bool is_policy_params_set () const;
+
+private:
+    bool known_queue_policy (const std::string &policy);
 };
 
 /*! qmanager option set class

--- a/resource/libjobspec/jobspec.cpp
+++ b/resource/libjobspec/jobspec.cpp
@@ -336,6 +336,9 @@ Attributes parse_yaml_attributes (const YAML::Node &attrs)
                 if (s.first.as<std::string>() == "duration") {
                     a.system.duration = s.second.as<double>();
                 }
+                else if (s.first.as<std::string>() == "queue") {
+                    a.system.queue = s.second.as<std::string>();
+                }
                 else if (s.first.as<std::string>() == "cwd") {
                     a.system.cwd = s.second.as<std::string>();
                 }
@@ -491,6 +494,7 @@ std::ostream& Flux::Jobspec::operator<<(std::ostream& s, Jobspec const& jobspec)
     s << "    " << "duration: " << jobspec.attributes.system.duration
       << std::endl;
     s << "    " << "cwd: " << jobspec.attributes.system.cwd << std::endl;
+    s << "    " << "queue: " << jobspec.attributes.system.queue << std::endl;
     s << "    " << "environment:" << std::endl;
     for (auto&& e : jobspec.attributes.system.environment) {
         s << "      " << e.first << ": " << e.second << std::endl;

--- a/resource/libjobspec/jobspec.hpp
+++ b/resource/libjobspec/jobspec.hpp
@@ -99,6 +99,7 @@ public:
 
 struct System {
     double duration = 0.0f;
+    std::string queue = "";
     std::string cwd = "";
     std::unordered_map<std::string, std::string> environment;
     std::unordered_map<std::string, YAML::Node> optional;

--- a/src/common/liboptmgr/optmgr.hpp
+++ b/src/common/liboptmgr/optmgr.hpp
@@ -69,6 +69,15 @@ public:
     }
 
     /*!
+     * Canonicalize the option set -- calls the same named method
+     * of the object of the option set class T which canonicalizes
+     * its internal state after all the composition completes.
+     */
+    T &canonicalize () {
+        return m_opt.canonicalize ();
+    }
+
+    /*!
      * Getter
      *
      * \return         Option set object of type T

--- a/src/common/liboptmgr/optmgr.hpp
+++ b/src/common/liboptmgr/optmgr.hpp
@@ -95,8 +95,10 @@ private:
  *  the option set from a single source (e.g., an option set passed from
  *  module-load time).
  *  Template class T should be a module option-set management class
- *  that provides a "parse" method. This method must take in an option
+ *  that provides a "parse" method.  This method must take in an option
  *  key-value pair from the optmgr_kv_t class and update its state.
+ *  In addition, T must provide "operator()" method to give specific
+ *  iteration order on the option set.
  */
 template <class T>
 struct optmgr_kv_t : public detail::optmgr_kv_impl_t<T> {

--- a/src/common/liboptmgr/optmgr_impl.hpp
+++ b/src/common/liboptmgr/optmgr_impl.hpp
@@ -96,7 +96,7 @@ protected:
 
 private:
     T m_opt;
-    std::map<std::string, std::string> m_kv;
+    std::map<std::string, std::string, T> m_kv;
 };
 
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -27,6 +27,7 @@ TESTS = \
     t1003-qmanager-policy.t \
     t1004-qmanager-optimize.t \
     t1005-qmanager-conf.t \
+    t1006-qmanager-multiqueue.t \
     t2000-tree-basic.t \
     t2001-tree-real.t \
     t3000-jobspec.t \

--- a/t/conf.d/16-multiqueue/qmanager.toml
+++ b/t/conf.d/16-multiqueue/qmanager.toml
@@ -1,0 +1,21 @@
+#
+# Configuration for the qmanager module
+#
+
+[qmanager]
+
+# multiple queues
+queues = "debug batch"
+
+# queueing policy type
+queue-policy = "fcfs"
+
+# general queue parameters
+    # max queue depth (applied to all policies)
+    # queue-depth (applied to all policies)
+queue-params = "max-queue-depth=1000000,queue-depth=8192"
+
+# queue policy parameters
+    # max depth for "conservative" and "hybrid"
+    # reservation depth for HYBRID
+policy-params = "max-reservation-depth=100000,reservation-depth=64"

--- a/t/conf.d/17-mq-hetero/qmanager.toml
+++ b/t/conf.d/17-mq-hetero/qmanager.toml
@@ -1,0 +1,21 @@
+#
+# Configuration for the qmanager module
+#
+
+[qmanager]
+
+# multiple queues
+queues = "debug batch"
+
+# queueing policy type
+queue-policy-per-queue = "debug:fcfs batch:hybrid"
+
+# general queue parameters
+    # max queue depth (applied to all policies)
+    # queue-depth (applied to all policies)
+queue-params-per-queue = "debug:queue-depth=16"
+
+# queue policy parameters
+    # max depth for "conservative" and "hybrid"
+    # reservation depth for HYBRID
+policy-params-per-queue = "batch:max-reservation-depth=100000,reservation-depth=64"

--- a/t/conf.d/18-mq-override/qmanager.toml
+++ b/t/conf.d/18-mq-override/qmanager.toml
@@ -1,0 +1,25 @@
+#
+# Configuration for the qmanager module
+#
+
+[qmanager]
+
+queue-policy = "easy"
+
+# general queue parameters
+    # max queue depth (applied to all policies)
+    # queue-depth (applied to all policies)
+queue-params = "max-queue-depth=1000000,queue-depth=8192"
+
+# multiple queues
+queues = "debug batch"
+
+# queueing policy type for one or more named queue
+#     batch should inherit the base policy (easy)
+queue-policy-per-queue = "debug:fcfs"
+
+# general queue parameters
+    # max queue depth (applied to all policies)
+    # queue-depth (applied to all policies)
+queue-params-per-queue = "debug:queue-depth=16"
+

--- a/t/t1005-qmanager-conf.t
+++ b/t/t1005-qmanager-conf.t
@@ -30,11 +30,11 @@ start_qmanager_noconfig () {
 }
 # Usage: check_enforced_policy outfile expected
 check_enforced_policy() {
-    test "$(grep "enforced policy" <$1 | awk "{ print \$5}" )" = $2
+    test "$(grep "enforced policy" <$1 | awk "{ print \$6}" )" = $2
 }
 
 check_params() {
-    res="$(grep "$3" <$1 | awk "{ print \$6}")"
+    res="$(grep "$3" <$1 | awk "{ print \$7}")"
     for tok in $(echo ${res} | sed -e 's@,@ @g')
     do
         echo ${2} | grep ${tok} || return 1

--- a/t/t1005-qmanager-conf.t
+++ b/t/t1005-qmanager-conf.t
@@ -215,5 +215,53 @@ test_expect_success 'qmanager: load succeeds on no qmanager category' '
     check_policy_params ${outfile} default
 '
 
+test_expect_success 'qmanager: homogeneous multiqueue configuration works' '
+    conf_name="16-multiqueue" &&
+    outfile=${conf_name}.out &&
+    start_qmanager ${conf_base}/${conf_name} > ${outfile} &&
+    grep "queue=debug" ${outfile} > ${outfile}.qdebug &&
+    grep "queue=batch" ${outfile} > ${outfile}.qbatch &&
+    check_enforced_policy ${outfile}.qdebug "fcfs" &&
+    check_queue_params ${outfile}.qdebug \
+        "queue-depth=8192,max-queue-depth=1000000" &&
+    check_policy_params ${outfile}.qdebug \
+        "reservation-depth=64,max-reservation-depth=100000" &&
+    check_enforced_policy ${outfile}.qbatch "fcfs" &&
+    check_queue_params ${outfile}.qbatch \
+        "queue-depth=8192,max-queue-depth=1000000" &&
+    check_policy_params ${outfile}.qbatch \
+        "reservation-depth=64,max-reservation-depth=100000"
+'
+
+test_expect_success 'qmanager: heterogeneous multiqueue configuration works' '
+    conf_name="17-mq-hetero" &&
+    outfile=${conf_name}.out &&
+    start_qmanager ${conf_base}/${conf_name} > ${outfile} &&
+    grep "queue=debug" ${outfile} > ${outfile}.qdebug &&
+    grep "queue=batch" ${outfile} > ${outfile}.qbatch &&
+    check_enforced_policy ${outfile}.qdebug "fcfs" &&
+    check_queue_params ${outfile}.qdebug "queue-depth=16" &&
+    check_policy_params ${outfile}.qdebug "default" &&
+    check_enforced_policy ${outfile}.qbatch "hybrid" &&
+    check_queue_params ${outfile}.qbatch "default" &&
+    check_policy_params ${outfile}.qbatch \
+        "reservation-depth=64,max-reservation-depth=100000"
+'
+
+test_expect_success 'qmanager: per-queue parameter overriding works' '
+    conf_name="18-mq-override" &&
+    outfile=${conf_name}.out &&
+    start_qmanager ${conf_base}/${conf_name} > ${outfile} &&
+    grep "queue=debug" ${outfile} > ${outfile}.qdebug &&
+    grep "queue=batch" ${outfile} > ${outfile}.qbatch &&
+    check_enforced_policy ${outfile}.qdebug "fcfs" &&
+    check_queue_params ${outfile}.qdebug "queue-depth=16" &&
+    check_policy_params ${outfile}.qdebug "default" &&
+    check_enforced_policy ${outfile}.qbatch "easy" &&
+    check_queue_params ${outfile}.qbatch \
+        "queue-depth=8192,max-queue-depth=1000000" &&
+    check_policy_params ${outfile}.qbatch "default"
+'
+
 test_done
 

--- a/t/t1006-qmanager-multiqueue.t
+++ b/t/t1006-qmanager-multiqueue.t
@@ -1,0 +1,152 @@
+#!/bin/sh
+
+test_description='Test multiple queue support within qmanager'
+
+ORIG_HOME=${HOME}
+
+. `dirname $0`/sharness.sh
+
+test_under_flux 1
+
+#
+# sharness modifies $HOME environment variable, but this interferes
+# with python's package search path, in particular its user site package.
+#
+HOME=${ORIG_HOME}
+
+conf_base=${SHARNESS_TEST_SRCDIR}/conf.d
+
+test_expect_success 'qmanager: loading qmanager with multiple queues' '
+    flux module remove sched-simple &&
+    flux module load resource prune-filters=ALL:core \
+subsystems=containment policy=low &&
+    flux module load qmanager queues="all batch debug"
+'
+
+test_expect_success 'qmanager: job can be submitted to queue=all' '
+    jobid=$(flux mini submit -n 1 --setattr system.queue=all hostname) &&
+    flux job wait-event -t 2 ${jobid} finish &&
+    queue=$(flux dmesg | grep alloc | grep ${jobid} | \
+awk "{print \$5}" | awk -F= "{print \$2}") &&
+    test ${queue} = all &&
+    queue=$(flux dmesg | grep free | grep ${jobid} | \
+awk "{print \$5}" | awk -F= "{print \$2}") &&
+    test ${queue} = all &&
+    flux dmesg -C
+'
+
+test_expect_success 'qmanager: job can be submitted to queue=batch' '
+    jobid=$(flux mini submit -n 1 --setattr system.queue=batch hostname) &&
+    flux job wait-event -t 2 ${jobid} finish &&
+    queue=$(flux dmesg | grep alloc | grep ${jobid} | \
+awk "{print \$5}" | awk -F= "{print \$2}") &&
+    test ${queue} = batch &&
+    queue=$(flux dmesg | grep free | grep ${jobid} | \
+awk "{print \$5}" | awk -F= "{print \$2}") &&
+    test ${queue} = batch &&
+    flux dmesg -C
+'
+
+test_expect_success 'qmanager: job can be submitted to queue=debug' '
+    jobid=$(flux mini submit -n 1 --setattr system.queue=debug hostname) &&
+    flux job wait-event -t 2 ${jobid} finish &&
+    queue=$(flux dmesg | grep alloc | grep ${jobid} | \
+awk "{print \$5}" | awk -F= "{print \$2}") &&
+    test ${queue} = debug &&
+    queue=$(flux dmesg | grep free | grep ${jobid} | \
+awk "{print \$5}" | awk -F= "{print \$2}") &&
+    test ${queue} = debug &&
+    flux dmesg -C
+'
+
+# when default-queue=queue-name is not given the lexicographically
+# earliest queue name becomes default
+test_expect_success 'qmanager: job enqueued into implicitly default queue' '
+    jobid=$(flux mini submit -n 1 hostname) &&
+    flux job wait-event -t 2 ${jobid} finish &&
+    queue=$(flux dmesg | grep alloc | grep ${jobid} | \
+awk "{print \$5}" | awk -F= "{print \$2}") &&
+    test ${queue} = all &&
+    queue=$(flux dmesg | grep free | grep ${jobid} | \
+awk "{print \$5}" | awk -F= "{print \$2}") &&
+    test ${queue} = all &&
+    flux dmesg -C
+'
+
+test_expect_success 'qmanager: qmanager with queues with different policies' '
+    flux module reload -f qmanager queues="queue1 queue2 queue3" \
+queue-policy-per-queue="queue1:easy queue2:hybrid queue3:fcfs" default-queue=queue3
+'
+
+test_expect_success 'qmanager: job can be submitted to queue=queue3 (fcfs)' '
+    jobid=$(flux mini submit -n 1 --setattr system.queue=queue3 hostname) &&
+    flux job wait-event -t 2 ${jobid} finish &&
+    queue=$(flux dmesg | grep alloc | grep ${jobid} | \
+awk "{print \$5}" | awk -F= "{print \$2}") &&
+    test ${queue} = queue3 &&
+    queue=$(flux dmesg | grep free | grep ${jobid} | \
+awk "{print \$5}" | awk -F= "{print \$2}") &&
+    test ${queue} = queue3 &&
+    flux dmesg -C
+'
+
+test_expect_success 'qmanager: job can be submitted to queue=queue2 (hybrid)' '
+    jobid=$(flux mini submit -n 1 --setattr system.queue=queue2 hostname) &&
+    flux job wait-event -t 2 ${jobid} finish &&
+    queue=$(flux dmesg | grep alloc | grep ${jobid} | \
+awk "{print \$5}" | awk -F= "{print \$2}") &&
+    test ${queue} = queue2 &&
+    queue=$(flux dmesg | grep free | grep ${jobid} | \
+awk "{print \$5}" | awk -F= "{print \$2}") &&
+    test ${queue} = queue2 &&
+    flux dmesg -C
+'
+
+test_expect_success 'qmanager: job submitted to queue=queue1 (conservative)' '
+    jobid=$(flux mini submit -n 1 --setattr system.queue=queue1 hostname) &&
+    flux job wait-event -t 2 ${jobid} finish &&
+    queue=$(flux dmesg | grep alloc | grep ${jobid} | \
+awk "{print \$5}" | awk -F= "{print \$2}") &&
+    test ${queue} = queue1 &&
+    queue=$(flux dmesg | grep free | grep ${jobid} | \
+awk "{print \$5}" | awk -F= "{print \$2}") &&
+    test ${queue} = queue1 &&
+    flux dmesg -C
+'
+
+test_expect_success 'qmanager: job enqueued into explicitly default queue' '
+    jobid=$(flux mini submit -n 1 hostname) &&
+    flux job wait-event -t 2 ${jobid} finish &&
+    queue=$(flux dmesg | grep alloc | grep ${jobid} | \
+awk "{print \$5}" | awk -F= "{print \$2}") &&
+    test ${queue} = queue3 &&
+    queue=$(flux dmesg | grep free | grep ${jobid} | \
+awk "{print \$5}" | awk -F= "{print \$2}") &&
+    test ${queue} = queue3 &&
+    flux dmesg -C
+'
+
+test_expect_success 'qmanager: job is denied when submitted to unknown queue' '
+    test_must_fail flux mini run -n 1 --setattr system.queue=foo hostname &&
+    flux dmesg -C
+'
+
+test_expect_success 'qmanager: incorrect default-queue name can be caught' '
+    flux module reload -f qmanager queues="queue1 queue2 queue3" \
+default-queue=foo &&
+    flux dmesg | grep "Unknown default queue (foo)"
+'
+
+test_expect_success 'qmanager: incorrect queue-policy-per-queue can be caught' '
+    flux module reload -f qmanager queues="queue1 queue2 queue3" \
+queue-policy-per-queue="queue1:easy queue2:foo queue3:fcfs" &&
+    flux dmesg | grep "Unknown queuing policy"
+'
+
+test_expect_success 'removing resource and qmanager modules' '
+    flux module remove qmanager &&
+    flux module remove resource
+'
+
+test_done
+


### PR DESCRIPTION
This PR is work in progress to add multi-queue support within `qmanager`.

Build on top of a merge of two pending PRs: PR #645 and PR #646.

As described in Issue #640, it adds the following modifications:
 - Replace a single queue object (of `queue_policy_base_t` class) with
a `std::map` that contains a configurable number of queue objects
keyed off of distinct queue names.
- Add ways to specify multiple queues both through configuration files
and module load options while keeping the current conf/load option
set backward compatible as much as possible. 
Each specified queue can enforce a queueing policy, queuing
parameters and queueing-policy parameters, independent of one another.
- Bring in libjobspec to fetch the queue information from
`system.attributes.queue` key of a jobspec and use
it to identify the corresponding queue.
- Adjust the business logic in each and every job-manager callbacks
like `jobmanager_alloc_cb`
- Add a few configuration tests into `t1005-qmanager-conf.t`

I still need to add a bunch more test cases to finish this up.
As we discussed before, I'm not entirely happy with the current
way of configuring  queues. But I thought there is a benefit of getting
the runtime logic correct as soon as possible and then improve
upon user friendliness later.

If you want to test this:

```console
ahn1@6e8124a3b9bc:/usr/src$ flux start -s 1
ahn1@6e8124a3b9bc:/usr/src$ flux module remove qmanager
ahn1@6e8124a3b9bc:/usr/src$ flux module load qmanager queues="debug batch"
ahn1@6e8124a3b9bc:/usr/src/t/multiqueue$ flux mini run -n 2 --dry-run hostname | jq '.attributes.system.queue="batch"' | flux job submit -
10022792724480
ahn1@6e8124a3b9bc:/usr/src/t/multiqueue$ flux mini run -n 2 --dry-run hostname | jq '.attributes.system.queue="debug"' | flux job submit -
10185330393088
ahn1@6e8124a3b9bc:/usr/src/t/multiqueue$ flux mini run -n 2 --dry-run hostname | flux job submit -
10675594199040
ahn1@6e8124a3b9bc:/usr/src/t/multiqueue$ flux dmesg | grep alloc
2020-05-02T00:38:41.891482Z qmanager.debug[0]: alloc success (queue=batch id=10022792724480)
2020-05-02T00:38:51.581285Z qmanager.debug[0]: alloc success (queue=debug id=10185330393088)
2020-05-02T00:39:20.800212Z qmanager.debug[0]: alloc success (queue=batch id=10675594199040)
```

