### PR TITLE
testsuite:  use monitor-force-up in load_test_resources()

### DIFF
--- a/t/sharness.d/sched-sharness.sh
+++ b/t/sharness.d/sched-sharness.sh
@@ -131,7 +131,7 @@ load_test_resources () {
         flux hwloc reload $1 &&
         flux kvs eventlog append resource.eventlog \
             hwloc-discover-finish "{\"loaded\":true}" &&
-        flux module load resource
+        flux module load resource monitor-force-up
 }
 
 # N.B. this assumes that a scheduler is loaded

--- a/t/t4004-match-hwloc.t
+++ b/t/t4004-match-hwloc.t
@@ -115,8 +115,8 @@ test_expect_success 'removing resource works' '
     remove_resource
 '
 
-test_expect_success 'reloading session/hwloc information with test data' '
-    flux hwloc reload ${excl_4N4B}
+test_expect_success 'load test resources (4N4B)' '
+    load_test_resources ${excl_4N4B}
 '
 
 test_expect_success 'loading resource module with default resource info source' '
@@ -138,11 +138,20 @@ test_expect_success 'match-allocate fails when all resources are allocated' '
     test_expect_code 16 flux ion-resource match allocate ${jobspec_2socket}
 '
 
-test_expect_success 'reloading sierra xml and match allocate' '
-    remove_resource &&
-    flux hwloc reload ${excl_4N4B_sierra2} &&
+test_expect_success 'unload fluxion resource' '
+    remove_resource
+'
+
+test_expect_success 'load test resources (4N4B_sierra2)' '
+    load_test_resources ${excl_4N4B_sierra2}
+'
+
+test_expect_success 'load fluxion resource' '
     load_resource subsystems=containment \
-policy=high load-allowlist=node,socket,core,gpu &&
+        policy=high load-allowlist=node,socket,core,gpu
+'
+
+test_expect_success 'match allocate' '
     flux ion-resource match allocate ${jobspec_1socket_2gpu} &&
     flux ion-resource match allocate ${jobspec_1socket_2gpu} &&
     flux ion-resource match allocate ${jobspec_1socket_2gpu} &&

--- a/t/t4009-match-update.t
+++ b/t/t4009-match-update.t
@@ -30,8 +30,8 @@ test_expect_success 'update: generate jobspec for a simple test job' '
     flux mini run --dry-run -N 1 -n 1 -t 1h hostname > basic.json
 '
 
-test_expect_success 'update: hwloc reload works' '
-    flux hwloc reload ${excl_4N4B}
+test_expect_success 'update: load test resources' '
+    load_test_resources ${excl_4N4B}
 '
 
 test_expect_success 'update: loading sched-fluxion-resource works' '

--- a/t/t6002-graph-hwloc.t
+++ b/t/t6002-graph-hwloc.t
@@ -21,8 +21,8 @@ skip_all_unless_have jq
 export FLUX_SCHED_MODULE=none
 test_under_flux 4
 
-test_expect_success 'qmanager: hwloc reload works' '
-    flux hwloc reload ${excl_4N4B}
+test_expect_success 'qmanager: load test resources' '
+    load_test_resources ${excl_4N4B}
 '
 
 test_expect_success 'qmanager: loading resource and qmanager modules works' '


### PR DESCRIPTION
This PR changes the `load_test_reosurces()` shell function to load the core resource module wiith the `monitor-force-up` option to ensure that all broker ranks are marked UP in the first response to `resource.acquire`.

The ensures that the change proposed in flux-framework/flux-core#3207 does not break scheduler tests.

Also, fix a couple of tests that were still calling `flux hwloc reload` directly to use `load_test_resources()`.

There is no harm in merging this PR before the core one, as the new option will simply be ignored by the resource module.