### PR TITLE
Fix various errors detected when run tests under valgrind

### DIFF
--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -1136,7 +1136,6 @@ static int parse_R (std::shared_ptr<resource_ctx_t> &ctx, const char *R,
 freemem_out:
     saved_errno = errno;
     json_decref (o);
-    json_decref (graph);
     errno = saved_errno;
 out:
     return rc;
@@ -1182,8 +1181,6 @@ out:
     saved_errno = errno;
     json_decref (o1);
     json_decref (o2);
-    json_decref (rlite1);
-    json_decref (rlite2);
     errno = saved_errno;
     return rc;
 }

--- a/t/t1001-qmanager-basic.t
+++ b/t/t1001-qmanager-basic.t
@@ -21,7 +21,7 @@ exec_testattr() {
 }
 
 test_expect_success 'qmanager: generate jobspec for a simple test job' '
-    flux jobspec srun -n1 -t 0:1 hostname | exec_test > basic.json
+    flux mini submit -n1 -t 100 --dry-run hostname > basic.json
 '
 
 test_expect_success 'qmanager: hwloc reload works' '
@@ -31,7 +31,7 @@ test_expect_success 'qmanager: hwloc reload works' '
 test_expect_success 'qmanager: loading resource and qmanager modules works' '
     flux module remove sched-simple &&
     flux module load sched-fluxion-resource prune-filters=ALL:core \
-subsystems=containment policy=low &&
+subsystems=containment policy=low load-allowlist=node,core &&
     load_qmanager
 '
 
@@ -44,7 +44,7 @@ test_expect_success 'qmanager: basic job runs in simulated mode' '
 '
 
 test_expect_success 'qmanager: canceling job during execution works' '
