### PR TITLE
testsuite: increase wait-event timeouts

### DIFF
--- a/t/t1001-qmanager-basic.t
+++ b/t/t1001-qmanager-basic.t
@@ -37,21 +37,21 @@ subsystems=containment policy=low &&
 
 test_expect_success 'qmanager: basic job runs in simulated mode' '
     jobid=$(flux job submit basic.json) &&
-    flux job wait-event -t 2 ${jobid} start &&
-    flux job wait-event -t 2 ${jobid} finish &&
-    flux job wait-event -t 2 ${jobid} release &&
-    flux job wait-event -t 2 ${jobid} clean
+    flux job wait-event -t 10 ${jobid} start &&
+    flux job wait-event -t 10 ${jobid} finish &&
+    flux job wait-event -t 10 ${jobid} release &&
+    flux job wait-event -t 10 ${jobid} clean
 '
 
 test_expect_success 'qmanager: canceling job during execution works' '
     jobid=$(flux jobspec srun -t 1 hostname | \
         exec_test | flux job submit) &&
-    flux job wait-event -vt 2.5 ${jobid} start &&
+    flux job wait-event -vt 10 ${jobid} start &&
     flux job cancel ${jobid} &&
-    flux job wait-event -t 2.5 ${jobid} exception &&
-    flux job wait-event -t 2.5 ${jobid} finish | grep status=15 &&
-    flux job wait-event -t 2.5 ${jobid} release &&
-    flux job wait-event -t 2.5 ${jobid} clean &&
+    flux job wait-event -t 10 ${jobid} exception &&
+    flux job wait-event -t 10 ${jobid} finish | grep status=15 &&
+    flux job wait-event -t 10 ${jobid} release &&
+    flux job wait-event -t 10 ${jobid} clean &&
     exec_eventlog $jobid | grep "complete" | grep "\"status\":15"
 '
 
@@ -59,11 +59,11 @@ test_expect_success 'qmanager: exception during initialization is supported' '
     flux jobspec srun hostname | \
       exec_testattr mock_exception init > ex1.json &&
     jobid=$(flux job submit ex1.json) &&
-    flux job wait-event -t 2.5 ${jobid} exception > exception.1.out &&
+    flux job wait-event -t 10 ${jobid} exception > exception.1.out &&
     test_debug "flux job eventlog ${jobid}" &&
     grep "type=\"exec\"" exception.1.out &&
     grep "mock initialization exception generated" exception.1.out &&
-    flux job wait-event -qt 2.5 ${jobid} clean &&
+    flux job wait-event -qt 10 ${jobid} clean &&
     flux job eventlog ${jobid} > eventlog.${jobid}.out &&
     test_must_fail grep "finish" eventlog.${jobid}.out
 '
@@ -72,10 +72,10 @@ test_expect_success 'qmanager: exception during run is supported' '
 	flux jobspec srun hostname | \
 	  exec_testattr mock_exception run > ex2.json &&
 	jobid=$(flux job submit ex2.json) &&
-	flux job wait-event -t 2.5 ${jobid} exception > exception.2.out &&
+	flux job wait-event -t 10 ${jobid} exception > exception.2.out &&
 	grep "type=\"exec\"" exception.2.out &&
 	grep "mock run exception generated" exception.2.out &&
-	flux job wait-event -qt 2.5 ${jobid} clean &&
+	flux job wait-event -qt 10 ${jobid} clean &&
 	flux job eventlog ${jobid} > eventlog.${jobid}.out &&
 	grep "finish status=15" eventlog.${jobid}.out
 '

--- a/t/t1002-qmanager-reload.t
+++ b/t/t1002-qmanager-reload.t
@@ -44,7 +44,7 @@ test_expect_success 'qmanager: submit 2 more as many jobs as there are cores ' '
     jobid1=$(submit_jobs basic.json 16) &&
     jobid2=$(flux job submit basic.json) &&
     jobid3=$(flux job submit basic.json) &&
