### PR TITLE
Add support for nodelist for RV1 change and R_lite compression

### DIFF
--- a/config/ax_flux_core.m4
+++ b/config/ax_flux_core.m4
@@ -26,6 +26,8 @@
 #   - FLUX_IDSET_CFLAGS    libflux-idset CFLAGS
 #   - FLUX_OPTPARSE_LIBS   libflux-optparse LIBS
 #   - FLUX_OPTPARSE_CFLAGS libflux-optparse CFLAGS
+#   - FLUX_HOSTLIST_LIBS   libflux-hostlist LIBS
+#   - FLUX_HOSTLIST_CFLAGS libflux-hostlist CFLAGS
 #
 # LICENSE
 #
@@ -90,6 +92,7 @@ AC_DEFUN([AX_FLUX_CORE], [
   PKG_CHECK_MODULES([FLUX_IDSET], [flux-idset], [], [])
   PKG_CHECK_MODULES([FLUX_SCHEDUTIL], [flux-schedutil], [], [])
   PKG_CHECK_MODULES([FLUX_OPTPARSE], [flux-optparse], [], [])
+  PKG_CHECK_MODULES([FLUX_HOSTLIST], [flux-hostlist], [], [])
 
   PKG_CONFIG_PATH=$saved_PKG_CONFIG_PATH
   export PKG_CONFIG_PATH

--- a/resource/Makefile.am
+++ b/resource/Makefile.am
@@ -79,11 +79,13 @@ libresource_la_SOURCES = \
 libresource_la_CXXFLAGS = \
     $(WARNING_CXXFLAGS) \
     $(CODE_COVERAGE_CFLAGS) \
-    $(AM_CXXFLAGS)
+    $(AM_CXXFLAGS) \
+    $(FLUX_HOSTLIST_CFLAGS)
 
 libresource_la_LIBADD = \
     $(top_builddir)/resource/planner/libplanner.la \
     $(top_builddir)/resource/libjobspec/libjobspec_conv.la \
+    $(FLUX_HOSTLIST_LIBS) \
     $(BOOST_LDFLAGS) \
     $(BOOST_SYSTEM_LIB) \
     $(BOOST_FILESYSTEM_LIB) \

--- a/resource/modules/Makefile.am
+++ b/resource/modules/Makefile.am
@@ -21,10 +21,12 @@ sched_fluxion_resource_la_SOURCES = \
 sched_fluxion_resource_la_CXXFLAGS = \
     $(AM_CXXFLAGS) \
     $(JOBSPEC_CFLAGS) \
+    $(FLUX_HOSTLIST_CFLAGS) \
     $(FLUX_CORE_CFLAGS)
 sched_fluxion_resource_la_LIBADD = \
     ../libresource.la \
     $(FLUX_IDSET_LIBS) \
+    $(FLUX_HOSTLIST_LIBS) \
     $(FLUX_CORE_LIBS) \
     $(DL_LIBS) \
     $(HWLOC_LIBS) \

--- a/resource/utilities/Makefile.am
+++ b/resource/utilities/Makefile.am
@@ -31,10 +31,12 @@ resource_query_SOURCES = \
     resource-query.cpp \
     command.cpp
 resource_query_CXXFLAGS = \
-    $(AM_CXXFLAGS)
+    $(AM_CXXFLAGS) \
+    $(FLUX_HOSTLIST_CFLAGS)
 resource_query_LDADD = \
     ../libresource.la \
     $(READLINE_LIBS) \
+    $(FLUX_HOSTLIST_LIBS) \
     $(BOOST_LDFLAGS) \
     $(BOOST_SYSTEM_LIB) \
     $(BOOST_FILESYSTEM_LIB) \

--- a/resource/writers/match_writers.cpp
+++ b/resource/writers/match_writers.cpp
@@ -73,7 +73,7 @@ bool sim_match_writers_t::empty ()
     return m_out.str ().empty ();
 }
 
-int sim_match_writers_t::emit_json (json_t **j_o)
+int sim_match_writers_t::emit_json (json_t **j_o, json_t **aux)
 {
     json_t *o = NULL;
     std::string str = m_out.str ();
@@ -161,7 +161,7 @@ bool jgf_match_writers_t::empty ()
     return (v_size == 0) && (e_size == 0);
 }
 
-int jgf_match_writers_t::emit_json (json_t **o)
+int jgf_match_writers_t::emit_json (json_t **o, json_t **aux)
 {
     int rc = 0;
 
@@ -488,7 +488,7 @@ bool rlite_match_writers_t::empty ()
     return (json_array_size (m_out) == 0)? true : false;
 }
 
-int rlite_match_writers_t::emit_json (json_t **o)
+int rlite_match_writers_t::emit_json (json_t **o, json_t **aux)
 {
     int rc = 0;
     if (!m_out) {
@@ -675,7 +675,7 @@ ret:
     return rc;
 }
 
-int rv1_match_writers_t::emit_json (json_t **j_o)
+int rv1_match_writers_t::emit_json (json_t **j_o, json_t **aux)
 {
     int rc = 0;
     int saved_errno;
@@ -798,7 +798,7 @@ bool rv1_nosched_match_writers_t::empty ()
     return rlite.empty ();
 }
 
-int rv1_nosched_match_writers_t::emit_json (json_t **j_o)
+int rv1_nosched_match_writers_t::emit_json (json_t **j_o, json_t **aux)
 {
     int rc = 0;
     json_t *rlite_o = NULL;
@@ -883,7 +883,7 @@ bool pretty_sim_match_writers_t::empty ()
     return empty;
 }
 
-int pretty_sim_match_writers_t::emit_json (json_t **j_o)
+int pretty_sim_match_writers_t::emit_json (json_t **j_o, json_t **aux)
 {
     json_t *o = NULL;
     std::string str = "";

--- a/resource/writers/match_writers.hpp
+++ b/resource/writers/match_writers.hpp
@@ -67,6 +67,8 @@ public:
         return 0;
     }
     int compress_ids (std::stringstream &o, const std::vector<int64_t> &ids);
+    int compress_hosts (const std::vector<std::string> &hosts,
+                        const char *hostlist_init, char **hostlist);
 };
 
 
@@ -141,12 +143,20 @@ public:
                           const f_resource_graph_t &g, const vtx_t &u,
                           unsigned int needs, bool exclusive);
 private:
+    class rank_host_t {
+    public:
+        int64_t rank;
+        std::string host;
+    };
     bool m_reducer_set ();
     int emit_gatherer (const f_resource_graph_t &g, const vtx_t &u);
+    int get_gatherer_children (std::string &children);
+    int fill (json_t *rlite_array, json_t *host_array);
+    int fill_hosts (std::vector<std::string> &hosts, json_t *host_array);
 
     std::map<std::string, std::vector<int64_t>> m_reducer;
+    std::map<std::string, std::vector<rank_host_t>> m_gl_gatherer;
     std::set<std::string> m_gatherer;
-    json_t *m_out = NULL;
 };
 
 

--- a/resource/writers/match_writers.hpp
+++ b/resource/writers/match_writers.hpp
@@ -66,7 +66,7 @@ public:
     virtual int emit_attrs (const std::string &k, const std::string &v) {
         return 0;
     }
-    void compress (std::stringstream &o, const std::set<int64_t> &ids);
+    int compress_ids (std::stringstream &o, const std::vector<int64_t> &ids);
 };
 
 
@@ -144,7 +144,7 @@ private:
     bool m_reducer_set ();
     int emit_gatherer (const f_resource_graph_t &g, const vtx_t &u);
 
-    std::map<std::string, std::set<int64_t>> m_reducer;
+    std::map<std::string, std::vector<int64_t>> m_reducer;
     std::set<std::string> m_gatherer;
     json_t *m_out = NULL;
 };

