### PR TITLE
Resource status

### DIFF
--- a/resource/readers/resource_reader_hwloc.cpp
+++ b/resource/readers/resource_reader_hwloc.cpp
@@ -102,6 +102,7 @@ vtx_t resource_reader_hwloc_t::add_new_vertex (resource_graph_t &g,
     g[v].name = basename + istr;
     g[v].paths[subsys] = prefix + "/" + g[v].name;
     g[v].idata.member_of[subsys] = "*";
+    g[v].status = resource_pool_t::status_t::UP;
 
     // Indexing for fast look-up
     m.by_path[g[v].paths[subsys]] = v;

--- a/resource/readers/resource_reader_jgf.cpp
+++ b/resource/readers/resource_reader_jgf.cpp
@@ -44,6 +44,7 @@ struct fetch_helper_t {
     int64_t size = 0;
     int64_t uniq_id = 0;
     int exclusive = 0;
+    resource_pool_t::status_t status = resource_pool_t::status_t::UP;
     const char *type = NULL;
     const char *name = NULL;
     const char *unit = NULL;
@@ -186,11 +187,11 @@ int resource_reader_jgf_t::unpack_vtx (json_t *element, fetch_helper_t &f)
         m_err_msg += std::string (f.vertex_id) + ".\n";
         goto done;
     }
-    if ( (json_unpack (metadata, "{ s:s s:s s:s s:I s:I s:I s:b s:s s:I }",
+    if ( (json_unpack (metadata, "{ s:s s:s s:s s:I s:I s:I s?:i s:b s:s s:I }",
                                  "type", &f.type, "basename", &f.basename,
                                  "name", &f.name, "id", &f.id,
                                  "uniq_id", &f.uniq_id, "rank", &f.rank,
-                                 "exclusive", &f.exclusive,
+                                 "status", &f.status, "exclusive", &f.exclusive,
                                  "unit", &f.unit, "size", &f.size)) < 0) {
         errno = EPROTO;
         m_err_msg += __FUNCTION__;
@@ -245,6 +246,7 @@ vtx_t resource_reader_jgf_t::create_vtx (resource_graph_t &g,
     g[v].size = fetcher.size;
     g[v].uniq_id = fetcher.uniq_id;
     g[v].rank = fetcher.rank;
+    g[v].status = fetcher.status;
     g[v].id = fetcher.id;
     g[v].name = fetcher.name;
     g[v].properties = fetcher.properties;

--- a/resource/schema/resource_data.cpp
+++ b/resource/schema/resource_data.cpp
@@ -106,6 +106,10 @@ resource_relation_t::~resource_relation_t ()
 
 }
 
+const resource_pool_t::string_to_status resource_pool_t::str_to_status = 
+      { { "up", resource_pool_t::status_t::UP }, 
+      { "down", resource_pool_t::status_t::DOWN } };
+
 
 } // Flux::resource_model
 } // Flux

--- a/resource/schema/resource_data.hpp
+++ b/resource/schema/resource_data.hpp
@@ -27,6 +27,7 @@
 #include <string>
 #include <cstring>
 #include <map>
+#include <unordered_map>
 #include <set>
 #include "resource/schema/color.hpp"
 #include "resource/schema/data_std.hpp"
@@ -44,6 +45,14 @@ struct resource_pool_t {
     resource_pool_t &operator= (const resource_pool_t &o);
     ~resource_pool_t ();
 
+    enum class status_t : int { 
+        UP = 0,
+        DOWN = 1
+    };
+
+    typedef std::unordered_map<std::string, status_t> string_to_status;
+    static const string_to_status str_to_status;
+
     // Resource pool data
     std::string type;
     std::map<std::string, std::string> paths;
@@ -58,6 +67,7 @@ struct resource_pool_t {
 
     schedule_t schedule;    //!< schedule data
     pool_infra_t idata;     //!< scheduling infrastructure data
+    status_t status = status_t::UP;
 };
 
 /*! Resource relationship type.

--- a/resource/traversers/dfu.cpp
+++ b/resource/traversers/dfu.cpp
@@ -286,8 +286,20 @@ int dfu_traverser_t::remove (int64_t jobid)
         return -1;
     }
 
-    vtx_t root = get_graph_db ()->metadata.roots.at(dom);
+    vtx_t root = get_graph_db ()->metadata.roots.at (dom);
     return detail::dfu_impl_t::remove (root, jobid);
+}
+
+int dfu_traverser_t::mark (const std::string &root_path, 
+                           resource_pool_t::status_t status)
+{
+    return detail::dfu_impl_t::mark (root_path, status);
+}
+
+int dfu_traverser_t::mark (std::set<int64_t> &ranks, 
+                           resource_pool_t::status_t status)
+{
+    return detail::dfu_impl_t::mark (ranks, status);
 }
 
 /*

--- a/resource/traversers/dfu.hpp
+++ b/resource/traversers/dfu.hpp
@@ -148,6 +148,24 @@ public:
      */
     int remove (int64_t jobid);
 
+    /*! Mark the resource status up|down|etc starting at subtree_root.
+     *
+     *  \param root_path     path to the root of the subtree to update.
+     *  \param status        new status value
+     *  \return              0 on success; -1 on error.
+     *                       EINVAL: roots or by_path not found.
+     */
+    int mark (const std::string &root_path, resource_pool_t::status_t status);
+
+    /*! Mark the resource status up|down|etc for subgraph represented by ranks.
+     *
+     *  \param ranks         set of ranks representing the subgraph to update.
+     *  \param status        new status value
+     *  \return              0 on success; -1 on error.
+     *                       EINVAL: roots or by_path not found.
+     */
+    int mark (std::set<int64_t> &ranks, resource_pool_t::status_t status);
+
 private:
     int schedule (Jobspec::Jobspec &jobspec, detail::jobmeta_t &meta,
                   bool x, match_op_t op, vtx_t root,

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -243,6 +243,25 @@ public:
      */
     int remove (vtx_t root, int64_t jobid);
 
+    /*! Update the resource status to up|down|etc starting at subtree_root.
+     *
+     *  \param root_path     path to the root of the subtree to update.
+     *  \param status        new status value
+     *  \return              0 on success; -1 on error.
+     *                       EINVAL: graph, roots or match callback not set.
+     */
+    int mark (const std::string &root_path, resource_pool_t::status_t status);
+
+    /*! Update the resource status to up|down|etc for subgraph 
+     *  represented by ranks.
+     *
+     *  \param ranks         set of ranks representing the subgraphs to update.
+     *  \param status        new status value
+     *  \return              0 on success; -1 on error.
+     *                       EINVAL: roots or by_path not found.
+     */
+    int mark (std::set<int64_t> &ranks, resource_pool_t::status_t status);
+
 private:
 
     /************************************************************************

--- a/resource/utilities/command.cpp
+++ b/resource/utilities/command.cpp
@@ -56,6 +56,8 @@ command_t commands[] = {
 "resource-query> set-property resource PROPERTY=VALUE" },
 { "get-property", "g", cmd_get_property, "Get all properties of a resource: "
 "resource-query> get-property resource" },
+{ "get-status", "e", cmd_get_status, "Get the graph resource vertex status: "
+"resource-query> get-status PATH_TO_VERTEX" },
     { "list", "l", cmd_list, "List all jobs: resource-query> list" },
     { "info", "i", cmd_info,
 "Print info on a jobid: resource-query> info jobid" },
@@ -418,6 +420,43 @@ int cmd_get_property (std::shared_ptr<resource_context_t> &ctx,
                     out << p_it->first << "=" << p_it->second << std::endl;
         }
     }
+    return 0;
+}
+
+int cmd_get_status (std::shared_ptr<resource_context_t> &ctx,
+                      std::vector<std::string> &args)
+{
+    if (args.size () != 2) {
+        std::cerr << "ERROR: malformed command" << std::endl;
+        return 0;
+    }
+    std::string vtx_path = args[1];
+    std::map<std::string, vtx_t>::const_iterator it =
+        ctx->db->metadata.by_path.find (vtx_path);
+    resource_pool_t::string_to_status sts = resource_pool_t::str_to_status;
+    std::string status = "";
+
+    if (it == ctx->db->metadata.by_path.end ()) {
+        std::cout << "Could not find path " << vtx_path
+                     << " in resource graph." << std::endl;
+        return 0;
+    }
+
+    for (auto &status_it : sts) {
+        if (status_it.second == ctx->db->resource_graph[it->second].status) {
+            status = status_it.first;
+            break;
+        }
+    }
+
+    if (status == "") {
+        std::cerr << "ERROR: vertex " << vtx_path
+                     << " has unknown status." << std::endl;
+        return 0;     
+    }
+
+    std::cout << vtx_path << " is " << status << std::endl;
+
     return 0;
 }
 

--- a/resource/utilities/command.cpp
+++ b/resource/utilities/command.cpp
@@ -56,6 +56,8 @@ command_t commands[] = {
 "resource-query> set-property resource PROPERTY=VALUE" },
 { "get-property", "g", cmd_get_property, "Get all properties of a resource: "
 "resource-query> get-property resource" },
+{ "set-status", "t", cmd_set_status, "Set resource status on vertex: "
+"resource-query> set-status PATH_TO_VERTEX {up|down}" },
 { "get-status", "e", cmd_get_status, "Get the graph resource vertex status: "
 "resource-query> get-status PATH_TO_VERTEX" },
     { "list", "l", cmd_list, "List all jobs: resource-query> list" },
@@ -421,6 +423,34 @@ int cmd_get_property (std::shared_ptr<resource_context_t> &ctx,
         }
     }
     return 0;
+}
+
+int cmd_set_status (std::shared_ptr<resource_context_t> &ctx,
+                      std::vector<std::string> &args)
+{
+    if (args.size () != 3) {
+        std::cerr << "ERROR: malformed command" << std::endl;
+        return 0;
+    }
+    std::string vtx_path = args[1];
+    std::string status = args[2];
+    std::map<std::string, vtx_t>::const_iterator it =
+        ctx->db->metadata.by_path.find (vtx_path);
+    resource_pool_t::string_to_status sts = resource_pool_t::str_to_status;
+
+    if (it == ctx->db->metadata.by_path.end ()) {
+        std::cout << "Could not find path " << vtx_path
+                     << " in resource graph." << std::endl;
+        return 0;
+    }
+
+    auto status_it = sts.find (status);
+    if (status_it == sts.end ()) {
+        std::cerr << "ERROR: unrecognized status" << std::endl;
+        return 0;
+    }
+
+    return ctx->traverser->mark (vtx_path, status_it->second);
 }
 
 int cmd_get_status (std::shared_ptr<resource_context_t> &ctx,

--- a/resource/utilities/command.hpp
+++ b/resource/utilities/command.hpp
@@ -91,6 +91,8 @@ int cmd_set_property (std::shared_ptr<resource_context_t> &ctx,
                       std::vector<std::string> &args);
 int cmd_get_property (std::shared_ptr<resource_context_t> &ctx,
                       std::vector<std::string> &args);
+int cmd_get_status (std::shared_ptr<resource_context_t> &ctx,
+                      std::vector<std::string> &args);
 int cmd_list (std::shared_ptr<resource_context_t> &ctx,
               std::vector<std::string> &args);
 int cmd_info (std::shared_ptr<resource_context_t> &ctx,

--- a/resource/utilities/command.hpp
+++ b/resource/utilities/command.hpp
@@ -91,6 +91,8 @@ int cmd_set_property (std::shared_ptr<resource_context_t> &ctx,
                       std::vector<std::string> &args);
 int cmd_get_property (std::shared_ptr<resource_context_t> &ctx,
                       std::vector<std::string> &args);
+int cmd_set_status (std::shared_ptr<resource_context_t> &ctx,
+                      std::vector<std::string> &args);
 int cmd_get_status (std::shared_ptr<resource_context_t> &ctx,
                       std::vector<std::string> &args);
 int cmd_list (std::shared_ptr<resource_context_t> &ctx,

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -57,6 +57,7 @@ TESTS = \
     t3021-resource-mtl3.t \
     t3022-resource-update.t \
     t3023-resource-update2.t \
+    t3024-resource-status.t \
     t4000-match-params.t \
     t4001-match-allocate.t \
     t4002-match-reserve.t \

--- a/t/data/resource/commands/status/cmds01
+++ b/t/data/resource/commands/status/cmds01
@@ -1,0 +1,2 @@
+get-status
+quit

--- a/t/data/resource/commands/status/cmds02
+++ b/t/data/resource/commands/status/cmds02
@@ -1,0 +1,2 @@
+get-status /dne
+quit

--- a/t/data/resource/commands/status/cmds03
+++ b/t/data/resource/commands/status/cmds03
@@ -1,0 +1,2 @@
+get-status /tiny0/rack0/node0
+quit

--- a/t/data/resource/commands/status/cmds04
+++ b/t/data/resource/commands/status/cmds04
@@ -1,0 +1,2 @@
+set-status
+quit

--- a/t/data/resource/commands/status/cmds05
+++ b/t/data/resource/commands/status/cmds05
@@ -1,0 +1,2 @@
+set-status /dne down
+quit

--- a/t/data/resource/commands/status/cmds06
+++ b/t/data/resource/commands/status/cmds06
@@ -1,0 +1,2 @@
+set-status /tiny0/rack0/node0 dwn
+quit

--- a/t/data/resource/commands/status/cmds07
+++ b/t/data/resource/commands/status/cmds07
@@ -1,0 +1,5 @@
+set-status /tiny0/rack0/node0 down
+get-status /tiny0/rack0/node0
+set-status /tiny0/rack0/node0 up
+get-status /tiny0/rack0/node0
+quit

--- a/t/data/resource/commands/status/cmds08
+++ b/t/data/resource/commands/status/cmds08
@@ -1,0 +1,6 @@
+get-status /cz0/pfs0/bandwidth0
+set-status /cz0/pfs0/bandwidth0 down
+get-status /cz0/pfs0/bandwidth0
+set-status /cz0/pfs0/bandwidth0 up
+get-status /cz0/pfs0/bandwidth0
+quit

--- a/t/data/resource/expected/status/001.R.out
+++ b/t/data/resource/expected/status/001.R.out
@@ -1,0 +1,1 @@
+ERROR: malformed command

--- a/t/data/resource/expected/status/002.R.out
+++ b/t/data/resource/expected/status/002.R.out
@@ -1,0 +1,4 @@
+INFO: Loading a matcher: CA
+resource-query> get-status /dne
+Could not find path /dne in resource graph.
+resource-query> quit

--- a/t/data/resource/expected/status/003.R.out
+++ b/t/data/resource/expected/status/003.R.out
@@ -1,0 +1,4 @@
+INFO: Loading a matcher: CA
+resource-query> get-status /tiny0/rack0/node0
+/tiny0/rack0/node0 is up
+resource-query> quit

--- a/t/data/resource/expected/status/004.R.out
+++ b/t/data/resource/expected/status/004.R.out
@@ -1,0 +1,1 @@
+ERROR: malformed command

--- a/t/data/resource/expected/status/005.R.out
+++ b/t/data/resource/expected/status/005.R.out
@@ -1,0 +1,4 @@
+INFO: Loading a matcher: CA
+resource-query> set-status /dne down
+Could not find path /dne in resource graph.
+resource-query> quit

--- a/t/data/resource/expected/status/006.R.out
+++ b/t/data/resource/expected/status/006.R.out
@@ -1,0 +1,1 @@
+ERROR: unrecognized status

--- a/t/data/resource/expected/status/007.R.out
+++ b/t/data/resource/expected/status/007.R.out
@@ -1,0 +1,8 @@
+INFO: Loading a matcher: CA
+resource-query> set-status /tiny0/rack0/node0 down
+resource-query> get-status /tiny0/rack0/node0
+/tiny0/rack0/node0 is down
+resource-query> set-status /tiny0/rack0/node0 up
+resource-query> get-status /tiny0/rack0/node0
+/tiny0/rack0/node0 is up
+resource-query> quit

--- a/t/data/resource/expected/status/008.R.out
+++ b/t/data/resource/expected/status/008.R.out
@@ -1,0 +1,10 @@
+INFO: Loading a matcher: CA
+resource-query> get-status /cz0/pfs0/bandwidth0
+/cz0/pfs0/bandwidth0 is up
+resource-query> set-status /cz0/pfs0/bandwidth0 down
+resource-query> get-status /cz0/pfs0/bandwidth0
+/cz0/pfs0/bandwidth0 is down
+resource-query> set-status /cz0/pfs0/bandwidth0 up
+resource-query> get-status /cz0/pfs0/bandwidth0
+/cz0/pfs0/bandwidth0 is up
+resource-query> quit

--- a/t/t3024-resource-status.t
+++ b/t/t3024-resource-status.t
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+test_description='Test Resource Status On Tiny Machine Configuration'
+
+. $(dirname $0)/sharness.sh
+
+cmd_dir="${SHARNESS_TEST_SRCDIR}/data/resource/commands/status"
+exp_dir="${SHARNESS_TEST_SRCDIR}/data/resource/expected/status"
+grugs="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/tiny.graphml"
+grug_aux="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/coarse_iobw.graphml"
+query="../../resource/utilities/resource-query"
+
+#
+# Selection Policy -- High ID first (-P high)
+#     The resource vertex with higher ID is preferred among its kind
+#     (e.g., node1 is preferred over node0 if available)
+#
+
+test001_desc="error on malformed get-status "
+test_expect_success "${test001_desc}" '
+    ${query} -L ${grugs} -F jgf -S CA -P high < ${cmd_dir}/cmds01 \
+2> 001.R.out &&
+    test_cmp 001.R.out ${exp_dir}/001.R.out
+'
+
+test002_desc="exit on get-status of nonexistent resource "
+test_expect_success "${test002_desc}" '
+    ${query} -L ${grugs} -F jgf -S CA -P high < ${cmd_dir}/cmds02 \
+> 002.R.out &&
+    test_cmp 002.R.out ${exp_dir}/002.R.out
+'
+
+test003_desc="get resource vertex status "
+test_expect_success "${test003_desc}" '
+    ${query} -L ${grugs} -F jgf -S CA -P high < ${cmd_dir}/cmds03 \
+> 003.R.out &&
+    test_cmp 003.R.out ${exp_dir}/003.R.out
+'
+
+test004_desc="error on malformed get-status "
+test_expect_success "${test004_desc}" '
+    ${query} -L ${grugs} -F jgf -S CA -P high < ${cmd_dir}/cmds04 \
+2> 004.R.out &&
+    test_cmp 004.R.out ${exp_dir}/004.R.out
+'
+
+test005_desc="exit on set-status of nonexistent resource "
+test_expect_success "${test005_desc}" '
+    ${query} -L ${grugs} -F jgf -S CA -P high < ${cmd_dir}/cmds05 \
+> 005.R.out &&
+    test_cmp 005.R.out ${exp_dir}/005.R.out
+'
+
+test006_desc="error on set-status of nonexistent status "
+test_expect_success "${test006_desc}" '
+    ${query} -L ${grugs} -F jgf -S CA -P high < ${cmd_dir}/cmds06 \
+2> 006.R.out &&
+    test_cmp 006.R.out ${exp_dir}/006.R.out
+'
+
+test007_desc="change resource vertex status and get output "
+test_expect_success "${test007_desc}" '
+    ${query} -L ${grugs} -F jgf -S CA -P high < ${cmd_dir}/cmds07 \
+> 007.R.out &&
+    test_cmp 007.R.out ${exp_dir}/007.R.out
+'
+
+test008_desc="change aux hierarchy resource vertex status and get output  "
+test_expect_success "${test008_desc}" '
+    ${query} -L ${grug_aux} -F jgf -S CA -P high < ${cmd_dir}/cmds08 \
+> 008.R.out &&
+    test_cmp 008.R.out ${exp_dir}/008.R.out
+'
+
+test_done


### PR DESCRIPTION
This PR addresses issue #662 item II.1 by creating an enum class as part of [`resource_pool_t`](https://github.com/flux-framework/flux-sched/blob/master/resource/schema/resource_data.hpp#L41) that tracks resource status (e.g. `UP` and `DOWN`).  To read, change status values, and enable testing, this PR makes additional contributions:

1. enable the JGF reader to unpack the optional `status` key
2. a new `resource-query` command (`dump`) to write the resource graph to a file according to status
2. a new `resource-query` command (`set-status`) to perform a DFV update of a resource subtree status

A follow-up PR will enable scheduling by resource status based on the additions here.