### PR TITLE
Use 9999 for test jobspec

### DIFF
--- a/resource/libjobspec/jobspec.cpp
+++ b/resource/libjobspec/jobspec.cpp
@@ -392,9 +392,9 @@ Jobspec::Jobspec(const YAML::Node &top)
                                "\"version\" must be an unsigned integer");
         }
         version = top["version"].as<unsigned int>();
-        if (version != 1) {
+        if (version < 1 || version > 9999) {
             throw parse_error (top["version"],
-                               "Only jobspec \"version\" 1 is supported");
+                      "Only jobspec \"version\" 1-9999 is supported");
         }
 
         /* Import attributes mappings */

--- a/resource/utilities/README.md
+++ b/resource/utilities/README.md
@@ -29,7 +29,7 @@ Once the graph data store is populated, an interactive command-line
 interface (cli) session is started for the user:
 
 ```
-% resource-query --grug=conf/default --match-subsystems=CA --match-policy=high
+% resource-query -L conf/default -F pretty_simple --match-subsystems=CA --match-policy=high
 % INFO: Loading a matcher: CA
 resource-query>
 ```
@@ -44,34 +44,30 @@ resource state.  By contrast, `allocate` will simply not allocate
 resources if matching resources are not found in the current resource state.
 
 The following command allocated the best-matching resources for the
-specification contained in `test.jobspec`:
+specification contained in `test.yaml`:
 
 
 ```
-resource-query> match allocate test.jobspec
-      ---------------core31[1:x]
-      ---------------core32[1:x]
-      ---------------core33[1:x]
-      ---------------core34[1:x]
-      ---------------core35[1:x]
-      ---------------gpu0[1:x]
-      ---------------memory1[2:x]
-      ---------------memory2[2:x]
-      ---------------memory3[2:x]
-      ------------socket0[1:x]
-      ---------------core67[1:x]
-      ---------------core68[1:x]
-      ---------------core69[1:x]
-      ---------------core70[1:x]
-      ---------------core71[1:x]
-      ---------------gpu1[1:x]
-      ---------------memory5[2:x]
-      ---------------memory6[2:x]
-      ---------------memory7[2:x]
-      ------------socket1[1:x]
-      ---------node1[1:s]
-      ------rack0[1:s]
-      ---tiny0[1:s]
+resource-query> match allocate test.yaml
+      ---medium-coarse-cluster0[1:shared]
+      ------rack3[1:shared]
+      ---------node71[1:shared]
+      ------------socket1[1:exclusive]
+      ---------------memory0[8:exclusive]
+      ---------------gpu1[1:exclusive]
+      ---------------core15[1:exclusive]
+      ---------------core14[1:exclusive]
+      ---------------core13[1:exclusive]
+      ---------------core12[1:exclusive]
+      ---------------core11[1:exclusive]
+      ------------socket0[1:exclusive]
+      ---------------memory0[8:exclusive]
+      ---------------gpu0[1:exclusive]
+      ---------------core7[1:exclusive]
+      ---------------core6[1:exclusive]
+      ---------------core5[1:exclusive]
+      ---------------core4[1:exclusive]
+      ---------------core3[1:exclusive]
 INFO: =============================
 INFO: JOBID=1
 INFO: RESOURCES=ALLOCATED
@@ -79,13 +75,13 @@ INFO: SCHEDULED AT=Now
 INFO: =============================
 ```
 
-The output format of an allocation or reservation is a reversed tree shape
-where the root resource vertex appears at the last line. Each resource is
-annotated with the allocated or reserved count and exclusive (x) vs.
-shared (s) access modes.
+The output format of an allocation or reservation is a tree shape
+where the root resource vertex appears in the beginning. Each resource is
+annotated with the allocated or reserved count and exclusive vs.
+shared access modes.
 
-For example, `core31[1:x]` indicates that the 1 unit of `core31` has been
-exclusively allocated. Similarly, `memory1[2:x]` shows that the 2 units
+For example, `core15[1:exclusive]` indicates that the 1 unit of `core15` has been
+exclusively allocated. Similarly, `memory0[8:exclusive]` shows that the 8 units
 (i.e., GB) of `memory1` have been exclusive allocated.
 
 Please note that the granularity of exclusive allocation/reservation is
