### PR TITLE
Handle invalid sibling requests in jobspec more gracefully 

### DIFF
--- a/resource/evaluators/edge_eval_api.cpp
+++ b/resource/evaluators/edge_eval_api.cpp
@@ -195,10 +195,28 @@ int evals_t::merge (evals_t &o)
     return 0;
 }
 
-void evals_t::rewind_iter_cur ()
+void evals_t::eval_egroups_iter_reset ()
 {
-    iter_cur = m_eval_egroups.begin ();
+    m_iter_cur_reset = true;
 }
+
+std::vector<eval_egroup_t>::iterator evals_t::eval_egroups_iter_next ()
+{
+    if (m_iter_cur_reset) {
+        m_iter_cur = m_eval_egroups.begin ();
+        m_iter_cur_reset = false;
+    }
+    else if (m_iter_cur != m_eval_egroups.end ()) {
+        m_iter_cur++;
+    }
+    return m_iter_cur;
+}
+
+std::vector<eval_egroup_t>::iterator evals_t::eval_egroups_end ()
+{
+    return m_eval_egroups.end ();
+}
+
 
 } // Flux::resource_model::detail
 } // Flux::resource_model

--- a/resource/evaluators/edge_eval_api.hpp
+++ b/resource/evaluators/edge_eval_api.hpp
@@ -80,7 +80,9 @@ public:
     unsigned int best_k () const;
     unsigned int best_i () const;
     int merge (evals_t &o);
-    void rewind_iter_cur ();
+    void eval_egroups_iter_reset ();
+    std::vector<eval_egroup_t>::iterator eval_egroups_iter_next ();
+    std::vector<eval_egroup_t>::iterator eval_egroups_end ();
 
     template<class compare_op>
     int choose_best_k (unsigned int k, compare_op comp)
@@ -129,10 +131,11 @@ public:
                                o_it, uop);
     }
 
-    std::vector<eval_egroup_t>::iterator iter_cur;
 
 private:
     std::vector<eval_egroup_t> m_eval_egroups;
+    std::vector<eval_egroup_t>::iterator m_iter_cur;
+    bool m_iter_cur_reset = true;
     std::string m_resrc_type;
     int64_t m_cutline = 0;
     unsigned int m_qual_count = 0;

--- a/resource/evaluators/scoring_api.cpp
+++ b/resource/evaluators/scoring_api.cpp
@@ -133,26 +133,31 @@ int64_t scoring_api_t::set_cutline (const subsystem_t &s, const std::string &r,
     return res_evals->set_cutline (c);
 }
 
-void scoring_api_t::rewind_iter_cur (const subsystem_t &s, const std::string &r)
+
+void scoring_api_t::eval_egroups_iter_reset (const subsystem_t &s,
+                                             const std::string &r)
 {
     handle_new_keys (s, r);
     auto res_evals = (*m_ssys_map[s])[r];
-    return res_evals->rewind_iter_cur ();
+    res_evals->eval_egroups_iter_reset ();
 }
 
-std::vector<eval_egroup_t>::iterator scoring_api_t::iter_cur (
-    const subsystem_t &s, const std::string &r)
+std::vector<eval_egroup_t>::iterator scoring_api_t::eval_egroups_iter_next (
+                                                        const subsystem_t &s,
+                                                        const std::string &r)
 {
     handle_new_keys (s, r);
     auto res_evals = (*m_ssys_map[s])[r];
-    return res_evals->iter_cur;
+    return res_evals->eval_egroups_iter_next ();
 }
 