-    flux job wait-event -t 2 ${jobid3} submit &&
+    flux job wait-event -t 10 ${jobid3} submit &&
     flux job list > jobs.list &&
     echo ${jobid1} > jobid1.out &&
     echo ${jobid2} > jobid2.out &&
@@ -63,13 +63,13 @@ test_expect_success 'qmanager: handle the alloc resubmitted by job-manager' '
     jobid2=$(cat jobid2.out) &&
     jobid3=$(cat jobid3.out) &&
     flux job cancel ${jobid1} &&
-    flux job wait-event -t 2 ${jobid2} start
+    flux job wait-event -t 10 ${jobid2} start
 '
 
 test_expect_success 'qmanager: canceling a pending job works' '
     jobid3=$(cat jobid3.out) &&
     flux job cancel ${jobid3} &&
-    flux job wait-event -t 2 ${jobid3} exception
+    flux job wait-event -t 10 ${jobid3} exception
 '
 
 test_expect_success 'removing resource and qmanager modules' '

--- a/t/t1003-qmanager-policy.t
+++ b/t/t1003-qmanager-policy.t
@@ -52,16 +52,16 @@ test_expect_success 'qmanager: EASY policy correctly schedules jobs' '
     jobid10=$(flux job submit C02.T18000.json) &&
     jobid11=$(flux job submit C02.T3600.json) && # BF B
 
-    flux job wait-event -t 2 ${jobid1} start &&
-    flux job wait-event -t 2 ${jobid6} start &&
-    flux job wait-event -t 2 ${jobid11} start &&
+    flux job wait-event -t 10 ${jobid1} start &&
+    flux job wait-event -t 10 ${jobid6} start &&
+    flux job wait-event -t 10 ${jobid11} start &&
     flux job cancel ${jobid6} &&
-    flux job wait-event -t 2 ${jobid7} start &&
-    flux job wait-event -t 2 ${jobid9} start &&
+    flux job wait-event -t 10 ${jobid7} start &&
+    flux job wait-event -t 10 ${jobid9} start &&
     test $(flux job list --states=active | wc -l) -eq 10 &&
     test $(flux job list --states=running| wc -l) -eq 4 &&
     flux job list --states=active | jq .id | xargs -L 1 flux job cancel &&
-    flux job wait-event -t 2 ${jobid10} clean
+    flux job wait-event -t 10 ${jobid10} clean
 '
 
 test_expect_success 'qmanager: loading qmanager (queue-policy=hybrid)' '
@@ -83,15 +83,15 @@ test_expect_success 'qmanager: HYBRID policy correctly schedules jobs' '
     jobid10=$(flux job submit C02.T18000.json) &&
     jobid11=$(flux job submit C02.T3600.json) && # BF B
 
-    flux job wait-event -t 2 ${jobid1} start &&
-    flux job wait-event -t 2 ${jobid7} start &&
-    flux job wait-event -t 2 ${jobid11} start &&
+    flux job wait-event -t 10 ${jobid1} start &&
+    flux job wait-event -t 10 ${jobid7} start &&
+    flux job wait-event -t 10 ${jobid11} start &&
     flux job cancel ${jobid7} &&
-    flux job wait-event -t 2 ${jobid9} start &&
+    flux job wait-event -t 10 ${jobid9} start &&
     test $(flux job list --states=active | wc -l) -eq 10 &&
     test $(flux job list --states=running| wc -l) -eq 3 &&
     flux job list --states=active | jq .id | xargs -L 1 flux job cancel &&
-    flux job wait-event -t 2 ${jobid11} clean
+    flux job wait-event -t 10 ${jobid11} clean
 '
 
 
@@ -113,15 +113,15 @@ test_expect_success 'qmanager: CONSERVATIVE correctly schedules jobs' '
     jobid10=$(flux job submit C02.T18000.json) && # reserved
     jobid11=$(flux job submit C02.T3600.json) && # BF B
 