@@ -94,45 +90,40 @@ fined-grained exclusive memory allocation, for instance, you should first
 model your memory pool vertices with smaller memory unit (e.g., 256MB).
 
 By contrast, the following command reserved the best-matching resources
-for `test.jobspec`. Notice the output difference: `SCHEDULED AT=Now`
+for `test.yaml`. Notice the output difference: `SCHEDULED AT=Now`
 vs. `SCHEDULED AT=3600`
 
 ```
-resource-query> match allocate_orelse_reserve test.jobspec
-      ---------------core31[1:x]
-      ---------------core32[1:x]
-      ---------------core33[1:x]
-      ---------------core34[1:x]
-      ---------------core35[1:x]
-      ---------------gpu0[1:x]
-      ---------------memory1[2:x]
-      ---------------memory2[2:x]
-      ---------------memory3[2:x]
-      ------------socket0[1:x]
-      ---------------core67[1:x]
-      ---------------core68[1:x]
-      ---------------core69[1:x]
-      ---------------core70[1:x]
-      ---------------core71[1:x]
-      ---------------gpu1[1:x]
-      ---------------memory5[2:x]
-      ---------------memory6[2:x]
-      ---------------memory7[2:x]
-      ------------socket1[1:x]
-      ---------node1[1:s]
-      ------rack0[1:s]
-      ---tiny0[1:s]
+resource-query> match allocate_orelse_reserve test.yaml
+      ---medium-coarse-cluster0[1:shared]
+      ------rack3[1:shared]
+      ---------node71[1:shared]
+      ------------socket1[1:exclusive]
+      ---------------memory0[8:exclusive]
+      ---------------gpu1[1:exclusive]
+      ---------------core15[1:exclusive]
+      ---------------core14[1:exclusive]
+      ---------------core13[1:exclusive]
+      ---------------core12[1:exclusive]
+      ---------------core11[1:exclusive]
+      ------------socket0[1:exclusive]
+      ---------------memory0[8:exclusive]
+      ---------------gpu0[1:exclusive]
+      ---------------core7[1:exclusive]
+      ---------------core6[1:exclusive]
+      ---------------core5[1:exclusive]
+      ---------------core4[1:exclusive]
+      ---------------core3[1:exclusive]
 INFO: =============================
-INFO: JOBID=3
+INFO: JOBID=73
 INFO: RESOURCES=RESERVED
 INFO: SCHEDULED AT=3600
 INFO: =============================
-```
 
-`test.jobspec` used in the above examples are the following:
+`test.yaml` used in the above examples are the following:
 
 ```yaml
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1
@@ -155,7 +146,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1
@@ -545,7 +536,7 @@ graph data used by `resource-query` is the following,
 then, the next fully hierarchically specifies the resource request:
 
 ```yaml
-version: 1
+version: 9999
 resources:
     - type: cluster
       count: 1
@@ -572,7 +563,7 @@ By contrast, the following partially hierarchically specifies the resource
 shape, as it omits from the `cluster` and `rack` levels.
 
 ```yaml
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1
@@ -612,7 +603,7 @@ nodes that can satisfy either type of node requirements: one with more cores
 and burst buffers (bb) and the other fewer cores with no advanced features.
 
 ```yaml
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1
@@ -666,6 +657,8 @@ underlying resource model labels the type of the rack with the beefy compute
 nodes as `rack` and the other as `birack`.
 
 ```yaml
+version: 9999
+resources:
   - type: cluster
     count: 1
     with:

--- a/resource/utilities/test/benchmark.yaml
+++ b/resource/utilities/test/benchmark.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
     - type: cluster
       count: 1

--- a/t/data/resource/jobspecs/advanced/test001.yaml
+++ b/t/data/resource/jobspecs/advanced/test001.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/advanced/test002.yaml
+++ b/t/data/resource/jobspecs/advanced/test002.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1

--- a/t/data/resource/jobspecs/advanced/test003.yaml
+++ b/t/data/resource/jobspecs/advanced/test003.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1

--- a/t/data/resource/jobspecs/advanced/test004.yaml
+++ b/t/data/resource/jobspecs/advanced/test004.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1

--- a/t/data/resource/jobspecs/advanced/test005.yaml
+++ b/t/data/resource/jobspecs/advanced/test005.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cpu_group
     count: 1

--- a/t/data/resource/jobspecs/basics/bad.yaml
+++ b/t/data/resource/jobspecs/basics/bad.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
     - type: cluster
 `      count: 1

