### PR TITLE
Add by_rank map to graph store

### DIFF
--- a/resource/modules/Makefile.am
+++ b/resource/modules/Makefile.am
@@ -24,6 +24,7 @@ sched_fluxion_resource_la_CXXFLAGS = \
     $(FLUX_CORE_CFLAGS)
 sched_fluxion_resource_la_LIBADD = \
     ../libresource.la \
+    $(FLUX_IDSET_LIBS) \
     $(FLUX_CORE_LIBS) \
     $(DL_LIBS) \
     $(HWLOC_LIBS) \

--- a/resource/readers/resource_reader_grug.cpp
+++ b/resource/readers/resource_reader_grug.cpp
@@ -228,6 +228,7 @@ vtx_t dfs_emitter_t::emit_vertex (ggv_t u, gge_t e, const gg_t &recipe,
     m.by_path[g[v].paths[ssys]] = v;
     m.by_type[g[v].type].push_back (v);
     m.by_name[g[v].name].push_back (v);
+    m.by_rank[m_rank].push_back (v);
     return v;
 }
 

--- a/resource/readers/resource_reader_hwloc.cpp
+++ b/resource/readers/resource_reader_hwloc.cpp
@@ -107,6 +107,7 @@ vtx_t resource_reader_hwloc_t::add_new_vertex (resource_graph_t &g,
     m.by_path[g[v].paths[subsys]] = v;
     m.by_type[g[v].type].push_back (v);
     m.by_name[g[v].name].push_back (v);
+    m.by_rank[rank].push_back (v);
     return v;
 }
 

--- a/resource/readers/resource_reader_jgf.cpp
+++ b/resource/readers/resource_reader_jgf.cpp
@@ -298,6 +298,7 @@ int resource_reader_jgf_t::add_graph_metadata (vtx_t v,
     }
     m.by_type[g[v].type].push_back (v);
     m.by_name[g[v].name].push_back (v);
+    m.by_rank[g[v].rank].push_back (v);
     rc = 0;
 
 done:

--- a/resource/store/resource_graph_store.hpp
+++ b/resource/store/resource_graph_store.hpp
@@ -42,6 +42,7 @@ struct resource_graph_metadata_t {
     std::map<subsystem_t, relation_infra_t> v_rt_edges;
     std::map<std::string, std::vector <vtx_t>> by_type;
     std::map<std::string, std::vector <vtx_t>> by_name;
+    std::map<int64_t, std::vector <vtx_t>> by_rank;
     std::map<std::string, vtx_t> by_path;
 };
 

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -500,6 +500,11 @@ static int populate_resource_db (std::shared_ptr<resource_context_t> &ctx)
                      ctx->db->metadata.by_name.size () << std::endl;
         std::cout << "INFO: by_path Key-Value Pairs: " <<
                      ctx->db->metadata.by_path.size () << std::endl;
+        for (auto it = ctx->db->metadata.by_rank.begin (); 
+                     it != ctx->db->metadata.by_rank.end (); ++it) {
+            std::cout << "INFO: number of vertices with rank " 
+                        << it->first << ": " << it->second.size () << "\n";
+        }
     }
 
 done:

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -69,7 +69,8 @@ TESTS = \
     t4009-match-update.t \
     t5000-valgrind.t \
     t6000-graph-size.t \
-    t6001-match-formats.t
+    t6001-match-formats.t \
+    t6002-graph-hwloc.t
 
 check_SCRIPTS = $(TESTS)
 

--- a/t/scripts/flux-ion-resource.py
+++ b/t/scripts/flux-ion-resource.py
@@ -156,6 +156,7 @@ def stat_action (args):
     resp = r.rpc_stat ()
     print ("Num. of Vertices: ", resp['V'])
     print ("Num. of Edges: ", resp['E'])
+    print ("Num. of Vertices by Rank: ", json.dumps (resp['by_rank']))
     print ("Graph Load Time: ", resp['load-time'], "Secs")
     print ("Num. of Jobs Matched: ", resp['njobs'])
     print ("Min. Match Time: ", resp['min-match'], "Secs")

--- a/t/t6000-graph-size.t
+++ b/t/t6000-graph-size.t
@@ -20,8 +20,10 @@ test_expect_success "vertex/edge counts for a tiny machine are correct" '
     test ${edg} -eq 198
 '
 
