### PR TITLE
news: Add NEWS.md for v0.11 release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,23 @@
+flux-sched version 0.11.0 - 2020-08-31
+--------------------------------------
+
+Note: Fluxion can now annotate its jobs with their
+start-time estimate and queue info (to be displayed by `flux-jobs`).
+
+### Fixes
+ * Handle invalid sibling requests in jobspecs more gracefully (#737)
+ * Fix various errors detected when tests are run under valgrind (#734)
+ * fluxion-resource: check return value of `find_first_not_of` (#715)
+
+### Features
+ * Add support for job annotation including its start-time estimate (#735)
+ * Add support for node-local storage to hwloc reader (#714)
+ * flux module load returns early for staggered system-instance bring-up (#719)
+
+### Cleanup
+ * Update for non-integer jobid encodings (#718)
+ * Use version 9999 for test jobspecs (#739)
+
 flux-sched version 0.10.0 - 2020-07-29
 --------------------------------------
 

--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -65,6 +65,7 @@ struct schedule_t {
     std::string R = "";
     bool reserved = false;
     int64_t at = 0;
+    int64_t old_at = 0;
     double ov = 0.0f;
 };
 

--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -121,6 +121,7 @@ protected:
     std::shared_ptr<job_t> alloced_pop ();
     std::shared_ptr<job_t> rejected_pop ();
     std::shared_ptr<job_t> complete_pop ();
+    std::shared_ptr<job_t> reserved_pop ();
     std::map<std::vector<double>, flux_jobid_t>::iterator to_running (
         std::map<std::vector<double>,
                  flux_jobid_t>::iterator pending_iter,
@@ -292,6 +293,18 @@ public:
      */
     std::shared_ptr<job_t> pending_pop ();
 
+    /* Query the first job from the pending job queue.
+     * \return           a shared pointer pointing to a job_t object
+     *                   on success; nullptr when the queue is empty.
+     */
+    std::shared_ptr<job_t> pending_begin ();
+
+    /* Query the next job from the pending job queue.
+     * \return           a shared pointer pointing to a job_t object
+     *                   on success; nullptr when the queue is empty.
+     */
+    std::shared_ptr<job_t> pending_next ();
+
     /*! Pop the first job from the alloced job queue. The popped
      *  job still remains in the queue policy layer (i.e., in the
      *  internal running job queue).
@@ -319,6 +332,9 @@ private:
                     std::unordered_map<std::string, std::string> &p_map);
     int set_param (std::string &kv,
                    std::unordered_map<std::string, std::string> &p_map);
+
+    std::map<std::vector<double>, flux_jobid_t>::iterator m_pending_iter;
+    bool m_iter_valid = false;
 };
 
 } // namespace Flux::queue_manager

--- a/qmanager/policies/base/queue_policy_base_impl.hpp
+++ b/qmanager/policies/base/queue_policy_base_impl.hpp
@@ -191,6 +191,41 @@ std::shared_ptr<job_t> queue_policy_base_t::pending_pop ()
     return detail::queue_policy_base_impl_t::pending_pop ();
 }
 
+std::shared_ptr<job_t> queue_policy_base_t::pending_begin ()
+{
+    std::shared_ptr<job_t> job_p = nullptr;
+    m_pending_iter = detail::queue_policy_base_impl_t::m_pending.begin ();
+    if (m_pending_iter == m_pending.end ()) {
+        m_iter_valid = false;
+    } else {
+        flux_jobid_t id = m_pending_iter->second;
+        m_iter_valid = true;
+        if (detail::queue_policy_base_impl_t::m_jobs.find (id)
+            != detail::queue_policy_base_impl_t::m_jobs.end ())
+            job_p = detail::queue_policy_base_impl_t::m_jobs[id];
+    }
+    return job_p;
+}
+
+std::shared_ptr<job_t> queue_policy_base_t::pending_next ()
+{
+    std::shared_ptr<job_t> job_p = nullptr;
+    if (!m_iter_valid)
+        goto ret;
+    m_pending_iter++;
+    if (m_pending_iter == m_pending.end ()) {
+        m_iter_valid = false;
+    } else {
+        flux_jobid_t id = m_pending_iter->second;
+        m_iter_valid = true;
+        if (detail::queue_policy_base_impl_t::m_jobs.find (id)
+            != detail::queue_policy_base_impl_t::m_jobs.end ())
+            job_p = detail::queue_policy_base_impl_t::m_jobs[id];
+    }
+ret:
+    return job_p;
+}
+
 std::shared_ptr<job_t> queue_policy_base_t::alloced_pop ()
 {
     return detail::queue_policy_base_impl_t::alloced_pop ();

--- a/qmanager/policies/queue_policy_bf_base_impl.hpp
+++ b/qmanager/policies/queue_policy_bf_base_impl.hpp
@@ -71,6 +71,7 @@ queue_policy_bf_base_t<reapi_type>::allocate_orelse_reserve (void *h,
 
 
 {
+    int64_t at = job->schedule.at;
     if (reapi_type::match_allocate (h, true, job->jobspec, job->id,
                                     job->schedule.reserved, job->schedule.R,
                                     job->schedule.at, job->schedule.ov) == 0) {
@@ -79,6 +80,7 @@ queue_policy_bf_base_t<reapi_type>::allocate_orelse_reserve (void *h,
             // High-priority job has been reserved, continue
             m_reserved.insert (std::pair<uint64_t, flux_jobid_t> (m_oq_cnt++,
                                                                   job->id));
+	    job->schedule.old_at = at;
             m_reservation_cnt++;
             iter++;
         } else {

--- a/qmanager/policies/queue_policy_bf_base_impl.hpp
+++ b/qmanager/policies/queue_policy_bf_base_impl.hpp
@@ -185,8 +185,8 @@ int queue_policy_bf_base_t<reapi_type>::run_sched_loop (void *h,
 {
     int rc = 0;
     rc = cancel_completed_jobs (h);
-    rc += allocate_orelse_reserve_jobs (h, use_alloced_queue);
     rc += cancel_reserved_jobs (h);
+    rc += allocate_orelse_reserve_jobs (h, use_alloced_queue);
     return rc;
 }
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -36,6 +36,7 @@ TESTS = \
     t1012-find-status.t \
     t1013-exclusion.t \
     t1013-qmanager-priority.t \
+    t1014-annotation.t \
     t2000-tree-basic.t \
     t2001-tree-real.t \
     t3000-jobspec.t \

--- a/t/t1012-find-status.t
+++ b/t/t1012-find-status.t
@@ -115,7 +115,7 @@ test_expect_success 'find/status: flux ion-resource status works' '
     diff full.R.json all.key.json &&
     diff full.R.json allocated.key.json &&
     downrank=$(cat down.key.json | jq " .execution.R_lite[].rank ") &&
-    test ${rank} = "\"1\""
+    test ${downrank} = "\"1\""
 
 '
 

--- a/t/t1012-find-status.t
+++ b/t/t1012-find-status.t
@@ -97,12 +97,10 @@ test_expect_success 'find/status: a 1sock jobspec cannot run' '
     test_must_fail flux job wait-event -t 1 ${jobid2} start
 '
 
-# Make sure jobid2 doesn't leave a temporary reservation behind
-# All reservations must be cleared up at the end of each schedule loop
-test_expect_success 'find/status: find status=reserved must be null' '
-    flux ion-resource find "sched-future=reserved" | tail -1 > null.out &&
-    null=$(cat null.out) &&
-    test ${null} = "null"
+test_expect_success 'find/status: find status=reserved must not be null' '
+    flux ion-resource find "sched-future=reserved" | tail -1 > rsv.out &&
+    rank=$(cat rsv.out | jq .execution.R_lite[].rank) &&
+    test ${rank} = "\"0\""
 '
 
 test_expect_success 'find/status: flux ion-resource status works' '

--- a/t/t1014-annotation.t
+++ b/t/t1014-annotation.t
@@ -1,0 +1,177 @@
+#!/bin/sh
+
+test_description='Test job annotation'
+
+. `dirname $0`/sharness.sh
+
+hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+# 4 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
+excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers"
+
+skip_all_unless_have jq
+
+test_under_flux 1
+
+nonexistent_annotation(){
+    jobid=$(flux job id ${1}) &&
+    ann=$(flux job list -A | grep ${jobid} | jq 'has("annotations")') &&
+    test "${ann}" = "false" 
+}
+
+validate_sched_annotation(){
+    jobid=$(flux job id ${1}) &&
+    queue_name=${2} &&
+    start_time=${3} &&
+    ann=$(flux job list -A | grep ${jobid} | jq -c '.annotations') &&
+    queue=$(echo ${ann} | jq '.sched.queue') &&
+    t_est=$(echo ${ann} | jq '.sched.t_estimate') &&
+    test "\"${queue_name}\"" = "${queue}" &&
+    test "${start_time}" != "${t_est}"
+}
+
+print_queue() {
+    flux jobs -o '{sched.queue:>10h}'
+}
+
+print_t_estimate() {
+    flux jobs -o '{sched.t_estimate!D:>10h}'
+}
+
+test_expect_success 'annotation: hwloc reload works' '
+    flux hwloc reload ${excl_4N4B}
+'
+
+test_expect_success 'annotation: loading qmanager (queue-policy=easy)' '
+    flux module remove sched-simple &&
+    load_resource prune-filters=ALL:core \
+subsystems=containment policy=low load-allowlist=cluster,node,core &&
+    load_qmanager queue-policy=easy
+'
+
+test_expect_success 'annotation: works with EASY policy' '
+    jobid1=$(flux mini submit -n 8 -t 360 sleep 300) &&
+    jobid2=$(flux mini submit -n 16 -t 360 sleep 300) && # reserved
+    jobid3=$(flux mini submit -n 16 -t 360 sleep 300) && # skipped
+    jobid4=$(flux mini submit -n 16 -t 360 sleep 300) && # skipped
+    jobid5=$(flux mini submit -n 2 -t 180 sleep 100) &&
+
+    flux job wait-event -t 10 ${jobid5} start &&
+    validate_sched_annotation ${jobid1} default 999 &&
+    validate_sched_annotation ${jobid2} default 0 &&
+    nonexistent_annotation ${jobid3} &&
+    nonexistent_annotation ${jobid4} &&
+    validate_sched_annotation ${jobid5} default 999 &&
+    print_queue
+'
+
+test_expect_success 'annotation: cancel all active jobs 1' '
+    active_jobs=$(flux job list --state=active | jq .id) &&
+    for job in ${active_jobs}; do flux job cancel ${job}; done &&
+    for job in ${active_jobs}; do flux job wait-event -t 10 ${job} clean; done
+'
+
+test_expect_failure 'annotation: flux-jobs fail when some jobs miss t_est' '
+    jobid1=$(flux mini submit -n 8 -t 360 sleep 300) &&
+    jobid2=$(flux mini submit -n 16 -t 360 sleep 300) && # reserved
+    jobid3=$(flux mini submit -n 16 -t 360 sleep 300) && # skipped
+    jobid4=$(flux mini submit -n 16 -t 360 sleep 300) && # skipped
+    jobid5=$(flux mini submit -n 2 -t 180 sleep 100) &&
+
+    flux job wait-event -t 10 ${jobid5} start &&
+    print_t_estimate
+'
+
+test_expect_success 'annotation: cancel all active jobs 2' '
+    active_jobs=$(flux job list --state=active | jq .id) &&
+    for job in ${active_jobs}; do flux job cancel ${job}; done &&
+    for job in ${active_jobs}; do flux job wait-event -t 10 ${job} clean; done
+'
+
+test_expect_success 'annotation: loading qmanager (queue-policy=hybrid)' '
+    remove_resource  &&
+    load_resource prune-filters=ALL:core \
+subsystems=containment policy=low load-allowlist=cluster,node,core &&
+    load_qmanager queue-policy=hybrid policy-params=reservation-depth=2
+'
+
+test_expect_success 'annotation: works with HYBRID policy' '
+    jobid1=$(flux mini submit -n 8 -t 360 sleep 300) &&
+    jobid2=$(flux mini submit -n 16 -t 360 sleep 300) && # reserved
+    jobid3=$(flux mini submit -n 16 -t 360 sleep 300) && # reserved
+    jobid4=$(flux mini submit -n 16 -t 360 sleep 300) && # skipped
+    jobid5=$(flux mini submit -n 2 -t 180 sleep 100) &&
+
+    flux job wait-event -t 10 ${jobid5} start &&
+    validate_sched_annotation ${jobid1} default 999 &&
+    validate_sched_annotation ${jobid2} default 0 &&
+    validate_sched_annotation ${jobid3} default 0 &&
+    nonexistent_annotation ${jobid4} &&
+    validate_sched_annotation ${jobid5} default 999
+'
+
+test_expect_success 'annotation: cancel all active jobs 3' '
+    active_jobs=$(flux job list --state=active | jq .id) &&
+    for job in ${active_jobs}; do flux job cancel ${job}; done &&
+    for job in ${active_jobs}; do flux job wait-event -t 10 ${job} clean; done
+'
+
+test_expect_success 'annotation: loading qmanager (queue-policy=conservative)' '
+    remove_resource  &&
+    load_resource prune-filters=ALL:core \
+subsystems=containment policy=low load-allowlist=cluster,node,core &&
+    load_qmanager queue-policy=conservative
+'
+
+test_expect_success 'annotation: works with CONSERVATIVE policy' '
+    jobid1=$(flux mini submit -n 8 -t 360 sleep 300) &&
+    jobid2=$(flux mini submit -n 16 -t 360 sleep 300) && # reserved
+    jobid3=$(flux mini submit -n 16 -t 360 sleep 300) && # reserved
+    jobid4=$(flux mini submit -n 16 -t 360 sleep 300) && # reserved
+    jobid5=$(flux mini submit -n 2 -t 180 sleep 100) &&
+
+    flux job wait-event -t 10 ${jobid5} start &&
+    validate_sched_annotation ${jobid1} default 999 &&
+    validate_sched_annotation ${jobid2} default 0 &&
+    validate_sched_annotation ${jobid3} default 0 &&
+    validate_sched_annotation ${jobid4} default 0 &&
+    validate_sched_annotation ${jobid5} default 999
+'
+
+test_expect_success 'annotation: cancel all active jobs 4' '
+    active_jobs=$(flux job list --state=active | jq .id) &&
+    for job in ${active_jobs}; do flux job cancel ${job}; done &&
+    for job in ${active_jobs}; do flux job wait-event -t 10 ${job} clean; done
+'
+
+test_expect_success 'annotation: loading qmanager (queue-policy=fcfs)' '
+    remove_resource  &&
+    load_resource prune-filters=ALL:core \
+subsystems=containment policy=low load-allowlist=cluster,node,core &&
+    load_qmanager
+'
+
+test_expect_success 'annotation: works with FCFS policy' '
+    jobid1=$(flux mini submit -n 8 -t 360 sleep 300) &&
+    jobid2=$(flux mini submit -n 16 -t 360 sleep 300) && # block
+    jobid3=$(flux mini submit -n 16 -t 360 sleep 300) &&
+    jobid4=$(flux mini submit -n 16 -t 360 sleep 300) &&
+    jobid5=$(flux mini submit -n 2 -t 180 sleep 100) &&
+
+    flux job wait-event -t 10 ${jobid1} start &&
+    flux job wait-event -t 10 ${jobid5} submit &&
+    validate_sched_annotation ${jobid1} default 999 &&
+    nonexistent_annotation ${jobid2} &&
+    nonexistent_annotation ${jobid3} &&
+    nonexistent_annotation ${jobid4} &&
+    nonexistent_annotation ${jobid5} &&
+    active_jobs=$(flux job list --state=active | jq .id) &&
+    for job in ${active_jobs}; do flux job cancel ${job}; done &&
+    for job in ${active_jobs}; do flux job wait-event -t 10 ${job} clean; done
+'
+
+test_expect_success 'removing resource and qmanager modules' '
+    remove_qmanager &&
+    remove_resource
+'
+
+test_done


### PR DESCRIPTION
flux-sched version 0.11.0 - 2020-08-31
--------------------------------------

Note: Fluxion can now annotate its jobs with their
start-time estimate and queue info (to be displayed by `flux-jobs`).

 * Handle invalid sibling requests in jobspecs more gracefully (#737)
 * Fix various errors detected when tests are run under valgrind (#734)
 * fluxion-resource: check return value of `find_first_not_of` (#715)

 * Add support for job annotation including its start-time estimate (#735)
 * Add support for node-local storage to hwloc reader (#714)
 * flux module load returns early for staggered system-instance bring-up (#719)

 * Update for non-integer jobid encodings (#718)
 * Use version 9999 for test jobspecs (#739)

Fix #738