--- a/t/data/resource/jobspecs/basics/test001.yaml
+++ b/t/data/resource/jobspecs/basics/test001.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
     - type: cluster
       count: 1

--- a/t/data/resource/jobspecs/basics/test002.yaml
+++ b/t/data/resource/jobspecs/basics/test002.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/basics/test003.yaml
+++ b/t/data/resource/jobspecs/basics/test003.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 2

--- a/t/data/resource/jobspecs/basics/test004.yaml
+++ b/t/data/resource/jobspecs/basics/test004.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/basics/test005.yaml
+++ b/t/data/resource/jobspecs/basics/test005.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 4

--- a/t/data/resource/jobspecs/basics/test006.yaml
+++ b/t/data/resource/jobspecs/basics/test006.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
     - type: cluster
       count: 1

--- a/t/data/resource/jobspecs/basics/test007.yaml
+++ b/t/data/resource/jobspecs/basics/test007.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
     - type: cluster
       count: 1

--- a/t/data/resource/jobspecs/basics/test008.yaml
+++ b/t/data/resource/jobspecs/basics/test008.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/basics/test009.yaml
+++ b/t/data/resource/jobspecs/basics/test009.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/basics/test010.yaml
+++ b/t/data/resource/jobspecs/basics/test010.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/basics/test011.yaml
+++ b/t/data/resource/jobspecs/basics/test011.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
     - type: node
       count: 2000

--- a/t/data/resource/jobspecs/basics/test012.yaml
+++ b/t/data/resource/jobspecs/basics/test012.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: socket
     count: 1

--- a/t/data/resource/jobspecs/basics/test013.yaml
+++ b/t/data/resource/jobspecs/basics/test013.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/basics/test014.yaml
+++ b/t/data/resource/jobspecs/basics/test014.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
     - type: cluster
       count: 1

--- a/t/data/resource/jobspecs/basics/test015.yaml
+++ b/t/data/resource/jobspecs/basics/test015.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
     - type: cluster
       count: 1

--- a/t/data/resource/jobspecs/cancel/test001.yaml
+++ b/t/data/resource/jobspecs/cancel/test001.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/cancel/test002.yaml
+++ b/t/data/resource/jobspecs/cancel/test002.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 100

--- a/t/data/resource/jobspecs/cancel/test003.yaml
+++ b/t/data/resource/jobspecs/cancel/test003.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     label: default

--- a/t/data/resource/jobspecs/cancel/test004.yaml
+++ b/t/data/resource/jobspecs/cancel/test004.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     label: default

--- a/t/data/resource/jobspecs/cancel/test005.yaml
+++ b/t/data/resource/jobspecs/cancel/test005.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 64

--- a/t/data/resource/jobspecs/cancel/test006.yaml
+++ b/t/data/resource/jobspecs/cancel/test006.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 13

--- a/t/data/resource/jobspecs/cancel/test007.yaml
+++ b/t/data/resource/jobspecs/cancel/test007.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 8

--- a/t/data/resource/jobspecs/cancel/test008.yaml
+++ b/t/data/resource/jobspecs/cancel/test008.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 15

--- a/t/data/resource/jobspecs/cancel/test009.yaml
+++ b/t/data/resource/jobspecs/cancel/test009.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     label: default

--- a/t/data/resource/jobspecs/cancel/test010.yaml
+++ b/t/data/resource/jobspecs/cancel/test010.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 13

--- a/t/data/resource/jobspecs/cancel/test011.yaml
+++ b/t/data/resource/jobspecs/cancel/test011.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 8

