### PR TITLE
rc: only load/unload scheduler on rank 0

### DIFF
--- a/etc/01-sched-fluxion-qmanager-stop
+++ b/etc/01-sched-fluxion-qmanager-stop
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+test $(flux getattr rank) -eq 0 || exit 0
+
 if [ -z ${FLUXION_QMANAGER_RC_NOOP} ]; then
     flux module remove -f sched-fluxion-qmanager
 fi

--- a/etc/01-sched-fluxion-resource-start
+++ b/etc/01-sched-fluxion-resource-start
@@ -18,6 +18,8 @@
 # We now use "flux reload -f resource" so that when these failing tests
 # load it via FLUX_RC_EXTRA, the in-tree version can be loaded.
 
+test $(flux getattr rank) -eq 0 || exit 0
+
 if [ -z ${FLUXION_RESOURCE_RC_NOOP} ]; then
     # Unloading sched-simple as sched-fluxion-resource requires resource.acquire
     # that is exclusively used by it.

--- a/etc/02-sched-fluxion-qmanager-start
+++ b/etc/02-sched-fluxion-qmanager-start
@@ -20,6 +20,8 @@
 # when these failing tests load it via FLUX_RC_EXTRA,
 # the in-tree version can be loaded.
 
+test $(flux getattr rank) -eq 0 || exit 0
+
 if [ -z ${FLUXION_QMANAGER_RC_NOOP} ]; then
     flux module remove -f sched-simple
     flux module reload -f sched-fluxion-qmanager ${FLUXION_QMANAGER_OPTIONS}

--- a/etc/02-sched-fluxion-resource-stop
+++ b/etc/02-sched-fluxion-resource-stop
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+test $(flux getattr rank) -eq 0 || exit 0
+
 if [ -z ${FLUXION_RESOURCE_RC_NOOP} ]; then
     flux module remove -f sched-fluxion-resource
 fi


### PR DESCRIPTION
Problem: flux-core is about to transition to rc1/rc3 scripts executing
on all ranks, which would cause the fluxion scheduler to be loaded
on all ranks.

Check the rank at the beginning of the rc scripts and exit 0 if running
on a rank other than 0.

This change has no effect when run with the current 0.19.0 flux-core, but it will allow flux-sched to continue to work into 0.20.0 development.