-    flux job wait-event -t 2 ${jobid1} start &&
-    flux job wait-event -t 2 ${jobid7} start &&
-    flux job wait-event -t 2 ${jobid11} start &&
+    flux job wait-event -t 10 ${jobid1} start &&
+    flux job wait-event -t 10 ${jobid7} start &&
+    flux job wait-event -t 10 ${jobid11} start &&
     flux job cancel ${jobid7} &&
-    flux job wait-event -t 2 ${jobid7} clean &&
+    flux job wait-event -t 10 ${jobid7} clean &&
     test $(flux job list --states=active | wc -l) -eq 10 &&
     test $(flux job list --states=running| wc -l) -eq 2 &&
     flux job list --states=active | jq .id | xargs -L 1 flux job cancel &&
-    flux job wait-event -t 2 ${jobid11} clean
+    flux job wait-event -t 10 ${jobid11} clean
 '
 
 test_expect_success 'removing resource and qmanager modules' '

--- a/t/t1004-qmanager-optimize.t
+++ b/t/t1004-qmanager-optimize.t
@@ -53,16 +53,16 @@ test_expect_success 'qmanager: EASY policy conforms to queue-depth=5' '
     jobid10=$(flux job submit C02.T18000.json) && # Cannot start because qd
     jobid11=$(flux job submit C02.T3600.json) &&
 
-    flux job wait-event -t 2 ${jobid1} start &&
-    flux job wait-event -t 2 ${jobid6} start &&
+    flux job wait-event -t 10 ${jobid1} start &&
+    flux job wait-event -t 10 ${jobid6} start &&
     flux job cancel ${jobid6} &&
-    flux job wait-event -t 2 ${jobid7} start &&
+    flux job wait-event -t 10 ${jobid7} start &&
     flux job cancel ${jobid7} &&
-    flux job wait-event -t 2 ${jobid8} start &&
+    flux job wait-event -t 10 ${jobid8} start &&
     test $(flux job list --states=active | wc -l) -eq 9 &&
     test $(flux job list --states=running | wc -l) -eq 2 &&
     flux job list --states=active | jq .id | xargs -L 1 flux job cancel &&
-    flux job wait-event -t 2 ${jobid11} clean
+    flux job wait-event -t 10 ${jobid11} clean
 '
 
 test_expect_success 'qmanager: loading with hybrid+queue-depth=5' '
@@ -84,11 +84,11 @@ test_expect_success 'qmanager: HYBRID policy conforms to queue-depth=5' '
     jobid10=$(flux job submit C02.T18000.json) &&
     jobid11=$(flux job submit C02.T3600.json) &&
 
-    flux job wait-event -t 2 ${jobid1} start &&
+    flux job wait-event -t 10 ${jobid1} start &&
     test $(flux job list --states=active | wc -l) -eq 11 &&
     test $(flux job list --states=running| wc -l) -eq 1 &&
     flux job list --states=active | jq .id | xargs -L 1 flux job cancel &&
-    flux job wait-event -t 2 ${jobid11} clean
+    flux job wait-event -t 10 ${jobid11} clean
 '
 
 test_expect_success 'qmanager: loading with conservative+queue-depth=5' '
@@ -110,11 +110,11 @@ test_expect_success 'qmanager: CONSERVATIVE policy conforms to queue-depth=5' '
     jobid10=$(flux job submit C02.T18000.json) &&
     jobid11=$(flux job submit C02.T3600.json) &&
 
-    flux job wait-event -t 2 ${jobid1} start &&
+    flux job wait-event -t 10 ${jobid1} start &&
     test $(flux job list --states=active | wc -l) -eq 11 &&
     test $(flux job list --states=running | wc -l) -eq 1 &&
     flux job list | jq .id | xargs -L 1 flux job cancel &&