--- a/t/data/resource/jobspecs/cancel/test012.yaml
+++ b/t/data/resource/jobspecs/cancel/test012.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 64

--- a/t/data/resource/jobspecs/cancel/test013.yaml
+++ b/t/data/resource/jobspecs/cancel/test013.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 7

--- a/t/data/resource/jobspecs/cancel/test014.yaml
+++ b/t/data/resource/jobspecs/cancel/test014.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 2

--- a/t/data/resource/jobspecs/cancel/test015.yaml
+++ b/t/data/resource/jobspecs/cancel/test015.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 6

--- a/t/data/resource/jobspecs/cancel/test016.yaml
+++ b/t/data/resource/jobspecs/cancel/test016.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 6

--- a/t/data/resource/jobspecs/cancel/test017.yaml
+++ b/t/data/resource/jobspecs/cancel/test017.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 44

--- a/t/data/resource/jobspecs/coarse_iobw/test001.yaml
+++ b/t/data/resource/jobspecs/coarse_iobw/test001.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 100

--- a/t/data/resource/jobspecs/coarse_iobw/test002.yaml
+++ b/t/data/resource/jobspecs/coarse_iobw/test002.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: zone
     count: 1

--- a/t/data/resource/jobspecs/exclusive/test001.yaml
+++ b/t/data/resource/jobspecs/exclusive/test001.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1

--- a/t/data/resource/jobspecs/exclusive/test002.yaml
+++ b/t/data/resource/jobspecs/exclusive/test002.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1

--- a/t/data/resource/jobspecs/exclusive/test003.yaml
+++ b/t/data/resource/jobspecs/exclusive/test003.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1

--- a/t/data/resource/jobspecs/exclusive/test004.yaml
+++ b/t/data/resource/jobspecs/exclusive/test004.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1

--- a/t/data/resource/jobspecs/exclusive/test005.yaml
+++ b/t/data/resource/jobspecs/exclusive/test005.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1

--- a/t/data/resource/jobspecs/exclusive/test006.yaml
+++ b/t/data/resource/jobspecs/exclusive/test006.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1

--- a/t/data/resource/jobspecs/exclusive/test007.yaml
+++ b/t/data/resource/jobspecs/exclusive/test007.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1

--- a/t/data/resource/jobspecs/exclusive/test008.yaml
+++ b/t/data/resource/jobspecs/exclusive/test008.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1

--- a/t/data/resource/jobspecs/exclusive/test009.yaml
+++ b/t/data/resource/jobspecs/exclusive/test009.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/exclusive/test010.yaml
+++ b/t/data/resource/jobspecs/exclusive/test010.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     label: nodelevel

--- a/t/data/resource/jobspecs/find/c1g1m1.yaml
+++ b/t/data/resource/jobspecs/find/c1g1m1.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
     - type: cluster
       count: 1

--- a/t/data/resource/jobspecs/find/full.yaml
+++ b/t/data/resource/jobspecs/find/full.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
     - type: cluster
       count: 1

--- a/t/data/resource/jobspecs/find/node1.yaml
+++ b/t/data/resource/jobspecs/find/node1.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
     - type: cluster
       count: 1

--- a/t/data/resource/jobspecs/find/sock1.yaml
+++ b/t/data/resource/jobspecs/find/sock1.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
     - type: cluster
       count: 1

--- a/t/data/resource/jobspecs/global_constraints/test001.yaml
+++ b/t/data/resource/jobspecs/global_constraints/test001.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1

--- a/t/data/resource/jobspecs/global_constraints/test002.yaml
+++ b/t/data/resource/jobspecs/global_constraints/test002.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1

--- a/t/data/resource/jobspecs/global_constraints/test003.yaml
+++ b/t/data/resource/jobspecs/global_constraints/test003.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1

--- a/t/data/resource/jobspecs/granule/test001.yaml
+++ b/t/data/resource/jobspecs/granule/test001.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/min_max/test001.yaml
+++ b/t/data/resource/jobspecs/min_max/test001.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 107

