### PR TITLE
qmanager: order pending jobs by priority/submit time

### DIFF
--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -33,6 +33,7 @@ extern "C" {
 }
 
 #include <map>
+#include <vector>
 #include <unordered_map>
 #include <string>
 #include <memory>
@@ -120,13 +121,15 @@ protected:
     std::shared_ptr<job_t> alloced_pop ();
     std::shared_ptr<job_t> rejected_pop ();
     std::shared_ptr<job_t> complete_pop ();
-    std::map<uint64_t, flux_jobid_t>::iterator to_running (
-        std::map<uint64_t, flux_jobid_t>::iterator pending_iter,
+    std::map<std::vector<double>, flux_jobid_t>::iterator to_running (
+        std::map<std::vector<double>,
+                 flux_jobid_t>::iterator pending_iter,
         bool use_alloced_queue);
     std::map<uint64_t, flux_jobid_t>::iterator to_complete (
         std::map<uint64_t, flux_jobid_t>::iterator running_iter);
-    std::map<uint64_t, flux_jobid_t>::iterator to_rejected (
-        std::map<uint64_t, flux_jobid_t>::iterator pending_iter,
+    std::map<std::vector<double>, flux_jobid_t>::iterator to_rejected (
+        std::map<std::vector<double>,
+                 flux_jobid_t>::iterator pending_iter,
         const std::string &note);
 
     uint64_t m_pq_cnt = 0;
@@ -136,7 +139,7 @@ protected:
     uint64_t m_oq_cnt = 0;
     unsigned int m_queue_depth = DEFAULT_QUEUE_DEPTH;
     unsigned int m_max_queue_depth = MAX_QUEUE_DEPTH;
-    std::map<uint64_t, flux_jobid_t> m_pending;
+    std::map<std::vector<double>, flux_jobid_t> m_pending;
     std::map<uint64_t, flux_jobid_t> m_running;
     std::map<uint64_t, flux_jobid_t> m_alloced;
     std::map<uint64_t, flux_jobid_t> m_complete;

--- a/qmanager/policies/base/queue_policy_base_impl.hpp
+++ b/qmanager/policies/base/queue_policy_base_impl.hpp
@@ -217,8 +217,10 @@ int queue_policy_base_impl_t::insert (std::shared_ptr<job_t> job)
     }
     job->state = job_state_kind_t::PENDING;
     job->t_stamps.pending_ts = m_pq_cnt++;
-    m_pending.insert (std::pair<uint64_t,
-                      flux_jobid_t> (job->t_stamps.pending_ts, job->id));
+    m_pending.insert (std::pair<std::vector<double>, flux_jobid_t> (
+        {static_cast<double> (job->priority),
+         static_cast<double> (job->t_submit),
+         static_cast<double> (job->t_stamps.pending_ts)}, job->id));
     m_jobs.insert (std::pair<flux_jobid_t, std::shared_ptr<job_t>> (job->id,
                                                                     job));
     rc = 0;
@@ -239,7 +241,9 @@ int queue_policy_base_impl_t::remove (flux_jobid_t id)
     job = m_jobs[id];
     switch (job->state) {
     case job_state_kind_t::PENDING:
-        m_pending.erase (job->t_stamps.pending_ts);
+        m_pending.erase ({static_cast<double> (job->priority),
+                          static_cast<double> (job->t_submit),
+                          static_cast<double> (job->t_stamps.pending_ts)});
         job->state = job_state_kind_t::CANCELED;
         m_jobs.erase (id);
         break;
@@ -305,8 +309,9 @@ out:
     return rc;
 }
 
-std::map<uint64_t, flux_jobid_t>::iterator queue_policy_base_impl_t::
-    to_running (std::map<uint64_t, flux_jobid_t>::iterator pending_iter,
+std::map<std::vector<double>, flux_jobid_t>::iterator queue_policy_base_impl_t::
+    to_running (std::map<std::vector<double>,
+                         flux_jobid_t>::iterator pending_iter,
                 bool use_alloced_queue)
 {
     flux_jobid_t id = pending_iter->second;
@@ -330,8 +335,9 @@ std::map<uint64_t, flux_jobid_t>::iterator queue_policy_base_impl_t::
     return m_pending.erase (pending_iter);
 }
 
-std::map<uint64_t, flux_jobid_t>::iterator queue_policy_base_impl_t::
-    to_rejected (std::map<uint64_t, flux_jobid_t>::iterator pending_iter,
+std::map<std::vector<double>, flux_jobid_t>::iterator queue_policy_base_impl_t::
+    to_rejected (std::map<std::vector<double>,
+                          flux_jobid_t>::iterator pending_iter,
                  const std::string &note)
 {
     flux_jobid_t id = pending_iter->second;
@@ -380,7 +386,9 @@ std::shared_ptr<job_t> queue_policy_base_impl_t::pending_pop ()
     if (m_jobs.find (id) == m_jobs.end ())
         return nullptr;
     job = m_jobs[id];
-    m_pending.erase (job->t_stamps.pending_ts);
+    m_pending.erase ({static_cast<double> (job->priority),
+                      static_cast<double> (job->t_submit),
+                      static_cast<double> (job->t_stamps.pending_ts)});
     m_jobs.erase (id);
     return job;
 }

--- a/qmanager/policies/queue_policy_bf_base.hpp
+++ b/qmanager/policies/queue_policy_bf_base.hpp
@@ -48,14 +48,14 @@ protected:
 private:
     int cancel_completed_jobs (void *h);
     int cancel_reserved_jobs (void *h);
-    std::map<uint64_t, flux_jobid_t>::iterator &
+    std::map<std::vector<double>, flux_jobid_t>::iterator &
         allocate_orelse_reserve (void *h, std::shared_ptr<job_t> job,
                                  bool use_alloced_queue,
-                                 std::map<uint64_t,
+                                 std::map<std::vector<double>,
                                      flux_jobid_t>::iterator &iter);
-    std::map<uint64_t, flux_jobid_t>::iterator &
+    std::map<std::vector<double>, flux_jobid_t>::iterator &
         allocate (void *h, std::shared_ptr<job_t> job, bool use_alloced_queue,
-        std::map<uint64_t, flux_jobid_t>::iterator &iter);
+        std::map<std::vector<double>, flux_jobid_t>::iterator &iter);
     int allocate_orelse_reserve_jobs (void *h, bool use_alloced_queue);
     std::map<uint64_t, flux_jobid_t> m_reserved;
     unsigned int m_reservation_cnt;

--- a/qmanager/policies/queue_policy_bf_base_impl.hpp
+++ b/qmanager/policies/queue_policy_bf_base_impl.hpp
@@ -62,11 +62,11 @@ int queue_policy_bf_base_t<reapi_type>::cancel_reserved_jobs (void *h)
 }
 
 template<class reapi_type>
-std::map<uint64_t, flux_jobid_t>::iterator &
+std::map<std::vector<double>, flux_jobid_t>::iterator &
 queue_policy_bf_base_t<reapi_type>::allocate_orelse_reserve (void *h,
                                                std::shared_ptr<job_t> job,
                                                bool use_alloced_queue,
-                                               std::map<uint64_t,
+                                               std::map<std::vector<double>,
                                                   flux_jobid_t>::iterator &iter)
 
 
@@ -105,10 +105,10 @@ queue_policy_bf_base_t<reapi_type>::allocate_orelse_reserve (void *h,
 }
 
 template<class reapi_type>
-std::map<uint64_t, flux_jobid_t>::iterator &
+std::map<std::vector<double>, flux_jobid_t>::iterator &
 queue_policy_bf_base_t<reapi_type>::allocate (void *h, std::shared_ptr<job_t> job,
                                               bool use_alloced_queue,
-                                              std::map<uint64_t,
+                                              std::map<std::vector<double>,
                                                   flux_jobid_t>::iterator &iter)
 {
     if (reapi_type::match_allocate (h, false, job->jobspec, job->id,
@@ -143,7 +143,8 @@ int queue_policy_bf_base_t<reapi_type>::allocate_orelse_reserve_jobs (void *h,
     // Iterate jobs in the pending job queue and try to allocate each
     // until you can't. When you can't allocate a job, you reserve it
     // and then try to backfill later jobs.
-    std::map<uint64_t, flux_jobid_t>::iterator iter = m_pending.begin ();
+    std::map<std::vector<double>, flux_jobid_t>::iterator iter
+        = m_pending.begin ();
     m_reservation_cnt = 0;
     int saved_errno = errno;
     while ((iter != m_pending.end ()) && (i < m_queue_depth)) {

--- a/qmanager/policies/queue_policy_fcfs_impl.hpp
+++ b/qmanager/policies/queue_policy_fcfs_impl.hpp
@@ -58,7 +58,7 @@ int queue_policy_fcfs_t<reapi_type>::allocate_jobs (void *h,
 {
     unsigned int i = 0;
     std::shared_ptr<job_t> job;
-    std::map<uint64_t, flux_jobid_t>::iterator iter;
+    std::map<std::vector<double>, flux_jobid_t>::iterator iter;
 
     // Iterate jobs in the pending job queue and try to allocate each
     // until you can't.

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -35,6 +35,7 @@ TESTS = \
     t1011-dynstate-change.t \
     t1012-find-status.t \
     t1013-exclusion.t \
+    t1013-qmanager-priority.t \
     t2000-tree-basic.t \
     t2001-tree-real.t \
     t3000-jobspec.t \

--- a/t/t1013-qmanager-priority.t
+++ b/t/t1013-qmanager-priority.t
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+test_description='Fluxion takes into account priority and t_submit'
+
+. `dirname $0`/sharness.sh
+
+hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+# 1 node, 2 sockets, 44 cores (22 per socket), 4 gpus (2 per socket)
+excl_1N1B="${hwloc_basepath}/004N/exclusive/04-brokers-sierra2"
+
+skip_all_unless_have jq
+
+test_under_flux 1
+
+test_expect_success 'priority: hwloc reload works' '
+    flux hwloc reload ${excl_1N1B} &&
+    flux module remove sched-simple &&
+    flux module reload resource
+'
+
+test_expect_success 'priority: loading fluxion modules works' '
+    load_resource load-allowlist=cluster,node,core,gpu &&
+    load_qmanager
+'
+
+test_expect_success 'priority: a full-size job can be scheduled and run' '
+    jobid1=$(flux mini submit -N 1 -n 1 -c 44 -g 4 -t 1h \
+--priority 16 sleep 3600) &&
+    flux job wait-event -t 10 ${jobid1} start
+'
+
+test_expect_success 'priority: 2 jobs with higher priority will not run' '
+    jobid2=$(flux mini submit -N 1 -n 1 -c 44 -g 4 -t 1h \
+--priority 17 sleep 3600) &&
+    jobid3=$(flux mini submit -N 1 -n 1 -c 44 -g 4 -t 1h \
+--priority 18 sleep 3600) &&
+    test_must_fail flux job wait-event -t 1 ${jobid2} start
+'
+
+test_expect_success 'priority: canceling the first job starts the last job' '
+    flux job cancel ${jobid1} &&
+    flux job wait-event -t 10 ${jobid3} start
+'
+
+test_expect_success 'priority: cancel all jobs' '
+    flux job cancel ${jobid2} &&
+    flux job cancel ${jobid3} &&
+    flux job wait-event -t 10 ${jobid2} clean &&
+    flux job wait-event -t 10 ${jobid3} release
+'
+
+test_expect_success 'priority: removing fluxion modules' '
+    remove_qmanager &&
+    remove_resource
+'
+
+# Reload the core scheduler so that rc3 won't hang waiting for
+# queue to become idle after jobs are canceled.
+test_expect_success 'priority: load sched-simple module' '
+    flux module load sched-simple
+'
+
+test_done
+


### PR DESCRIPTION
This is a bug fix PR fixing Issue #612.

Order pending jobs by priority and submit time:

Problem: Currently the pending jobs within
fluxion's qmanager is ordered by enqueue time
as seenby qmanager, not by the enqueue time as seen
by job-manager. Further, it doesn't take
into account the job's priority either, which
can lead to various side-effects.

Change the "key" of the pending queue map from
uint64_t to be std::vector<double> such that
pending jobs are now ordered lexicographically
according to this vector.

Use <priority, t_submit> as the current key.

This change can easily accomodate other
order-affecting changes that are expected
to be introduced in the future including
fair share priorities.

Fixes Issue #612.

This PR is written on top of PR #694
and only consists of three commits.