### PR TITLE
Let flux module load return early

### DIFF
--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -394,6 +394,13 @@ static int enforce_options (std::shared_ptr<qmanager_ctx_t> &ctx)
         flux_log_error (ctx->h, "%s: enforce_queues", __FUNCTION__);
         return rc;
     }
+    return rc;
+}
+
+static int handshake (std::shared_ptr<qmanager_ctx_t> &ctx)
+{
+    int rc = 0;
+
     if ( (rc = handshake_resource (ctx)) < 0) {
         flux_log_error (ctx->h, "%s: handshake_resource", __FUNCTION__);
         return rc;
@@ -476,7 +483,12 @@ int mod_start (flux_t *h, int argc, char **argv)
         return rc;
     }
     if ( (rc = enforce_options (ctx)) < 0) {
-        flux_log_error (h, "%s: enforce_queue_policy", __FUNCTION__);
+        flux_log_error (h, "%s: enforce_options", __FUNCTION__);
+        qmanager_destroy (ctx);
+        return rc;
+    }
+    if ( (rc = handshake (ctx)) < 0) {
+        flux_log_error (h, "%s: handshake", __FUNCTION__);
         qmanager_destroy (ctx);
         return rc;
     }

--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -487,6 +487,15 @@ int mod_start (flux_t *h, int argc, char **argv)
         qmanager_destroy (ctx);
         return rc;
     }
+    /* Before beginning synchronous handshakes with fluxion-resource
+      * and job-manager, set module status to 'running' to let flux module load
+      * return success.
+      */
+    if ( (rc = flux_module_set_running (ctx->h)) < 0) {
+        flux_log_error (ctx->h, "%s: flux_module_set_running", __FUNCTION__);
+        qmanager_destroy (ctx);
+        return rc;
+    }
     if ( (rc = handshake (ctx)) < 0) {
         flux_log_error (h, "%s: handshake", __FUNCTION__);
         qmanager_destroy (ctx);

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -1962,6 +1962,14 @@ extern "C" int mod_main (flux_t *h, int argc, char **argv)
         flux_aux_set (h, "sched-fluxion-resource", &ctx, NULL);
         flux_log (h, LOG_DEBUG, "%s: resource module starting", __FUNCTION__);
 
+        /* Before beginning synchronous resource.acquire RPC, set module status
+         * to 'running' to let flux module load return success.
+         */
+        if ( (rc = flux_module_set_running (ctx->h)) < 0) {
+            flux_log_error (ctx->h, "%s: flux_module_set_running",
+                            __FUNCTION__);
+            goto done;
+        }
         if ( (rc = init_resource_graph (ctx)) != 0) {
             flux_log (h, LOG_ERR,
                       "%s: can't initialize resource graph database",

--- a/t/t1008-recovery-none.t
+++ b/t/t1008-recovery-none.t
@@ -37,7 +37,8 @@ test_expect_success 'recovery: submit a job (rv1_nosched)' '
 
 test_expect_success 'recovery: qmanager w/o an option must fail (rv1_nosched)' '
     reload_resource load-allowlist=node,core,gpu match-format=rv1_nosched &&
-    test_must_fail reload_qmanager
+    reload_qmanager &&
+    test_must_fail flux module stats sched-fluxion-qmanager
 '
 
 test_expect_success 'removing resource and qmanager modules' '

--- a/t/t1010-sync-modules.t
+++ b/t/t1010-sync-modules.t
@@ -9,12 +9,14 @@ test_under_flux 1
 # sched-simple acquires "exclusive" access to resource.
 test_expect_success 'sync: fluxion-resource cannot load w/ sched-simple' '
     flux module info sched-simple &&
-    test_must_fail load_resource policy=low load-allowlist=node,socket,core,gpu
+    load_resource policy=low load-allowlist=node,socket,core,gpu &&
+    test_must_fail flux module stats sched-fluxion-resource
 '
 
 test_expect_success 'sync: qmanager does not load w/o fluxion-resource' '
     flux module remove sched-simple &&
-    test_must_fail load_qmanager
+    load_qmanager &&
+    test_must_fail flux module stats sched-fluxion-qmanager
 '
 
 # sched-simple releases the exclusive access to resource.

--- a/t/t4000-match-params.t
+++ b/t/t4000-match-params.t
@@ -63,22 +63,31 @@ test_expect_success 'loading resource module with no option works' '
 
 test_expect_success 'loading resource module with a nonexistent GRUG fails' '
     unload_resource &&
-    test_expect_code 1 load_resource \
-load-file=${ne_grug} load-format=grug prune-filters=ALL:core 2> error1 &&
+    flux dmesg -C &&
+    load_resource load-file=${ne_grug} load-format=grug \
+prune-filters=ALL:core &&
+    test_must_fail flux module stats sched-fluxion-resource &&
+    flux dmesg > error1 &&
     test_must_fail grep -i Success error1
 '
 
 test_expect_success 'loading resource module with a nonexistent XML fails' '
     unload_resource &&
-    test_expect_code 1 load_resource \
-load-file=${ne_xml} load-format=hwloc prune-filters=ALL:core 2> error2 &&
+    flux dmesg -C &&
+    load_resource load-file=${ne_xml} load-format=hwloc \
+prune-filters=ALL:core &&
+    test_must_fail flux module stats sched-fluxion-resource &&
+    flux dmesg > error2 &&
     test_must_fail grep -i Success error2
 '
 
 test_expect_success 'loading resource module with incorrect reader fails' '
     unload_resource &&
-    test_expect_code 1 load_resource \
-load-file=${xml} load-format=grug prune-filters=ALL:core 2> error3 &&
+    flux dmesg -C &&
+    load_resource load-file=${xml} load-format=grug \
+prune-filters=ALL:core &&
+    test_must_fail flux module stats sched-fluxion-resource &&
+    flux dmesg > error3 &&
     grep -i "Invalid argument" error3
 '
 


### PR DESCRIPTION
This PR is the rework of @garlick's closed PR #716.

- Call flux_module_set_running() before beginning synchronous RPCs in `sched-fluxion-qmanager` and `sched-fluxion-resource` so that flux module load doesn't block until the initialization completes. This resolves a deadlock introduced by broker initialization changes introduced in flux-framework/flux-core#3057.

- Adjust the test cases that require `flux module load` of a fluxion module to fail. When `flux_module_set_running()` was called, the error hasn't yet happened so `flux module load` returned successfully, producing some test failures. Use `flux module stats` to test the module initialization failure, instead.

Fixes #712 and #713.