--- a/t/data/resource/jobspecs/min_max/test002.yaml
+++ b/t/data/resource/jobspecs/min_max/test002.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/min_max/test003.yaml
+++ b/t/data/resource/jobspecs/min_max/test003.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/min_max/test004.yaml
+++ b/t/data/resource/jobspecs/min_max/test004.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count:

--- a/t/data/resource/jobspecs/min_max/test005.yaml
+++ b/t/data/resource/jobspecs/min_max/test005.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count:

--- a/t/data/resource/jobspecs/min_max/test006.yaml
+++ b/t/data/resource/jobspecs/min_max/test006.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count:

--- a/t/data/resource/jobspecs/mt-storage/L0/storage-constrained.yaml
+++ b/t/data/resource/jobspecs/mt-storage/L0/storage-constrained.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/mt-storage/L0/test001.yaml
+++ b/t/data/resource/jobspecs/mt-storage/L0/test001.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/mt-storage/L1/storage-constrained-same-rack.yaml
+++ b/t/data/resource/jobspecs/mt-storage/L1/storage-constrained-same-rack.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: rack
     count: 1

--- a/t/data/resource/jobspecs/mt-storage/L1/storage-constrained.yaml
+++ b/t/data/resource/jobspecs/mt-storage/L1/storage-constrained.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/mt-storage/L1/test001.yaml
+++ b/t/data/resource/jobspecs/mt-storage/L1/test001.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/mt-storage/L2/storage-constrained.yaml
+++ b/t/data/resource/jobspecs/mt-storage/L2/storage-constrained.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: rack
     count: 1

--- a/t/data/resource/jobspecs/mt-storage/L2/test001.yaml
+++ b/t/data/resource/jobspecs/mt-storage/L2/test001.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: rack
     count: 1

--- a/t/data/resource/jobspecs/mt-storage/L3/storage-constrained-global.yaml
+++ b/t/data/resource/jobspecs/mt-storage/L3/storage-constrained-global.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: rack
     count: 1

--- a/t/data/resource/jobspecs/mt-storage/L3/storage-constrained-same-rack.yaml
+++ b/t/data/resource/jobspecs/mt-storage/L3/storage-constrained-same-rack.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: rack
     count: 1

--- a/t/data/resource/jobspecs/mt-storage/L3/test001.yaml
+++ b/t/data/resource/jobspecs/mt-storage/L3/test001.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: rack
     count: 1

--- a/t/data/resource/jobspecs/mt-storage/L3/test002.yaml
+++ b/t/data/resource/jobspecs/mt-storage/L3/test002.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: rack
     count: 1

--- a/t/data/resource/jobspecs/node_local_storage/catalyst-full-drive.yaml
+++ b/t/data/resource/jobspecs/node_local_storage/catalyst-full-drive.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/node_local_storage/catalyst-small-drive.yaml
+++ b/t/data/resource/jobspecs/node_local_storage/catalyst-small-drive.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/node_local_storage/corona-full-drive.yaml
+++ b/t/data/resource/jobspecs/node_local_storage/corona-full-drive.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/node_local_storage/corona-small-drive.yaml
+++ b/t/data/resource/jobspecs/node_local_storage/corona-small-drive.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/node_local_storage/lassen-full-drive.yaml
+++ b/t/data/resource/jobspecs/node_local_storage/lassen-full-drive.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/node_local_storage/lassen-small-drive.yaml
+++ b/t/data/resource/jobspecs/node_local_storage/lassen-small-drive.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/omit_prefix/test001.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test001.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1

--- a/t/data/resource/jobspecs/omit_prefix/test002.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test002.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1

--- a/t/data/resource/jobspecs/omit_prefix/test003.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test003.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1

--- a/t/data/resource/jobspecs/omit_prefix/test004.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test004.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1

--- a/t/data/resource/jobspecs/omit_prefix/test005.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test005.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1

--- a/t/data/resource/jobspecs/omit_prefix/test006.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test006.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1

--- a/t/data/resource/jobspecs/omit_prefix/test007.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test007.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1

--- a/t/data/resource/jobspecs/omit_prefix/test008.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test008.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1

--- a/t/data/resource/jobspecs/omit_prefix/test009.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test009.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1

