### PR TITLE
build: bump minimum jansson version to 2.10

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,7 +47,7 @@ AC_CHECK_LIB([dl], [dlerror],
                         [Define if you have libdl])],
              [AC_MSG_ERROR([Please install dl])])
 PKG_CHECK_MODULES([HWLOC], [hwloc >= 1.11.1], [], [])
-PKG_CHECK_MODULES([JANSSON], [jansson >= 2.6], [], [])
+PKG_CHECK_MODULES([JANSSON], [jansson >= 2.10], [], [])
 PKG_CHECK_MODULES([XML2], [libxml-2.0])
 AX_VALGRIND_H
 


### PR DESCRIPTION
For consistency to flux-core issue #3239, increase the minimum
jansson version to 2.10.