### PR TITLE
Fix t2002-qmanager-reload.t with new core resource module

### DIFF
--- a/t/t1002-qmanager-reload.t
+++ b/t/t1002-qmanager-reload.t
@@ -27,7 +27,10 @@ test_expect_success 'qmanager: generate jobspec for a simple test job' '
 '
 
 test_expect_success 'qmanager: hwloc reload works' '
-    flux hwloc reload ${excl_4N4B}
+    flux hwloc reload ${excl_4N4B} &&
+    flux module unload sched-simple &&
+    flux module reload resource &&
+    flux module load sched-simple
 '
 
 test_expect_success 'qmanager: loading resource and qmanager modules works' '


### PR DESCRIPTION
This PR fixes a hang that will come up once flux-framework/flux-core#2949 is merged. Since the `resource` module now shares resource configuration with sched-simple via the acquire interface, this module must be reloaded once hwloc data is manually overridden, or else sched-simple will reject free requests after it is reloaded at the end of the test.

I suppose since #657 has not been merged yet, I can tack this onto that PR if that would be better.