--- a/t/data/resource/jobspecs/omit_prefix/test010.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test010.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: rack
     count: 1

--- a/t/data/resource/jobspecs/omit_prefix/test011.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test011.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: rack
     count: 1

--- a/t/data/resource/jobspecs/omit_prefix/test012.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test012.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: rack
     count: 1

--- a/t/data/resource/jobspecs/omit_prefix/test013.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test013.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: rack
     count: 1

--- a/t/data/resource/jobspecs/omit_prefix/test014.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test014.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: rack
     count: 1

--- a/t/data/resource/jobspecs/omit_prefix/test015.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test015.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: rack
     count: 1

--- a/t/data/resource/jobspecs/omit_prefix/test016.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test016.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: rack
     count: 1

--- a/t/data/resource/jobspecs/omit_prefix/test017.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test017.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: rack
     count: 1

--- a/t/data/resource/jobspecs/omit_prefix/test018.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test018.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: rack
     count: 1

--- a/t/data/resource/jobspecs/omit_prefix/test019.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test019.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/omit_prefix/test020.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test020.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/omit_prefix/test021.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test021.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 2

--- a/t/data/resource/jobspecs/omit_prefix/test022.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test022.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 2

--- a/t/data/resource/jobspecs/omit_prefix/test023.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test023.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 4

--- a/t/data/resource/jobspecs/omit_prefix/test024.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test024.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 4

--- a/t/data/resource/jobspecs/omit_prefix/test025.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test025.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/omit_prefix/test026.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test026.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 2

--- a/t/data/resource/jobspecs/omit_prefix/test027.yaml
+++ b/t/data/resource/jobspecs/omit_prefix/test027.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 4

--- a/t/data/resource/jobspecs/power/test001.yaml
+++ b/t/data/resource/jobspecs/power/test001.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: powerpanel
     count: 1

--- a/t/data/resource/jobspecs/power/test002.yaml
+++ b/t/data/resource/jobspecs/power/test002.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 2

--- a/t/data/resource/jobspecs/reservation/test001.yaml
+++ b/t/data/resource/jobspecs/reservation/test001.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/reservation/test002.yaml
+++ b/t/data/resource/jobspecs/reservation/test002.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 100

--- a/t/data/resource/jobspecs/reservation/test003.yaml
+++ b/t/data/resource/jobspecs/reservation/test003.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     label: default

--- a/t/data/resource/jobspecs/reservation/test004.yaml
+++ b/t/data/resource/jobspecs/reservation/test004.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     label: default

--- a/t/data/resource/jobspecs/reservation/test005.yaml
+++ b/t/data/resource/jobspecs/reservation/test005.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 64

--- a/t/data/resource/jobspecs/reservation/test006.yaml
+++ b/t/data/resource/jobspecs/reservation/test006.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 13

--- a/t/data/resource/jobspecs/reservation/test007.yaml
+++ b/t/data/resource/jobspecs/reservation/test007.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 8

--- a/t/data/resource/jobspecs/reservation/test008.yaml
+++ b/t/data/resource/jobspecs/reservation/test008.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 15

--- a/t/data/resource/jobspecs/reservation/test009.yaml
+++ b/t/data/resource/jobspecs/reservation/test009.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     label: default

--- a/t/data/resource/jobspecs/reservation/test010.yaml
+++ b/t/data/resource/jobspecs/reservation/test010.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 13

--- a/t/data/resource/jobspecs/reservation/test011.yaml
+++ b/t/data/resource/jobspecs/reservation/test011.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 8

--- a/t/data/resource/jobspecs/reservation/test012.yaml
+++ b/t/data/resource/jobspecs/reservation/test012.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 64

--- a/t/data/resource/jobspecs/reservation/test013.yaml
+++ b/t/data/resource/jobspecs/reservation/test013.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 7

--- a/t/data/resource/jobspecs/reservation/test014.yaml
+++ b/t/data/resource/jobspecs/reservation/test014.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 2

--- a/t/data/resource/jobspecs/reservation/test015.yaml
+++ b/t/data/resource/jobspecs/reservation/test015.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 6