-    jobid=$(flux jobspec srun -t 1 hostname | \
+    jobid=$(flux jobspec srun -t 100 hostname | \
         exec_test | flux job submit) &&
     flux job wait-event -vt 10 ${jobid} start &&
     flux job cancel ${jobid} &&

--- a/t/t1002-qmanager-reload.t
+++ b/t/t1002-qmanager-reload.t
@@ -12,7 +12,6 @@ skip_all_unless_have jq
 
 test_under_flux 1
 
-exec_test()     { ${jq} '.attributes.system.exec.test = {}'; }
 submit_jobs()   {
     local id
     for i in `seq 1 $2`
@@ -23,7 +22,7 @@ submit_jobs()   {
 }
 
 test_expect_success 'qmanager: generate jobspec for a simple test job' '
-    flux jobspec srun -n1 -t 100 hostname | exec_test > basic.json
+    flux mini submit -n 1 -t 100 --dry-run sleep 10 > basic.json
 '
 
 test_expect_success 'qmanager: hwloc reload works' '

--- a/t/t1003-qmanager-policy.t
+++ b/t/t1003-qmanager-policy.t
@@ -60,12 +60,15 @@ test_expect_success 'qmanager: EASY policy correctly schedules jobs' '
     flux job wait-event -t 10 ${jobid9} start &&
     test $(flux job list --states=active | wc -l) -eq 10 &&
     test $(flux job list --states=running| wc -l) -eq 4 &&
-    flux job list --states=active | jq .id | xargs -L 1 flux job cancel &&
-    flux job wait-event -t 10 ${jobid10} clean
+    active_jobs=$(flux job list --states=active | jq .id) &&
+    for job in ${active_jobs}; do flux job cancel ${job}; done &&
+    for job in ${active_jobs}; do flux job wait-event -t 10 ${job} clean; done
 '
 
 test_expect_success 'qmanager: loading qmanager (queue-policy=hybrid)' '
-    remove_qmanager &&
+    remove_resource &&
+    load_resource prune-filters=ALL:core \
+subsystems=containment policy=low load-allowlist=cluster,node,core &&
     load_qmanager queue-policy=hybrid \
 policy-params=reservation-depth=3
 '
@@ -90,13 +93,16 @@ test_expect_success 'qmanager: HYBRID policy correctly schedules jobs' '
     flux job wait-event -t 10 ${jobid9} start &&
     test $(flux job list --states=active | wc -l) -eq 10 &&
     test $(flux job list --states=running| wc -l) -eq 3 &&
-    flux job list --states=active | jq .id | xargs -L 1 flux job cancel &&
-    flux job wait-event -t 10 ${jobid11} clean
+    active_jobs=$(flux job list --states=active | jq .id) &&
+    for job in ${active_jobs}; do flux job cancel ${job}; done &&
+    for job in ${active_jobs}; do flux job wait-event -t 10 ${job} clean; done
 '
 
 
 test_expect_success 'qmanager: loading qmanager (queue-policy=conservative)' '
-    remove_qmanager &&
+    remove_resource &&
+    load_resource prune-filters=ALL:core \
+subsystems=containment policy=low load-allowlist=cluster,node,core &&
     load_qmanager queue-policy=conservative
 '
 
@@ -120,8 +126,9 @@ test_expect_success 'qmanager: CONSERVATIVE correctly schedules jobs' '
     flux job wait-event -t 10 ${jobid7} clean &&
     test $(flux job list --states=active | wc -l) -eq 10 &&
     test $(flux job list --states=running| wc -l) -eq 2 &&
-    flux job list --states=active | jq .id | xargs -L 1 flux job cancel &&
-    flux job wait-event -t 10 ${jobid11} clean
+    active_jobs=$(flux job list --states=active | jq .id) &&
+    for job in ${active_jobs}; do flux job cancel ${job}; done &&
+    for job in ${active_jobs}; do flux job wait-event -t 10 ${job} clean; done
 '
 
 test_expect_success 'removing resource and qmanager modules' '

--- a/t/t1004-qmanager-optimize.t
+++ b/t/t1004-qmanager-optimize.t
@@ -61,12 +61,15 @@ test_expect_success 'qmanager: EASY policy conforms to queue-depth=5' '
     flux job wait-event -t 10 ${jobid8} start &&
     test $(flux job list --states=active | wc -l) -eq 9 &&
     test $(flux job list --states=running | wc -l) -eq 2 &&
-    flux job list --states=active | jq .id | xargs -L 1 flux job cancel &&
-    flux job wait-event -t 10 ${jobid11} clean
+    active_jobs=$(flux job list --states=active | jq .id) &&
+    for job in ${active_jobs}; do flux job cancel ${job}; done &&
+    for job in ${active_jobs}; do flux job wait-event -t 10 ${job} clean; done
 '
 
 test_expect_success 'qmanager: loading with hybrid+queue-depth=5' '
-    remove_qmanager &&
+    remove_resource &&
+    load_resource prune-filters=ALL:core \
+subsystems=containment policy=low load-allowlist=cluster,node,core &&
     load_qmanager queue-policy=hybrid \
 queue-params=queue-depth=5 policy-params=reservation-depth=3
 '
@@ -87,12 +90,15 @@ test_expect_success 'qmanager: HYBRID policy conforms to queue-depth=5' '
     flux job wait-event -t 10 ${jobid1} start &&
     test $(flux job list --states=active | wc -l) -eq 11 &&
     test $(flux job list --states=running| wc -l) -eq 1 &&
-    flux job list --states=active | jq .id | xargs -L 1 flux job cancel &&
-    flux job wait-event -t 10 ${jobid11} clean
+    active_jobs=$(flux job list --states=active | jq .id) &&
+    for job in ${active_jobs}; do flux job cancel ${job}; done &&
+    for job in ${active_jobs}; do flux job wait-event -t 10 ${job} clean; done
 '
 
 test_expect_success 'qmanager: loading with conservative+queue-depth=5' '
-    remove_qmanager &&
+    remove_resource &&
+    load_resource prune-filters=ALL:core \
+subsystems=containment policy=low load-allowlist=cluster,node,core &&
     load_qmanager queue-policy=conservative \
 queue-params=queue-depth=5
 '
@@ -113,8 +119,9 @@ test_expect_success 'qmanager: CONSERVATIVE policy conforms to queue-depth=5' '
     flux job wait-event -t 10 ${jobid1} start &&
     test $(flux job list --states=active | wc -l) -eq 11 &&
     test $(flux job list --states=running | wc -l) -eq 1 &&
-    flux job list | jq .id | xargs -L 1 flux job cancel &&
-    flux job wait-event -t 10 ${jobid11} clean
+    active_jobs=$(flux job list --states=active | jq .id) &&
+    for job in ${active_jobs}; do flux job cancel ${job}; done &&
+    for job in ${active_jobs}; do flux job wait-event -t 10 ${job} clean; done
 '
 
 test_expect_success 'removing resource and qmanager modules' '

--- a/t/t1009-recovery-multiqueue.t
+++ b/t/t1009-recovery-multiqueue.t
@@ -56,6 +56,8 @@ test_expect_success 'recovery: works when both modules restart (rv1)' '
     flux dmesg -C &&
     reload_resource load-allowlist=node,core,gpu match-format=rv1 &&
     reload_qmanager "queues=batch debug" &&
+    flux module stats sched-fluxion-qmanager &&
+    flux module stats sched-fluxion-resource &&
     check_requeue ${jobid1} batch &&
     check_requeue ${jobid2} debug &&
     test_must_fail flux job wait-event -t 0.5 ${jobid3} start &&

--- a/t/t1010-sync-modules.t
+++ b/t/t1010-sync-modules.t
@@ -25,7 +25,9 @@ test_expect_success 'sync: fluxion-resource loads w/ sched-simple unloaded' '
 '
 
 test_expect_success 'sync: qmanager loads w/ sched-fluxion-resource loaded' '
-    load_qmanager
+    load_qmanager &&
+    flux module stats sched-fluxion-qmanager &&
+    flux module stats sched-fluxion-resource
 '
 
 test_expect_success 'sync: unloading fluxion-resource removes qmanager' '
@@ -43,6 +45,8 @@ test_expect_success 'sync: qmanager will not prematurely proceed' '
     load_resource load-allowlist=node,socket,core,gpu &&
     flux dmesg -C &&
     load_qmanager &&
+    flux module stats sched-fluxion-qmanager &&
+    flux module stats sched-fluxion-resource &&
     flux dmesg > out &&
     sync1=$(grep -n "handshaking with sched-fluxion-resource" out) &&
     sync2=$(grep -n "handshaking with job-manager" out) &&


### PR DESCRIPTION
This PR fixes various errors that manifest themselves under `FLUX_TEST_VALGRIND=t`

- Fix a few double frees detected by Valgrind!
- Fix various synchronization issues in our test scripts that led to hangs and failures. They were exposed as Flux significantly slows down under Valgrind.

Fix Issue #506, #585, #733.