### PR TITLE
testsuite: update flux-sharness.sh from flux-core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
        - CXX=g++-8
        - DISTCHECK=t
        - GITHUB_RELEASES_DEPLOY=t
+       - TEST_CHECK_PREREQS=t
     - name: "Ubuntu: clang-6.0 chain-lint"
       compiler: clang-6.0
       env:

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -121,6 +121,7 @@ docker run --rm \
     -e USER \
     -e TRAVIS \
     -e TAP_DRIVER_QUIET \
+    -e TEST_CHECK_PREREQS \
     --cap-add SYS_PTRACE \
     --tty \
     ${INTERACTIVE:+--interactive} \

--- a/t/scripts/run_timeout.py
+++ b/t/scripts/run_timeout.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""run command with a timeout, timeout as a float is first argument, rest are command"""
+import sys
+import os
+import signal
+import argparse
+import subprocess as s
+
+parser = argparse.ArgumentParser(description="run command with a timeout")
+parser.add_argument(
+    "-s", "--signal", help="signal to send, default is SIGKILL", default=signal.SIGKILL
+)
+parser.add_argument(
+    "-e",
+    "--env",
+    help="environment variable to set of the form KEY=VAL",
+    action="append",
+    default=[],
+)
+parser.add_argument(
+    "-k",
+    "--kill-after",
+    type=float,
+    help="secondary timeout before kill if first does not kill it",
+    default=1.0,
+)
+parser.add_argument("timeout", type=float, help="timeout in float seconds")
+parser.add_argument("cmd")
+parser.add_argument("cmd_args", nargs=argparse.REMAINDER)
+
+args = parser.parse_args()
+
+
+def resolve_signal():
+    if not isinstance(args.signal, int):
+        try:
+            args.signal = int(args.signal)
+            return
+        except ValueError:
+            pass
+        try:
+            args.signal = getattr(signal, args.signal)
+            return
+        except AttributeError:
+            pass
+        try:
+            args.signal = getattr(signal, f"SIG{args.signal}")
+            return
+        except AttributeError:
+            pass
+        raise ValueError(f"value passed for signal is invalid: {args.signal}")
+
+
+def exit_signal(rc):
+    # python "helpfully" translates signal return codes for us, translate back
+    if rc < 0:
+        rc = 128 + abs(rc)
+    sys.exit(rc)
+
+
+def do_timeout():
+    environ = dict(os.environ)
+    for e in args.env:
+        (k, v) = e.split("=")
+        environ[k] = v
+    try:
+        # add cmd onto the front of the cmd arg list
+        args.cmd_args.insert(0, args.cmd)
+        p = s.Popen(args.cmd_args, env=environ)
+        # run with timeout, on success exits with return code
+        r = p.wait(timeout=args.timeout)
+    except s.TimeoutExpired:
+        # send signal to timeout process
+        p.send_signal(args.signal)
+        if args.kill_after > 0:
+            try:
+                # wait to make sure it actually stops
+                r = p.wait(timeout=args.kill_after)
+            except s.TimeoutExpired:
+                p.kill()
+                r = p.wait()
+    exit_signal(r)
+
+
+resolve_signal()
+do_timeout()

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -156,4 +156,11 @@ fi
 #  Some tests in flux don't work with --chain-lint, add a prereq for
 #   --no-chain-lint:
 test "$chain_lint" = "t" || test_set_prereq NO_CHAIN_LINT
+
+# Sanitize PMI_* environment for all tests. This allows commands like
+#  `flux broker` in tests to boot as singleton even when run under a
+#  job of an existing RM.
+for var in $(env | grep ^PMI); do unset ${var%=*}; done
+for var in $(env | grep ^SLURM); do unset ${var%=*}; done
+
 # vi: ts=4 sw=4 expandtab

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -7,7 +7,15 @@
 #  Extra functions for Flux testsuite
 #
 run_timeout() {
-    perl -e 'use Time::HiRes qw( ualarm ) ; ualarm ((shift @ARGV) * 1000000) ; exec @ARGV or die "$!"' "$@"
+    if test -z "$LD_PRELOAD" ; then
+        "${PYTHON:-python3}" -S "${SHARNESS_TEST_SRCDIR}/scripts/run_timeout.py" "$@"
+    else
+        (
+            TIMEOUT_PRELOAD="$LD_PRELOAD"
+            unset -v LD_PRELOAD
+            exec "${PYTHON:-python3}" -S "${SHARNESS_TEST_SRCDIR}/scripts/run_timeout.py" -e LD_PRELOAD="$TIMEOUT_PRELOAD" "$@"
+        )
+    fi
 }
 
 #
@@ -89,6 +97,8 @@ test_under_flux() {
     timeout="-o -Sinit.rc2_timeout=300"
     if test -n "$FLUX_TEST_DISABLE_TIMEOUT"; then
         timeout=""
+    elif test_have_prereq LONGTEST; then
+        timeout="-o,-Sinit.rc2_timeout=900"
     fi
 
     if test "$personality" = "minimal"; then
@@ -110,8 +120,15 @@ test_under_flux() {
         valgrind="$valgrind,--trace-children=no,--child-silent-after-fork=yes"
         valgrind="$valgrind,--leak-resolution=med,--error-exitcode=1"
         valgrind="$valgrind,--suppressions=${VALGRIND_SUPPRESSIONS}"
+        gracetime="-o,-g,10"
     fi
-
+    # Extend timeouts when running under AddressSanitizer
+    if test_have_prereq ASAN; then
+        gracetime="-o,-g,10"
+        timeout="-o -Sinit.rc2_timeout=800"
+        # Set log_path for ASan o/w errors from broker may be lost
+        ASAN_OPTIONS=${ASAN_OPTIONS}:log_path=${TEST_NAME}.asan
+    fi
     logopts="-o -Slog-filename=${log_file},-Slog-forward-level=7"
     TEST_UNDER_FLUX_ACTIVE=t \
     TERM=${ORIGINAL_TERM} \
@@ -120,6 +137,7 @@ test_under_flux() {
                       ${RC3_PATH+-o -Sbroker.rc3_path=${RC3_PATH}} \
                       ${logopts} \
                       ${timeout} \
+                      ${gracetime} \
                       ${valgrind} \
                      "sh $0 ${flags}"
 }
@@ -144,12 +162,71 @@ test_on_rank() {
     flux exec --rank=${ranks} "$@"
 }
 
+#
+# Check for a program and skip all tests immediately if not found.
+# Exports the program in SHARNESS_test_skip_all_prereq for later
+# check in TEST_CHECK_PREREQS
+#
+skip_all_unless_have()
+{
+    prog_path=$(which $1 2>/dev/null)
+    if test -z "$prog_path"; then
+        skip_all="$1 not found. Skipping all tests"
+        test_done
+    fi
+    eval "$1=$prog_path"
+    export SHARNESS_test_skip_all_prereq="$SHARNESS_test_skip_all_prereq,$1"
+}
+
+GLOBAL_PROGRAM_PREREQS="HAVE_JQ:jq"
+
+#
+#  Check for programs in GLOBAL_PROGRAM_PREREQS and set prereq and
+#   "<name>=<program_path>" if found. If TEST_CHECK_PREREQS is set, then
+#   create a wrapper script in trash-directory/bin which will ensure the
+#   prereq (or global skip_all above) has been used before each invocation
+#   of program. This will catch places in testsuite where program is used
+#   without testing the prerequisite.
+#
+for prereq in $GLOBAL_PROGRAM_PREREQS; do
+    prog=${prereq#*:}
+    path_prog=$(which ${prog} 2>/dev/null || echo "/bin/false")
+    req=${prereq%:*}
+    test "${path_prog}" = "/bin/false" || test_set_prereq ${req}
+    eval "${prog}=${path_prog}"
+    if test -n "$TEST_CHECK_PREREQS"; then
+		dir=${SHARNESS_TRASH_DIRECTORY}/bin
+		mkdir -p ${dir}
+		cat <<-EOF > ${dir}/$prog
+		#!/bin/sh
+		saved_IFS=\$IFS
+		IFS=,
+		for x in \$test_prereq; do
+		  test "\$x" = "$req" && ok=t
+		done
+		for x in \$SHARNESS_test_skip_all_prereq; do
+		  test "\$x" = "$prog" && ok=t
+		done
+		test -n "\$ok" && exec $path_prog "\$@"
+		echo >&2 "Use of $prog without prereq $req!"
+		exit 1
+		EOF
+		chmod +x ${dir}/$prog
+		# Override $$prog to point to wrapper script:
+		eval "${prog}=${dir}/${prog}"
+    fi
+done
+
+if test -n "$TEST_CHECK_PREREQS"; then
+    export PATH=${SHARNESS_TRASH_DIRECTORY}/bin:${PATH}
+fi
+
 #  Export a shorter name for this test
 TEST_NAME=$SHARNESS_TEST_NAME
 export TEST_NAME
 
 #  Test requirements for testsuite
-if ! run_timeout 1.0 lua -e 'require "posix"'; then
+if ! run_timeout 10.0 lua -e 'require "posix"'; then
     error "failed to find lua posix module in path"
 fi
 
@@ -157,10 +234,22 @@ fi
 #   --no-chain-lint:
 test "$chain_lint" = "t" || test_set_prereq NO_CHAIN_LINT
 
+#  Set LONGTEST prereq
+if test "$TEST_LONG" = "t" || test "$LONGTEST" = "t"; then
+    test_set_prereq LONGTEST
+fi
+
+#  Set ASAN or NO_ASAN prereq
+if flux version | grep -q +asan; then
+    test_set_prereq ASAN
+else
+    test_set_prereq NO_ASAN
+fi
+
 # Sanitize PMI_* environment for all tests. This allows commands like
 #  `flux broker` in tests to boot as singleton even when run under a
 #  job of an existing RM.
-for var in $(env | grep ^PMI); do unset ${var%=*}; done
-for var in $(env | grep ^SLURM); do unset ${var%=*}; done
+for var in $(env | grep ^PMI); do unset ${var%%=*}; done
+for var in $(env | grep ^SLURM); do unset ${var%%=*}; done
 
 # vi: ts=4 sw=4 expandtab

--- a/t/t1001-qmanager-basic.t
+++ b/t/t1001-qmanager-basic.t
@@ -8,15 +8,9 @@ hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 4 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
 excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers"
 
-test_under_flux 1
+skip_all_unless_have jq
 
-#  Set path to jq(1)
-#
-jq=$(which jq 2>/dev/null)
-if test -z "$jq"; then
-    skip_all='jq not found. Skipping all tests'
-    test_done
-fi
+test_under_flux 1
 
 job_kvsdir()    { flux job id --to=kvs $1; }
 exec_eventlog() { flux kvs get -r $(job_kvsdir $1).guest.exec.eventlog; }

--- a/t/t1002-qmanager-reload.t
+++ b/t/t1002-qmanager-reload.t
@@ -8,15 +8,9 @@ hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 4 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
 excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers"
 
-test_under_flux 1
+skip_all_unless_have jq
 
-#  Set path to jq(1)
-#
-jq=$(which jq 2>/dev/null)
-if test -z "$jq"; then
-    skip_all='jq not found. Skipping all tests'
-    test_done
-fi
+test_under_flux 1
 
 exec_test()     { ${jq} '.attributes.system.exec.test = {}'; }
 submit_jobs()   {

--- a/t/t1003-qmanager-policy.t
+++ b/t/t1003-qmanager-policy.t
@@ -8,15 +8,9 @@ hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 4 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
 excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers"
 
-test_under_flux 1
+skip_all_unless_have jq
 
-#  Set path to jq(1)
-#
-jq=$(which jq 2>/dev/null)
-if test -z "$jq"; then
-    skip_all='jq not found. Skipping all tests'
-    test_done
-fi
+test_under_flux 1
 
 exec_test()     { ${jq} '.attributes.system.exec.test = {}'; }
 

--- a/t/t1004-qmanager-optimize.t
+++ b/t/t1004-qmanager-optimize.t
@@ -8,15 +8,9 @@ hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 4 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
 excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers"
 
-test_under_flux 1
+skip_all_unless_have jq
 
-#  Set path to jq(1)
-#
-jq=$(which jq 2>/dev/null)
-if test -z "$jq"; then
-    skip_all='jq not found. Skipping all tests'
-    test_done
-fi
+test_under_flux 1
 
 exec_test()     { ${jq} '.attributes.system.exec.test = {}'; }
 

--- a/t/t4008-match-jgf.t
+++ b/t/t4008-match-jgf.t
@@ -62,7 +62,7 @@ ${jgf_4core} > bad_edges.json
     jq ' del(.graph.nodes[1].metadata.paths) ' ${jgf_4core} > bad_paths.json
 }
 
-test_expect_success 'generate bad JGF files' '
+test_expect_success HAVE_JQ 'generate bad JGF files' '
     create_bad_jgfs
 '
 

--- a/t/t6001-match-formats.t
+++ b/t/t6001-match-formats.t
@@ -35,7 +35,7 @@ test_expect_success LONGTEST "Large R emitted with -F jgf validates" '
     flux jsonschemalint -v ${schema} o3.json
 '
 
-test_expect_success "--match-format=rv1 works" '
+test_expect_success HAVE_JQ "--match-format=rv1 works" '
     echo "match allocate ${jobspec}" > in5.txt &&
     echo "quit" >> in5.txt &&
     ${query} -L ${tiny_grug} -F rv1 -d -t o5 < in5.txt &&
@@ -43,7 +43,7 @@ test_expect_success "--match-format=rv1 works" '
     flux jsonschemalint -v ${schema} o5.json
 '
 
-test_expect_success "--match-format=rv1_nosched and =rlite works" '
+test_expect_success HAVE_JQ "--match-format=rv1_nosched and =rlite works" '
     echo "match allocate ${jobspec}" > in7.txt &&
     echo "quit" >> in7.txt &&
     ${query} -L ${tiny_grug} -F rv1_nosched -d -t o7 < in7.txt &&
@@ -61,7 +61,7 @@ test_expect_success "--match-format=pretty_simple works" '
     test -s o9.simple
 '
 
-test_expect_success "rv1 contains starttime and expiration keys" '
+test_expect_success HAVE_JQ "rv1 contains starttime and expiration keys" '
     echo "match allocate ${jobspec}" > in10.txt &&
     echo "quit" >> in10.txt &&
     ${query} -L ${tiny_grug} -F rv1_nosched -d -t o10 < in10.txt &&
@@ -71,7 +71,7 @@ test_expect_success "rv1 contains starttime and expiration keys" '
     test ${expiration} -eq 3600
 '
 
-test_expect_success "rv1_nosched contains starttime and expiration keys" '
+test_expect_success HAVE_JQ "rv1_nosched contains starttime and expiration keys" '
     echo "match allocate ${jobspec}" > in11.txt &&
     echo "quit" >> in11.txt &&
     ${query} -L ${tiny_grug} -F rv1 -d -t o11 < in11.txt &&


### PR DESCRIPTION
This PR updates `t/sharness.d/flux-sharness.sh` from flux-core, including

 * @trws's `run_timeout.py` test timeout improvements
 * Support for `TEST_CHECK_PREREQS` to validate `jq` usage protected by `HAVE_JQ`

Also adds `TEST_CHECK_PREREQS=t` to one travis builder, and fixes resulting fallout.

The test is based on #655, so that name changes would not conflict. This PR should go in after that one is merged.