--- a/t/data/resource/jobspecs/reservation/test016.yaml
+++ b/t/data/resource/jobspecs/reservation/test016.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 6

--- a/t/data/resource/jobspecs/reservation/test017.yaml
+++ b/t/data/resource/jobspecs/reservation/test017.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 44

--- a/t/data/resource/jobspecs/satisfiability/test001.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test001.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
     - type: cluster
       count: 1

--- a/t/data/resource/jobspecs/satisfiability/test002.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test002.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/satisfiability/test003.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test003.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/satisfiability/test004.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test004.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/satisfiability/test005.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test005.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 3

--- a/t/data/resource/jobspecs/satisfiability/test006.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test006.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
     - type: cluster
       count: 1

--- a/t/data/resource/jobspecs/satisfiability/test007.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test007.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 2

--- a/t/data/resource/jobspecs/satisfiability/test008.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test008.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: rack
     count: 3

--- a/t/data/resource/jobspecs/satisfiability/test009.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test009.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: zone
     count: 1

--- a/t/data/resource/jobspecs/satisfiability/test010.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test010.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
     - type: cluster
       count: 1

--- a/t/data/resource/jobspecs/satisfiability/test011.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test011.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
     - type: cluster
       count: 1

--- a/t/data/resource/jobspecs/satisfiability/test012.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test012.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     label: default

--- a/t/data/resource/jobspecs/satisfiability/test013.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test013.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: socket
     count: 1

--- a/t/data/resource/jobspecs/satisfiability/test014.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test014.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: socket
     count: 2

--- a/t/data/resource/jobspecs/satisfiability/test015.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test015.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     label: default

--- a/t/data/resource/jobspecs/satisfiability/test016.yaml
+++ b/t/data/resource/jobspecs/satisfiability/test016.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     label: default

--- a/t/data/resource/jobspecs/sibling/test001.yaml
+++ b/t/data/resource/jobspecs/sibling/test001.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/sibling/test002.yaml
+++ b/t/data/resource/jobspecs/sibling/test002.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/sibling/test003.yaml
+++ b/t/data/resource/jobspecs/sibling/test003.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/update/test001.yaml
+++ b/t/data/resource/jobspecs/update/test001.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
     - type: cluster
       count: 1

--- a/t/data/resource/jobspecs/update/test002.yaml
+++ b/t/data/resource/jobspecs/update/test002.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
     - type: cluster
       count: 1

--- a/t/data/resource/jobspecs/update/test003.yaml
+++ b/t/data/resource/jobspecs/update/test003.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
     - type: cluster
       count: 1

--- a/t/data/resource/jobspecs/update/test004.yaml
+++ b/t/data/resource/jobspecs/update/test004.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/update/test005.yaml
+++ b/t/data/resource/jobspecs/update/test005.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 36

--- a/t/data/resource/jobspecs/update/test006.yaml
+++ b/t/data/resource/jobspecs/update/test006.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 36

--- a/t/data/resource/jobspecs/validation/invalid/attributes_bad_entry.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/attributes_bad_entry.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/validation/invalid/attributes_not_mapping.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/attributes_not_mapping.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/validation/invalid/missing_attributes.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/missing_attributes.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/validation/invalid/missing_resources.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/missing_resources.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 tasks:
   - command: [ "app" ]
     slot: foo

--- a/t/data/resource/jobspecs/validation/invalid/missing_tasks.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/missing_tasks.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/validation/invalid/resource_count_bad_type.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_count_bad_type.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count:

--- a/t/data/resource/jobspecs/validation/invalid/resource_count_missing_max.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_count_missing_max.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count:

--- a/t/data/resource/jobspecs/validation/invalid/resource_count_missing_min.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_count_missing_min.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count:

--- a/t/data/resource/jobspecs/validation/invalid/resource_count_missing_operand.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_count_missing_operand.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count:

--- a/t/data/resource/jobspecs/validation/invalid/resource_count_missing_operator.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_count_missing_operator.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count:

--- a/t/data/resource/jobspecs/validation/invalid/resource_count_scalar_bad_value.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_count_scalar_bad_value.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: bar