--- a/resource/writers/match_writers.hpp
+++ b/resource/writers/match_writers.hpp
@@ -51,7 +51,7 @@ class match_writers_t {
 public:
     virtual ~match_writers_t () {}
     virtual bool empty () = 0;
-    virtual int emit_json (json_t **o) = 0;
+    virtual int emit_json (json_t **o, json_t **aux = nullptr) = 0;
     virtual int emit (std::stringstream &out) = 0;
     virtual int emit_vtx (const std::string &prefix,
                           const f_resource_graph_t &g, const vtx_t &u,
@@ -77,7 +77,7 @@ class sim_match_writers_t : public match_writers_t
 public:
     virtual ~sim_match_writers_t () {}
     virtual bool empty ();
-    virtual int emit_json (json_t **o);
+    virtual int emit_json (json_t **o, json_t **aux = nullptr);
     virtual int emit (std::stringstream &out);
     virtual int emit_vtx (const std::string &prefix,
                           const f_resource_graph_t &g, const vtx_t &u,
@@ -98,7 +98,7 @@ public:
     virtual ~jgf_match_writers_t ();
 
     virtual bool empty ();
-    virtual int emit_json (json_t **o);
+    virtual int emit_json (json_t **o, json_t **aux = nullptr);
     virtual int emit (std::stringstream &out);
     virtual int emit_vtx (const std::string &prefix,
                           const f_resource_graph_t &g, const vtx_t &u,
@@ -134,7 +134,7 @@ public:
     virtual ~rlite_match_writers_t ();
 
     virtual bool empty ();
-    virtual int emit_json (json_t **o);
+    virtual int emit_json (json_t **o, json_t **aux = nullptr);
     virtual int emit (std::stringstream &out, bool newline);
     virtual int emit (std::stringstream &out);
     virtual int emit_vtx (const std::string &prefix,
@@ -156,7 +156,7 @@ class rv1_match_writers_t : public match_writers_t
 {
 public:
     virtual bool empty ();
-    virtual int emit_json (json_t **o);
+    virtual int emit_json (json_t **o, json_t **aux = nullptr);
     virtual int emit (std::stringstream &out);
     virtual int emit_vtx (const std::string &prefix,
                           const f_resource_graph_t &g, const vtx_t &u,
@@ -182,7 +182,7 @@ class rv1_nosched_match_writers_t : public match_writers_t
 {
 public:
     virtual bool empty ();
-    virtual int emit_json (json_t **o);
+    virtual int emit_json (json_t **o, json_t **aux = nullptr);
     virtual int emit (std::stringstream &out);
     virtual int emit_vtx (const std::string &prefix,
                           const f_resource_graph_t &g, const vtx_t &u,
@@ -201,7 +201,7 @@ class pretty_sim_match_writers_t : public match_writers_t
 {
 public:
     virtual bool empty ();
-    virtual int emit_json (json_t **o);
+    virtual int emit_json (json_t **o, json_t **aux = nullptr);
     virtual int emit (std::stringstream &out);
     virtual int emit_vtx (const std::string &prefix,
                           const f_resource_graph_t &g, const vtx_t &u,

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -67,6 +67,7 @@ TESTS = \
     t3025-resource-find.t \
     t3026-resource-node-local-storage.t \
     t3026-resource-sibling.t \
+    t3027-resource-RV.t \
     t4000-match-params.t \
     t4001-match-allocate.t \
     t4002-match-reserve.t \

--- a/t/data/resource/expected/RV/R1.out
+++ b/t/data/resource/expected/RV/R1.out
@@ -1,0 +1,6 @@
+{"version": 1, "execution": {"R_lite": [{"rank": "0-3", "children": {"core": "0-35", "gpu": "0-1"}}], "nodelist": ["node[0-3]"], "starttime": 0, "expiration": 3600}}
+INFO: =============================
+INFO: JOBID=1
+INFO: RESOURCES=ALLOCATED
+INFO: SCHEDULED AT=Now
+INFO: =============================

--- a/t/data/resource/expected/RV/R2.out
+++ b/t/data/resource/expected/RV/R2.out
@@ -1,0 +1,6 @@
+{"version": 1, "execution": {"R_lite": [{"rank": "1-3", "children": {"core": "0-35", "gpu": "0-1"}}, {"rank": "0", "children": {"core": "1-35,100", "gpu": "0-1"}}], "nodelist": ["node[1-3,0]"], "starttime": 0, "expiration": 3600}}
+INFO: =============================
+INFO: JOBID=1
+INFO: RESOURCES=ALLOCATED
+INFO: SCHEDULED AT=Now
+INFO: =============================

--- a/t/data/resource/expected/RV/R3.out
+++ b/t/data/resource/expected/RV/R3.out
@@ -1,0 +1,6 @@
+{"version": 1, "execution": {"R_lite": [{"rank": "0,2-3", "children": {"core": "0-35", "gpu": "0-1"}}, {"rank": "1", "children": {"core": "1-35,100", "gpu": "0-1"}}], "nodelist": ["node[3,1-2,0]"], "starttime": 0, "expiration": 3600}}
+INFO: =============================
+INFO: JOBID=1
+INFO: RESOURCES=ALLOCATED
+INFO: SCHEDULED AT=Now
+INFO: =============================

--- a/t/data/resource/jgfs/4node.rank0123.nid0123.mod.json
+++ b/t/data/resource/jgfs/4node.rank0123.nid0123.mod.json
@@ -1,0 +1,4315 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "14",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core0",
+          "id": 100,
+          "uniq_id": 14,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core0"
+          }
+        }
+      },
+      {
+        "id": "15",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core1",
+          "id": 1,
+          "uniq_id": 15,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core1"
+          }
+        }
+      },
+      {
+        "id": "16",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core2",
+          "id": 2,
+          "uniq_id": 16,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core2"
+          }
+        }
+      },
+      {
+        "id": "17",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core3",
+          "id": 3,
+          "uniq_id": 17,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core3"
+          }
+        }
+      },
+      {
+        "id": "18",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core4",
+          "id": 4,
+          "uniq_id": 18,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core4"
+          }
+        }
+      },
+      {
+        "id": "19",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core5",
+          "id": 5,
+          "uniq_id": 19,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core5"
+          }
+        }
+      },
+      {
+        "id": "20",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core6",
+          "id": 6,
+          "uniq_id": 20,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core6"
+          }
+        }
+      },
+      {
+        "id": "21",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core7",
+          "id": 7,
+          "uniq_id": 21,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core7"
+          }
+        }
+      },
+      {
+        "id": "22",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core8",
+          "id": 8,
+          "uniq_id": 22,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core8"
+          }
+        }
+      },
+      {
+        "id": "23",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core9",
+          "id": 9,
+          "uniq_id": 23,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core9"
+          }
+        }
+      },
+      {
+        "id": "24",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core10",
+          "id": 10,
+          "uniq_id": 24,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core10"
+          }
+        }
+      },
+      {
+        "id": "25",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core11",
+          "id": 11,
+          "uniq_id": 25,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core11"
+          }
+        }
+      },
+      {
+        "id": "26",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core12",
+          "id": 12,
+          "uniq_id": 26,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core12"
+          }
+        }
+      },
+      {
+        "id": "27",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core13",
+          "id": 13,
+          "uniq_id": 27,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core13"
+          }
+        }
+      },
+      {
+        "id": "28",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core14",
+          "id": 14,
+          "uniq_id": 28,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core14"
+          }
+        }
+      },
+      {
+        "id": "29",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core15",
+          "id": 15,
+          "uniq_id": 29,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core15"
+          }
+        }
+      },
+      {
+        "id": "30",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core16",
+          "id": 16,
+          "uniq_id": 30,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core16"
+          }
+        }
+      },
+      {
+        "id": "31",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core17",
+          "id": 17,
+          "uniq_id": 31,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core17"
+          }
+        }
+      },
+      {
+        "id": "158",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu0",
+          "id": 0,
+          "uniq_id": 158,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/gpu0"
+          }
+        }
+      },
+      {
+        "id": "6",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket0",
+          "id": 0,
+          "uniq_id": 6,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0"
+          }
+        }
+      },
+      {
+        "id": "32",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core18",
+          "id": 18,
+          "uniq_id": 32,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core18"
+          }
+        }
+      },
+      {
+        "id": "33",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core19",
+          "id": 19,
+          "uniq_id": 33,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core19"
+          }
+        }
+      },
+      {
+        "id": "34",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core20",
+          "id": 20,
+          "uniq_id": 34,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core20"
+          }
+        }
+      },
+      {
+        "id": "35",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core21",
+          "id": 21,
+          "uniq_id": 35,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core21"
+          }
+        }
+      },
+      {
+        "id": "36",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core22",
+          "id": 22,
+          "uniq_id": 36,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core22"
+          }
+        }
+      },
+      {
+        "id": "37",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core23",
+          "id": 23,
+          "uniq_id": 37,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core23"
+          }
+        }
+      },
+      {
+        "id": "38",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core24",
+          "id": 24,
+          "uniq_id": 38,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core24"
+          }
+        }
+      },
+      {
+        "id": "39",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core25",
+          "id": 25,
+          "uniq_id": 39,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core25"
+          }
+        }
+      },
+      {
+        "id": "40",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core26",
+          "id": 26,
+          "uniq_id": 40,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core26"
+          }
+        }
+      },
+      {
+        "id": "41",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core27",
+          "id": 27,
+          "uniq_id": 41,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core27"
+          }
+        }
+      },
+      {
+        "id": "42",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core28",
+          "id": 28,
+          "uniq_id": 42,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core28"
+          }
+        }
+      },
+      {
+        "id": "43",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core29",
+          "id": 29,
+          "uniq_id": 43,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core29"
+          }
+        }
+      },
+      {
+        "id": "44",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core30",
+          "id": 30,
+          "uniq_id": 44,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core30"
+          }
+        }
+      },
+      {
+        "id": "45",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core31",
+          "id": 31,
+          "uniq_id": 45,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core31"
+          }
+        }
+      },
+      {
+        "id": "46",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core32",
+          "id": 32,
+          "uniq_id": 46,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core32"
+          }
+        }
+      },
+      {
+        "id": "47",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core33",
+          "id": 33,
+          "uniq_id": 47,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core33"
+          }
+        }
+      },
+      {
+        "id": "48",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core34",
+          "id": 34,
+          "uniq_id": 48,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core34"
+          }
+        }
+      },
+      {
+        "id": "49",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core35",
+          "id": 35,
+          "uniq_id": 49,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core35"
+          }
+        }
+      },
+      {
+        "id": "159",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu1",
+          "id": 1,
+          "uniq_id": 159,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/gpu1"
+          }
+        }
+      },
+      {
+        "id": "7",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket1",
+          "id": 1,
+          "uniq_id": 7,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1"
+          }
+        }
+      },
+      {
+        "id": "2",
+        "metadata": {
+          "type": "node",
+          "basename": "node",
+          "name": "node0",
+          "id": 0,
+          "uniq_id": 2,
+          "rank": 0,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0"
+          }
+        }
+      },
+      {
+        "id": "50",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core0",
+          "id": 0,
+          "uniq_id": 50,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core0"
+          }
+        }
+      },
+      {
+        "id": "51",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core1",
+          "id": 1,
+          "uniq_id": 51,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core1"
+          }
+        }
+      },
+      {
+        "id": "52",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core2",
+          "id": 2,
+          "uniq_id": 52,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core2"
+          }
+        }
+      },
+      {
+        "id": "53",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core3",
+          "id": 3,
+          "uniq_id": 53,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core3"
+          }
+        }
+      },
+      {
+        "id": "54",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core4",
+          "id": 4,
+          "uniq_id": 54,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core4"
+          }
+        }
+      },
+      {
+        "id": "55",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core5",
+          "id": 5,
+          "uniq_id": 55,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core5"
+          }
+        }
+      },
+      {
+        "id": "56",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core6",
+          "id": 6,
+          "uniq_id": 56,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core6"
+          }
+        }
+      },
+      {
+        "id": "57",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core7",
+          "id": 7,
+          "uniq_id": 57,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core7"
+          }
+        }
+      },
+      {
+        "id": "58",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core8",
+          "id": 8,
+          "uniq_id": 58,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core8"
+          }
+        }
+      },
+      {
+        "id": "59",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core9",
+          "id": 9,
+          "uniq_id": 59,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core9"
+          }
+        }
+      },
+      {
+        "id": "60",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core10",
+          "id": 10,
+          "uniq_id": 60,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core10"
+          }
+        }
+      },
+      {
+        "id": "61",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core11",
+          "id": 11,
+          "uniq_id": 61,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core11"
+          }
+        }
+      },
+      {
+        "id": "62",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core12",
+          "id": 12,
+          "uniq_id": 62,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core12"
+          }
+        }
+      },
+      {
+        "id": "63",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core13",
+          "id": 13,
+          "uniq_id": 63,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core13"
+          }
+        }
+      },
+      {
+        "id": "64",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core14",
+          "id": 14,
+          "uniq_id": 64,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core14"
+          }
+        }
+      },
+      {
+        "id": "65",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core15",
+          "id": 15,
+          "uniq_id": 65,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core15"
+          }
+        }
+      },
+      {
+        "id": "66",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core16",
+          "id": 16,
+          "uniq_id": 66,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core16"
+          }
+        }
+      },
+      {
+        "id": "67",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core17",
+          "id": 17,
+          "uniq_id": 67,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core17"
+          }
+        }
+      },
+      {
+        "id": "160",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu0",
+          "id": 0,
+          "uniq_id": 160,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/gpu0"
+          }
+        }
+      },
+      {
+        "id": "8",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket0",
+          "id": 0,
+          "uniq_id": 8,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0"
+          }
+        }
+      },
+      {
+        "id": "68",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core18",
+          "id": 18,
+          "uniq_id": 68,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core18"
+          }
+        }
+      },
+      {
+        "id": "69",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core19",
+          "id": 19,
+          "uniq_id": 69,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core19"
+          }
+        }
+      },
+      {
+        "id": "70",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core20",
+          "id": 20,
+          "uniq_id": 70,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core20"
+          }
+        }
+      },
+      {
+        "id": "71",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core21",
+          "id": 21,
+          "uniq_id": 71,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core21"
+          }
+        }
+      },
+      {
+        "id": "72",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core22",
+          "id": 22,
+          "uniq_id": 72,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core22"
+          }
+        }
+      },
+      {
+        "id": "73",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core23",
+          "id": 23,
+          "uniq_id": 73,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core23"
+          }
+        }
+      },
+      {
+        "id": "74",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core24",
+          "id": 24,
+          "uniq_id": 74,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core24"
+          }
+        }
+      },
+      {
+        "id": "75",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core25",
+          "id": 25,
+          "uniq_id": 75,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core25"
+          }
+        }
+      },
+      {
+        "id": "76",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core26",
+          "id": 26,
+          "uniq_id": 76,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core26"
+          }
+        }
+      },
+      {
+        "id": "77",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core27",
+          "id": 27,
+          "uniq_id": 77,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core27"
+          }
+        }
+      },
+      {
+        "id": "78",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core28",
+          "id": 28,
+          "uniq_id": 78,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core28"
+          }
+        }
+      },
+      {
+        "id": "79",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core29",
+          "id": 29,
+          "uniq_id": 79,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core29"
+          }
+        }
+      },
+      {
+        "id": "80",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core30",
+          "id": 30,
+          "uniq_id": 80,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core30"
+          }
+        }
+      },
+      {
+        "id": "81",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core31",
+          "id": 31,
+          "uniq_id": 81,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core31"
+          }
+        }
+      },
+      {
+        "id": "82",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core32",
+          "id": 32,
+          "uniq_id": 82,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core32"
+          }
+        }
+      },
+      {
+        "id": "83",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core33",
+          "id": 33,
+          "uniq_id": 83,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core33"
+          }
+        }
+      },
+      {
+        "id": "84",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core34",
+          "id": 34,
+          "uniq_id": 84,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core34"
+          }
+        }
+      },
+      {
+        "id": "85",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core35",
+          "id": 35,
+          "uniq_id": 85,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core35"
+          }
+        }
+      },
+      {
+        "id": "161",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu1",
+          "id": 1,
+          "uniq_id": 161,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/gpu1"
+          }
+        }
+      },
+      {
+        "id": "9",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket1",
+          "id": 1,
+          "uniq_id": 9,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1"
+          }
+        }
+      },
+      {
+        "id": "3",
+        "metadata": {
+          "type": "node",
+          "basename": "node",
+          "name": "node1",
+          "id": 1,
+          "uniq_id": 3,
+          "rank": 1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1"
+          }
+        }
+      },
+      {
+        "id": "86",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core0",
+          "id": 0,
+          "uniq_id": 86,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core0"
+          }
+        }
+      },
+      {
+        "id": "87",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core1",
+          "id": 1,
+          "uniq_id": 87,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core1"
+          }
+        }
+      },
+      {
+        "id": "88",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core2",
+          "id": 2,
+          "uniq_id": 88,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core2"
+          }
+        }
+      },
+      {
+        "id": "89",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core3",
+          "id": 3,
+          "uniq_id": 89,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core3"
+          }
+        }
+      },
+      {
+        "id": "90",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core4",
+          "id": 4,
+          "uniq_id": 90,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core4"
+          }
+        }
+      },
+      {
+        "id": "91",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core5",
+          "id": 5,
+          "uniq_id": 91,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core5"
+          }
+        }
+      },
+      {
+        "id": "92",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core6",
+          "id": 6,
+          "uniq_id": 92,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core6"
+          }
+        }
+      },
+      {
+        "id": "93",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core7",
+          "id": 7,
+          "uniq_id": 93,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core7"
+          }
+        }
+      },
+      {
+        "id": "94",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core8",
+          "id": 8,
+          "uniq_id": 94,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core8"
+          }
+        }
+      },
+      {
+        "id": "95",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core9",
+          "id": 9,
+          "uniq_id": 95,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core9"
+          }
+        }
+      },
+      {
+        "id": "96",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core10",
+          "id": 10,
+          "uniq_id": 96,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core10"
+          }
+        }
+      },
+      {
+        "id": "97",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core11",
+          "id": 11,
+          "uniq_id": 97,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core11"
+          }
+        }
+      },
+      {
+        "id": "98",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core12",
+          "id": 12,
+          "uniq_id": 98,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core12"
+          }
+        }
+      },
+      {
+        "id": "99",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core13",
+          "id": 13,
+          "uniq_id": 99,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core13"
+          }
+        }
+      },
+      {
+        "id": "100",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core14",
+          "id": 14,
+          "uniq_id": 100,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core14"
+          }
+        }
+      },
+      {
+        "id": "101",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core15",
+          "id": 15,
+          "uniq_id": 101,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core15"
+          }
+        }
+      },
+      {
+        "id": "102",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core16",
+          "id": 16,
+          "uniq_id": 102,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core16"
+          }
+        }
+      },
+      {
+        "id": "103",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core17",
+          "id": 17,
+          "uniq_id": 103,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core17"
+          }
+        }
+      },
+      {
+        "id": "162",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu0",
+          "id": 0,
+          "uniq_id": 162,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/gpu0"
+          }
+        }
+      },
+      {
+        "id": "10",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket0",
+          "id": 0,
+          "uniq_id": 10,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0"
+          }
+        }
+      },
+      {
+        "id": "104",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core18",
+          "id": 18,
+          "uniq_id": 104,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core18"
+          }
+        }
+      },
+      {
+        "id": "105",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core19",
+          "id": 19,
+          "uniq_id": 105,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core19"
+          }
+        }
+      },
+      {
+        "id": "106",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core20",
+          "id": 20,
+          "uniq_id": 106,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core20"
+          }
+        }
+      },
+      {
+        "id": "107",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core21",
+          "id": 21,
+          "uniq_id": 107,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core21"
+          }
+        }
+      },
+      {
+        "id": "108",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core22",
+          "id": 22,
+          "uniq_id": 108,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core22"
+          }
+        }
+      },
+      {
+        "id": "109",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core23",
+          "id": 23,
+          "uniq_id": 109,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core23"
+          }
+        }
+      },
+      {
+        "id": "110",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core24",
+          "id": 24,
+          "uniq_id": 110,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core24"
+          }
+        }
+      },
+      {
+        "id": "111",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core25",
+          "id": 25,
+          "uniq_id": 111,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core25"
+          }
+        }
+      },
+      {
+        "id": "112",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core26",
+          "id": 26,
+          "uniq_id": 112,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core26"
+          }
+        }
+      },
+      {
+        "id": "113",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core27",
+          "id": 27,
+          "uniq_id": 113,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core27"
+          }
+        }
+      },
+      {
+        "id": "114",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core28",
+          "id": 28,
+          "uniq_id": 114,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core28"
+          }
+        }
+      },
+      {
+        "id": "115",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core29",
+          "id": 29,
+          "uniq_id": 115,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core29"
+          }
+        }
+      },
+      {
+        "id": "116",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core30",
+          "id": 30,
+          "uniq_id": 116,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core30"
+          }
+        }
+      },
+      {
+        "id": "117",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core31",
+          "id": 31,
+          "uniq_id": 117,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core31"
+          }
+        }
+      },
+      {
+        "id": "118",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core32",
+          "id": 32,
+          "uniq_id": 118,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core32"
+          }
+        }
+      },
+      {
+        "id": "119",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core33",
+          "id": 33,
+          "uniq_id": 119,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core33"
+          }
+        }
+      },
+      {
+        "id": "120",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core34",
+          "id": 34,
+          "uniq_id": 120,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core34"
+          }
+        }
+      },
+      {
+        "id": "121",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core35",
+          "id": 35,
+          "uniq_id": 121,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core35"
+          }
+        }
+      },
+      {
+        "id": "163",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu1",
+          "id": 1,
+          "uniq_id": 163,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/gpu1"
+          }
+        }
+      },
+      {
+        "id": "11",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket1",
+          "id": 1,
+          "uniq_id": 11,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1"
+          }
+        }
+      },
+      {
+        "id": "4",
+        "metadata": {
+          "type": "node",
+          "basename": "node",
+          "name": "node2",
+          "id": 2,
+          "uniq_id": 4,
+          "rank": 2,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2"
+          }
+        }
+      },
+      {
+        "id": "122",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core0",
+          "id": 0,
+          "uniq_id": 122,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core0"
+          }
+        }
+      },
+      {
+        "id": "123",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core1",
+          "id": 1,
+          "uniq_id": 123,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core1"
+          }
+        }
+      },
+      {
+        "id": "124",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core2",
+          "id": 2,
+          "uniq_id": 124,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core2"
+          }
+        }
+      },
+      {
+        "id": "125",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core3",
+          "id": 3,
+          "uniq_id": 125,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core3"
+          }
+        }
+      },
+      {
+        "id": "126",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core4",
+          "id": 4,
+          "uniq_id": 126,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core4"
+          }
+        }
+      },
+      {
+        "id": "127",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core5",
+          "id": 5,
+          "uniq_id": 127,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core5"
+          }
+        }
+      },
+      {
+        "id": "128",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core6",
+          "id": 6,
+          "uniq_id": 128,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core6"
+          }
+        }
+      },
+      {
+        "id": "129",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core7",
+          "id": 7,
+          "uniq_id": 129,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core7"
+          }
+        }
+      },
+      {
+        "id": "130",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core8",
+          "id": 8,
+          "uniq_id": 130,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core8"
+          }
+        }
+      },
+      {
+        "id": "131",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core9",
+          "id": 9,
+          "uniq_id": 131,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core9"
+          }
+        }
+      },
+      {
+        "id": "132",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core10",
+          "id": 10,
+          "uniq_id": 132,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core10"
+          }
+        }
+      },
+      {
+        "id": "133",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core11",
+          "id": 11,
+          "uniq_id": 133,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core11"
+          }
+        }
+      },
+      {
+        "id": "134",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core12",
+          "id": 12,
+          "uniq_id": 134,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core12"
+          }
+        }
+      },
+      {
+        "id": "135",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core13",
+          "id": 13,
+          "uniq_id": 135,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core13"
+          }
+        }
+      },
+      {
+        "id": "136",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core14",
+          "id": 14,
+          "uniq_id": 136,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core14"
+          }
+        }
+      },
+      {
+        "id": "137",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core15",
+          "id": 15,
+          "uniq_id": 137,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core15"
+          }
+        }
+      },
+      {
+        "id": "138",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core16",
+          "id": 16,
+          "uniq_id": 138,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core16"
+          }
+        }
+      },
+      {
+        "id": "139",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core17",
+          "id": 17,
+          "uniq_id": 139,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core17"
+          }
+        }
+      },
+      {
+        "id": "164",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu0",
+          "id": 0,
+          "uniq_id": 164,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/gpu0"
+          }
+        }
+      },
+      {
+        "id": "12",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket0",
+          "id": 0,
+          "uniq_id": 12,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0"
+          }
+        }
+      },
+      {
+        "id": "140",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core18",
+          "id": 18,
+          "uniq_id": 140,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core18"
+          }
+        }
+      },
+      {
+        "id": "141",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core19",
+          "id": 19,
+          "uniq_id": 141,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core19"
+          }
+        }
+      },
+      {
+        "id": "142",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core20",
+          "id": 20,
+          "uniq_id": 142,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core20"
+          }
+        }
+      },
+      {
+        "id": "143",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core21",
+          "id": 21,
+          "uniq_id": 143,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core21"
+          }
+        }
+      },
+      {
+        "id": "144",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core22",
+          "id": 22,
+          "uniq_id": 144,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core22"
+          }
+        }
+      },
+      {
+        "id": "145",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core23",
+          "id": 23,
+          "uniq_id": 145,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core23"
+          }
+        }
+      },
+      {
+        "id": "146",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core24",
+          "id": 24,
+          "uniq_id": 146,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core24"
+          }
+        }
+      },
+      {
+        "id": "147",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core25",
+          "id": 25,
+          "uniq_id": 147,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core25"
+          }
+        }
+      },
+      {
+        "id": "148",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core26",
+          "id": 26,
+          "uniq_id": 148,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core26"
+          }
+        }
+      },
+      {
+        "id": "149",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core27",
+          "id": 27,
+          "uniq_id": 149,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core27"
+          }
+        }
+      },
+      {
+        "id": "150",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core28",
+          "id": 28,
+          "uniq_id": 150,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core28"
+          }
+        }
+      },
+      {
+        "id": "151",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core29",
+          "id": 29,
+          "uniq_id": 151,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core29"
+          }
+        }
+      },
+      {
+        "id": "152",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core30",
+          "id": 30,
+          "uniq_id": 152,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core30"
+          }
+        }
+      },
+      {
+        "id": "153",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core31",
+          "id": 31,
+          "uniq_id": 153,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core31"
+          }
+        }
+      },
+      {
+        "id": "154",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core32",
+          "id": 32,
+          "uniq_id": 154,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core32"
+          }
+        }
+      },
+      {
+        "id": "155",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core33",
+          "id": 33,
+          "uniq_id": 155,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core33"
+          }
+        }
+      },
+      {
+        "id": "156",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core34",
+          "id": 34,
+          "uniq_id": 156,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core34"
+          }
+        }
+      },
+      {
+        "id": "157",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core35",
+          "id": 35,
+          "uniq_id": 157,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core35"
+          }
+        }
+      },
+      {
+        "id": "165",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu1",
+          "id": 1,
+          "uniq_id": 165,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/gpu1"
+          }
+        }
+      },
+      {
+        "id": "13",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket1",
+          "id": 1,
+          "uniq_id": 13,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1"
+          }
+        }
+      },
+      {
+        "id": "5",
+        "metadata": {
+          "type": "node",
+          "basename": "node",
+          "name": "node3",
+          "id": 3,
+          "uniq_id": 5,
+          "rank": 3,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3"
+          }
+        }
+      },
+      {
+        "id": "1",
+        "metadata": {
+          "type": "rack",
+          "basename": "rack",
+          "name": "rack0",
+          "id": 0,
+          "uniq_id": 1,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0"
+          }
+        }
+      },
+      {
+        "id": "0",
+        "metadata": {
+          "type": "cluster",
+          "basename": "tiny++",
+          "name": "tiny++0",
+          "id": 0,
+          "uniq_id": 0,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0"
+          }
+        }
+      }
+    ],
+    "edges": [
+      {
+        "source": "6",
+        "target": "14",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "15",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "16",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "17",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "18",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "19",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "20",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "21",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "22",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "23",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "24",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "25",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "26",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "27",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "28",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "29",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "30",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "31",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "158",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "2",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "32",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "33",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "34",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "35",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "36",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "37",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "38",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "39",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "40",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "41",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "42",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "43",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "44",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "45",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "46",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "47",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "48",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "49",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "159",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "2",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "1",
+        "target": "2",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "50",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "51",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "52",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "53",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "54",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "55",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "56",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "57",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "58",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "59",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "60",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "61",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "62",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "63",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "64",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "65",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "66",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "67",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "160",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "3",
+        "target": "8",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "68",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "69",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "70",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "71",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "72",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "73",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "74",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "75",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "76",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "77",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "78",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "79",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "80",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "81",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "82",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "83",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "84",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "85",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "161",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "3",
+        "target": "9",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "1",
+        "target": "3",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "86",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "87",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "88",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "89",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "90",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "91",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "92",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "93",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "94",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "95",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "96",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "97",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "98",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "99",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "100",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "101",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "102",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "103",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "162",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "10",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "104",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "105",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "106",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "107",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "108",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "109",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "110",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "111",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "112",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "113",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "114",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "115",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "116",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "117",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "118",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "119",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "120",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "121",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "163",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "11",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "1",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "122",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "123",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "124",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "125",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "126",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "127",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "128",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "129",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "130",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "131",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "132",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "133",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "134",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "135",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "136",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "137",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "138",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "139",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "164",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "12",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "140",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "141",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "142",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "143",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "144",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "145",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "146",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "147",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "148",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "149",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "150",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "151",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "152",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "153",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "154",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "155",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "156",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "157",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "165",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "13",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "1",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "0",
+        "target": "1",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/t/data/resource/jgfs/4node.rank0123.nid0123.orig.json
+++ b/t/data/resource/jgfs/4node.rank0123.nid0123.orig.json
@@ -1,0 +1,4315 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "14",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core0",
+          "id": 0,
+          "uniq_id": 14,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core0"
+          }
+        }
+      },
+      {
+        "id": "15",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core1",
+          "id": 1,
+          "uniq_id": 15,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core1"
+          }
+        }
+      },
+      {
+        "id": "16",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core2",
+          "id": 2,
+          "uniq_id": 16,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core2"
+          }
+        }
+      },
+      {
+        "id": "17",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core3",
+          "id": 3,
+          "uniq_id": 17,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core3"
+          }
+        }
+      },
+      {
+        "id": "18",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core4",
+          "id": 4,
+          "uniq_id": 18,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core4"
+          }
+        }
+      },
+      {
+        "id": "19",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core5",
+          "id": 5,
+          "uniq_id": 19,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core5"
+          }
+        }
+      },
+      {
+        "id": "20",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core6",
+          "id": 6,
+          "uniq_id": 20,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core6"
+          }
+        }
+      },
+      {
+        "id": "21",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core7",
+          "id": 7,
+          "uniq_id": 21,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core7"
+          }
+        }
+      },
+      {
+        "id": "22",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core8",
+          "id": 8,
+          "uniq_id": 22,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core8"
+          }
+        }
+      },
+      {
+        "id": "23",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core9",
+          "id": 9,
+          "uniq_id": 23,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core9"
+          }
+        }
+      },
+      {
+        "id": "24",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core10",
+          "id": 10,
+          "uniq_id": 24,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core10"
+          }
+        }
+      },
+      {
+        "id": "25",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core11",
+          "id": 11,
+          "uniq_id": 25,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core11"
+          }
+        }
+      },
+      {
+        "id": "26",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core12",
+          "id": 12,
+          "uniq_id": 26,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core12"
+          }
+        }
+      },
+      {
+        "id": "27",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core13",
+          "id": 13,
+          "uniq_id": 27,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core13"
+          }
+        }
+      },
+      {
+        "id": "28",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core14",
+          "id": 14,
+          "uniq_id": 28,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core14"
+          }
+        }
+      },
+      {
+        "id": "29",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core15",
+          "id": 15,
+          "uniq_id": 29,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core15"
+          }
+        }
+      },
+      {
+        "id": "30",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core16",
+          "id": 16,
+          "uniq_id": 30,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core16"
+          }
+        }
+      },
+      {
+        "id": "31",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core17",
+          "id": 17,
+          "uniq_id": 31,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core17"
+          }
+        }
+      },
+      {
+        "id": "158",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu0",
+          "id": 0,
+          "uniq_id": 158,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/gpu0"
+          }
+        }
+      },
+      {
+        "id": "6",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket0",
+          "id": 0,
+          "uniq_id": 6,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0"
+          }
+        }
+      },
+      {
+        "id": "32",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core18",
+          "id": 18,
+          "uniq_id": 32,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core18"
+          }
+        }
+      },
+      {
+        "id": "33",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core19",
+          "id": 19,
+          "uniq_id": 33,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core19"
+          }
+        }
+      },
+      {
+        "id": "34",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core20",
+          "id": 20,
+          "uniq_id": 34,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core20"
+          }
+        }
+      },
+      {
+        "id": "35",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core21",
+          "id": 21,
+          "uniq_id": 35,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core21"
+          }
+        }
+      },
+      {
+        "id": "36",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core22",
+          "id": 22,
+          "uniq_id": 36,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core22"
+          }
+        }
+      },
+      {
+        "id": "37",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core23",
+          "id": 23,
+          "uniq_id": 37,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core23"
+          }
+        }
+      },
+      {
+        "id": "38",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core24",
+          "id": 24,
+          "uniq_id": 38,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core24"
+          }
+        }
+      },
+      {
+        "id": "39",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core25",
+          "id": 25,
+          "uniq_id": 39,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core25"
+          }
+        }
+      },
+      {
+        "id": "40",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core26",
+          "id": 26,
+          "uniq_id": 40,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core26"
+          }
+        }
+      },
+      {
+        "id": "41",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core27",
+          "id": 27,
+          "uniq_id": 41,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core27"
+          }
+        }
+      },
+      {
+        "id": "42",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core28",
+          "id": 28,
+          "uniq_id": 42,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core28"
+          }
+        }
+      },
+      {
+        "id": "43",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core29",
+          "id": 29,
+          "uniq_id": 43,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core29"
+          }
+        }
+      },
+      {
+        "id": "44",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core30",
+          "id": 30,
+          "uniq_id": 44,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core30"
+          }
+        }
+      },
+      {
+        "id": "45",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core31",
+          "id": 31,
+          "uniq_id": 45,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core31"
+          }
+        }
+      },
+      {
+        "id": "46",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core32",
+          "id": 32,
+          "uniq_id": 46,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core32"
+          }
+        }
+      },
+      {
+        "id": "47",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core33",
+          "id": 33,
+          "uniq_id": 47,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core33"
+          }
+        }
+      },
+      {
+        "id": "48",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core34",
+          "id": 34,
+          "uniq_id": 48,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core34"
+          }
+        }
+      },
+      {
+        "id": "49",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core35",
+          "id": 35,
+          "uniq_id": 49,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core35"
+          }
+        }
+      },
+      {
+        "id": "159",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu1",
+          "id": 1,
+          "uniq_id": 159,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/gpu1"
+          }
+        }
+      },
+      {
+        "id": "7",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket1",
+          "id": 1,
+          "uniq_id": 7,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1"
+          }
+        }
+      },
+      {
+        "id": "2",
+        "metadata": {
+          "type": "node",
+          "basename": "node",
+          "name": "node0",
+          "id": 0,
+          "uniq_id": 2,
+          "rank": 0,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0"
+          }
+        }
+      },
+      {
+        "id": "50",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core0",
+          "id": 0,
+          "uniq_id": 50,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core0"
+          }
+        }
+      },
+      {
+        "id": "51",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core1",
+          "id": 1,
+          "uniq_id": 51,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core1"
+          }
+        }
+      },
+      {
+        "id": "52",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core2",
+          "id": 2,
+          "uniq_id": 52,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core2"
+          }
+        }
+      },
+      {
+        "id": "53",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core3",
+          "id": 3,
+          "uniq_id": 53,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core3"
+          }
+        }
+      },
+      {
+        "id": "54",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core4",
+          "id": 4,
+          "uniq_id": 54,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core4"
+          }
+        }
+      },
+      {
+        "id": "55",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core5",
+          "id": 5,
+          "uniq_id": 55,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core5"
+          }
+        }
+      },
+      {
+        "id": "56",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core6",
+          "id": 6,
+          "uniq_id": 56,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core6"
+          }
+        }
+      },
+      {
+        "id": "57",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core7",
+          "id": 7,
+          "uniq_id": 57,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core7"
+          }
+        }
+      },
+      {
+        "id": "58",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core8",
+          "id": 8,
+          "uniq_id": 58,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core8"
+          }
+        }
+      },
+      {
+        "id": "59",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core9",
+          "id": 9,
+          "uniq_id": 59,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core9"
+          }
+        }
+      },
+      {
+        "id": "60",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core10",
+          "id": 10,
+          "uniq_id": 60,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core10"
+          }
+        }
+      },
+      {
+        "id": "61",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core11",
+          "id": 11,
+          "uniq_id": 61,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core11"
+          }
+        }
+      },
+      {
+        "id": "62",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core12",
+          "id": 12,
+          "uniq_id": 62,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core12"
+          }
+        }
+      },
+      {
+        "id": "63",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core13",
+          "id": 13,
+          "uniq_id": 63,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core13"
+          }
+        }
+      },
+      {
+        "id": "64",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core14",
+          "id": 14,
+          "uniq_id": 64,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core14"
+          }
+        }
+      },
+      {
+        "id": "65",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core15",
+          "id": 15,
+          "uniq_id": 65,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core15"
+          }
+        }
+      },
+      {
+        "id": "66",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core16",
+          "id": 16,
+          "uniq_id": 66,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core16"
+          }
+        }
+      },
+      {
+        "id": "67",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core17",
+          "id": 17,
+          "uniq_id": 67,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core17"
+          }
+        }
+      },
+      {
+        "id": "160",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu0",
+          "id": 0,
+          "uniq_id": 160,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/gpu0"
+          }
+        }
+      },
+      {
+        "id": "8",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket0",
+          "id": 0,
+          "uniq_id": 8,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0"
+          }
+        }
+      },
+      {
+        "id": "68",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core18",
+          "id": 18,
+          "uniq_id": 68,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core18"
+          }
+        }
+      },
+      {
+        "id": "69",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core19",
+          "id": 19,
+          "uniq_id": 69,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core19"
+          }
+        }
+      },
+      {
+        "id": "70",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core20",
+          "id": 20,
+          "uniq_id": 70,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core20"
+          }
+        }
+      },
+      {
+        "id": "71",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core21",
+          "id": 21,
+          "uniq_id": 71,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core21"
+          }
+        }
+      },
+      {
+        "id": "72",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core22",
+          "id": 22,
+          "uniq_id": 72,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core22"
+          }
+        }
+      },
+      {
+        "id": "73",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core23",
+          "id": 23,
+          "uniq_id": 73,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core23"
+          }
+        }
+      },
+      {
+        "id": "74",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core24",
+          "id": 24,
+          "uniq_id": 74,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core24"
+          }
+        }
+      },
+      {
+        "id": "75",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core25",
+          "id": 25,
+          "uniq_id": 75,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core25"
+          }
+        }
+      },
+      {
+        "id": "76",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core26",
+          "id": 26,
+          "uniq_id": 76,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core26"
+          }
+        }
+      },
+      {
+        "id": "77",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core27",
+          "id": 27,
+          "uniq_id": 77,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core27"
+          }
+        }
+      },
+      {
+        "id": "78",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core28",
+          "id": 28,
+          "uniq_id": 78,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core28"
+          }
+        }
+      },
+      {
+        "id": "79",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core29",
+          "id": 29,
+          "uniq_id": 79,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core29"
+          }
+        }
+      },
+      {
+        "id": "80",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core30",
+          "id": 30,
+          "uniq_id": 80,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core30"
+          }
+        }
+      },
+      {
+        "id": "81",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core31",
+          "id": 31,
+          "uniq_id": 81,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core31"
+          }
+        }
+      },
+      {
+        "id": "82",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core32",
+          "id": 32,
+          "uniq_id": 82,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core32"
+          }
+        }
+      },
+      {
+        "id": "83",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core33",
+          "id": 33,
+          "uniq_id": 83,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core33"
+          }
+        }
+      },
+      {
+        "id": "84",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core34",
+          "id": 34,
+          "uniq_id": 84,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core34"
+          }
+        }
+      },
+      {
+        "id": "85",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core35",
+          "id": 35,
+          "uniq_id": 85,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core35"
+          }
+        }
+      },
+      {
+        "id": "161",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu1",
+          "id": 1,
+          "uniq_id": 161,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/gpu1"
+          }
+        }
+      },
+      {
+        "id": "9",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket1",
+          "id": 1,
+          "uniq_id": 9,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1"
+          }
+        }
+      },
+      {
+        "id": "3",
+        "metadata": {
+          "type": "node",
+          "basename": "node",
+          "name": "node1",
+          "id": 1,
+          "uniq_id": 3,
+          "rank": 1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1"
+          }
+        }
+      },
+      {
+        "id": "86",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core0",
+          "id": 0,
+          "uniq_id": 86,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core0"
+          }
+        }
+      },
+      {
+        "id": "87",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core1",
+          "id": 1,
+          "uniq_id": 87,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core1"
+          }
+        }
+      },
+      {
+        "id": "88",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core2",
+          "id": 2,
+          "uniq_id": 88,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core2"
+          }
+        }
+      },
+      {
+        "id": "89",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core3",
+          "id": 3,
+          "uniq_id": 89,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core3"
+          }
+        }
+      },
+      {
+        "id": "90",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core4",
+          "id": 4,
+          "uniq_id": 90,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core4"
+          }
+        }
+      },
+      {
+        "id": "91",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core5",
+          "id": 5,
+          "uniq_id": 91,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core5"
+          }
+        }
+      },
+      {
+        "id": "92",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core6",
+          "id": 6,
+          "uniq_id": 92,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core6"
+          }
+        }
+      },
+      {
+        "id": "93",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core7",
+          "id": 7,
+          "uniq_id": 93,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core7"
+          }
+        }
+      },
+      {
+        "id": "94",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core8",
+          "id": 8,
+          "uniq_id": 94,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core8"
+          }
+        }
+      },
+      {
+        "id": "95",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core9",
+          "id": 9,
+          "uniq_id": 95,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core9"
+          }
+        }
+      },
+      {
+        "id": "96",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core10",
+          "id": 10,
+          "uniq_id": 96,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core10"
+          }
+        }
+      },
+      {
+        "id": "97",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core11",
+          "id": 11,
+          "uniq_id": 97,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core11"
+          }
+        }
+      },
+      {
+        "id": "98",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core12",
+          "id": 12,
+          "uniq_id": 98,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core12"
+          }
+        }
+      },
+      {
+        "id": "99",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core13",
+          "id": 13,
+          "uniq_id": 99,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core13"
+          }
+        }
+      },
+      {
+        "id": "100",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core14",
+          "id": 14,
+          "uniq_id": 100,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core14"
+          }
+        }
+      },
+      {
+        "id": "101",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core15",
+          "id": 15,
+          "uniq_id": 101,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core15"
+          }
+        }
+      },
+      {
+        "id": "102",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core16",
+          "id": 16,
+          "uniq_id": 102,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core16"
+          }
+        }
+      },
+      {
+        "id": "103",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core17",
+          "id": 17,
+          "uniq_id": 103,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core17"
+          }
+        }
+      },
+      {
+        "id": "162",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu0",
+          "id": 0,
+          "uniq_id": 162,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/gpu0"
+          }
+        }
+      },
+      {
+        "id": "10",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket0",
+          "id": 0,
+          "uniq_id": 10,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0"
+          }
+        }
+      },
+      {
+        "id": "104",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core18",
+          "id": 18,
+          "uniq_id": 104,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core18"
+          }
+        }
+      },
+      {
+        "id": "105",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core19",
+          "id": 19,
+          "uniq_id": 105,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core19"
+          }
+        }
+      },
+      {
+        "id": "106",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core20",
+          "id": 20,
+          "uniq_id": 106,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core20"
+          }
+        }
+      },
+      {
+        "id": "107",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core21",
+          "id": 21,
+          "uniq_id": 107,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core21"
+          }
+        }
+      },
+      {
+        "id": "108",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core22",
+          "id": 22,
+          "uniq_id": 108,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core22"
+          }
+        }
+      },
+      {
+        "id": "109",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core23",
+          "id": 23,
+          "uniq_id": 109,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core23"
+          }
+        }
+      },
+      {
+        "id": "110",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core24",
+          "id": 24,
+          "uniq_id": 110,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core24"
+          }
+        }
+      },
+      {
+        "id": "111",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core25",
+          "id": 25,
+          "uniq_id": 111,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core25"
+          }
+        }
+      },
+      {
+        "id": "112",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core26",
+          "id": 26,
+          "uniq_id": 112,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core26"
+          }
+        }
+      },
+      {
+        "id": "113",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core27",
+          "id": 27,
+          "uniq_id": 113,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core27"
+          }
+        }
+      },
+      {
+        "id": "114",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core28",
+          "id": 28,
+          "uniq_id": 114,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core28"
+          }
+        }
+      },
+      {
+        "id": "115",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core29",
+          "id": 29,
+          "uniq_id": 115,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core29"
+          }
+        }
+      },
+      {
+        "id": "116",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core30",
+          "id": 30,
+          "uniq_id": 116,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core30"
+          }
+        }
+      },
+      {
+        "id": "117",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core31",
+          "id": 31,
+          "uniq_id": 117,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core31"
+          }
+        }
+      },
+      {
+        "id": "118",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core32",
+          "id": 32,
+          "uniq_id": 118,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core32"
+          }
+        }
+      },
+      {
+        "id": "119",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core33",
+          "id": 33,
+          "uniq_id": 119,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core33"
+          }
+        }
+      },
+      {
+        "id": "120",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core34",
+          "id": 34,
+          "uniq_id": 120,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core34"
+          }
+        }
+      },
+      {
+        "id": "121",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core35",
+          "id": 35,
+          "uniq_id": 121,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core35"
+          }
+        }
+      },
+      {
+        "id": "163",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu1",
+          "id": 1,
+          "uniq_id": 163,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/gpu1"
+          }
+        }
+      },
+      {
+        "id": "11",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket1",
+          "id": 1,
+          "uniq_id": 11,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1"
+          }
+        }
+      },
+      {
+        "id": "4",
+        "metadata": {
+          "type": "node",
+          "basename": "node",
+          "name": "node2",
+          "id": 2,
+          "uniq_id": 4,
+          "rank": 2,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2"
+          }
+        }
+      },
+      {
+        "id": "122",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core0",
+          "id": 0,
+          "uniq_id": 122,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core0"
+          }
+        }
+      },
+      {
+        "id": "123",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core1",
+          "id": 1,
+          "uniq_id": 123,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core1"
+          }
+        }
+      },
+      {
+        "id": "124",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core2",
+          "id": 2,
+          "uniq_id": 124,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core2"
+          }
+        }
+      },
+      {
+        "id": "125",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core3",
+          "id": 3,
+          "uniq_id": 125,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core3"
+          }
+        }
+      },
+      {
+        "id": "126",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core4",
+          "id": 4,
+          "uniq_id": 126,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core4"
+          }
+        }
+      },
+      {
+        "id": "127",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core5",
+          "id": 5,
+          "uniq_id": 127,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core5"
+          }
+        }
+      },
+      {
+        "id": "128",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core6",
+          "id": 6,
+          "uniq_id": 128,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core6"
+          }
+        }
+      },
+      {
+        "id": "129",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core7",
+          "id": 7,
+          "uniq_id": 129,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core7"
+          }
+        }
+      },
+      {
+        "id": "130",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core8",
+          "id": 8,
+          "uniq_id": 130,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core8"
+          }
+        }
+      },
+      {
+        "id": "131",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core9",
+          "id": 9,
+          "uniq_id": 131,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core9"
+          }
+        }
+      },
+      {
+        "id": "132",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core10",
+          "id": 10,
+          "uniq_id": 132,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core10"
+          }
+        }
+      },
+      {
+        "id": "133",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core11",
+          "id": 11,
+          "uniq_id": 133,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core11"
+          }
+        }
+      },
+      {
+        "id": "134",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core12",
+          "id": 12,
+          "uniq_id": 134,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core12"
+          }
+        }
+      },
+      {
+        "id": "135",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core13",
+          "id": 13,
+          "uniq_id": 135,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core13"
+          }
+        }
+      },
+      {
+        "id": "136",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core14",
+          "id": 14,
+          "uniq_id": 136,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core14"
+          }
+        }
+      },
+      {
+        "id": "137",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core15",
+          "id": 15,
+          "uniq_id": 137,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core15"
+          }
+        }
+      },
+      {
+        "id": "138",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core16",
+          "id": 16,
+          "uniq_id": 138,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core16"
+          }
+        }
+      },
+      {
+        "id": "139",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core17",
+          "id": 17,
+          "uniq_id": 139,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core17"
+          }
+        }
+      },
+      {
+        "id": "164",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu0",
+          "id": 0,
+          "uniq_id": 164,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/gpu0"
+          }
+        }
+      },
+      {
+        "id": "12",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket0",
+          "id": 0,
+          "uniq_id": 12,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0"
+          }
+        }
+      },
+      {
+        "id": "140",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core18",
+          "id": 18,
+          "uniq_id": 140,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core18"
+          }
+        }
+      },
+      {
+        "id": "141",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core19",
+          "id": 19,
+          "uniq_id": 141,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core19"
+          }
+        }
+      },
+      {
+        "id": "142",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core20",
+          "id": 20,
+          "uniq_id": 142,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core20"
+          }
+        }
+      },
+      {
+        "id": "143",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core21",
+          "id": 21,
+          "uniq_id": 143,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core21"
+          }
+        }
+      },
+      {
+        "id": "144",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core22",
+          "id": 22,
+          "uniq_id": 144,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core22"
+          }
+        }
+      },
+      {
+        "id": "145",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core23",
+          "id": 23,
+          "uniq_id": 145,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core23"
+          }
+        }
+      },
+      {
+        "id": "146",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core24",
+          "id": 24,
+          "uniq_id": 146,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core24"
+          }
+        }
+      },
+      {
+        "id": "147",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core25",
+          "id": 25,
+          "uniq_id": 147,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core25"
+          }
+        }
+      },
+      {
+        "id": "148",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core26",
+          "id": 26,
+          "uniq_id": 148,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core26"
+          }
+        }
+      },
+      {
+        "id": "149",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core27",
+          "id": 27,
+          "uniq_id": 149,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core27"
+          }
+        }
+      },
+      {
+        "id": "150",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core28",
+          "id": 28,
+          "uniq_id": 150,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core28"
+          }
+        }
+      },
+      {
+        "id": "151",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core29",
+          "id": 29,
+          "uniq_id": 151,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core29"
+          }
+        }
+      },
+      {
+        "id": "152",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core30",
+          "id": 30,
+          "uniq_id": 152,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core30"
+          }
+        }
+      },
+      {
+        "id": "153",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core31",
+          "id": 31,
+          "uniq_id": 153,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core31"
+          }
+        }
+      },
+      {
+        "id": "154",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core32",
+          "id": 32,
+          "uniq_id": 154,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core32"
+          }
+        }
+      },
+      {
+        "id": "155",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core33",
+          "id": 33,
+          "uniq_id": 155,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core33"
+          }
+        }
+      },
+      {
+        "id": "156",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core34",
+          "id": 34,
+          "uniq_id": 156,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core34"
+          }
+        }
+      },
+      {
+        "id": "157",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core35",
+          "id": 35,
+          "uniq_id": 157,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core35"
+          }
+        }
+      },
+      {
+        "id": "165",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu1",
+          "id": 1,
+          "uniq_id": 165,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/gpu1"
+          }
+        }
+      },
+      {
+        "id": "13",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket1",
+          "id": 1,
+          "uniq_id": 13,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1"
+          }
+        }
+      },
+      {
+        "id": "5",
+        "metadata": {
+          "type": "node",
+          "basename": "node",
+          "name": "node3",
+          "id": 3,
+          "uniq_id": 5,
+          "rank": 3,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3"
+          }
+        }
+      },
+      {
+        "id": "1",
+        "metadata": {
+          "type": "rack",
+          "basename": "rack",
+          "name": "rack0",
+          "id": 0,
+          "uniq_id": 1,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0"
+          }
+        }
+      },
+      {
+        "id": "0",
+        "metadata": {
+          "type": "cluster",
+          "basename": "tiny++",
+          "name": "tiny++0",
+          "id": 0,
+          "uniq_id": 0,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0"
+          }
+        }
+      }
+    ],
+    "edges": [
+      {
+        "source": "6",
+        "target": "14",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "15",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "16",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "17",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "18",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "19",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "20",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "21",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "22",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "23",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "24",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "25",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "26",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "27",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "28",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "29",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "30",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "31",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "158",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "2",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "32",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "33",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "34",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "35",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "36",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "37",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "38",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "39",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "40",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "41",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "42",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "43",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "44",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "45",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "46",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "47",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "48",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "49",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "159",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "2",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "1",
+        "target": "2",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "50",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "51",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "52",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "53",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "54",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "55",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "56",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "57",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "58",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "59",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "60",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "61",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "62",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "63",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "64",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "65",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "66",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "67",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "160",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "3",
+        "target": "8",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "68",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "69",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "70",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "71",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "72",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "73",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "74",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "75",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "76",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "77",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "78",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "79",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "80",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "81",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "82",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "83",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "84",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "85",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "161",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "3",
+        "target": "9",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "1",
+        "target": "3",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "86",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "87",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "88",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "89",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "90",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "91",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "92",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "93",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "94",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "95",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "96",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "97",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "98",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "99",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "100",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "101",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "102",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "103",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "162",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "10",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "104",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "105",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "106",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "107",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "108",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "109",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "110",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "111",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "112",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "113",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "114",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "115",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "116",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "117",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "118",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "119",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "120",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "121",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "163",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "11",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "1",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "122",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "123",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "124",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "125",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "126",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "127",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "128",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "129",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "130",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "131",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "132",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "133",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "134",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "135",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "136",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "137",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "138",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "139",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "164",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "12",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "140",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "141",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "142",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "143",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "144",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "145",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "146",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "147",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "148",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "149",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "150",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "151",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "152",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "153",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "154",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "155",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "156",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "157",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "165",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "13",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "1",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "0",
+        "target": "1",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/t/data/resource/jgfs/4node.rank1230.nid0123.mod.json
+++ b/t/data/resource/jgfs/4node.rank1230.nid0123.mod.json
@@ -1,0 +1,4315 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "14",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core0",
+          "id": 100,
+          "uniq_id": 14,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core0"
+          }
+        }
+      },
+      {
+        "id": "15",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core1",
+          "id": 1,
+          "uniq_id": 15,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core1"
+          }
+        }
+      },
+      {
+        "id": "16",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core2",
+          "id": 2,
+          "uniq_id": 16,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core2"
+          }
+        }
+      },
+      {
+        "id": "17",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core3",
+          "id": 3,
+          "uniq_id": 17,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core3"
+          }
+        }
+      },
+      {
+        "id": "18",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core4",
+          "id": 4,
+          "uniq_id": 18,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core4"
+          }
+        }
+      },
+      {
+        "id": "19",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core5",
+          "id": 5,
+          "uniq_id": 19,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core5"
+          }
+        }
+      },
+      {
+        "id": "20",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core6",
+          "id": 6,
+          "uniq_id": 20,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core6"
+          }
+        }
+      },
+      {
+        "id": "21",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core7",
+          "id": 7,
+          "uniq_id": 21,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core7"
+          }
+        }
+      },
+      {
+        "id": "22",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core8",
+          "id": 8,
+          "uniq_id": 22,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core8"
+          }
+        }
+      },
+      {
+        "id": "23",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core9",
+          "id": 9,
+          "uniq_id": 23,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core9"
+          }
+        }
+      },
+      {
+        "id": "24",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core10",
+          "id": 10,
+          "uniq_id": 24,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core10"
+          }
+        }
+      },
+      {
+        "id": "25",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core11",
+          "id": 11,
+          "uniq_id": 25,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core11"
+          }
+        }
+      },
+      {
+        "id": "26",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core12",
+          "id": 12,
+          "uniq_id": 26,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core12"
+          }
+        }
+      },
+      {
+        "id": "27",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core13",
+          "id": 13,
+          "uniq_id": 27,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core13"
+          }
+        }
+      },
+      {
+        "id": "28",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core14",
+          "id": 14,
+          "uniq_id": 28,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core14"
+          }
+        }
+      },
+      {
+        "id": "29",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core15",
+          "id": 15,
+          "uniq_id": 29,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core15"
+          }
+        }
+      },
+      {
+        "id": "30",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core16",
+          "id": 16,
+          "uniq_id": 30,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core16"
+          }
+        }
+      },
+      {
+        "id": "31",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core17",
+          "id": 17,
+          "uniq_id": 31,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/core17"
+          }
+        }
+      },
+      {
+        "id": "158",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu0",
+          "id": 0,
+          "uniq_id": 158,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0/gpu0"
+          }
+        }
+      },
+      {
+        "id": "6",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket0",
+          "id": 0,
+          "uniq_id": 6,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket0"
+          }
+        }
+      },
+      {
+        "id": "32",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core18",
+          "id": 18,
+          "uniq_id": 32,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core18"
+          }
+        }
+      },
+      {
+        "id": "33",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core19",
+          "id": 19,
+          "uniq_id": 33,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core19"
+          }
+        }
+      },
+      {
+        "id": "34",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core20",
+          "id": 20,
+          "uniq_id": 34,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core20"
+          }
+        }
+      },
+      {
+        "id": "35",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core21",
+          "id": 21,
+          "uniq_id": 35,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core21"
+          }
+        }
+      },
+      {
+        "id": "36",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core22",
+          "id": 22,
+          "uniq_id": 36,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core22"
+          }
+        }
+      },
+      {
+        "id": "37",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core23",
+          "id": 23,
+          "uniq_id": 37,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core23"
+          }
+        }
+      },
+      {
+        "id": "38",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core24",
+          "id": 24,
+          "uniq_id": 38,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core24"
+          }
+        }
+      },
+      {
+        "id": "39",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core25",
+          "id": 25,
+          "uniq_id": 39,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core25"
+          }
+        }
+      },
+      {
+        "id": "40",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core26",
+          "id": 26,
+          "uniq_id": 40,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core26"
+          }
+        }
+      },
+      {
+        "id": "41",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core27",
+          "id": 27,
+          "uniq_id": 41,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core27"
+          }
+        }
+      },
+      {
+        "id": "42",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core28",
+          "id": 28,
+          "uniq_id": 42,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core28"
+          }
+        }
+      },
+      {
+        "id": "43",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core29",
+          "id": 29,
+          "uniq_id": 43,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core29"
+          }
+        }
+      },
+      {
+        "id": "44",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core30",
+          "id": 30,
+          "uniq_id": 44,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core30"
+          }
+        }
+      },
+      {
+        "id": "45",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core31",
+          "id": 31,
+          "uniq_id": 45,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core31"
+          }
+        }
+      },
+      {
+        "id": "46",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core32",
+          "id": 32,
+          "uniq_id": 46,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core32"
+          }
+        }
+      },
+      {
+        "id": "47",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core33",
+          "id": 33,
+          "uniq_id": 47,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core33"
+          }
+        }
+      },
+      {
+        "id": "48",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core34",
+          "id": 34,
+          "uniq_id": 48,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core34"
+          }
+        }
+      },
+      {
+        "id": "49",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core35",
+          "id": 35,
+          "uniq_id": 49,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/core35"
+          }
+        }
+      },
+      {
+        "id": "159",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu1",
+          "id": 1,
+          "uniq_id": 159,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1/gpu1"
+          }
+        }
+      },
+      {
+        "id": "7",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket1",
+          "id": 1,
+          "uniq_id": 7,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0/socket1"
+          }
+        }
+      },
+      {
+        "id": "2",
+        "metadata": {
+          "type": "node",
+          "basename": "node",
+          "name": "node0",
+          "id": 0,
+          "uniq_id": 2,
+          "rank": 1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node0"
+          }
+        }
+      },
+      {
+        "id": "50",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core0",
+          "id": 0,
+          "uniq_id": 50,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core0"
+          }
+        }
+      },
+      {
+        "id": "51",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core1",
+          "id": 1,
+          "uniq_id": 51,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core1"
+          }
+        }
+      },
+      {
+        "id": "52",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core2",
+          "id": 2,
+          "uniq_id": 52,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core2"
+          }
+        }
+      },
+      {
+        "id": "53",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core3",
+          "id": 3,
+          "uniq_id": 53,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core3"
+          }
+        }
+      },
+      {
+        "id": "54",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core4",
+          "id": 4,
+          "uniq_id": 54,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core4"
+          }
+        }
+      },
+      {
+        "id": "55",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core5",
+          "id": 5,
+          "uniq_id": 55,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core5"
+          }
+        }
+      },
+      {
+        "id": "56",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core6",
+          "id": 6,
+          "uniq_id": 56,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core6"
+          }
+        }
+      },
+      {
+        "id": "57",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core7",
+          "id": 7,
+          "uniq_id": 57,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core7"
+          }
+        }
+      },
+      {
+        "id": "58",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core8",
+          "id": 8,
+          "uniq_id": 58,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core8"
+          }
+        }
+      },
+      {
+        "id": "59",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core9",
+          "id": 9,
+          "uniq_id": 59,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core9"
+          }
+        }
+      },
+      {
+        "id": "60",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core10",
+          "id": 10,
+          "uniq_id": 60,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core10"
+          }
+        }
+      },
+      {
+        "id": "61",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core11",
+          "id": 11,
+          "uniq_id": 61,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core11"
+          }
+        }
+      },
+      {
+        "id": "62",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core12",
+          "id": 12,
+          "uniq_id": 62,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core12"
+          }
+        }
+      },
+      {
+        "id": "63",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core13",
+          "id": 13,
+          "uniq_id": 63,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core13"
+          }
+        }
+      },
+      {
+        "id": "64",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core14",
+          "id": 14,
+          "uniq_id": 64,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core14"
+          }
+        }
+      },
+      {
+        "id": "65",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core15",
+          "id": 15,
+          "uniq_id": 65,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core15"
+          }
+        }
+      },
+      {
+        "id": "66",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core16",
+          "id": 16,
+          "uniq_id": 66,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core16"
+          }
+        }
+      },
+      {
+        "id": "67",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core17",
+          "id": 17,
+          "uniq_id": 67,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/core17"
+          }
+        }
+      },
+      {
+        "id": "160",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu0",
+          "id": 0,
+          "uniq_id": 160,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0/gpu0"
+          }
+        }
+      },
+      {
+        "id": "8",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket0",
+          "id": 0,
+          "uniq_id": 8,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket0"
+          }
+        }
+      },
+      {
+        "id": "68",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core18",
+          "id": 18,
+          "uniq_id": 68,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core18"
+          }
+        }
+      },
+      {
+        "id": "69",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core19",
+          "id": 19,
+          "uniq_id": 69,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core19"
+          }
+        }
+      },
+      {
+        "id": "70",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core20",
+          "id": 20,
+          "uniq_id": 70,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core20"
+          }
+        }
+      },
+      {
+        "id": "71",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core21",
+          "id": 21,
+          "uniq_id": 71,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core21"
+          }
+        }
+      },
+      {
+        "id": "72",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core22",
+          "id": 22,
+          "uniq_id": 72,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core22"
+          }
+        }
+      },
+      {
+        "id": "73",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core23",
+          "id": 23,
+          "uniq_id": 73,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core23"
+          }
+        }
+      },
+      {
+        "id": "74",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core24",
+          "id": 24,
+          "uniq_id": 74,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core24"
+          }
+        }
+      },
+      {
+        "id": "75",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core25",
+          "id": 25,
+          "uniq_id": 75,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core25"
+          }
+        }
+      },
+      {
+        "id": "76",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core26",
+          "id": 26,
+          "uniq_id": 76,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core26"
+          }
+        }
+      },
+      {
+        "id": "77",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core27",
+          "id": 27,
+          "uniq_id": 77,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core27"
+          }
+        }
+      },
+      {
+        "id": "78",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core28",
+          "id": 28,
+          "uniq_id": 78,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core28"
+          }
+        }
+      },
+      {
+        "id": "79",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core29",
+          "id": 29,
+          "uniq_id": 79,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core29"
+          }
+        }
+      },
+      {
+        "id": "80",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core30",
+          "id": 30,
+          "uniq_id": 80,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core30"
+          }
+        }
+      },
+      {
+        "id": "81",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core31",
+          "id": 31,
+          "uniq_id": 81,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core31"
+          }
+        }
+      },
+      {
+        "id": "82",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core32",
+          "id": 32,
+          "uniq_id": 82,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core32"
+          }
+        }
+      },
+      {
+        "id": "83",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core33",
+          "id": 33,
+          "uniq_id": 83,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core33"
+          }
+        }
+      },
+      {
+        "id": "84",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core34",
+          "id": 34,
+          "uniq_id": 84,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core34"
+          }
+        }
+      },
+      {
+        "id": "85",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core35",
+          "id": 35,
+          "uniq_id": 85,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/core35"
+          }
+        }
+      },
+      {
+        "id": "161",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu1",
+          "id": 1,
+          "uniq_id": 161,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1/gpu1"
+          }
+        }
+      },
+      {
+        "id": "9",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket1",
+          "id": 1,
+          "uniq_id": 9,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1/socket1"
+          }
+        }
+      },
+      {
+        "id": "3",
+        "metadata": {
+          "type": "node",
+          "basename": "node",
+          "name": "node1",
+          "id": 1,
+          "uniq_id": 3,
+          "rank": 2,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node1"
+          }
+        }
+      },
+      {
+        "id": "86",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core0",
+          "id": 0,
+          "uniq_id": 86,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core0"
+          }
+        }
+      },
+      {
+        "id": "87",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core1",
+          "id": 1,
+          "uniq_id": 87,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core1"
+          }
+        }
+      },
+      {
+        "id": "88",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core2",
+          "id": 2,
+          "uniq_id": 88,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core2"
+          }
+        }
+      },
+      {
+        "id": "89",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core3",
+          "id": 3,
+          "uniq_id": 89,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core3"
+          }
+        }
+      },
+      {
+        "id": "90",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core4",
+          "id": 4,
+          "uniq_id": 90,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core4"
+          }
+        }
+      },
+      {
+        "id": "91",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core5",
+          "id": 5,
+          "uniq_id": 91,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core5"
+          }
+        }
+      },
+      {
+        "id": "92",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core6",
+          "id": 6,
+          "uniq_id": 92,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core6"
+          }
+        }
+      },
+      {
+        "id": "93",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core7",
+          "id": 7,
+          "uniq_id": 93,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core7"
+          }
+        }
+      },
+      {
+        "id": "94",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core8",
+          "id": 8,
+          "uniq_id": 94,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core8"
+          }
+        }
+      },
+      {
+        "id": "95",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core9",
+          "id": 9,
+          "uniq_id": 95,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core9"
+          }
+        }
+      },
+      {
+        "id": "96",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core10",
+          "id": 10,
+          "uniq_id": 96,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core10"
+          }
+        }
+      },
+      {
+        "id": "97",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core11",
+          "id": 11,
+          "uniq_id": 97,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core11"
+          }
+        }
+      },
+      {
+        "id": "98",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core12",
+          "id": 12,
+          "uniq_id": 98,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core12"
+          }
+        }
+      },
+      {
+        "id": "99",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core13",
+          "id": 13,
+          "uniq_id": 99,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core13"
+          }
+        }
+      },
+      {
+        "id": "100",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core14",
+          "id": 14,
+          "uniq_id": 100,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core14"
+          }
+        }
+      },
+      {
+        "id": "101",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core15",
+          "id": 15,
+          "uniq_id": 101,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core15"
+          }
+        }
+      },
+      {
+        "id": "102",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core16",
+          "id": 16,
+          "uniq_id": 102,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core16"
+          }
+        }
+      },
+      {
+        "id": "103",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core17",
+          "id": 17,
+          "uniq_id": 103,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/core17"
+          }
+        }
+      },
+      {
+        "id": "162",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu0",
+          "id": 0,
+          "uniq_id": 162,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0/gpu0"
+          }
+        }
+      },
+      {
+        "id": "10",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket0",
+          "id": 0,
+          "uniq_id": 10,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket0"
+          }
+        }
+      },
+      {
+        "id": "104",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core18",
+          "id": 18,
+          "uniq_id": 104,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core18"
+          }
+        }
+      },
+      {
+        "id": "105",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core19",
+          "id": 19,
+          "uniq_id": 105,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core19"
+          }
+        }
+      },
+      {
+        "id": "106",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core20",
+          "id": 20,
+          "uniq_id": 106,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core20"
+          }
+        }
+      },
+      {
+        "id": "107",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core21",
+          "id": 21,
+          "uniq_id": 107,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core21"
+          }
+        }
+      },
+      {
+        "id": "108",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core22",
+          "id": 22,
+          "uniq_id": 108,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core22"
+          }
+        }
+      },
+      {
+        "id": "109",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core23",
+          "id": 23,
+          "uniq_id": 109,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core23"
+          }
+        }
+      },
+      {
+        "id": "110",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core24",
+          "id": 24,
+          "uniq_id": 110,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core24"
+          }
+        }
+      },
+      {
+        "id": "111",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core25",
+          "id": 25,
+          "uniq_id": 111,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core25"
+          }
+        }
+      },
+      {
+        "id": "112",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core26",
+          "id": 26,
+          "uniq_id": 112,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core26"
+          }
+        }
+      },
+      {
+        "id": "113",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core27",
+          "id": 27,
+          "uniq_id": 113,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core27"
+          }
+        }
+      },
+      {
+        "id": "114",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core28",
+          "id": 28,
+          "uniq_id": 114,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core28"
+          }
+        }
+      },
+      {
+        "id": "115",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core29",
+          "id": 29,
+          "uniq_id": 115,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core29"
+          }
+        }
+      },
+      {
+        "id": "116",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core30",
+          "id": 30,
+          "uniq_id": 116,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core30"
+          }
+        }
+      },
+      {
+        "id": "117",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core31",
+          "id": 31,
+          "uniq_id": 117,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core31"
+          }
+        }
+      },
+      {
+        "id": "118",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core32",
+          "id": 32,
+          "uniq_id": 118,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core32"
+          }
+        }
+      },
+      {
+        "id": "119",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core33",
+          "id": 33,
+          "uniq_id": 119,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core33"
+          }
+        }
+      },
+      {
+        "id": "120",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core34",
+          "id": 34,
+          "uniq_id": 120,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core34"
+          }
+        }
+      },
+      {
+        "id": "121",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core35",
+          "id": 35,
+          "uniq_id": 121,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/core35"
+          }
+        }
+      },
+      {
+        "id": "163",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu1",
+          "id": 1,
+          "uniq_id": 163,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1/gpu1"
+          }
+        }
+      },
+      {
+        "id": "11",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket1",
+          "id": 1,
+          "uniq_id": 11,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2/socket1"
+          }
+        }
+      },
+      {
+        "id": "4",
+        "metadata": {
+          "type": "node",
+          "basename": "node",
+          "name": "node2",
+          "id": 2,
+          "uniq_id": 4,
+          "rank": 3,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node2"
+          }
+        }
+      },
+      {
+        "id": "122",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core0",
+          "id": 0,
+          "uniq_id": 122,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core0"
+          }
+        }
+      },
+      {
+        "id": "123",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core1",
+          "id": 1,
+          "uniq_id": 123,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core1"
+          }
+        }
+      },
+      {
+        "id": "124",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core2",
+          "id": 2,
+          "uniq_id": 124,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core2"
+          }
+        }
+      },
+      {
+        "id": "125",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core3",
+          "id": 3,
+          "uniq_id": 125,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core3"
+          }
+        }
+      },
+      {
+        "id": "126",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core4",
+          "id": 4,
+          "uniq_id": 126,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core4"
+          }
+        }
+      },
+      {
+        "id": "127",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core5",
+          "id": 5,
+          "uniq_id": 127,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core5"
+          }
+        }
+      },
+      {
+        "id": "128",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core6",
+          "id": 6,
+          "uniq_id": 128,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core6"
+          }
+        }
+      },
+      {
+        "id": "129",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core7",
+          "id": 7,
+          "uniq_id": 129,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core7"
+          }
+        }
+      },
+      {
+        "id": "130",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core8",
+          "id": 8,
+          "uniq_id": 130,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core8"
+          }
+        }
+      },
+      {
+        "id": "131",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core9",
+          "id": 9,
+          "uniq_id": 131,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core9"
+          }
+        }
+      },
+      {
+        "id": "132",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core10",
+          "id": 10,
+          "uniq_id": 132,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core10"
+          }
+        }
+      },
+      {
+        "id": "133",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core11",
+          "id": 11,
+          "uniq_id": 133,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core11"
+          }
+        }
+      },
+      {
+        "id": "134",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core12",
+          "id": 12,
+          "uniq_id": 134,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core12"
+          }
+        }
+      },
+      {
+        "id": "135",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core13",
+          "id": 13,
+          "uniq_id": 135,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core13"
+          }
+        }
+      },
+      {
+        "id": "136",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core14",
+          "id": 14,
+          "uniq_id": 136,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core14"
+          }
+        }
+      },
+      {
+        "id": "137",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core15",
+          "id": 15,
+          "uniq_id": 137,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core15"
+          }
+        }
+      },
+      {
+        "id": "138",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core16",
+          "id": 16,
+          "uniq_id": 138,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core16"
+          }
+        }
+      },
+      {
+        "id": "139",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core17",
+          "id": 17,
+          "uniq_id": 139,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/core17"
+          }
+        }
+      },
+      {
+        "id": "164",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu0",
+          "id": 0,
+          "uniq_id": 164,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0/gpu0"
+          }
+        }
+      },
+      {
+        "id": "12",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket0",
+          "id": 0,
+          "uniq_id": 12,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket0"
+          }
+        }
+      },
+      {
+        "id": "140",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core18",
+          "id": 18,
+          "uniq_id": 140,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core18"
+          }
+        }
+      },
+      {
+        "id": "141",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core19",
+          "id": 19,
+          "uniq_id": 141,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core19"
+          }
+        }
+      },
+      {
+        "id": "142",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core20",
+          "id": 20,
+          "uniq_id": 142,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core20"
+          }
+        }
+      },
+      {
+        "id": "143",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core21",
+          "id": 21,
+          "uniq_id": 143,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core21"
+          }
+        }
+      },
+      {
+        "id": "144",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core22",
+          "id": 22,
+          "uniq_id": 144,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core22"
+          }
+        }
+      },
+      {
+        "id": "145",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core23",
+          "id": 23,
+          "uniq_id": 145,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core23"
+          }
+        }
+      },
+      {
+        "id": "146",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core24",
+          "id": 24,
+          "uniq_id": 146,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core24"
+          }
+        }
+      },
+      {
+        "id": "147",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core25",
+          "id": 25,
+          "uniq_id": 147,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core25"
+          }
+        }
+      },
+      {
+        "id": "148",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core26",
+          "id": 26,
+          "uniq_id": 148,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core26"
+          }
+        }
+      },
+      {
+        "id": "149",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core27",
+          "id": 27,
+          "uniq_id": 149,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core27"
+          }
+        }
+      },
+      {
+        "id": "150",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core28",
+          "id": 28,
+          "uniq_id": 150,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core28"
+          }
+        }
+      },
+      {
+        "id": "151",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core29",
+          "id": 29,
+          "uniq_id": 151,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core29"
+          }
+        }
+      },
+      {
+        "id": "152",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core30",
+          "id": 30,
+          "uniq_id": 152,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core30"
+          }
+        }
+      },
+      {
+        "id": "153",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core31",
+          "id": 31,
+          "uniq_id": 153,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core31"
+          }
+        }
+      },
+      {
+        "id": "154",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core32",
+          "id": 32,
+          "uniq_id": 154,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core32"
+          }
+        }
+      },
+      {
+        "id": "155",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core33",
+          "id": 33,
+          "uniq_id": 155,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core33"
+          }
+        }
+      },
+      {
+        "id": "156",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core34",
+          "id": 34,
+          "uniq_id": 156,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core34"
+          }
+        }
+      },
+      {
+        "id": "157",
+        "metadata": {
+          "type": "core",
+          "basename": "core",
+          "name": "core35",
+          "id": 35,
+          "uniq_id": 157,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/core35"
+          }
+        }
+      },
+      {
+        "id": "165",
+        "metadata": {
+          "type": "gpu",
+          "basename": "gpu",
+          "name": "gpu1",
+          "id": 1,
+          "uniq_id": 165,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1/gpu1"
+          }
+        }
+      },
+      {
+        "id": "13",
+        "metadata": {
+          "type": "socket",
+          "basename": "socket",
+          "name": "socket1",
+          "id": 1,
+          "uniq_id": 13,
+          "rank": -1,
+          "exclusive": true,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3/socket1"
+          }
+        }
+      },
+      {
+        "id": "5",
+        "metadata": {
+          "type": "node",
+          "basename": "node",
+          "name": "node3",
+          "id": 3,
+          "uniq_id": 5,
+          "rank": 0,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0/node3"
+          }
+        }
+      },
+      {
+        "id": "1",
+        "metadata": {
+          "type": "rack",
+          "basename": "rack",
+          "name": "rack0",
+          "id": 0,
+          "uniq_id": 1,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0/rack0"
+          }
+        }
+      },
+      {
+        "id": "0",
+        "metadata": {
+          "type": "cluster",
+          "basename": "tiny++",
+          "name": "tiny++0",
+          "id": 0,
+          "uniq_id": 0,
+          "rank": -1,
+          "exclusive": false,
+          "unit": "",
+          "size": 1,
+          "paths": {
+            "containment": "/tiny++0"
+          }
+        }
+      }
+    ],
+    "edges": [
+      {
+        "source": "6",
+        "target": "14",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "15",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "16",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "17",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "18",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "19",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "20",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "21",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "22",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "23",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "24",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "25",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "26",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "27",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "28",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "29",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "30",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "31",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "6",
+        "target": "158",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "2",
+        "target": "6",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "32",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "33",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "34",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "35",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "36",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "37",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "38",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "39",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "40",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "41",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "42",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "43",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "44",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "45",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "46",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "47",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "48",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "49",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "7",
+        "target": "159",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "2",
+        "target": "7",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "1",
+        "target": "2",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "50",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "51",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "52",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "53",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "54",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "55",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "56",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "57",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "58",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "59",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "60",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "61",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "62",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "63",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "64",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "65",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "66",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "67",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "8",
+        "target": "160",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "3",
+        "target": "8",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "68",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "69",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "70",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "71",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "72",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "73",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "74",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "75",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "76",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "77",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "78",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "79",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "80",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "81",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "82",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "83",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "84",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "85",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "9",
+        "target": "161",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "3",
+        "target": "9",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "1",
+        "target": "3",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "86",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "87",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "88",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "89",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "90",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "91",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "92",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "93",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "94",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "95",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "96",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "97",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "98",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "99",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "100",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "101",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "102",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "103",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "10",
+        "target": "162",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "10",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "104",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "105",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "106",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "107",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "108",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "109",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "110",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "111",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "112",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "113",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "114",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "115",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "116",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "117",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "118",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "119",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "120",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "121",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "11",
+        "target": "163",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "4",
+        "target": "11",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "1",
+        "target": "4",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "122",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "123",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "124",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "125",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "126",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "127",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "128",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "129",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "130",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "131",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "132",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "133",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "134",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "135",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "136",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "137",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "138",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "139",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "12",
+        "target": "164",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "12",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "140",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "141",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "142",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "143",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "144",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "145",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "146",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "147",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "148",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "149",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "150",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "151",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "152",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "153",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "154",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "155",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "156",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "157",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "13",
+        "target": "165",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "5",
+        "target": "13",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "1",
+        "target": "5",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      },
+      {
+        "source": "0",
+        "target": "1",
+        "metadata": {
+          "name": {
+            "containment": "contains"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/t/data/resource/jobspecs/RV/full.yaml
+++ b/t/data/resource/jobspecs/RV/full.yaml
@@ -1,0 +1,25 @@
+version: 9999
+resources:
+  - type: node
+    count: 4
+    with:
+      - type: slot
+        count: 1
+        label: default
+        with:
+          - type: socket
+            count: 2
+            with:
+              - type: core
+                count: 18
+              - type: gpu
+                count: 1
+
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: [ "app" ]
+    slot: default
+    count:
+      per_slot: 1

--- a/t/t1010-sync-modules.t
+++ b/t/t1010-sync-modules.t
@@ -20,8 +20,7 @@ test_expect_success 'sync: fluxion-resource cannot load w/ sched-simple' '
 '
 
 test_expect_success 'sync: qmanager does not load w/o fluxion-resource' '
-    load_qmanager &&
-    test_must_fail flux module stats sched-fluxion-qmanager
+    test_must_fail load_qmanager
 '
 
 test_expect_success 'remove sched-simple' '

--- a/t/t3027-resource-RV.t
+++ b/t/t3027-resource-RV.t
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+test_description='Test emitted resource-set correctness as schema changes'
+
+. $(dirname $0)/sharness.sh
+
+full_job="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/RV/full.yaml"
+exp_dir="${SHARNESS_TEST_SRCDIR}/data/resource/expected/RV"
+jgf_dir="${SHARNESS_TEST_SRCDIR}/data/resource/jgfs"
+jgf_orig="${jgf_dir}/4node.rank0123.nid0123.orig.json"
+jgf_mod1="${jgf_dir}/4node.rank0123.nid0123.mod.json"
+jgf_mod2="${jgf_dir}/4node.rank1230.nid0123.mod.json"
+query="../../resource/utilities/resource-query"
+
+test_expect_success 'RV1 is correct on rank and node ID order match' '
+    cat > cmds001 <<-EOF &&
+	match allocate ${full_job}
+	quit
+EOF
+    ${query} -L ${jgf_orig} -f jgf -F rv1_nosched -t R1.out < cmds001 &&
+    test_cmp R1.out ${exp_dir}/R1.out
+'
+
+test_expect_success 'RV1 is correct on core ID modified' '
+    cat > cmds002 <<-EOF &&
+	match allocate ${full_job}
+	quit
+EOF
+    ${query} -L ${jgf_mod1} -f jgf -F rv1_nosched -t R2.out < cmds002 &&
+    test_cmp R2.out ${exp_dir}/R2.out
+'
+
+test_expect_success 'RV1 correct on rank/node ID mismatch + core ID modified' '
+    cat > cmds003 <<-EOF &&
+	match allocate ${full_job}
+	quit
+EOF
+    ${query} -L ${jgf_mod2} -f jgf -F rv1_nosched -t R3.out < cmds003 &&
+    test_cmp R3.out ${exp_dir}/R3.out
+'
+
+test_done


### PR DESCRIPTION
This PR adds support for the recent RV1 change: https://github.com/flux-framework/rfc/pull/268. Other changes include:

- Compress the `execution.R_lite` JSON array. Without the actual node names in this array, we will get an extremely high compression rate and thus we do this now.

- Add test cases using three simple 4-node machine configurations. 

- Move `schedutil_create` into the "constructor" of qmanager as starting up a multi-node testing was failing on the latest rc1 change in flux-core.

Fix Issue #761, #753.