-    flux job wait-event -t 2 ${jobid11} clean
+    flux job wait-event -t 10 ${jobid11} clean
 '
 
 test_expect_success 'removing resource and qmanager modules' '

--- a/t/t1006-qmanager-multiqueue.t
+++ b/t/t1006-qmanager-multiqueue.t
@@ -25,7 +25,7 @@ subsystems=containment policy=low &&
 
 test_expect_success 'qmanager: job can be submitted to queue=all' '
     jobid=$(flux mini submit -n 1 --setattr system.queue=all hostname) &&
-    flux job wait-event -t 2 ${jobid} finish &&
+    flux job wait-event -t 10 ${jobid} finish &&
     queue=$(flux dmesg | grep alloc | grep ${jobid} | \
 awk "{print \$5}" | awk -F= "{print \$2}") &&
     test ${queue} = all &&
@@ -37,7 +37,7 @@ awk "{print \$5}" | awk -F= "{print \$2}") &&
 
 test_expect_success 'qmanager: job can be submitted to queue=batch' '
     jobid=$(flux mini submit -n 1 --setattr system.queue=batch hostname) &&
-    flux job wait-event -t 2 ${jobid} finish &&
+    flux job wait-event -t 10 ${jobid} finish &&
     queue=$(flux dmesg | grep alloc | grep ${jobid} | \
 awk "{print \$5}" | awk -F= "{print \$2}") &&
     test ${queue} = batch &&
@@ -49,7 +49,7 @@ awk "{print \$5}" | awk -F= "{print \$2}") &&
 
 test_expect_success 'qmanager: job can be submitted to queue=debug' '
     jobid=$(flux mini submit -n 1 --setattr system.queue=debug hostname) &&
-    flux job wait-event -t 2 ${jobid} finish &&
+    flux job wait-event -t 10 ${jobid} finish &&
     queue=$(flux dmesg | grep alloc | grep ${jobid} | \
 awk "{print \$5}" | awk -F= "{print \$2}") &&
     test ${queue} = debug &&
@@ -63,7 +63,7 @@ awk "{print \$5}" | awk -F= "{print \$2}") &&
 # earliest queue name becomes default
 test_expect_success 'qmanager: job enqueued into implicitly default queue' '
     jobid=$(flux mini submit -n 1 hostname) &&
-    flux job wait-event -t 2 ${jobid} finish &&
+    flux job wait-event -t 10 ${jobid} finish &&
     queue=$(flux dmesg | grep alloc | grep ${jobid} | \
 awk "{print \$5}" | awk -F= "{print \$2}") &&
     test ${queue} = all &&
@@ -80,7 +80,7 @@ queue-policy-per-queue="queue1:easy queue2:hybrid queue3:fcfs" default-queue=que
 
 test_expect_success 'qmanager: job can be submitted to queue=queue3 (fcfs)' '
     jobid=$(flux mini submit -n 1 --setattr system.queue=queue3 hostname) &&
-    flux job wait-event -t 2 ${jobid} finish &&
+    flux job wait-event -t 10 ${jobid} finish &&
     queue=$(flux dmesg | grep alloc | grep ${jobid} | \
 awk "{print \$5}" | awk -F= "{print \$2}") &&
     test ${queue} = queue3 &&
@@ -92,7 +92,7 @@ awk "{print \$5}" | awk -F= "{print \$2}") &&
 
 test_expect_success 'qmanager: job can be submitted to queue=queue2 (hybrid)' '
     jobid=$(flux mini submit -n 1 --setattr system.queue=queue2 hostname) &&
-    flux job wait-event -t 2 ${jobid} finish &&
+    flux job wait-event -t 10 ${jobid} finish &&
     queue=$(flux dmesg | grep alloc | grep ${jobid} | \
 awk "{print \$5}" | awk -F= "{print \$2}") &&
     test ${queue} = queue2 &&
