### PR TITLE
testsuite: change method of setting test resources

### DIFF
--- a/t/sharness.d/sched-sharness.sh
+++ b/t/sharness.d/sched-sharness.sh
@@ -125,13 +125,12 @@ remove_resource () {
 # Usage: load_test_resources hwloc-dir
 #   where hwloc-dir contains <rank>.xml files
 load_test_resources () {
-    flux kvs get --waitcreate resource.hwloc.by_rank &&
+    flux kvs get --waitcreate resource.R &&
         flux module remove resource &&
         flux kvs unlink -R resource
         flux hwloc reload $1 &&
-        flux kvs eventlog append resource.eventlog \
-            hwloc-discover-finish "{\"loaded\":true}" &&
-        flux module load resource monitor-force-up
+        flux kvs copy resource.hwloc.by_rank resource.R &&
+        flux module load resource monitor-force-up noverify
 }
 
 # N.B. this assumes that a scheduler is loaded

--- a/t/t1007-recovery-full.t
+++ b/t/t1007-recovery-full.t
@@ -25,7 +25,7 @@ test_expect_success 'load test resources' '
 '
 
 test_expect_success 'recovery: loading flux-sched modules works (rv1)' '
-    flux module reload -f resource &&
+    flux module reload -f resource noverify &&
     load_resource load-allowlist=node,core,gpu match-format=rv1 &&
     load_qmanager
 '

--- a/t/t1013-exclusion.t
+++ b/t/t1013-exclusion.t
@@ -52,7 +52,7 @@ test_expect_success 'exclusion: reloading resource with a config file' '
 	exclude = "2-3"
 EOF
     flux config reload &&
-    flux module reload resource
+    flux module reload resource noverify
 '
 
 test_expect_success 'exclusion: loading fluxion modules works' '


### PR DESCRIPTION
Note: This PR should not be merged until flux-framework/flux-core#3265 is merged.

Problem: verification of fake test resources fail with
latest changes to the core resource module.

The core resource module now checks that probed resources
match configured resources.  This check must be disabled
by loading the resource module with the 'noverify' option
in test.

Also, it is no longer necessary to post a 'hwloc-discover-finish'
event in the resource.eventlog when setting up fake resources.

Finally, the fake resource object (still in by_rank format at this time)
needs to be located in the KVS at resource.R.