--- a/t/data/resource/jobspecs/validation/invalid/resource_exclusive_invalid.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_exclusive_invalid.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/validation/invalid/resource_exclusive_not_scalar.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_exclusive_not_scalar.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/validation/invalid/resource_id_not_scalar.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_id_not_scalar.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/validation/invalid/resource_label_not_scalar.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_label_not_scalar.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/validation/invalid/resource_missing_count.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_missing_count.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/validation/invalid/resource_missing_type.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_missing_type.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/validation/invalid/resource_not_mapping.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_not_mapping.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - - type: slot
     - count: 1

--- a/t/data/resource/jobspecs/validation/invalid/resource_slot_not_labelled.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_slot_not_labelled.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/validation/invalid/resource_unit_not_scalar.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resource_unit_not_scalar.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/validation/invalid/resources_not_sequence.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/resources_not_sequence.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   type: slot
   count: 1

--- a/t/data/resource/jobspecs/validation/invalid/task_command_not_array.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/task_command_not_array.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/validation/invalid/task_count_not_mapping.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/task_count_not_mapping.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/validation/invalid/task_missing_command.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/task_missing_command.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/validation/invalid/task_missing_count.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/task_missing_count.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/validation/invalid/task_missing_slot.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/task_missing_slot.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/validation/invalid/task_not_mapping.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/task_not_mapping.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/validation/invalid/tasks_not_sequence.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/tasks_not_sequence.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/validation/valid/basic.yaml
+++ b/t/data/resource/jobspecs/validation/valid/basic.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 1

--- a/t/data/resource/jobspecs/validation/valid/example1.yaml
+++ b/t/data/resource/jobspecs/validation/valid/example1.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 4

--- a/t/data/resource/jobspecs/validation/valid/example2.yaml
+++ b/t/data/resource/jobspecs/validation/valid/example2.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 4

--- a/t/data/resource/jobspecs/validation/valid/use_case_1.1.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_1.1.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 4

--- a/t/data/resource/jobspecs/validation/valid/use_case_1.2.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_1.2.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count:

--- a/t/data/resource/jobspecs/validation/valid/use_case_1.3.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_1.3.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 4

--- a/t/data/resource/jobspecs/validation/valid/use_case_1.4.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_1.4.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 4

--- a/t/data/resource/jobspecs/validation/valid/use_case_1.5.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_1.5.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: cluster
     count: 1

--- a/t/data/resource/jobspecs/validation/valid/use_case_1.6.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_1.6.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
     - type: cluster
       count: 2

--- a/t/data/resource/jobspecs/validation/valid/use_case_1.7.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_1.7.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: switch
     count: 3

--- a/t/data/resource/jobspecs/validation/valid/use_case_2.1.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_2.1.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     label: default

--- a/t/data/resource/jobspecs/validation/valid/use_case_2.2.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_2.2.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     count: 4

--- a/t/data/resource/jobspecs/validation/valid/use_case_2.3.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_2.3.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     label: default

--- a/t/data/resource/jobspecs/validation/valid/use_case_2.4.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_2.4.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/validation/valid/use_case_2.5.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_2.5.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     label: default

--- a/t/data/resource/jobspecs/validation/valid/use_case_2.6.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_2.6.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: slot
     label: 4GB-node

--- a/t/data/resource/jobspecs/var_aware/job_1N.yaml
+++ b/t/data/resource/jobspecs/var_aware/job_1N.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 1

--- a/t/data/resource/jobspecs/var_aware/job_2N.yaml
+++ b/t/data/resource/jobspecs/var_aware/job_2N.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 2

--- a/t/data/resource/jobspecs/var_aware/job_4N.yaml
+++ b/t/data/resource/jobspecs/var_aware/job_4N.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 9999
 resources:
   - type: node
     count: 4


### PR DESCRIPTION
This PR mainly fixes Issue #688.

As flux-core introduced Jobspec V1 and soon V2, using version 1 for some of the advanced jobspecs doesn't make sense any longer.

- Make a wholesale change of versions from version 1 to version 9999.
- Update resource/utilities/README.md. 