### PR TITLE
Update for non-integer jobid encodings

### DIFF
--- a/src/cmd/flux-tree
+++ b/src/cmd/flux-tree
@@ -568,7 +568,7 @@ rollup_exit_code() {
         fi
     done
 
-    if [[ ${FT_MAX_FLUX_JOBID} -ne 0 ]]
+    if [[ "${FT_MAX_FLUX_JOBID}" != "0" ]]
     then
         flux job attach ${FT_MAX_FLUX_JOBID} || true
     fi

--- a/t/scripts/flux-ion-resource.py
+++ b/t/scripts/flux-ion-resource.py
@@ -12,6 +12,8 @@ import json
 import flux
 import time
 
+from flux.job import JobID
+
 def heading ():
     return '{:20} {:20} {:20} {:20}'.format ('JOBID', 'STATUS',
                                              'AT', 'OVERHEAD (Secs)')
@@ -277,13 +279,13 @@ def main ():
     # Positional argument for update sub-command
     #
     parser_u.add_argument ('RV1', metavar='RV1', type=str, help='RV1 file name')
-    parser_u.add_argument ('jobid', metavar='Jobid', type=int, help='Jobid')
+    parser_u.add_argument ('jobid', metavar='Jobid', type=JobID, help='Jobid')
     parser_u.set_defaults (func=update_action)
 
     #
     # Positional argument for info sub-command
     #
-    parser_i.add_argument ('jobid', metavar='Jobid', type=int, help='Jobid')
+    parser_i.add_argument ('jobid', metavar='Jobid', type=JobID, help='Jobid')
     parser_i.set_defaults (func=info_action)
 
     #
@@ -294,7 +296,7 @@ def main ():
     #
     # Positional argument for cancel sub-command
     #
-    parser_c.add_argument ('jobid', metavar='Jobid', type=int, help='Jobid')
+    parser_c.add_argument ('jobid', metavar='Jobid', type=JobID, help='Jobid')
     parser_c.set_defaults (func=cancel_action)
 
     #

--- a/t/t1009-recovery-multiqueue.t
+++ b/t/t1009-recovery-multiqueue.t
@@ -11,7 +11,7 @@ excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers"
 test_under_flux 1
 
 check_requeue() {
-    local jobid=${1}
+    local jobid=$(flux job id ${1})
     local correct_queue=${2}
 
     flux ion-resource info ${jobid} | grep "ALLOCATED"


### PR DESCRIPTION
This small PR updates various parts of flux-sched to avoid the assumption of integer-only jobids.

Most of the changes are straightforward, and should work whether flux-core commands are emitting integer or F58 encoded jobids. So this paves the way for an update in flux-core to allow more F58 encoded jobids.