### PR TITLE
resource: errno support for std::ifstream open

### DIFF
--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -476,11 +476,8 @@ static int populate_resource_db (std::shared_ptr<resource_ctx_t> &ctx)
 
     gettimeofday (&st, NULL);
     if (ctx->args.load_file != "") {
-        if (populate_resource_db_file (ctx, rd) < 0) {
-            flux_log (ctx->h, LOG_ERR, "%s: error loading resources from file",
-                      __FUNCTION__);
+        if (populate_resource_db_file (ctx, rd) < 0)
             goto done;
-        }
         flux_log (ctx->h, LOG_INFO, "%s: loaded resources from %s",
                   __FUNCTION__,  ctx->args.load_file.c_str ());
     } else {

--- a/t/t4000-match-params.t
+++ b/t/t4000-match-params.t
@@ -63,13 +63,22 @@ test_expect_success 'loading resource module with no option works' '
 test_expect_success 'loading resource module with a nonexistent GRUG fails' '
     unload_resource &&
     test_expect_code 1 load_resource \
-load-file=${ne_grug} load-format=grug prune-filters=ALL:core
+load-file=${ne_grug} load-format=grug prune-filters=ALL:core 2> error1 &&
+    test_must_fail grep -i Success error1
 '
 
 test_expect_success 'loading resource module with a nonexistent XML fails' '
     unload_resource &&
     test_expect_code 1 load_resource \
-load-file=${ne_xml} load-format=hwloc prune-filters=ALL:core
+load-file=${ne_xml} load-format=hwloc prune-filters=ALL:core 2> error2 &&
+    test_must_fail grep -i Success error2
+'
+
+test_expect_success 'loading resource module with incorrect reader fails' '
+    unload_resource &&
+    test_expect_code 1 load_resource \
+load-file=${xml} load-format=grug prune-filters=ALL:core 2> error3 &&
+    grep -i "Invalid argument" error3
 '
 
 test_expect_success 'loading resource module with known policies works' '


### PR DESCRIPTION
This PR fixes Issue #561 

Problem:
We currently set `errno=EIO` when
`ifstreamm::good()` returns false after
`ifstream::open()`. Errno from
`std::ifstream` operations is undefined
in C++ standards so we manually set it
this way to describe "all IO errorrs."
However, `EIO` is often too broad for this
purpose. For example, if `open` fails because
the file does not exist, the most common case,
you would rather want to see `errno=ENOENT`

Solution:
Leverage the fact that most of platforms will
actually set `errno` correctly as they are set
from the underlying system libraries and we
only set `errno=EIO` when it is not the case.

Augment the testing of `errno` behavior for
a few failure modes. 