### PR TITLE
resource: check return value of `find_first_not_of`

### DIFF
--- a/resource/evaluators/expr_eval_api.cpp
+++ b/resource/evaluators/expr_eval_api.cpp
@@ -37,6 +37,9 @@ namespace resource_model {
 bool expr_eval_api_t::is_paren (const std::string &e, std::size_t at) const
 {
     std::size_t fnws = e.find_first_not_of (" \t", at);
+    if (fnws == std::string::npos) {
+        return false;
+    }
     return (e[fnws] == '(');
 }
 


### PR DESCRIPTION
Problem: `find_first_not_of` can return `string::npos`, which if passed
as an index to an element acess, can cause an out-of-bounds access

Solution: check for this possible return value, and handle it
appropriately

Related: #711 