### PR TITLE
qmanager: Update for flux-core annotation support changes

### DIFF
--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -141,7 +141,7 @@ static int handshake_jobmanager (std::shared_ptr<qmanager_ctx_t> &ctx)
                                ctx->h,
                                &qmanager_safe_cb_t::jobmanager_alloc_cb,
                                &qmanager_safe_cb_t::jobmanager_free_cb,
-                               &qmanager_safe_cb_t::jobmanager_exception_cb,
+                               &qmanager_safe_cb_t::jobmanager_cancel_cb,
                                std::static_pointer_cast<
                                    qmanager_cb_ctx_t> (ctx).get ()))) {
         flux_log_error (ctx->h, "%s: schedutil_create", __FUNCTION__);

--- a/qmanager/modules/qmanager_callbacks.hpp
+++ b/qmanager/modules/qmanager_callbacks.hpp
@@ -54,9 +54,8 @@ protected:
                                      const char *jobspec, void *arg);
     static void jobmanager_free_cb (flux_t *h, const flux_msg_t *msg,
                                     const char *R, void *arg);
-    static void jobmanager_exception_cb (flux_t *h, flux_jobid_t id,
-                                         const char *type, int severity,
-                                         void *arg);
+    static void jobmanager_cancel_cb (flux_t *h, flux_jobid_t id,
+                                      void *arg);
     static int post_sched_loop (flux_t *h,
         schedutil_t *schedutil,
         std::map<std::string, std::shared_ptr<
@@ -71,9 +70,8 @@ struct qmanager_safe_cb_t : public qmanager_cb_t {
                                      const char *jobspec, void *arg);
     static void jobmanager_free_cb (flux_t *h, const flux_msg_t *msg,
                                     const char *R, void *arg);
-    static void jobmanager_exception_cb (flux_t *h, flux_jobid_t id,
-                                         const char *type, int severity,
-                                         void *arg);
+    static void jobmanager_cancel_cb (flux_t *h, flux_jobid_t id,
+                                      void *arg);
 };
 
 #endif // #define QMANAGER_CALLBACKS_HPP

--- a/t/t1001-qmanager-basic.t
+++ b/t/t1001-qmanager-basic.t
@@ -80,6 +80,13 @@ test_expect_success 'qmanager: exception during run is supported' '
 	grep "finish status=15" eventlog.${jobid}.out
 '
 
+test_expect_success 'qmanager: unsatisfiable jobspec rejected' '
+    jobid=$(flux jobspec srun -N 64 hostname | \
+        exec_test | flux job submit) &&
+    flux job wait-event -t 10 ${jobid} clean &&
+    flux job wait-event -t 10 ${jobid} exception | grep "unsatisfiable"
+'
+
 test_expect_success 'removing resource and qmanager modules' '
     remove_qmanager &&
     remove_resource


### PR DESCRIPTION
@dongahn and flux-sched team

I know you were going to handle the changes, but since https://github.com/flux-framework/flux-core/pull/2960  has a lot of changes to `libschedutil`, I decided to do a quick run to get `flux-sched` to compile to show you the high level changes.  This patch is mostly informational.  You can just close the PR if you'd like or take the patch as a starting point or if you think it's close to what you'd want, LMK and I can clean it up and finish it.

I did not look at anything beyond just "make it compile" and did not look at any fallout from these changes.  And (somewhat naturally) it doesn't take advantage of anything new (which should probably be later, once support is in `flux-jobs`).

The 1 logical change made was to the `exception_cb` functions, which should call `alloc_cancel()` instead of `alloc_deny()` now.  I didn't rename the functions to `cancel_cb`, but they should probably be renamed for consistency.

I did see this test fail once in awhile when running `make -j16 check`.

```
FAIL: t1001-qmanager-basic.t 4 - qmanager: basic job runs in simulated mode
```

not sure why its racy (or maybe it was racy to begin with) or was to due to the `exception_cb` logic change.