@@ -104,7 +104,7 @@ awk "{print \$5}" | awk -F= "{print \$2}") &&
 
 test_expect_success 'qmanager: job submitted to queue=queue1 (conservative)' '
     jobid=$(flux mini submit -n 1 --setattr system.queue=queue1 hostname) &&
-    flux job wait-event -t 2 ${jobid} finish &&
+    flux job wait-event -t 10 ${jobid} finish &&
     queue=$(flux dmesg | grep alloc | grep ${jobid} | \
 awk "{print \$5}" | awk -F= "{print \$2}") &&
     test ${queue} = queue1 &&
@@ -116,7 +116,7 @@ awk "{print \$5}" | awk -F= "{print \$2}") &&
 
 test_expect_success 'qmanager: job enqueued into explicitly default queue' '
     jobid=$(flux mini submit -n 1 hostname) &&
-    flux job wait-event -t 2 ${jobid} finish &&
+    flux job wait-event -t 10 ${jobid} finish &&
     queue=$(flux dmesg | grep alloc | grep ${jobid} | \
 awk "{print \$5}" | awk -F= "{print \$2}") &&
     test ${queue} = queue3 &&

--- a/t/t1007-recovery-full.t
+++ b/t/t1007-recovery-full.t
@@ -39,15 +39,15 @@ test_expect_success 'recovery: submit to occupy resources fully (rv1)' '
     jobid5=$(flux job submit basic.json) &&
     jobid6=$(flux job submit basic.json) &&
     jobid7=$(flux job submit basic.json) &&
-    flux job wait-event -t 2 ${jobid4} start &&
-    flux job wait-event -t 2 ${jobid7} submit
+    flux job wait-event -t 10 ${jobid4} start &&
+    flux job wait-event -t 10 ${jobid7} submit
 '
 
 test_expect_success 'recovery: cancel one running job without fluxion' '
     remove_resource &&
     remove_qmanager &&
     flux job cancel ${jobid1} &&
-    flux job wait-event -t 2 ${jobid1} release
+    flux job wait-event -t 10 ${jobid1} release
 '
 
 test_expect_success 'recovery: works when both modules restart (rv1)' '
@@ -57,13 +57,13 @@ test_expect_success 'recovery: works when both modules restart (rv1)' '
     flux ion-resource info ${jobid2} | grep "ALLOCATED" &&
     flux ion-resource info ${jobid3} | grep "ALLOCATED" &&
     flux ion-resource info ${jobid4} | grep "ALLOCATED" &&
-    flux job wait-event -t 2 ${jobid5} start &&
+    flux job wait-event -t 10 ${jobid5} start &&
     test_expect_code 3 flux ion-resource info ${jobid6}
 '
 
 test_expect_success 'recovery: a cancel leads to a job schedule (rv1)' '
     flux job cancel ${jobid2} &&
-    flux job wait-event -t 2 ${jobid6} start
+    flux job wait-event -t 10 ${jobid6} start
 '
 
 test_expect_success 'recovery: works when only qmanager restarts (rv1)' '
@@ -79,7 +79,7 @@ test_expect_success 'recovery: works when only qmanager restarts (rv1)' '
 
 test_expect_success 'recovery: a cancel leads to a job schedule (rv1)' '
     flux job cancel ${jobid3} &&
-    flux job wait-event -t 2 ${jobid7} start
+    flux job wait-event -t 10 ${jobid7} start
 '
 
 test_expect_success 'recovery: both modules restart (rv1->rv1_nosched)' '
@@ -104,7 +104,7 @@ test_expect_success 'recovery: cancel all jobs (rv1_nosched)' '
     flux job cancel ${jobid5} &&
     flux job cancel ${jobid6} &&
     flux job cancel ${jobid7} &&
-    flux job wait-event -t 2 ${jobid7} release
+    flux job wait-event -t 10 ${jobid7} release
 '
 
 test_expect_success 'recovery: restart w/ no running jobs (rv1_nosched)' '
