### PR TITLE
WIP:  let flux module load return early

### DIFF
--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -394,6 +394,14 @@ static int enforce_options (std::shared_ptr<qmanager_ctx_t> &ctx)
         flux_log_error (ctx->h, "%s: enforce_queues", __FUNCTION__);
         return rc;
     }
+    /* Before beginning synchronous handshakes with fluxion-resource
+     * and job-manager, set module status to 'running' to let flux module load
+     * return success.
+     */
+    if ( (rc = flux_module_set_running (ctx->h)) < 0) {
+        flux_log_error (ctx->h, "%s: flux_module_set_running", __FUNCTION__);
+        return rc;
+    }
     if ( (rc = handshake_resource (ctx)) < 0) {
         flux_log_error (ctx->h, "%s: handshake_resource", __FUNCTION__);
         return rc;

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -869,6 +869,13 @@ static int populate_resource_db (std::shared_ptr<resource_ctx_t> &ctx)
         flux_log_error (ctx->h, "%s: gettimeofday", __FUNCTION__);
         goto done;
     }
+    /* Before beginning synchronous resource.acquire RPC, set module status
+     * to 'running' to let flux module load return success.
+     */
+    if ( (rc = flux_module_set_running (ctx->h)) < 0) {
+        flux_log_error (ctx->h, "%s: flux_module_set_running", __FUNCTION__);
+        goto done;
+    }
     if (ctx->args.load_file != "") {
         if (populate_resource_db_file (ctx) < 0)
             goto done;


### PR DESCRIPTION
Call `flux_module_set_running()` before beginning synchronous RPCs in fluxion-qmanager and fluxion-resource so that `flux module load` doesn't block until the initialization completes.  This resolves a deadlock introduced by broker initialization changes introduced in flux-framework/flux-core#3057.

Fixes #712 and #713.

Marking as a WIP until this can be tested with the broker initialization changes.