### PR TITLE
qmanager: remove t_estimate when job alloc success

### DIFF
--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -69,10 +69,10 @@ int qmanager_cb_t::post_sched_loop (flux_t *h, schedutil_t *schedutil,
         while ( (job = queue->alloced_pop ()) != nullptr) {
             if (schedutil_alloc_respond_success_pack (schedutil, job->msg,
                                                       job->schedule.R.c_str (),
-                                                      "{ s:{s:s s:f} }",
+                                                      "{ s:{s:s s:n} }",
                                                       "sched",
                                                           "queue", queue_name.c_str (),
-                                                          "t_estimate", 0.0) < 0) {
+                                                          "t_estimate") < 0) {
                 flux_log_error (h, "%s: schedutil_alloc_respond_pack (queue=%s)",
                                 __FUNCTION__, queue_name.c_str ());
                 goto out;

--- a/t/t1014-annotation.t
+++ b/t/t1014-annotation.t
@@ -28,7 +28,7 @@ validate_sched_annotation(){
     test "\"${queue_name}\"" = "${queue}" &&
     if test x"${start_time_is_zero}" = x"TRUE";
     then
-        test "${t_est}" = "0"
+        test "${t_est}" = "null"
     else
         test "${t_est}" != "0"
     fi


### PR DESCRIPTION
When a job allocation is successful, rather than set t_estimate to
0.0, remove the annotation.

Update tests in t/t1014-annotation.t accordingly.