-test_expect_success "by_type, by_name, and by_path map sizes are correct \
-for GRUG" '
+# Note that by default the rank is -1, meaning that the by_rank map 
+# contains the same number of vertices as the overall resource graph. 
+test_expect_success "by_type, by_name, by_path, and by_rank map sizes are \
+correct for GRUG" '
     echo "quit" > input2.txt &&
     ${query} -L ${tiny_grug} -e -S CA -P high < input2.txt > out2.txt &&
     by_type=$(grep "by_type" out2.txt | sed "s/INFO: by_type Key-Value \
@@ -30,13 +32,21 @@ Pairs: //") &&
 Pairs: //") &&
     by_path=$(grep "by_path" out2.txt | sed "s/INFO: by_path Key-Value \
 Pairs: //") &&
+    by_rank=$(grep "number of" out2.txt | sed "s/INFO: number of \
+vertices with rank //") &&
+    rank=$( echo ${by_rank} | sed "s/:.*//" ) &&
+    nvertices=$( echo ${by_rank} | sed "s/[^:]*://" ) &&
     test ${by_type} -eq 7 &&
     test ${by_name} -eq 52 &&
-    test ${by_path} -eq 100
+    test ${by_path} -eq 100 &&
+    test ${rank} -eq -1 &&
+    test ${nvertices} -eq 100
 '
 
-test_expect_success "by_type, by_name, and by_path map sizes are correct \
-for JGF" '
+# Note that by default the rank is -1, meaning that the by_rank map 
+# contains the same number of vertices as the overall resource graph. 
+test_expect_success "by_type, by_name, by_path, and by_rank map sizes are \
+correct for JGF." '
     echo "quit" > input3.txt &&
     ${query} -L ${tiny_jgf} -e -S CA -P high -f jgf < input3.txt > \
 out3.txt &&
@@ -46,13 +56,21 @@ Pairs: //") &&
 Pairs: //") &&
     by_path=$(grep "by_path" out3.txt | sed "s/INFO: by_path Key-Value \
 Pairs: //") &&
+    by_rank=$(grep "number of" out3.txt | sed "s/INFO: number of \
+vertices with rank //") &&
+    rank=$( echo ${by_rank} | sed "s/:.*//" ) &&
+    nvertices=$( echo ${by_rank} | sed "s/[^:]*://" ) &&
     test ${by_type} -eq 7 &&
     test ${by_name} -eq 52 &&
-    test ${by_path} -eq 100 
+    test ${by_path} -eq 100 &&
+    test ${rank} -eq -1 &&
+    test ${nvertices} -eq 100
 '
 
-test_expect_success "by_type, by_name, and by_path map sizes are correct \
-for hwloc" '
+# Note that by default the rank is -1, meaning that the by_rank map 
+# contains the same number of vertices as the overall resource graph. 
+test_expect_success "by_type, by_name, by_path, and by_rank map sizes are \
+correct for hwloc" '
     echo "quit" > input4.txt &&
     ${query} -L ${exclusive_001N_hwloc} -e -S CA -P high -f hwloc < \
 input4.txt > out4.txt &&
@@ -62,9 +80,15 @@ Pairs: //") &&
 Pairs: //") &&
     by_path=$(grep "by_path" out4.txt | sed "s/INFO: by_path Key-Value \
 Pairs: //") &&
+    by_rank=$(grep "number of" out4.txt | sed "s/INFO: number of \
+vertices with rank //") &&
+    rank=$( echo ${by_rank} | sed "s/:.*//" ) &&
+    nvertices=$( echo ${by_rank} | sed "s/[^:]*://" ) &&
     test ${by_type} -eq 7 &&
     test ${by_name} -eq 21 &&
-    test ${by_path} -eq 21
+    test ${by_path} -eq 21 &&
+    test ${rank} -eq -1 &&
+    test ${nvertices} -eq 21
 '
 
 test_expect_success "--reserve-vtx-vec works" '


### PR DESCRIPTION
This PR addresses [item II.3](https://github.com/flux-framework/flux-sched/issues/662#issue-628053510) from issue #662 by introducing a `by_rank` map to `resource_graph_metadata_t`.  The map is keyed by the `int64_t` `rank` and takes a `std::vector` of `vtx_t` corresponding to the subgraph associated with the rank.  The changes include populating the map in the GRUG, JGF, and hwloc readers and the addtion of testsuite checks for correct subgraph sizes.

This PR should be merged before #665 and #667 as those depend on the features created here.