@@ -118,8 +118,8 @@ test_expect_success 'recovery: submit to occupy resources fully (rv1_nosched)' '
     jobid3=$(flux job submit basic.json) &&
     jobid4=$(flux job submit basic.json) &&
     jobid5=$(flux job submit basic.json) &&
-    flux job wait-event -t 2 ${jobid4} start &&
-    flux job wait-event -t 2 ${jobid5} submit
+    flux job wait-event -t 10 ${jobid4} start &&
+    flux job wait-event -t 10 ${jobid5} submit
 '
 
 test_expect_success 'recovery: qmanager restarts (rv1_nosched->rv1_nosched)' '
@@ -134,7 +134,7 @@ test_expect_success 'recovery: qmanager restarts (rv1_nosched->rv1_nosched)' '
 
 test_expect_success 'recovery: a cancel leads to a job schedule (rv1_nosched)' '
     flux job cancel ${jobid1} &&
-    flux job wait-event -t 2 ${jobid5} start
+    flux job wait-event -t 10 ${jobid5} start
 '
 
 test_expect_success 'recovery: cancel all jobs (rv1_nosched)' '
@@ -142,7 +142,7 @@ test_expect_success 'recovery: cancel all jobs (rv1_nosched)' '
     flux job cancel ${jobid3} &&
     flux job cancel ${jobid4} &&
     flux job cancel ${jobid5} &&
-    flux job wait-event -t 2 ${jobid5} release
+    flux job wait-event -t 10 ${jobid5} release
 '
 
 test_expect_success 'removing resource and qmanager modules' '

--- a/t/t1008-recovery-none.t
+++ b/t/t1008-recovery-none.t
@@ -32,7 +32,7 @@ test_expect_success 'recovery: loading flux-sched modules works (rv1_nosched)' '
 
 test_expect_success 'recovery: submit a job (rv1_nosched)' '
     jobid1=$(flux job submit basic.json) &&
-    flux job wait-event -t 2 ${jobid1} start
+    flux job wait-event -t 10 ${jobid1} start
 '
 
 test_expect_success 'recovery: qmanager w/o an option must fail (rv1_nosched)' '

--- a/t/t1009-recovery-multiqueue.t
+++ b/t/t1009-recovery-multiqueue.t
@@ -48,8 +48,8 @@ test_expect_success 'recovery: submit to occupy resources fully (rv1)' '
     jobid2=$(flux job submit basic.debug.json) &&
     jobid3=$(flux job submit basic.batch.json) &&
     jobid4=$(flux job submit basic.debug.json) &&
-    flux job wait-event -t 2 ${jobid2} start &&
-    flux job wait-event -t 2 ${jobid4} submit
+    flux job wait-event -t 10 ${jobid2} start &&
+    flux job wait-event -t 10 ${jobid4} submit
 '
 
 test_expect_success 'recovery: works when both modules restart (rv1)' '
@@ -64,14 +64,14 @@ test_expect_success 'recovery: works when both modules restart (rv1)' '
 
 test_expect_success 'recovery: a cancel leads to a job schedule (rv1)' '
     flux job cancel ${jobid2} &&
-    flux job wait-event -t 2 ${jobid4} start
+    flux job wait-event -t 10 ${jobid4} start
 '
 
 test_expect_success 'recovery: cancel all jobs (rv1_nosched)' '
     flux job cancel ${jobid1} &&
     flux job cancel ${jobid3} &&
     flux job cancel ${jobid4} &&
-    flux job wait-event -t 2 ${jobid4} release
+    flux job wait-event -t 10 ${jobid4} release
 '
 
 test_expect_success 'removing resource and qmanager modules' '


### PR DESCRIPTION
To avoid test failures on slower systems like travis, increase
wait-event timeouts from 2 to 10 in all sharness tests.

Fixes #687