-void scoring_api_t::incr_iter_cur (const subsystem_t &s, const std::string &r)
+std::vector<eval_egroup_t>::iterator scoring_api_t::eval_egroups_end (
+                                                        const subsystem_t &s,
+                                                        const std::string &r)
 {
     handle_new_keys (s, r);
     auto res_evals = (*m_ssys_map[s])[r];
-    res_evals->iter_cur++;
+    return res_evals->eval_egroups_end ();
 }
 
 int scoring_api_t::add (const subsystem_t &s, const std::string &r,

--- a/resource/evaluators/scoring_api.hpp
+++ b/resource/evaluators/scoring_api.hpp
@@ -48,10 +48,14 @@ public:
 
     int64_t cutline (const subsystem_t &s, const std::string &r);
     int64_t set_cutline (const subsystem_t &s, const std::string &r, int64_t c);
-    void rewind_iter_cur (const subsystem_t &s, const std::string &r);
-    std::vector<eval_egroup_t>::iterator iter_cur (const subsystem_t &s,
-                                                   const std::string &r);
-    void incr_iter_cur (const subsystem_t &s, const std::string &r);
+
+    void eval_egroups_iter_reset (const subsystem_t &s, const std::string &r);
+    std::vector<eval_egroup_t>::iterator eval_egroups_iter_next (
+                                             const subsystem_t &s,
+                                             const std::string &r);
+    std::vector<eval_egroup_t>::iterator eval_egroups_end (const subsystem_t &s,
+                                                           const std::string &r);
+
     int add (const subsystem_t &s, const std::string &r,
              const eval_egroup_t &eg);
     //! Can throw an out_of_range exception

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -331,7 +331,7 @@ private:
     /*! Test various matching conditions between jobspec and graph
      * including slot match
      */
-    void match (vtx_t u, const std::vector<Jobspec::Resource> &resources,
+    int match (vtx_t u, const std::vector<Jobspec::Resource> &resources,
                 const Jobspec::Resource **slot_resource,
                 const Jobspec::Resource **match_resource);
     bool slot_match (vtx_t u, const Jobspec::Resource *slot_resource);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -65,6 +65,7 @@ TESTS = \
     t3024-resource-status.t \
     t3025-resource-find.t \
     t3026-resource-node-local-storage.t \
+    t3026-resource-sibling.t \
     t4000-match-params.t \
     t4001-match-allocate.t \
     t4002-match-reserve.t \

--- a/t/data/resource/commands/sibling/cmds01.in
+++ b/t/data/resource/commands/sibling/cmds01.in
@@ -1,0 +1,5 @@
+# node[1]->slot[1]->socket[1]->core[24]
+#                 ->socket[1]->core[24]
+#
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/sibling/test001.yaml
+quit

--- a/t/data/resource/commands/sibling/cmds02.in
+++ b/t/data/resource/commands/sibling/cmds02.in
@@ -1,0 +1,5 @@
+# slot[1]->node[1]->socket[1]->core[24]
+#                 ->socket[1]->core[24]
+#
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/sibling/test002.yaml
+quit

--- a/t/data/resource/commands/sibling/cmds03.in
+++ b/t/data/resource/commands/sibling/cmds03.in
@@ -1,0 +1,6 @@
+# slot[1]->node[1]->socket[1]->core[1]
+#                            ->core[1]
+#                            ->core[1]
+#
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/sibling/test003.yaml
+quit

--- a/t/data/resource/expected/sibling/001.R.out
+++ b/t/data/resource/expected/sibling/001.R.out
@@ -1,0 +1,4 @@
+INFO: =============================
+INFO: No matching resources found
+INFO: JOBID=1
+INFO: =============================

--- a/t/data/resource/expected/sibling/002.R.out
+++ b/t/data/resource/expected/sibling/002.R.out
@@ -1,0 +1,4 @@
+INFO: =============================
+INFO: No matching resources found
+INFO: JOBID=1
+INFO: =============================

--- a/t/data/resource/expected/sibling/003.R.out
+++ b/t/data/resource/expected/sibling/003.R.out
@@ -1,0 +1,4 @@
+INFO: =============================
+INFO: No matching resources found
+INFO: JOBID=1
+INFO: =============================

--- a/t/data/resource/jobspecs/sibling/test001.yaml
+++ b/t/data/resource/jobspecs/sibling/test001.yaml
@@ -1,0 +1,29 @@
+version: 1
+resources:
+  - type: node
+    count: 1
+    with:
+      - type: slot
+        label: default
+        count: 1
+        with:
+          - type: socket
+            count: 1
+            with:
+              - type: core
+                count: 24
+          - type: socket
+            count: 1
+            with:
+              - type: core
+                count: 24
+
+# a comment
+attributes:
+  system:
+    duration: 57600
+tasks:
+  - command: [ "default" ]
+    slot: default
+    count:
+      per_slot: 1

--- a/t/data/resource/jobspecs/sibling/test002.yaml
+++ b/t/data/resource/jobspecs/sibling/test002.yaml
@@ -1,0 +1,29 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: default
+    with:
+      - type: node
+        count: 1
+        with:
+          - type: socket
+            count: 1
+            with:
+              - type: core
+                count: 24
+          - type: socket
+            count: 1
+            with:
+              - type: core
+                count: 24
+
+# a comment
+attributes:
+  system:
+    duration: 57600
+tasks:
+  - command: [ "default" ]
+    slot: default
+    count:
+      per_slot: 1

--- a/t/data/resource/jobspecs/sibling/test003.yaml
+++ b/t/data/resource/jobspecs/sibling/test003.yaml
@@ -1,0 +1,28 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: default
+    with:
+      - type: node
+        count: 1
+        with:
+          - type: socket
+            count: 1
+            with:
+              - type: core
+                count: 1
+              - type: core
+                count: 1
+              - type: core
+                count: 1
+
+# a comment
+attributes:
+  system:
+    duration: 57600
+tasks:
+  - command: [ "default" ]
+    slot: default
+    count:
+      per_slot: 1

--- a/t/t3026-resource-sibling.t
+++ b/t/t3026-resource-sibling.t
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+test_description='Test Scheduling Correctness on Vertex Granularity'
+
+. $(dirname $0)/sharness.sh
+
+cmd_dir="${SHARNESS_TEST_SRCDIR}/data/resource/commands/sibling"
+exp_dir="${SHARNESS_TEST_SRCDIR}/data/resource/expected/sibling"
+xml="${SHARNESS_TEST_SRCDIR}/data/hwloc-data/001N/amd_gpu/corona11.xml"
+query="../../resource/utilities/resource-query"
+
+cmds001="${cmd_dir}/cmds01.in"
+test001_desc="sibling (under slot) each requesting 1 socket cannot be matched"
+test_expect_success "${test001_desc}" '
+    sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds001} > cmds001 &&
+    ${query} -L ${xml} -f hwloc -W node,socket,core -S CA -P high \
+    -t 001.R.out < cmds001 &&
+    test_cmp 001.R.out ${exp_dir}/001.R.out
+'
+
+cmds002="${cmd_dir}/cmds02.in"
+test002_desc="sibling each requesting 1 socket cannot be matched"
+test_expect_success "${test002_desc}" '
+    sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds002} > cmds002 &&
+    ${query} -L ${xml} -f hwloc -W node,socket,core -S CA -P high \
+    -t 002.R.out < cmds002 &&
+    test_cmp 002.R.out ${exp_dir}/002.R.out
+'
+
+cmds003="${cmd_dir}/cmds03.in"
+test003_desc="sibling each requesting 1 core cannot be matched"
+test_expect_success "${test003_desc}" '
+    sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds003} > cmds003 &&
+    ${query} -L ${xml} -f hwloc -W node,socket,core -S CA -P high \
+    -t 003.R.out < cmds003 &&
+    test_cmp 003.R.out ${exp_dir}/003.R.out
+'
+
+test_done


### PR DESCRIPTION
This PR adds support for detecting and more gracefully handling a class of invalid sibling requests within jobspecs. While our DFU traverser has in-line documents and README to describe its fundamental inability to match a jobspec containing sibling requests with the same resource type, for example,

```
    node[1]->socket[1]
           ->socekt[1]
```

the current code does not detect and handle this condition gracefully.

- Detect this condition at the `match()` method and bubble this up to the upper calls so that they can deem this as `match_kind_t::NONE_MATCH`;

- Related, avoid a potential buffer overflow that can arise when we iterate through the slots discovered by the DFU walk from the visiting resource vertex. This condition can occur if `cnt_slot()` incorrectly counts the number of available slots. Because `cnt_slot()` depends on the user-provided jobspec input, this can be exploited or at least lead to a less robust or undefined behavior;

- Add sharess test cases to check if `resource-query` can handle this class of jobspecs for three different job specs.

Fix Issue #709.