### PR TITLE
expect Rv1 from resource.acquire, use flux resource reload

### DIFF
--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -462,42 +462,6 @@ error:
  *                                                                            *
  ******************************************************************************/
 
-/* Block until value of 'key' becomes non-NULL.
- * It is an EPROTO error if value is type other than json_type_string.
- * On success returns value, otherwise NULL with errno set.
- */
-static json_t *get_string_blocking (flux_t *h, const char *key)
-{
-    flux_future_t *f = NULL;
-    const char *json_str;
-    json_t *o = NULL;
-    int saved_errno;
-
-    if (!(f = flux_kvs_lookup (h, NULL, FLUX_KVS_WAITCREATE, key))) {
-        saved_errno = errno;
-        goto error;
-    }
-
-    if (flux_kvs_lookup_get (f, &json_str) < 0) {
-        saved_errno = errno;
-        goto error;
-    }
-
-    if (!json_str || !(o = Jfromstr (json_str))
-                  || !json_is_string (o)) {
-        saved_errno = EPROTO;
-        goto error;
-    }
-
-    flux_future_destroy (f);
-    return o;
-error:
-    flux_future_destroy (f);
-    Jput (o);
-    errno = saved_errno;
-    return NULL;
-}
-
 static int populate_resource_db_file (std::shared_ptr<resource_ctx_t> &ctx)
 {
     int rc = -1;
@@ -533,15 +497,14 @@ done:
     return rc;
 }
 
+/* Add resources associated with 'rank' execution target,
+ * defined by hwloc_xml.  This function may be called with
+ * rank == IDSET_INVALID_ID, to instantiate an empty graph.
+ */
 static int grow (std::shared_ptr<resource_ctx_t> &ctx,
-                 vtx_t v, unsigned int rank)
+                 vtx_t v, unsigned int rank, const char *hwloc_xml)
 {
-    int n = -1;
     int rc = -1;
-    char k[64] = {0};
-    json_t *o = NULL;
-    int saved_errno = 0;
-    const char *hwloc_xml = NULL;
     resource_graph_db_t &db = *(ctx->db);
 
     if (rank == IDSET_INVALID_ID) {
@@ -553,38 +516,41 @@ static int grow (std::shared_ptr<resource_ctx_t> &ctx,
         goto ret;
     }
 
-    n = snprintf (k, sizeof (k), "resource.hwloc.xml.%" PRIu32 "", rank);
-    if ((n < 0) || ((unsigned int) n > sizeof (k))) {
-        errno = ENOMEM;
-        goto ret;
-    }
-    if ( !(o = get_string_blocking (ctx->h, k))) {
-        flux_log_error (ctx->h, "%s: get_string_blocking", __FUNCTION__);
-        goto ret;
-    }
-    hwloc_xml = json_string_value (o);
     if (v == boost::graph_traits<resource_graph_t>::null_vertex ()) {
         if ( (rc = db.load (hwloc_xml, ctx->reader, rank)) < 0) {
             flux_log (ctx->h, LOG_ERR, "%s: reader: %s",
                       __FUNCTION__,  ctx->reader->err_message ().c_str ());
-            goto freemem_ret;
+            goto ret;
         }
     } else {
         if ( (rc = db.load (hwloc_xml, ctx->reader, v, rank)) < 0) {
             flux_log (ctx->h, LOG_ERR, "%s: reader: %s",
                       __FUNCTION__,  ctx->reader->err_message ().c_str ());
-            goto freemem_ret;
+            goto ret;
         }
    }
 
-freemem_ret:
-    saved_errno = errno;
-    json_decref (o);
-    errno = saved_errno;
 ret:
     return rc;
 }
 
+static const char *get_array_string (json_t *array, size_t index)
+{
+    json_t *entry;
+    const char *s;
+
+    if (!(entry = json_array_get (array, index))
+            || !(s = json_string_value (entry))) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return s;
+}
+
+/* Grow resources for execution targets 'ids', fetching resource
+ * details in hwloc XML form from the core resource module.
+ * If 'ids' is the empty set, an empty resource vertex will be instantiated.
+ */
 static int grow_resource_db (std::shared_ptr<resource_ctx_t> &ctx,
                              struct idset *ids)
 {
@@ -592,9 +558,23 @@ static int grow_resource_db (std::shared_ptr<resource_ctx_t> &ctx,
     resource_graph_db_t &db = *(ctx->db);
     unsigned int rank = idset_first (ids);
     vtx_t v = boost::graph_traits<resource_graph_t>::null_vertex ();
+    flux_future_t *f = NULL;
+    json_t *xml_array;
+    const char *hwloc_xml;
+
+    if (!(f = flux_rpc (ctx->h, "resource.get-xml", NULL, 0, 0)))
+        goto done;
+    if (flux_rpc_get_unpack (f, "{s:o}", "xml", &xml_array) < 0)
+        goto done;
 
     if (db.metadata.roots.find ("containment") == db.metadata.roots.end ()) {
-        if ( (rc = grow (ctx, v, rank)) < 0)
+        if (rank != IDSET_INVALID_ID) {
+            if (!(hwloc_xml = get_array_string (xml_array, rank)))
+                goto done;
+        }
+        else
+            hwloc_xml = NULL;
+        if ( (rc = grow (ctx, v, rank, hwloc_xml)) < 0)
             goto done;
     }
 
@@ -612,12 +592,15 @@ static int grow_resource_db (std::shared_ptr<resource_ctx_t> &ctx,
     rank = idset_next (ids, rank);
     while (rank != IDSET_INVALID_ID) {
         // For the rest of the ranks -- general case
-        if ( (rc = grow (ctx, v, rank)) < 0)
+        if (!(hwloc_xml = get_array_string (xml_array, rank)))
+            goto done;
+        if ( (rc = grow (ctx, v, rank, hwloc_xml)) < 0)
             goto done;
         rank = idset_next (ids, rank);
     }
 
 done:
+    flux_future_destroy (f);
     return rc;
 }
 

--- a/t/data/hwloc-data/001N/exclusive/01-brokers-sierra2/0.xml
+++ b/t/data/hwloc-data/001N/exclusive/01-brokers-sierra2/0.xml
@@ -1,0 +1,592 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0xf0000000,,,,,,,0x00000101" complete_nodeset="0xf0000000,,,,,,,0x00000101" allowed_nodeset="0xf0000000,,,,,,,0x00000101">
+    <info name="PlatformName" value="PowerNV"/>
+    <info name="PlatformModel" value="PowerNV 8335-GTW"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/allocation_54106"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="4.14.0-49.6.1.el7a.ppc64le"/>
+    <info name="OSVersion" value="#1 SMP Wed May 16 21:05:05 UTC 2018"/>
+    <info name="HostName" value="sierra3682"/>
+    <info name="Architecture" value="ppc64le"/>
+    <info name="hwlocVersion" value="1.11.10"/>
+    <info name="ProcessName" value="hwloc_xml"/>
+    <distances nbobjs="6" relative_depth="3" latency_base="1.000000">
+      <latency value="10.000000"/>
+      <latency value="40.000000"/>
+      <latency value="80.000000"/>
+      <latency value="80.000000"/>
+      <latency value="80.000000"/>
+      <latency value="80.000000"/>
+      <latency value="40.000000"/>
+      <latency value="10.000000"/>
+      <latency value="80.000000"/>
+      <latency value="80.000000"/>
+      <latency value="80.000000"/>
+      <latency value="80.000000"/>
+      <latency value="80.000000"/>
+      <latency value="80.000000"/>
+      <latency value="10.000000"/>
+      <latency value="80.000000"/>
+      <latency value="80.000000"/>
+      <latency value="80.000000"/>
+      <latency value="80.000000"/>
+      <latency value="80.000000"/>
+      <latency value="80.000000"/>
+      <latency value="10.000000"/>
+      <latency value="80.000000"/>
+      <latency value="80.000000"/>
+      <latency value="80.000000"/>
+      <latency value="80.000000"/>
+      <latency value="80.000000"/>
+      <latency value="80.000000"/>
+      <latency value="10.000000"/>
+      <latency value="80.000000"/>
+      <latency value="80.000000"/>
+      <latency value="80.000000"/>
+      <latency value="80.000000"/>
+      <latency value="80.000000"/>
+      <latency value="80.000000"/>
+      <latency value="10.000000"/>
+    </distances>
+    <object type="Group" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0x00000101" complete_nodeset="0x00000101" allowed_nodeset="0x00000101" depth="0">
+      <object type="NUMANode" os_index="0" cpuset="0x00ffffff,0xffffffff,0xffffffff" complete_cpuset="0x00ffffff,0xffffffff,0xffffffff" online_cpuset="0x00ffffff,0xffffffff,0xffffffff" allowed_cpuset="0x00ffffff,0xffffffff,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="137132310528">
+        <page_type size="65536" count="2092473"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Group" cpuset="0x00ffffff,0xffffffff,0xffffffff" complete_cpuset="0x00ffffff,0xffffffff,0xffffffff" online_cpuset="0x00ffffff,0xffffffff,0xffffffff" allowed_cpuset="0x00ffffff,0xffffffff,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" depth="1">
+          <object type="Socket" os_index="0" cpuset="0x00ffffff,0xffffffff,0xffffffff" complete_cpuset="0x00ffffff,0xffffffff,0xffffffff" online_cpuset="0x00ffffff,0xffffffff,0xffffffff" allowed_cpuset="0x00ffffff,0xffffffff,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+            <info name="CPUModel" value="POWER9, altivec supported"/>
+            <info name="CPURevision" value="2.1 (pvr 004e 1201)"/>
+            <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Core" os_index="8" cpuset="0x0000000f" complete_cpuset="0x0000000f" online_cpuset="0x0000000f" allowed_cpuset="0x0000000f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+              <object type="Core" os_index="12" cpuset="0x000000f0" complete_cpuset="0x000000f0" online_cpuset="0x000000f0" allowed_cpuset="0x000000f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+            <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Core" os_index="16" cpuset="0x00000f00" complete_cpuset="0x00000f00" online_cpuset="0x00000f00" allowed_cpuset="0x00000f00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+              <object type="Core" os_index="20" cpuset="0x0000f000" complete_cpuset="0x0000f000" online_cpuset="0x0000f000" allowed_cpuset="0x0000f000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+            <object type="Cache" cpuset="0x00ff0000" complete_cpuset="0x00ff0000" online_cpuset="0x00ff0000" allowed_cpuset="0x00ff0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Core" os_index="24" cpuset="0x000f0000" complete_cpuset="0x000f0000" online_cpuset="0x000f0000" allowed_cpuset="0x000f0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+              <object type="Core" os_index="28" cpuset="0x00f00000" complete_cpuset="0x00f00000" online_cpuset="0x00f00000" allowed_cpuset="0x00f00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+            <object type="Cache" cpuset="0xff000000" complete_cpuset="0xff000000" online_cpuset="0xff000000" allowed_cpuset="0xff000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Core" os_index="32" cpuset="0x0f000000" complete_cpuset="0x0f000000" online_cpuset="0x0f000000" allowed_cpuset="0x0f000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+              <object type="Core" os_index="36" cpuset="0xf0000000" complete_cpuset="0xf0000000" online_cpuset="0xf0000000" allowed_cpuset="0xf0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+            <object type="Cache" cpuset="0x000000ff,0x0" complete_cpuset="0x000000ff,0x0" online_cpuset="0x000000ff,0x0" allowed_cpuset="0x000000ff,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Core" os_index="40" cpuset="0x0000000f,0x0" complete_cpuset="0x0000000f,0x0" online_cpuset="0x0000000f,0x0" allowed_cpuset="0x0000000f,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+              <object type="Core" os_index="44" cpuset="0x000000f0,0x0" complete_cpuset="0x000000f0,0x0" online_cpuset="0x000000f0,0x0" allowed_cpuset="0x000000f0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+            <object type="Cache" cpuset="0x0000ff00,0x0" complete_cpuset="0x0000ff00,0x0" online_cpuset="0x0000ff00,0x0" allowed_cpuset="0x0000ff00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Core" os_index="48" cpuset="0x00000f00,0x0" complete_cpuset="0x00000f00,0x0" online_cpuset="0x00000f00,0x0" allowed_cpuset="0x00000f00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+              <object type="Core" os_index="52" cpuset="0x0000f000,0x0" complete_cpuset="0x0000f000,0x0" online_cpuset="0x0000f000,0x0" allowed_cpuset="0x0000f000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+            <object type="Cache" cpuset="0x00ff0000,0x0" complete_cpuset="0x00ff0000,0x0" online_cpuset="0x00ff0000,0x0" allowed_cpuset="0x00ff0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Core" os_index="56" cpuset="0x000f0000,0x0" complete_cpuset="0x000f0000,0x0" online_cpuset="0x000f0000,0x0" allowed_cpuset="0x000f0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+              <object type="Core" os_index="60" cpuset="0x00f00000,0x0" complete_cpuset="0x00f00000,0x0" online_cpuset="0x00f00000,0x0" allowed_cpuset="0x00f00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+            <object type="Cache" cpuset="0xff000000,0x0" complete_cpuset="0xff000000,0x0" online_cpuset="0xff000000,0x0" allowed_cpuset="0xff000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Core" os_index="64" cpuset="0x0f000000,0x0" complete_cpuset="0x0f000000,0x0" online_cpuset="0x0f000000,0x0" allowed_cpuset="0x0f000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+              <object type="Core" os_index="68" cpuset="0xf0000000,0x0" complete_cpuset="0xf0000000,0x0" online_cpuset="0xf0000000,0x0" allowed_cpuset="0xf0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+            <object type="Cache" cpuset="0x000000ff,,0x0" complete_cpuset="0x000000ff,,0x0" online_cpuset="0x000000ff,,0x0" allowed_cpuset="0x000000ff,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Core" os_index="72" cpuset="0x0000000f,,0x0" complete_cpuset="0x0000000f,,0x0" online_cpuset="0x0000000f,,0x0" allowed_cpuset="0x0000000f,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+              <object type="Core" os_index="76" cpuset="0x000000f0,,0x0" complete_cpuset="0x000000f0,,0x0" online_cpuset="0x000000f0,,0x0" allowed_cpuset="0x000000f0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+            <object type="Cache" cpuset="0x0000ff00,,0x0" complete_cpuset="0x0000ff00,,0x0" online_cpuset="0x0000ff00,,0x0" allowed_cpuset="0x0000ff00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Core" os_index="80" cpuset="0x00000f00,,0x0" complete_cpuset="0x00000f00,,0x0" online_cpuset="0x00000f00,,0x0" allowed_cpuset="0x00000f00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+              <object type="Core" os_index="84" cpuset="0x0000f000,,0x0" complete_cpuset="0x0000f000,,0x0" online_cpuset="0x0000f000,,0x0" allowed_cpuset="0x0000f000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+            <object type="Cache" cpuset="0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,0x0" online_cpuset="0x00ff0000,,0x0" allowed_cpuset="0x00ff0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Core" os_index="88" cpuset="0x000f0000,,0x0" complete_cpuset="0x000f0000,,0x0" online_cpuset="0x000f0000,,0x0" allowed_cpuset="0x000f0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+              <object type="Core" os_index="92" cpuset="0x00f00000,,0x0" complete_cpuset="0x00f00000,,0x0" online_cpuset="0x00f00000,,0x0" allowed_cpuset="0x00f00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-01]">
+            <object type="PCIDev" os_index="4096" name="Samsung Electronics Co Ltd NVMe SSD Controller 172Xa" pci_busid="0000:01:00.0" pci_type="0108 [144d:a822] [1014:0621] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Samsung Electronics Co Ltd"/>
+              <info name="PCIDevice" value="NVMe SSD Controller 172Xa"/>
+              <object type="OSDev" name="nvme0n1" osdev_type="0">
+                <info name="LinuxDeviceID" value="259:0"/>
+                <info name="SerialNumber" value="S3RVNA0J802449"/>
+                <info name="Type" value="Disk"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0002:[00-02]">
+            <object type="PCIDev" os_index="2105344" name="ASPEED Technology, Inc. ASPEED Graphics Family" pci_busid="0002:02:00.0" pci_type="0300 [1a03:2000] [1a03:2000] 41" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+              <info name="PCIDevice" value="ASPEED Graphics Family"/>
+              <object type="OSDev" name="card4" osdev_type="1"/>
+              <object type="OSDev" name="controlD68" osdev_type="1"/>
+            </object>
+          </object>
+          <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0003:[00-01]">
+            <object type="PCIDev" os_index="3149824" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0003:01:00.0" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Mellanox Technologies"/>
+              <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+              <object type="OSDev" name="hsi0" osdev_type="2">
+                <info name="Address" value="00:00:10:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:49:a2:12"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" name="mlx5_0" osdev_type="3">
+                <info name="NodeGUID" value="ec0d:9a03:0049:a212"/>
+                <info name="SysImageGUID" value="ec0d:9a03:0049:a212"/>
+                <info name="Port1State" value="4"/>
+                <info name="Port1LID" value="0x2dbf"/>
+                <info name="Port1LMC" value="0"/>
+                <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:0049:a212"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="3149825" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0003:01:00.1" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Mellanox Technologies"/>
+              <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+              <object type="OSDev" name="hsi1" osdev_type="2">
+                <info name="Address" value="00:00:18:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:49:a2:13"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" name="mlx5_1" osdev_type="3">
+                <info name="NodeGUID" value="ec0d:9a03:0049:a213"/>
+                <info name="SysImageGUID" value="ec0d:9a03:0049:a212"/>
+                <info name="Port1State" value="4"/>
+                <info name="Port1LID" value="0x2dc0"/>
+                <info name="Port1LMC" value="0"/>
+                <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:0049:a213"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" os_index="4" bridge_type="0-1" depth="0" bridge_pci="0004:[00-0a]">
+            <object type="PCIDev" os_index="4206592" name="Marvell Technology Group Ltd. 88SE9235 PCIe 2.0 x2 4-port SATA 6 Gb/s Controller" pci_busid="0004:03:00.0" pci_type="0106 [1b4b:9235] [1014:0612] 11" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Marvell Technology Group Ltd."/>
+              <info name="PCIDevice" value="88SE9235 PCIe 2.0 x2 4-port SATA 6 Gb/s Controller"/>
+            </object>
+            <object type="PCIDev" os_index="4210688" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0004:04:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="NVIDIA Corporation"/>
+              <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+              <object type="OSDev" name="renderD128" osdev_type="1"/>
+              <object type="OSDev" name="card0" osdev_type="1"/>
+              <object type="OSDev" name="cuda0" osdev_type="5">
+                <info name="Backend" value="CUDA"/>
+                <info name="GPUVendor" value="NVIDIA Corporation"/>
+                <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+                <info name="CUDAGlobalMemorySize" value="16515072"/>
+                <info name="CUDAL2CacheSize" value="6144"/>
+                <info name="CUDAMultiProcessors" value="80"/>
+                <info name="CUDACoresPerMP" value="64"/>
+                <info name="CUDASharedMemorySizePerMP" value="48"/>
+                <info name="CoProcType" value="CUDA"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="4214784" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0004:05:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="NVIDIA Corporation"/>
+              <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+              <object type="OSDev" name="card1" osdev_type="1"/>
+              <object type="OSDev" name="renderD129" osdev_type="1"/>
+              <object type="OSDev" name="cuda1" osdev_type="5">
+                <info name="Backend" value="CUDA"/>
+                <info name="GPUVendor" value="NVIDIA Corporation"/>
+                <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+                <info name="CUDAGlobalMemorySize" value="16515072"/>
+                <info name="CUDAL2CacheSize" value="6144"/>
+                <info name="CUDAMultiProcessors" value="80"/>
+                <info name="CUDACoresPerMP" value="64"/>
+                <info name="CUDASharedMemorySizePerMP" value="48"/>
+                <info name="CoProcType" value="CUDA"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" os_index="5" bridge_type="0-1" depth="0" bridge_pci="0005:[00-01]">
+            <object type="PCIDev" os_index="5246976" name="Broadcom Limited NetXtreme BCM5719 Gigabit Ethernet PCIe" pci_busid="0005:01:00.0" pci_type="0200 [14e4:1657] [14e4:1981] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Broadcom Limited"/>
+              <info name="PCIDevice" value="NetXtreme BCM5719 Gigabit Ethernet PCIe"/>
+              <object type="OSDev" name="enP5p1s0f0" osdev_type="2">
+                <info name="Address" value="70:e2:84:14:6c:1c"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="5246977" name="Broadcom Limited NetXtreme BCM5719 Gigabit Ethernet PCIe" pci_busid="0005:01:00.1" pci_type="0200 [14e4:1657] [14e4:1657] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Broadcom Limited"/>
+              <info name="PCIDevice" value="NetXtreme BCM5719 Gigabit Ethernet PCIe"/>
+              <object type="OSDev" name="enP5p1s0f1" osdev_type="2">
+                <info name="Address" value="70:e2:84:14:6c:1d"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="8" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" local_memory="137166979072">
+        <page_type size="65536" count="2093002"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Group" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" depth="1">
+          <object type="Socket" os_index="8" cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" complete_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" online_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" allowed_cpuset="0x0000ffff,0xffffffff,0xffffffff,0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+            <info name="CPUModel" value="POWER9, altivec supported"/>
+            <info name="CPURevision" value="2.1 (pvr 004e 1201)"/>
+            <object type="Cache" cpuset="0xff000000,,0x0" complete_cpuset="0xff000000,,0x0" online_cpuset="0xff000000,,0x0" allowed_cpuset="0xff000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Core" os_index="2048" cpuset="0x0f000000,,0x0" complete_cpuset="0x0f000000,,0x0" online_cpuset="0x0f000000,,0x0" allowed_cpuset="0x0f000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+              </object>
+              <object type="Core" os_index="2052" cpuset="0xf0000000,,0x0" complete_cpuset="0xf0000000,,0x0" online_cpuset="0xf0000000,,0x0" allowed_cpuset="0xf0000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+              </object>
+            </object>
+            <object type="Cache" cpuset="0x000000ff,,,0x0" complete_cpuset="0x000000ff,,,0x0" online_cpuset="0x000000ff,,,0x0" allowed_cpuset="0x000000ff,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Core" os_index="2056" cpuset="0x0000000f,,,0x0" complete_cpuset="0x0000000f,,,0x0" online_cpuset="0x0000000f,,,0x0" allowed_cpuset="0x0000000f,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                <object type="PU" os_index="96" cpuset="0x00000001,,,0x0" complete_cpuset="0x00000001,,,0x0" online_cpuset="0x00000001,,,0x0" allowed_cpuset="0x00000001,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="97" cpuset="0x00000002,,,0x0" complete_cpuset="0x00000002,,,0x0" online_cpuset="0x00000002,,,0x0" allowed_cpuset="0x00000002,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="98" cpuset="0x00000004,,,0x0" complete_cpuset="0x00000004,,,0x0" online_cpuset="0x00000004,,,0x0" allowed_cpuset="0x00000004,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="99" cpuset="0x00000008,,,0x0" complete_cpuset="0x00000008,,,0x0" online_cpuset="0x00000008,,,0x0" allowed_cpuset="0x00000008,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+              </object>
+              <object type="Core" os_index="2060" cpuset="0x000000f0,,,0x0" complete_cpuset="0x000000f0,,,0x0" online_cpuset="0x000000f0,,,0x0" allowed_cpuset="0x000000f0,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                <object type="PU" os_index="100" cpuset="0x00000010,,,0x0" complete_cpuset="0x00000010,,,0x0" online_cpuset="0x00000010,,,0x0" allowed_cpuset="0x00000010,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="101" cpuset="0x00000020,,,0x0" complete_cpuset="0x00000020,,,0x0" online_cpuset="0x00000020,,,0x0" allowed_cpuset="0x00000020,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="102" cpuset="0x00000040,,,0x0" complete_cpuset="0x00000040,,,0x0" online_cpuset="0x00000040,,,0x0" allowed_cpuset="0x00000040,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="103" cpuset="0x00000080,,,0x0" complete_cpuset="0x00000080,,,0x0" online_cpuset="0x00000080,,,0x0" allowed_cpuset="0x00000080,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+              </object>
+            </object>
+            <object type="Cache" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Core" os_index="2068" cpuset="0x00000f00,,,0x0" complete_cpuset="0x00000f00,,,0x0" online_cpuset="0x00000f00,,,0x0" allowed_cpuset="0x00000f00,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                <object type="PU" os_index="104" cpuset="0x00000100,,,0x0" complete_cpuset="0x00000100,,,0x0" online_cpuset="0x00000100,,,0x0" allowed_cpuset="0x00000100,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="105" cpuset="0x00000200,,,0x0" complete_cpuset="0x00000200,,,0x0" online_cpuset="0x00000200,,,0x0" allowed_cpuset="0x00000200,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="106" cpuset="0x00000400,,,0x0" complete_cpuset="0x00000400,,,0x0" online_cpuset="0x00000400,,,0x0" allowed_cpuset="0x00000400,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="107" cpuset="0x00000800,,,0x0" complete_cpuset="0x00000800,,,0x0" online_cpuset="0x00000800,,,0x0" allowed_cpuset="0x00000800,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+              </object>
+            </object>
+            <object type="Cache" cpuset="0x000ff000,,,0x0" complete_cpuset="0x000ff000,,,0x0" online_cpuset="0x000ff000,,,0x0" allowed_cpuset="0x000ff000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Core" os_index="2072" cpuset="0x0000f000,,,0x0" complete_cpuset="0x0000f000,,,0x0" online_cpuset="0x0000f000,,,0x0" allowed_cpuset="0x0000f000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                <object type="PU" os_index="108" cpuset="0x00001000,,,0x0" complete_cpuset="0x00001000,,,0x0" online_cpuset="0x00001000,,,0x0" allowed_cpuset="0x00001000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="109" cpuset="0x00002000,,,0x0" complete_cpuset="0x00002000,,,0x0" online_cpuset="0x00002000,,,0x0" allowed_cpuset="0x00002000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="110" cpuset="0x00004000,,,0x0" complete_cpuset="0x00004000,,,0x0" online_cpuset="0x00004000,,,0x0" allowed_cpuset="0x00004000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="111" cpuset="0x00008000,,,0x0" complete_cpuset="0x00008000,,,0x0" online_cpuset="0x00008000,,,0x0" allowed_cpuset="0x00008000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+              </object>
+              <object type="Core" os_index="2076" cpuset="0x000f0000,,,0x0" complete_cpuset="0x000f0000,,,0x0" online_cpuset="0x000f0000,,,0x0" allowed_cpuset="0x000f0000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                <object type="PU" os_index="112" cpuset="0x00010000,,,0x0" complete_cpuset="0x00010000,,,0x0" online_cpuset="0x00010000,,,0x0" allowed_cpuset="0x00010000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="113" cpuset="0x00020000,,,0x0" complete_cpuset="0x00020000,,,0x0" online_cpuset="0x00020000,,,0x0" allowed_cpuset="0x00020000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="114" cpuset="0x00040000,,,0x0" complete_cpuset="0x00040000,,,0x0" online_cpuset="0x00040000,,,0x0" allowed_cpuset="0x00040000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="115" cpuset="0x00080000,,,0x0" complete_cpuset="0x00080000,,,0x0" online_cpuset="0x00080000,,,0x0" allowed_cpuset="0x00080000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+              </object>
+            </object>
+            <object type="Cache" cpuset="0x0ff00000,,,0x0" complete_cpuset="0x0ff00000,,,0x0" online_cpuset="0x0ff00000,,,0x0" allowed_cpuset="0x0ff00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Core" os_index="2080" cpuset="0x00f00000,,,0x0" complete_cpuset="0x00f00000,,,0x0" online_cpuset="0x00f00000,,,0x0" allowed_cpuset="0x00f00000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                <object type="PU" os_index="116" cpuset="0x00100000,,,0x0" complete_cpuset="0x00100000,,,0x0" online_cpuset="0x00100000,,,0x0" allowed_cpuset="0x00100000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="117" cpuset="0x00200000,,,0x0" complete_cpuset="0x00200000,,,0x0" online_cpuset="0x00200000,,,0x0" allowed_cpuset="0x00200000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="118" cpuset="0x00400000,,,0x0" complete_cpuset="0x00400000,,,0x0" online_cpuset="0x00400000,,,0x0" allowed_cpuset="0x00400000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="119" cpuset="0x00800000,,,0x0" complete_cpuset="0x00800000,,,0x0" online_cpuset="0x00800000,,,0x0" allowed_cpuset="0x00800000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+              </object>
+              <object type="Core" os_index="2084" cpuset="0x0f000000,,,0x0" complete_cpuset="0x0f000000,,,0x0" online_cpuset="0x0f000000,,,0x0" allowed_cpuset="0x0f000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                <object type="PU" os_index="120" cpuset="0x01000000,,,0x0" complete_cpuset="0x01000000,,,0x0" online_cpuset="0x01000000,,,0x0" allowed_cpuset="0x01000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="121" cpuset="0x02000000,,,0x0" complete_cpuset="0x02000000,,,0x0" online_cpuset="0x02000000,,,0x0" allowed_cpuset="0x02000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="122" cpuset="0x04000000,,,0x0" complete_cpuset="0x04000000,,,0x0" online_cpuset="0x04000000,,,0x0" allowed_cpuset="0x04000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="123" cpuset="0x08000000,,,0x0" complete_cpuset="0x08000000,,,0x0" online_cpuset="0x08000000,,,0x0" allowed_cpuset="0x08000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+              </object>
+            </object>
+            <object type="Cache" cpuset="0x0000000f,0xf0000000,,,0x0" complete_cpuset="0x0000000f,0xf0000000,,,0x0" online_cpuset="0x0000000f,0xf0000000,,,0x0" allowed_cpuset="0x0000000f,0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Core" os_index="2088" cpuset="0xf0000000,,,0x0" complete_cpuset="0xf0000000,,,0x0" online_cpuset="0xf0000000,,,0x0" allowed_cpuset="0xf0000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                <object type="PU" os_index="124" cpuset="0x10000000,,,0x0" complete_cpuset="0x10000000,,,0x0" online_cpuset="0x10000000,,,0x0" allowed_cpuset="0x10000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="125" cpuset="0x20000000,,,0x0" complete_cpuset="0x20000000,,,0x0" online_cpuset="0x20000000,,,0x0" allowed_cpuset="0x20000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="126" cpuset="0x40000000,,,0x0" complete_cpuset="0x40000000,,,0x0" online_cpuset="0x40000000,,,0x0" allowed_cpuset="0x40000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="127" cpuset="0x80000000,,,0x0" complete_cpuset="0x80000000,,,0x0" online_cpuset="0x80000000,,,0x0" allowed_cpuset="0x80000000,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+              </object>
+              <object type="Core" os_index="2092" cpuset="0x0000000f,,,,0x0" complete_cpuset="0x0000000f,,,,0x0" online_cpuset="0x0000000f,,,,0x0" allowed_cpuset="0x0000000f,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                <object type="PU" os_index="128" cpuset="0x00000001,,,,0x0" complete_cpuset="0x00000001,,,,0x0" online_cpuset="0x00000001,,,,0x0" allowed_cpuset="0x00000001,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="129" cpuset="0x00000002,,,,0x0" complete_cpuset="0x00000002,,,,0x0" online_cpuset="0x00000002,,,,0x0" allowed_cpuset="0x00000002,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="130" cpuset="0x00000004,,,,0x0" complete_cpuset="0x00000004,,,,0x0" online_cpuset="0x00000004,,,,0x0" allowed_cpuset="0x00000004,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="131" cpuset="0x00000008,,,,0x0" complete_cpuset="0x00000008,,,,0x0" online_cpuset="0x00000008,,,,0x0" allowed_cpuset="0x00000008,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+              </object>
+            </object>
+            <object type="Cache" cpuset="0x00000ff0,,,,0x0" complete_cpuset="0x00000ff0,,,,0x0" online_cpuset="0x00000ff0,,,,0x0" allowed_cpuset="0x00000ff0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Core" os_index="2096" cpuset="0x000000f0,,,,0x0" complete_cpuset="0x000000f0,,,,0x0" online_cpuset="0x000000f0,,,,0x0" allowed_cpuset="0x000000f0,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                <object type="PU" os_index="132" cpuset="0x00000010,,,,0x0" complete_cpuset="0x00000010,,,,0x0" online_cpuset="0x00000010,,,,0x0" allowed_cpuset="0x00000010,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="133" cpuset="0x00000020,,,,0x0" complete_cpuset="0x00000020,,,,0x0" online_cpuset="0x00000020,,,,0x0" allowed_cpuset="0x00000020,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="134" cpuset="0x00000040,,,,0x0" complete_cpuset="0x00000040,,,,0x0" online_cpuset="0x00000040,,,,0x0" allowed_cpuset="0x00000040,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="135" cpuset="0x00000080,,,,0x0" complete_cpuset="0x00000080,,,,0x0" online_cpuset="0x00000080,,,,0x0" allowed_cpuset="0x00000080,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+              </object>
+              <object type="Core" os_index="2100" cpuset="0x00000f00,,,,0x0" complete_cpuset="0x00000f00,,,,0x0" online_cpuset="0x00000f00,,,,0x0" allowed_cpuset="0x00000f00,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                <object type="PU" os_index="136" cpuset="0x00000100,,,,0x0" complete_cpuset="0x00000100,,,,0x0" online_cpuset="0x00000100,,,,0x0" allowed_cpuset="0x00000100,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="137" cpuset="0x00000200,,,,0x0" complete_cpuset="0x00000200,,,,0x0" online_cpuset="0x00000200,,,,0x0" allowed_cpuset="0x00000200,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="138" cpuset="0x00000400,,,,0x0" complete_cpuset="0x00000400,,,,0x0" online_cpuset="0x00000400,,,,0x0" allowed_cpuset="0x00000400,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="139" cpuset="0x00000800,,,,0x0" complete_cpuset="0x00000800,,,,0x0" online_cpuset="0x00000800,,,,0x0" allowed_cpuset="0x00000800,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+              </object>
+            </object>
+            <object type="Cache" cpuset="0x0000f000,,,,0x0" complete_cpuset="0x0000f000,,,,0x0" online_cpuset="0x0000f000,,,,0x0" allowed_cpuset="0x0000f000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Core" os_index="2104" cpuset="0x0000f000,,,,0x0" complete_cpuset="0x0000f000,,,,0x0" online_cpuset="0x0000f000,,,,0x0" allowed_cpuset="0x0000f000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                <object type="PU" os_index="140" cpuset="0x00001000,,,,0x0" complete_cpuset="0x00001000,,,,0x0" online_cpuset="0x00001000,,,,0x0" allowed_cpuset="0x00001000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="141" cpuset="0x00002000,,,,0x0" complete_cpuset="0x00002000,,,,0x0" online_cpuset="0x00002000,,,,0x0" allowed_cpuset="0x00002000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="142" cpuset="0x00004000,,,,0x0" complete_cpuset="0x00004000,,,,0x0" online_cpuset="0x00004000,,,,0x0" allowed_cpuset="0x00004000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="143" cpuset="0x00008000,,,,0x0" complete_cpuset="0x00008000,,,,0x0" online_cpuset="0x00008000,,,,0x0" allowed_cpuset="0x00008000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+              </object>
+            </object>
+            <object type="Cache" cpuset="0x00ff0000,,,,0x0" complete_cpuset="0x00ff0000,,,,0x0" online_cpuset="0x00ff0000,,,,0x0" allowed_cpuset="0x00ff0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Core" os_index="2112" cpuset="0x000f0000,,,,0x0" complete_cpuset="0x000f0000,,,,0x0" online_cpuset="0x000f0000,,,,0x0" allowed_cpuset="0x000f0000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                <object type="PU" os_index="144" cpuset="0x00010000,,,,0x0" complete_cpuset="0x00010000,,,,0x0" online_cpuset="0x00010000,,,,0x0" allowed_cpuset="0x00010000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="145" cpuset="0x00020000,,,,0x0" complete_cpuset="0x00020000,,,,0x0" online_cpuset="0x00020000,,,,0x0" allowed_cpuset="0x00020000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="146" cpuset="0x00040000,,,,0x0" complete_cpuset="0x00040000,,,,0x0" online_cpuset="0x00040000,,,,0x0" allowed_cpuset="0x00040000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="147" cpuset="0x00080000,,,,0x0" complete_cpuset="0x00080000,,,,0x0" online_cpuset="0x00080000,,,,0x0" allowed_cpuset="0x00080000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+              </object>
+              <object type="Core" os_index="2116" cpuset="0x00f00000,,,,0x0" complete_cpuset="0x00f00000,,,,0x0" online_cpuset="0x00f00000,,,,0x0" allowed_cpuset="0x00f00000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                <object type="PU" os_index="148" cpuset="0x00100000,,,,0x0" complete_cpuset="0x00100000,,,,0x0" online_cpuset="0x00100000,,,,0x0" allowed_cpuset="0x00100000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="149" cpuset="0x00200000,,,,0x0" complete_cpuset="0x00200000,,,,0x0" online_cpuset="0x00200000,,,,0x0" allowed_cpuset="0x00200000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="150" cpuset="0x00400000,,,,0x0" complete_cpuset="0x00400000,,,,0x0" online_cpuset="0x00400000,,,,0x0" allowed_cpuset="0x00400000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="151" cpuset="0x00800000,,,,0x0" complete_cpuset="0x00800000,,,,0x0" online_cpuset="0x00800000,,,,0x0" allowed_cpuset="0x00800000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+              </object>
+            </object>
+            <object type="Cache" cpuset="0xff000000,,,,0x0" complete_cpuset="0xff000000,,,,0x0" online_cpuset="0xff000000,,,,0x0" allowed_cpuset="0xff000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Core" os_index="2120" cpuset="0x0f000000,,,,0x0" complete_cpuset="0x0f000000,,,,0x0" online_cpuset="0x0f000000,,,,0x0" allowed_cpuset="0x0f000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                <object type="PU" os_index="152" cpuset="0x01000000,,,,0x0" complete_cpuset="0x01000000,,,,0x0" online_cpuset="0x01000000,,,,0x0" allowed_cpuset="0x01000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="153" cpuset="0x02000000,,,,0x0" complete_cpuset="0x02000000,,,,0x0" online_cpuset="0x02000000,,,,0x0" allowed_cpuset="0x02000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="154" cpuset="0x04000000,,,,0x0" complete_cpuset="0x04000000,,,,0x0" online_cpuset="0x04000000,,,,0x0" allowed_cpuset="0x04000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="155" cpuset="0x08000000,,,,0x0" complete_cpuset="0x08000000,,,,0x0" online_cpuset="0x08000000,,,,0x0" allowed_cpuset="0x08000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+              </object>
+              <object type="Core" os_index="2124" cpuset="0xf0000000,,,,0x0" complete_cpuset="0xf0000000,,,,0x0" online_cpuset="0xf0000000,,,,0x0" allowed_cpuset="0xf0000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                <object type="PU" os_index="156" cpuset="0x10000000,,,,0x0" complete_cpuset="0x10000000,,,,0x0" online_cpuset="0x10000000,,,,0x0" allowed_cpuset="0x10000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="157" cpuset="0x20000000,,,,0x0" complete_cpuset="0x20000000,,,,0x0" online_cpuset="0x20000000,,,,0x0" allowed_cpuset="0x20000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="158" cpuset="0x40000000,,,,0x0" complete_cpuset="0x40000000,,,,0x0" online_cpuset="0x40000000,,,,0x0" allowed_cpuset="0x40000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="159" cpuset="0x80000000,,,,0x0" complete_cpuset="0x80000000,,,,0x0" online_cpuset="0x80000000,,,,0x0" allowed_cpuset="0x80000000,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+              </object>
+            </object>
+            <object type="Cache" cpuset="0x000000ff,,,,,0x0" complete_cpuset="0x000000ff,,,,,0x0" online_cpuset="0x000000ff,,,,,0x0" allowed_cpuset="0x000000ff,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Core" os_index="2128" cpuset="0x0000000f,,,,,0x0" complete_cpuset="0x0000000f,,,,,0x0" online_cpuset="0x0000000f,,,,,0x0" allowed_cpuset="0x0000000f,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                <object type="PU" os_index="160" cpuset="0x00000001,,,,,0x0" complete_cpuset="0x00000001,,,,,0x0" online_cpuset="0x00000001,,,,,0x0" allowed_cpuset="0x00000001,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="161" cpuset="0x00000002,,,,,0x0" complete_cpuset="0x00000002,,,,,0x0" online_cpuset="0x00000002,,,,,0x0" allowed_cpuset="0x00000002,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="162" cpuset="0x00000004,,,,,0x0" complete_cpuset="0x00000004,,,,,0x0" online_cpuset="0x00000004,,,,,0x0" allowed_cpuset="0x00000004,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="163" cpuset="0x00000008,,,,,0x0" complete_cpuset="0x00000008,,,,,0x0" online_cpuset="0x00000008,,,,,0x0" allowed_cpuset="0x00000008,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+              </object>
+              <object type="Core" os_index="2132" cpuset="0x000000f0,,,,,0x0" complete_cpuset="0x000000f0,,,,,0x0" online_cpuset="0x000000f0,,,,,0x0" allowed_cpuset="0x000000f0,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                <object type="PU" os_index="164" cpuset="0x00000010,,,,,0x0" complete_cpuset="0x00000010,,,,,0x0" online_cpuset="0x00000010,,,,,0x0" allowed_cpuset="0x00000010,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="165" cpuset="0x00000020,,,,,0x0" complete_cpuset="0x00000020,,,,,0x0" online_cpuset="0x00000020,,,,,0x0" allowed_cpuset="0x00000020,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="166" cpuset="0x00000040,,,,,0x0" complete_cpuset="0x00000040,,,,,0x0" online_cpuset="0x00000040,,,,,0x0" allowed_cpuset="0x00000040,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="167" cpuset="0x00000080,,,,,0x0" complete_cpuset="0x00000080,,,,,0x0" online_cpuset="0x00000080,,,,,0x0" allowed_cpuset="0x00000080,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+              </object>
+            </object>
+            <object type="Cache" cpuset="0x0000ff00,,,,,0x0" complete_cpuset="0x0000ff00,,,,,0x0" online_cpuset="0x0000ff00,,,,,0x0" allowed_cpuset="0x0000ff00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100" cache_size="10485760" depth="3" cache_linesize="0" cache_associativity="0" cache_type="0">
+              <object type="Core" os_index="2136" cpuset="0x00000f00,,,,,0x0" complete_cpuset="0x00000f00,,,,,0x0" online_cpuset="0x00000f00,,,,,0x0" allowed_cpuset="0x00000f00,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                <object type="PU" os_index="168" cpuset="0x00000100,,,,,0x0" complete_cpuset="0x00000100,,,,,0x0" online_cpuset="0x00000100,,,,,0x0" allowed_cpuset="0x00000100,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="169" cpuset="0x00000200,,,,,0x0" complete_cpuset="0x00000200,,,,,0x0" online_cpuset="0x00000200,,,,,0x0" allowed_cpuset="0x00000200,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="170" cpuset="0x00000400,,,,,0x0" complete_cpuset="0x00000400,,,,,0x0" online_cpuset="0x00000400,,,,,0x0" allowed_cpuset="0x00000400,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="171" cpuset="0x00000800,,,,,0x0" complete_cpuset="0x00000800,,,,,0x0" online_cpuset="0x00000800,,,,,0x0" allowed_cpuset="0x00000800,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+              </object>
+              <object type="Core" os_index="2140" cpuset="0x0000f000,,,,,0x0" complete_cpuset="0x0000f000,,,,,0x0" online_cpuset="0x0000f000,,,,,0x0" allowed_cpuset="0x0000f000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100">
+                <object type="PU" os_index="172" cpuset="0x00001000,,,,,0x0" complete_cpuset="0x00001000,,,,,0x0" online_cpuset="0x00001000,,,,,0x0" allowed_cpuset="0x00001000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="173" cpuset="0x00002000,,,,,0x0" complete_cpuset="0x00002000,,,,,0x0" online_cpuset="0x00002000,,,,,0x0" allowed_cpuset="0x00002000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="174" cpuset="0x00004000,,,,,0x0" complete_cpuset="0x00004000,,,,,0x0" online_cpuset="0x00004000,,,,,0x0" allowed_cpuset="0x00004000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+                <object type="PU" os_index="175" cpuset="0x00008000,,,,,0x0" complete_cpuset="0x00008000,,,,,0x0" online_cpuset="0x00008000,,,,,0x0" allowed_cpuset="0x00008000,,,,,0x0" nodeset="0x00000100" complete_nodeset="0x00000100" allowed_nodeset="0x00000100"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" os_index="9" bridge_type="0-1" depth="0" bridge_pci="0033:[00-01]">
+            <object type="PCIDev" os_index="53481472" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0033:01:00.0" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Mellanox Technologies"/>
+              <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+              <object type="OSDev" name="hsi2" osdev_type="2">
+                <info name="Address" value="00:00:14:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:49:a2:14"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" name="mlx5_2" osdev_type="3">
+                <info name="NodeGUID" value="ec0d:9a03:0049:a214"/>
+                <info name="SysImageGUID" value="ec0d:9a03:0049:a212"/>
+                <info name="Port1State" value="4"/>
+                <info name="Port1LID" value="0x2e21"/>
+                <info name="Port1LMC" value="0"/>
+                <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:0049:a214"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="53481473" name="Mellanox Technologies MT28800 Family [ConnectX-5 Ex]" pci_busid="0033:01:00.1" pci_type="0207 [15b3:1019] [1014:0617] 00" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Mellanox Technologies"/>
+              <info name="PCIDevice" value="MT28800 Family [ConnectX-5 Ex]"/>
+              <object type="OSDev" name="hsi3" osdev_type="2">
+                <info name="Address" value="00:00:1c:87:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:49:a2:15"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" name="mlx5_3" osdev_type="3">
+                <info name="NodeGUID" value="ec0d:9a03:0049:a215"/>
+                <info name="SysImageGUID" value="ec0d:9a03:0049:a212"/>
+                <info name="Port1State" value="4"/>
+                <info name="Port1LID" value="0x2e1f"/>
+                <info name="Port1LMC" value="0"/>
+                <info name="Port1GID0" value="fe80:0000:0000:0000:ec0d:9a03:0049:a215"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" os_index="11" bridge_type="0-1" depth="0" bridge_pci="0035:[00-09]">
+            <object type="PCIDev" os_index="55586816" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0035:03:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="NVIDIA Corporation"/>
+              <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+              <object type="OSDev" name="card2" osdev_type="1"/>
+              <object type="OSDev" name="renderD130" osdev_type="1"/>
+              <object type="OSDev" name="cuda2" osdev_type="5">
+                <info name="Backend" value="CUDA"/>
+                <info name="GPUVendor" value="NVIDIA Corporation"/>
+                <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+                <info name="CUDAGlobalMemorySize" value="16515072"/>
+                <info name="CUDAL2CacheSize" value="6144"/>
+                <info name="CUDAMultiProcessors" value="80"/>
+                <info name="CUDACoresPerMP" value="64"/>
+                <info name="CUDASharedMemorySizePerMP" value="48"/>
+                <info name="CoProcType" value="CUDA"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="55590912" name="NVIDIA Corporation GV100GL [Tesla V100 SXM2]" pci_busid="0035:04:00.0" pci_type="0302 [10de:1db1] [10de:1212] a1" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="NVIDIA Corporation"/>
+              <info name="PCIDevice" value="GV100GL [Tesla V100 SXM2]"/>
+              <object type="OSDev" name="card3" osdev_type="1"/>
+              <object type="OSDev" name="renderD131" osdev_type="1"/>
+              <object type="OSDev" name="cuda3" osdev_type="5">
+                <info name="Backend" value="CUDA"/>
+                <info name="GPUVendor" value="NVIDIA Corporation"/>
+                <info name="GPUModel" value="Tesla V100-SXM2-16GB"/>
+                <info name="CUDAGlobalMemorySize" value="16515072"/>
+                <info name="CUDAL2CacheSize" value="6144"/>
+                <info name="CUDAMultiProcessors" value="80"/>
+                <info name="CUDACoresPerMP" value="64"/>
+                <info name="CUDASharedMemorySizePerMP" value="48"/>
+                <info name="CoProcType" value="CUDA"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="NUMANode" os_index="252" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x10000000,,,,,,,0x0" complete_nodeset="0x10000000,,,,,,,0x0" allowed_nodeset="0x10000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+      <object type="Group" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x10000000,,,,,,,0x0" complete_nodeset="0x10000000,,,,,,,0x0" allowed_nodeset="0x10000000,,,,,,,0x0" depth="1"/>
+    </object>
+    <object type="NUMANode" os_index="253" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x20000000,,,,,,,0x0" complete_nodeset="0x20000000,,,,,,,0x0" allowed_nodeset="0x20000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+      <object type="Group" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x20000000,,,,,,,0x0" complete_nodeset="0x20000000,,,,,,,0x0" allowed_nodeset="0x20000000,,,,,,,0x0" depth="1"/>
+    </object>
+    <object type="NUMANode" os_index="254" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x40000000,,,,,,,0x0" complete_nodeset="0x40000000,,,,,,,0x0" allowed_nodeset="0x40000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+      <object type="Group" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x40000000,,,,,,,0x0" complete_nodeset="0x40000000,,,,,,,0x0" allowed_nodeset="0x40000000,,,,,,,0x0" depth="1"/>
+    </object>
+    <object type="NUMANode" os_index="255" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x80000000,,,,,,,0x0" complete_nodeset="0x80000000,,,,,,,0x0" allowed_nodeset="0x80000000,,,,,,,0x0" local_memory="16911433728">
+      <page_type size="65536" count="258048"/>
+      <page_type size="2097152" count="0"/>
+      <page_type size="1073741824" count="0"/>
+      <object type="Group" cpuset="0x0" complete_cpuset="0x0" online_cpuset="0x0" allowed_cpuset="0x0" nodeset="0x80000000,,,,,,,0x0" complete_nodeset="0x80000000,,,,,,,0x0" allowed_nodeset="0x80000000,,,,,,,0x0" depth="1"/>
+    </object>
+  </object>
+</topology>

--- a/t/data/hwloc-data/001N/exclusive/01-brokers/0.xml
+++ b/t/data/hwloc-data/001N/exclusive/01-brokers/0.xml
@@ -1,0 +1,701 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0x0000ffff" complete_cpuset="0x0000ffff" online_cpuset="0x0000ffff" allowed_cpuset="0x0000ffff" nodeset="0x00000003" complete_nodeset="0x00000003" allowed_nodeset="0x00000003">
+    <page_type size="4096" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <info name="DMIProductName" value="appro-512x"/>
+    <info name="DMIProductVersion" value="...................."/>
+    <info name="DMIBoardVendor" value="Intel Corporation"/>
+    <info name="DMIBoardName" value="S2600JF"/>
+    <info name="DMIBoardVersion" value="G28033-504"/>
+    <info name="DMIBoardAssetTag" value="...................."/>
+    <info name="DMIChassisVendor" value="appro"/>
+    <info name="DMIChassisType" value="17"/>
+    <info name="DMIChassisVersion" value="appro-512x"/>
+    <info name="DMIChassisAssetTag" value="...................."/>
+    <info name="DMIBIOSVendor" value="Intel Corp."/>
+    <info name="DMIBIOSVersion" value="SE5C600.86B.02.03.0003.041920141333"/>
+    <info name="DMIBIOSDate" value="04/19/2014"/>
+    <info name="DMISysVendor" value="appro"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="2.6.32-573.8.1.2chaos.ch5.4.x86_64"/>
+    <info name="OSVersion" value="#1 SMP Tue Dec 1 12:16:54 PST 2015"/>
+    <info name="HostName" value="cab1234"/>
+    <info name="Architecture" value="x86_64"/>
+    <object type="NUMANode" os_index="0" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="17097461760">
+      <page_type size="4096" count="4174185"/>
+      <page_type size="2097152" count="0"/>
+      <object type="Socket" os_index="0" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+        <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz"/>
+        <info name="CPUType" value="x86_64"/>
+        <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-08]">
+        <object type="PCIDev" os_index="0" name="Intel Corporation Xeon E5/Core i7 DMI2" pci_busid="0000:00:00.0" pci_type="0600 [8086:3c00] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMI2"/>
+        </object>
+        <object type="Bridge" os_index="16" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 1a" bridge_type="1-1" depth="0" bridge_pci="0000:[01-01]" pci_busid="0000:00:01.0" pci_type="0604 [8086:3c02] [0000:0000] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 1a"/>
+        </object>
+        <object type="Bridge" os_index="32" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 2a" bridge_type="1-1" depth="0" bridge_pci="0000:[02-02]" pci_busid="0000:00:02.0" pci_type="0604 [8086:3c04] [0000:0000] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 2a"/>
+          <object type="PCIDev" os_index="8192" name="QLogic Corp. IBA7322 QDR InfiniBand HCA" pci_busid="0000:02:00.0" pci_type="0c06 [1077:7322] [0077:0022] 02" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="QLogic Corp."/>
+            <info name="PCIDevice" value="IBA7322 QDR InfiniBand HCA"/>
+            <object type="OSDev" name="ib0" osdev_type="2">
+              <info name="Address" value="80:00:00:03:fe:80:00:00:00:00:00:00:00:11:75:00:00:77:29:06"/>
+              <info name="Port" value="1"/>
+            </object>
+            <object type="OSDev" name="qib0" osdev_type="3"/>
+          </object>
+        </object>
+        <object type="Bridge" os_index="48" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode" bridge_type="1-1" depth="0" bridge_pci="0000:[03-03]" pci_busid="0000:00:03.0" pci_type="0604 [8086:3c08] [0000:0000] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode"/>
+        </object>
+        <object type="PCIDev" os_index="64" name="Intel Corporation Xeon E5/Core i7 DMA Channel 0" pci_busid="0000:00:04.0" pci_type="0880 [8086:3c20] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 0"/>
+          <object type="OSDev" name="dma0chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="65" name="Intel Corporation Xeon E5/Core i7 DMA Channel 1" pci_busid="0000:00:04.1" pci_type="0880 [8086:3c21] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 1"/>
+          <object type="OSDev" name="dma1chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="66" name="Intel Corporation Xeon E5/Core i7 DMA Channel 2" pci_busid="0000:00:04.2" pci_type="0880 [8086:3c22] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 2"/>
+          <object type="OSDev" name="dma2chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="67" name="Intel Corporation Xeon E5/Core i7 DMA Channel 3" pci_busid="0000:00:04.3" pci_type="0880 [8086:3c23] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 3"/>
+          <object type="OSDev" name="dma3chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="68" name="Intel Corporation Xeon E5/Core i7 DMA Channel 4" pci_busid="0000:00:04.4" pci_type="0880 [8086:3c24] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 4"/>
+          <object type="OSDev" name="dma4chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="69" name="Intel Corporation Xeon E5/Core i7 DMA Channel 5" pci_busid="0000:00:04.5" pci_type="0880 [8086:3c25] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 5"/>
+          <object type="OSDev" name="dma5chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="70" name="Intel Corporation Xeon E5/Core i7 DMA Channel 6" pci_busid="0000:00:04.6" pci_type="0880 [8086:3c26] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 6"/>
+          <object type="OSDev" name="dma6chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="71" name="Intel Corporation Xeon E5/Core i7 DMA Channel 7" pci_busid="0000:00:04.7" pci_type="0880 [8086:3c27] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 7"/>
+          <object type="OSDev" name="dma7chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="80" name="Intel Corporation Xeon E5/Core i7 Address Map, VTd_Misc, System Management" pci_busid="0000:00:05.0" pci_type="0880 [8086:3c28] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 Address Map, VTd_Misc, System Management"/>
+        </object>
+        <object type="PCIDev" os_index="82" name="Intel Corporation Xeon E5/Core i7 Control Status and Global Errors" pci_busid="0000:00:05.2" pci_type="0880 [8086:3c2a] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 Control Status and Global Errors"/>
+        </object>
+        <object type="PCIDev" os_index="84" name="Intel Corporation Xeon E5/Core i7 I/O APIC" pci_busid="0000:00:05.4" pci_type="0800 [8086:3c2c] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 I/O APIC"/>
+        </object>
+        <object type="Bridge" os_index="272" name="Intel Corporation C600/X79 series chipset PCI Express Virtual Root Port" bridge_type="1-1" depth="0" bridge_pci="0000:[04-04]" pci_busid="0000:00:11.0" pci_type="0604 [8086:1d3e] [0000:0000] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset PCI Express Virtual Root Port"/>
+        </object>
+        <object type="PCIDev" os_index="352" name="Intel Corporation C600/X79 series chipset MEI Controller #1" pci_busid="0000:00:16.0" pci_type="0780 [8086:1d3a] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset MEI Controller #1"/>
+        </object>
+        <object type="PCIDev" os_index="353" name="Intel Corporation C600/X79 series chipset MEI Controller #2" pci_busid="0000:00:16.1" pci_type="0780 [8086:1d3b] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset MEI Controller #2"/>
+        </object>
+        <object type="PCIDev" os_index="416" name="Intel Corporation C600/X79 series chipset USB2 Enhanced Host Controller #2" pci_busid="0000:00:1a.0" pci_type="0c03 [8086:1d2d] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset USB2 Enhanced Host Controller #2"/>
+        </object>
+        <object type="Bridge" os_index="448" name="Intel Corporation C600/X79 series chipset PCI Express Root Port 1" bridge_type="1-1" depth="0" bridge_pci="0000:[05-06]" pci_busid="0000:00:1c.0" pci_type="0604 [8086:1d10] [0000:0000] b5" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset PCI Express Root Port 1"/>
+          <object type="PCIDev" os_index="20480" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:05:00.0" pci_type="0200 [8086:1521] [0086:008c] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Intel Corporation"/>
+            <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+            <object type="OSDev" name="eth0" osdev_type="2">
+              <info name="Address" value="00:1e:67:2c:b9:db"/>
+            </object>
+          </object>
+          <object type="PCIDev" os_index="20481" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:05:00.1" pci_type="0200 [8086:1521] [0086:008c] 01" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Intel Corporation"/>
+            <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+            <object type="OSDev" name="eth1" osdev_type="2">
+              <info name="Address" value="00:1e:67:2c:b9:dc"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="455" name="Intel Corporation C600/X79 series chipset PCI Express Root Port 8" bridge_type="1-1" depth="0" bridge_pci="0000:[07-07]" pci_busid="0000:00:1c.7" pci_type="0604 [8086:1d1e] [0000:0000] b5" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset PCI Express Root Port 8"/>
+          <object type="PCIDev" os_index="28672" name="Matrox Electronics Systems Ltd. MGA G200e [Pilot] ServerEngines (SEP1)" pci_busid="0000:07:00.0" pci_type="0300 [102b:0522] [0086:0003] 04" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Matrox Electronics Systems Ltd."/>
+            <info name="PCIDevice" value="MGA G200e [Pilot] ServerEngines (SEP1)"/>
+          </object>
+        </object>
+        <object type="PCIDev" os_index="464" name="Intel Corporation C600/X79 series chipset USB2 Enhanced Host Controller #1" pci_busid="0000:00:1d.0" pci_type="0c03 [8086:1d26] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset USB2 Enhanced Host Controller #1"/>
+        </object>
+        <object type="Bridge" os_index="480" name="Intel Corporation 82801 PCI Bridge" bridge_type="1-1" depth="0" bridge_pci="0000:[08-08]" pci_busid="0000:00:1e.0" pci_type="0604 [8086:244e] [0000:0000] a5" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="82801 PCI Bridge"/>
+        </object>
+        <object type="PCIDev" os_index="496" name="Intel Corporation C600/X79 series chipset LPC Controller" pci_busid="0000:00:1f.0" pci_type="0601 [8086:1d41] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset LPC Controller"/>
+        </object>
+        <object type="PCIDev" os_index="498" name="Intel Corporation C600/X79 series chipset 6-Port SATA AHCI Controller" pci_busid="0000:00:1f.2" pci_type="0106 [8086:1d02] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset 6-Port SATA AHCI Controller"/>
+        </object>
+        <object type="PCIDev" os_index="499" name="Intel Corporation C600/X79 series chipset SMBus Host Controller" pci_busid="0000:00:1f.3" pci_type="0c05 [8086:1d22] [0086:008c] 05" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="C600/X79 series chipset SMBus Host Controller"/>
+        </object>
+      </object>
+    </object>
+    <object type="NUMANode" os_index="1" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" local_memory="17179869184">
+      <page_type size="4096" count="4194304"/>
+      <page_type size="2097152" count="0"/>
+      <object type="Socket" os_index="1" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+        <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz"/>
+        <info name="CPUType" value="x86_64"/>
+        <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <object type="Cache" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="0" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="1" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="2" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="3" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="4" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="5" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="6" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <object type="Cache" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <object type="Core" os_index="7" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0000:[80-81]">
+        <object type="Bridge" os_index="524336" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode" bridge_type="1-1" depth="0" bridge_pci="0000:[81-81]" pci_busid="0000:80:03.0" pci_type="0604 [8086:3c08] [0000:0000] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode"/>
+        </object>
+        <object type="PCIDev" os_index="524352" name="Intel Corporation Xeon E5/Core i7 DMA Channel 0" pci_busid="0000:80:04.0" pci_type="0880 [8086:3c20] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 0"/>
+          <object type="OSDev" name="dma8chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524353" name="Intel Corporation Xeon E5/Core i7 DMA Channel 1" pci_busid="0000:80:04.1" pci_type="0880 [8086:3c21] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 1"/>
+          <object type="OSDev" name="dma9chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524354" name="Intel Corporation Xeon E5/Core i7 DMA Channel 2" pci_busid="0000:80:04.2" pci_type="0880 [8086:3c22] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 2"/>
+          <object type="OSDev" name="dma10chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524355" name="Intel Corporation Xeon E5/Core i7 DMA Channel 3" pci_busid="0000:80:04.3" pci_type="0880 [8086:3c23] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 3"/>
+          <object type="OSDev" name="dma11chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524356" name="Intel Corporation Xeon E5/Core i7 DMA Channel 4" pci_busid="0000:80:04.4" pci_type="0880 [8086:3c24] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 4"/>
+          <object type="OSDev" name="dma12chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524357" name="Intel Corporation Xeon E5/Core i7 DMA Channel 5" pci_busid="0000:80:04.5" pci_type="0880 [8086:3c25] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 5"/>
+          <object type="OSDev" name="dma13chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524358" name="Intel Corporation Xeon E5/Core i7 DMA Channel 6" pci_busid="0000:80:04.6" pci_type="0880 [8086:3c26] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 6"/>
+          <object type="OSDev" name="dma14chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524359" name="Intel Corporation Xeon E5/Core i7 DMA Channel 7" pci_busid="0000:80:04.7" pci_type="0880 [8086:3c27] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 7"/>
+          <object type="OSDev" name="dma15chan0" osdev_type="4"/>
+        </object>
+        <object type="PCIDev" os_index="524368" name="Intel Corporation Xeon E5/Core i7 Address Map, VTd_Misc, System Management" pci_busid="0000:80:05.0" pci_type="0880 [8086:3c28] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 Address Map, VTd_Misc, System Management"/>
+        </object>
+        <object type="PCIDev" os_index="524370" name="Intel Corporation Xeon E5/Core i7 Control Status and Global Errors" pci_busid="0000:80:05.2" pci_type="0880 [8086:3c2a] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 Control Status and Global Errors"/>
+        </object>
+        <object type="PCIDev" os_index="524372" name="Intel Corporation Xeon E5/Core i7 I/O APIC" pci_busid="0000:80:05.4" pci_type="0800 [8086:3c2c] [0086:008c] 06" pci_link_speed="0.000000">
+          <info name="PCIVendor" value="Intel Corporation"/>
+          <info name="PCIDevice" value="Xeon E5/Core i7 I/O APIC"/>
+        </object>
+      </object>
+    </object>
+    <object type="Bridge" os_index="1" bridge_type="0-1" depth="0" bridge_pci="0000:[7f-7f]">
+      <object type="PCIDev" os_index="520320" name="Intel Corporation Xeon E5/Core i7 QPI Link 0" pci_busid="0000:7f:08.0" pci_type="0880 [8086:3c80] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 0"/>
+      </object>
+      <object type="PCIDev" os_index="520336" name="Intel Corporation Xeon E5/Core i7 QPI Link 1" pci_busid="0000:7f:09.0" pci_type="0880 [8086:3c90] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 1"/>
+      </object>
+      <object type="PCIDev" os_index="520352" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 0" pci_busid="0000:7f:0a.0" pci_type="0880 [8086:3cc0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 0"/>
+      </object>
+      <object type="PCIDev" os_index="520353" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 1" pci_busid="0000:7f:0a.1" pci_type="0880 [8086:3cc1] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 1"/>
+      </object>
+      <object type="PCIDev" os_index="520354" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 2" pci_busid="0000:7f:0a.2" pci_type="0880 [8086:3cc2] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 2"/>
+      </object>
+      <object type="PCIDev" os_index="520355" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 3" pci_busid="0000:7f:0a.3" pci_type="0880 [8086:3cd0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 3"/>
+      </object>
+      <object type="PCIDev" os_index="520368" name="Intel Corporation Xeon E5/Core i7 Interrupt Control Registers" pci_busid="0000:7f:0b.0" pci_type="0880 [8086:3ce0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Interrupt Control Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520371" name="Intel Corporation Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers" pci_busid="0000:7f:0b.3" pci_type="0880 [8086:3ce3] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520384" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520385" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520386" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520387" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520390" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0" pci_busid="0000:7f:0c.6" pci_type="0880 [8086:3cf4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0"/>
+      </object>
+      <object type="PCIDev" os_index="520391" name="Intel Corporation Xeon E5/Core i7 System Address Decoder" pci_busid="0000:7f:0c.7" pci_type="0880 [8086:3cf6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 System Address Decoder"/>
+      </object>
+      <object type="PCIDev" os_index="520400" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520401" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520402" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520403" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="520406" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1" pci_busid="0000:7f:0d.6" pci_type="0880 [8086:3cf5] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1"/>
+      </object>
+      <object type="PCIDev" os_index="520416" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent" pci_busid="0000:7f:0e.0" pci_type="0880 [8086:3ca0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent"/>
+      </object>
+      <object type="PCIDev" os_index="520417" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent Performance Monitoring" pci_busid="0000:7f:0e.1" pci_type="1101 [8086:3c46] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent Performance Monitoring"/>
+      </object>
+      <object type="PCIDev" os_index="520432" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Registers" pci_busid="0000:7f:0f.0" pci_type="0880 [8086:3ca8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520433" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller RAS Registers" pci_busid="0000:7f:0f.1" pci_type="0880 [8086:3c71] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller RAS Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520434" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0" pci_busid="0000:7f:0f.2" pci_type="0880 [8086:3caa] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0"/>
+      </object>
+      <object type="PCIDev" os_index="520435" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1" pci_busid="0000:7f:0f.3" pci_type="0880 [8086:3cab] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1"/>
+      </object>
+      <object type="PCIDev" os_index="520436" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2" pci_busid="0000:7f:0f.4" pci_type="0880 [8086:3cac] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2"/>
+      </object>
+      <object type="PCIDev" os_index="520437" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3" pci_busid="0000:7f:0f.5" pci_type="0880 [8086:3cad] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3"/>
+      </object>
+      <object type="PCIDev" os_index="520438" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4" pci_busid="0000:7f:0f.6" pci_type="0880 [8086:3cae] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4"/>
+      </object>
+      <object type="PCIDev" os_index="520448" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0" pci_busid="0000:7f:10.0" pci_type="0880 [8086:3cb0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0"/>
+      </object>
+      <object type="PCIDev" os_index="520449" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1" pci_busid="0000:7f:10.1" pci_type="0880 [8086:3cb1] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1"/>
+      </object>
+      <object type="PCIDev" os_index="520450" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0" pci_busid="0000:7f:10.2" pci_type="0880 [8086:3cb2] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0"/>
+      </object>
+      <object type="PCIDev" os_index="520451" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1" pci_busid="0000:7f:10.3" pci_type="0880 [8086:3cb3] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1"/>
+      </object>
+      <object type="PCIDev" os_index="520452" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2" pci_busid="0000:7f:10.4" pci_type="0880 [8086:3cb4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2"/>
+      </object>
+      <object type="PCIDev" os_index="520453" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3" pci_busid="0000:7f:10.5" pci_type="0880 [8086:3cb5] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3"/>
+      </object>
+      <object type="PCIDev" os_index="520454" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2" pci_busid="0000:7f:10.6" pci_type="0880 [8086:3cb6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2"/>
+      </object>
+      <object type="PCIDev" os_index="520455" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3" pci_busid="0000:7f:10.7" pci_type="0880 [8086:3cb7] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3"/>
+      </object>
+      <object type="PCIDev" os_index="520464" name="Intel Corporation Xeon E5/Core i7 DDRIO" pci_busid="0000:7f:11.0" pci_type="0880 [8086:3cb8] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 DDRIO"/>
+      </object>
+      <object type="PCIDev" os_index="520496" name="Intel Corporation Xeon E5/Core i7 R2PCIe" pci_busid="0000:7f:13.0" pci_type="0880 [8086:3ce4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 R2PCIe"/>
+      </object>
+      <object type="PCIDev" os_index="520497" name="Intel Corporation Xeon E5/Core i7 Ring to PCI Express Performance Monitor" pci_busid="0000:7f:13.1" pci_type="1101 [8086:3c43] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to PCI Express Performance Monitor"/>
+      </object>
+      <object type="PCIDev" os_index="520500" name="Intel Corporation Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers" pci_busid="0000:7f:13.4" pci_type="1101 [8086:3ce6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers"/>
+      </object>
+      <object type="PCIDev" os_index="520501" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor" pci_busid="0000:7f:13.5" pci_type="1101 [8086:3c44] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor"/>
+      </object>
+      <object type="PCIDev" os_index="520502" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor" pci_busid="0000:7f:13.6" pci_type="0880 [8086:3c45] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor"/>
+      </object>
+    </object>
+    <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0000:[ff-ff]">
+      <object type="PCIDev" os_index="1044608" name="Intel Corporation Xeon E5/Core i7 QPI Link 0" pci_busid="0000:ff:08.0" pci_type="0880 [8086:3c80] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044624" name="Intel Corporation Xeon E5/Core i7 QPI Link 1" pci_busid="0000:ff:09.0" pci_type="0880 [8086:3c90] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044640" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 0" pci_busid="0000:ff:0a.0" pci_type="0880 [8086:3cc0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044641" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 1" pci_busid="0000:ff:0a.1" pci_type="0880 [8086:3cc1] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044642" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 2" pci_busid="0000:ff:0a.2" pci_type="0880 [8086:3cc2] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 2"/>
+      </object>
+      <object type="PCIDev" os_index="1044643" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 3" pci_busid="0000:ff:0a.3" pci_type="0880 [8086:3cd0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 3"/>
+      </object>
+      <object type="PCIDev" os_index="1044656" name="Intel Corporation Xeon E5/Core i7 Interrupt Control Registers" pci_busid="0000:ff:0b.0" pci_type="0880 [8086:3ce0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Interrupt Control Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044659" name="Intel Corporation Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers" pci_busid="0000:ff:0b.3" pci_type="0880 [8086:3ce3] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044672" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044673" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044674" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044675" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044678" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0" pci_busid="0000:ff:0c.6" pci_type="0880 [8086:3cf4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044679" name="Intel Corporation Xeon E5/Core i7 System Address Decoder" pci_busid="0000:ff:0c.7" pci_type="0880 [8086:3cf6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 System Address Decoder"/>
+      </object>
+      <object type="PCIDev" os_index="1044688" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044689" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044690" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044691" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044694" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1" pci_busid="0000:ff:0d.6" pci_type="0880 [8086:3cf5] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044704" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent" pci_busid="0000:ff:0e.0" pci_type="0880 [8086:3ca0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent"/>
+      </object>
+      <object type="PCIDev" os_index="1044705" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent Performance Monitoring" pci_busid="0000:ff:0e.1" pci_type="1101 [8086:3c46] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent Performance Monitoring"/>
+      </object>
+      <object type="PCIDev" os_index="1044720" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Registers" pci_busid="0000:ff:0f.0" pci_type="0880 [8086:3ca8] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044721" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller RAS Registers" pci_busid="0000:ff:0f.1" pci_type="0880 [8086:3c71] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller RAS Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044722" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0" pci_busid="0000:ff:0f.2" pci_type="0880 [8086:3caa] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044723" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1" pci_busid="0000:ff:0f.3" pci_type="0880 [8086:3cab] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044724" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2" pci_busid="0000:ff:0f.4" pci_type="0880 [8086:3cac] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2"/>
+      </object>
+      <object type="PCIDev" os_index="1044725" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3" pci_busid="0000:ff:0f.5" pci_type="0880 [8086:3cad] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3"/>
+      </object>
+      <object type="PCIDev" os_index="1044726" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4" pci_busid="0000:ff:0f.6" pci_type="0880 [8086:3cae] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4"/>
+      </object>
+      <object type="PCIDev" os_index="1044736" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0" pci_busid="0000:ff:10.0" pci_type="0880 [8086:3cb0] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044737" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1" pci_busid="0000:ff:10.1" pci_type="0880 [8086:3cb1] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044738" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0" pci_busid="0000:ff:10.2" pci_type="0880 [8086:3cb2] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0"/>
+      </object>
+      <object type="PCIDev" os_index="1044739" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1" pci_busid="0000:ff:10.3" pci_type="0880 [8086:3cb3] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1"/>
+      </object>
+      <object type="PCIDev" os_index="1044740" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2" pci_busid="0000:ff:10.4" pci_type="0880 [8086:3cb4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2"/>
+      </object>
+      <object type="PCIDev" os_index="1044741" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3" pci_busid="0000:ff:10.5" pci_type="0880 [8086:3cb5] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3"/>
+      </object>
+      <object type="PCIDev" os_index="1044742" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2" pci_busid="0000:ff:10.6" pci_type="0880 [8086:3cb6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2"/>
+      </object>
+      <object type="PCIDev" os_index="1044743" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3" pci_busid="0000:ff:10.7" pci_type="0880 [8086:3cb7] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3"/>
+      </object>
+      <object type="PCIDev" os_index="1044752" name="Intel Corporation Xeon E5/Core i7 DDRIO" pci_busid="0000:ff:11.0" pci_type="0880 [8086:3cb8] [0086:0000] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 DDRIO"/>
+      </object>
+      <object type="PCIDev" os_index="1044784" name="Intel Corporation Xeon E5/Core i7 R2PCIe" pci_busid="0000:ff:13.0" pci_type="0880 [8086:3ce4] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 R2PCIe"/>
+      </object>
+      <object type="PCIDev" os_index="1044785" name="Intel Corporation Xeon E5/Core i7 Ring to PCI Express Performance Monitor" pci_busid="0000:ff:13.1" pci_type="1101 [8086:3c43] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to PCI Express Performance Monitor"/>
+      </object>
+      <object type="PCIDev" os_index="1044788" name="Intel Corporation Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers" pci_busid="0000:ff:13.4" pci_type="1101 [8086:3ce6] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers"/>
+      </object>
+      <object type="PCIDev" os_index="1044789" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor" pci_busid="0000:ff:13.5" pci_type="1101 [8086:3c44] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor"/>
+      </object>
+      <object type="PCIDev" os_index="1044790" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor" pci_busid="0000:ff:13.6" pci_type="0880 [8086:3c45] [0086:008c] 06" pci_link_speed="0.000000">
+        <info name="PCIVendor" value="Intel Corporation"/>
+        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor"/>
+      </object>
+    </object>
+  </object>
+</topology>
+

--- a/t/data/hwloc-data/004N/exclusive/04-brokers/0.xml
+++ b/t/data/hwloc-data/004N/exclusive/04-brokers/0.xml
@@ -2,8 +2,6 @@
 <!DOCTYPE topology SYSTEM "hwloc.dtd">
 <topology>
   <object type="Machine" os_index="0" cpuset="0x0000ffff" complete_cpuset="0x0000ffff" online_cpuset="0x0000ffff" allowed_cpuset="0x0000ffff" nodeset="0x00000003" complete_nodeset="0x00000003" allowed_nodeset="0x00000003">
-    <page_type size="4096" count="0"/>
-    <page_type size="2097152" count="0"/>
     <info name="DMIProductName" value="appro-512x"/>
     <info name="DMIProductVersion" value="...................."/>
     <info name="DMIBoardVendor" value="Intel Corporation"/>
@@ -31,204 +29,74 @@
       <object type="Socket" os_index="0" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz"/>
         <info name="CPUType" value="x86_64"/>
-        <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
-          <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
+        <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-      </object>
-      <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-08]">
-        <object type="PCIDev" os_index="0" name="Intel Corporation Xeon E5/Core i7 DMI2" pci_busid="0000:00:00.0" pci_type="0600 [8086:3c00] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMI2"/>
+        <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="Bridge" os_index="16" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 1a" bridge_type="1-1" depth="0" bridge_pci="0000:[01-01]" pci_busid="0000:00:01.0" pci_type="0604 [8086:3c02] [0000:0000] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 1a"/>
+        <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="Bridge" os_index="32" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 2a" bridge_type="1-1" depth="0" bridge_pci="0000:[02-02]" pci_busid="0000:00:02.0" pci_type="0604 [8086:3c04] [0000:0000] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 2a"/>
-          <object type="PCIDev" os_index="8192" name="QLogic Corp. IBA7322 QDR InfiniBand HCA" pci_busid="0000:02:00.0" pci_type="0c06 [1077:7322] [0077:0022] 02" pci_link_speed="0.000000">
-            <info name="PCIVendor" value="QLogic Corp."/>
-            <info name="PCIDevice" value="IBA7322 QDR InfiniBand HCA"/>
-            <object type="OSDev" name="ib0" osdev_type="2">
-              <info name="Address" value="80:00:00:03:fe:80:00:00:00:00:00:00:00:11:75:00:00:77:29:06"/>
-              <info name="Port" value="1"/>
-            </object>
-            <object type="OSDev" name="qib0" osdev_type="3"/>
-          </object>
+        <object type="Core" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="Bridge" os_index="48" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode" bridge_type="1-1" depth="0" bridge_pci="0000:[03-03]" pci_busid="0000:00:03.0" pci_type="0604 [8086:3c08] [0000:0000] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode"/>
+        <object type="Core" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="PCIDev" os_index="64" name="Intel Corporation Xeon E5/Core i7 DMA Channel 0" pci_busid="0000:00:04.0" pci_type="0880 [8086:3c20] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 0"/>
-          <object type="OSDev" name="dma0chan0" osdev_type="4"/>
+        <object type="Core" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="PCIDev" os_index="65" name="Intel Corporation Xeon E5/Core i7 DMA Channel 1" pci_busid="0000:00:04.1" pci_type="0880 [8086:3c21] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 1"/>
-          <object type="OSDev" name="dma1chan0" osdev_type="4"/>
+        <object type="Core" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="PCIDev" os_index="66" name="Intel Corporation Xeon E5/Core i7 DMA Channel 2" pci_busid="0000:00:04.2" pci_type="0880 [8086:3c22] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 2"/>
-          <object type="OSDev" name="dma2chan0" osdev_type="4"/>
+        <object type="Core" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="PCIDev" os_index="67" name="Intel Corporation Xeon E5/Core i7 DMA Channel 3" pci_busid="0000:00:04.3" pci_type="0880 [8086:3c23] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 3"/>
-          <object type="OSDev" name="dma3chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="68" name="Intel Corporation Xeon E5/Core i7 DMA Channel 4" pci_busid="0000:00:04.4" pci_type="0880 [8086:3c24] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 4"/>
-          <object type="OSDev" name="dma4chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="69" name="Intel Corporation Xeon E5/Core i7 DMA Channel 5" pci_busid="0000:00:04.5" pci_type="0880 [8086:3c25] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 5"/>
-          <object type="OSDev" name="dma5chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="70" name="Intel Corporation Xeon E5/Core i7 DMA Channel 6" pci_busid="0000:00:04.6" pci_type="0880 [8086:3c26] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 6"/>
-          <object type="OSDev" name="dma6chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="71" name="Intel Corporation Xeon E5/Core i7 DMA Channel 7" pci_busid="0000:00:04.7" pci_type="0880 [8086:3c27] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 7"/>
-          <object type="OSDev" name="dma7chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="80" name="Intel Corporation Xeon E5/Core i7 Address Map, VTd_Misc, System Management" pci_busid="0000:00:05.0" pci_type="0880 [8086:3c28] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 Address Map, VTd_Misc, System Management"/>
-        </object>
-        <object type="PCIDev" os_index="82" name="Intel Corporation Xeon E5/Core i7 Control Status and Global Errors" pci_busid="0000:00:05.2" pci_type="0880 [8086:3c2a] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 Control Status and Global Errors"/>
-        </object>
-        <object type="PCIDev" os_index="84" name="Intel Corporation Xeon E5/Core i7 I/O APIC" pci_busid="0000:00:05.4" pci_type="0800 [8086:3c2c] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 I/O APIC"/>
-        </object>
-        <object type="Bridge" os_index="272" name="Intel Corporation C600/X79 series chipset PCI Express Virtual Root Port" bridge_type="1-1" depth="0" bridge_pci="0000:[04-04]" pci_busid="0000:00:11.0" pci_type="0604 [8086:1d3e] [0000:0000] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset PCI Express Virtual Root Port"/>
-        </object>
-        <object type="PCIDev" os_index="352" name="Intel Corporation C600/X79 series chipset MEI Controller #1" pci_busid="0000:00:16.0" pci_type="0780 [8086:1d3a] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset MEI Controller #1"/>
-        </object>
-        <object type="PCIDev" os_index="353" name="Intel Corporation C600/X79 series chipset MEI Controller #2" pci_busid="0000:00:16.1" pci_type="0780 [8086:1d3b] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset MEI Controller #2"/>
-        </object>
-        <object type="PCIDev" os_index="416" name="Intel Corporation C600/X79 series chipset USB2 Enhanced Host Controller #2" pci_busid="0000:00:1a.0" pci_type="0c03 [8086:1d2d] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset USB2 Enhanced Host Controller #2"/>
-        </object>
-        <object type="Bridge" os_index="448" name="Intel Corporation C600/X79 series chipset PCI Express Root Port 1" bridge_type="1-1" depth="0" bridge_pci="0000:[05-06]" pci_busid="0000:00:1c.0" pci_type="0604 [8086:1d10] [0000:0000] b5" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset PCI Express Root Port 1"/>
-          <object type="PCIDev" os_index="20480" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:05:00.0" pci_type="0200 [8086:1521] [0086:008c] 01" pci_link_speed="0.000000">
+        <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-08]">
+          <object type="Bridge" os_index="32" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 2a" bridge_type="1-1" depth="1" bridge_pci="0000:[02-02]" pci_busid="0000:00:02.0" pci_type="0604 [8086:3c04] [0000:0000] 06" pci_link_speed="0.000000">
             <info name="PCIVendor" value="Intel Corporation"/>
-            <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
-            <object type="OSDev" name="eth0" osdev_type="2">
-              <info name="Address" value="00:1e:67:2c:b9:db"/>
+            <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 2a"/>
+            <object type="PCIDev" os_index="8192" name="QLogic Corp. IBA7322 QDR InfiniBand HCA" pci_busid="0000:02:00.0" pci_type="0c06 [1077:7322] [0077:0022] 02" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="QLogic Corp."/>
+              <info name="PCIDevice" value="IBA7322 QDR InfiniBand HCA"/>
+              <object type="OSDev" name="ib0" osdev_type="2">
+                <info name="Address" value="80:00:00:03:fe:80:00:00:00:00:00:00:00:11:75:00:00:77:29:06"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" name="qib0" osdev_type="3"/>
             </object>
           </object>
-          <object type="PCIDev" os_index="20481" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:05:00.1" pci_type="0200 [8086:1521] [0086:008c] 01" pci_link_speed="0.000000">
+          <object type="Bridge" os_index="448" name="Intel Corporation C600/X79 series chipset PCI Express Root Port 1" bridge_type="1-1" depth="1" bridge_pci="0000:[05-06]" pci_busid="0000:00:1c.0" pci_type="0604 [8086:1d10] [0000:0000] b5" pci_link_speed="0.000000">
             <info name="PCIVendor" value="Intel Corporation"/>
-            <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
-            <object type="OSDev" name="eth1" osdev_type="2">
-              <info name="Address" value="00:1e:67:2c:b9:dc"/>
+            <info name="PCIDevice" value="C600/X79 series chipset PCI Express Root Port 1"/>
+            <object type="PCIDev" os_index="20480" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:05:00.0" pci_type="0200 [8086:1521] [0086:008c] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Intel Corporation"/>
+              <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+              <object type="OSDev" name="eth0" osdev_type="2">
+                <info name="Address" value="00:1e:67:2c:b9:db"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="20481" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:05:00.1" pci_type="0200 [8086:1521] [0086:008c] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Intel Corporation"/>
+              <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+              <object type="OSDev" name="eth1" osdev_type="2">
+                <info name="Address" value="00:1e:67:2c:b9:dc"/>
+              </object>
             </object>
           </object>
-        </object>
-        <object type="Bridge" os_index="455" name="Intel Corporation C600/X79 series chipset PCI Express Root Port 8" bridge_type="1-1" depth="0" bridge_pci="0000:[07-07]" pci_busid="0000:00:1c.7" pci_type="0604 [8086:1d1e] [0000:0000] b5" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset PCI Express Root Port 8"/>
-          <object type="PCIDev" os_index="28672" name="Matrox Electronics Systems Ltd. MGA G200e [Pilot] ServerEngines (SEP1)" pci_busid="0000:07:00.0" pci_type="0300 [102b:0522] [0086:0003] 04" pci_link_speed="0.000000">
-            <info name="PCIVendor" value="Matrox Electronics Systems Ltd."/>
-            <info name="PCIDevice" value="MGA G200e [Pilot] ServerEngines (SEP1)"/>
+          <object type="Bridge" os_index="455" name="Intel Corporation C600/X79 series chipset PCI Express Root Port 8" bridge_type="1-1" depth="1" bridge_pci="0000:[07-07]" pci_busid="0000:00:1c.7" pci_type="0604 [8086:1d1e] [0000:0000] b5" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Intel Corporation"/>
+            <info name="PCIDevice" value="C600/X79 series chipset PCI Express Root Port 8"/>
+            <object type="PCIDev" os_index="28672" name="Matrox Electronics Systems Ltd. MGA G200e [Pilot] ServerEngines (SEP1)" pci_busid="0000:07:00.0" pci_type="0300 [102b:0522] [0086:0003] 04" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Matrox Electronics Systems Ltd."/>
+              <info name="PCIDevice" value="MGA G200e [Pilot] ServerEngines (SEP1)"/>
+            </object>
           </object>
-        </object>
-        <object type="PCIDev" os_index="464" name="Intel Corporation C600/X79 series chipset USB2 Enhanced Host Controller #1" pci_busid="0000:00:1d.0" pci_type="0c03 [8086:1d26] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset USB2 Enhanced Host Controller #1"/>
-        </object>
-        <object type="Bridge" os_index="480" name="Intel Corporation 82801 PCI Bridge" bridge_type="1-1" depth="0" bridge_pci="0000:[08-08]" pci_busid="0000:00:1e.0" pci_type="0604 [8086:244e] [0000:0000] a5" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="82801 PCI Bridge"/>
-        </object>
-        <object type="PCIDev" os_index="496" name="Intel Corporation C600/X79 series chipset LPC Controller" pci_busid="0000:00:1f.0" pci_type="0601 [8086:1d41] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset LPC Controller"/>
-        </object>
-        <object type="PCIDev" os_index="498" name="Intel Corporation C600/X79 series chipset 6-Port SATA AHCI Controller" pci_busid="0000:00:1f.2" pci_type="0106 [8086:1d02] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset 6-Port SATA AHCI Controller"/>
-        </object>
-        <object type="PCIDev" os_index="499" name="Intel Corporation C600/X79 series chipset SMBus Host Controller" pci_busid="0000:00:1f.3" pci_type="0c05 [8086:1d22] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset SMBus Host Controller"/>
+          <object type="PCIDev" os_index="498" name="Intel Corporation C600/X79 series chipset 6-Port SATA AHCI Controller" pci_busid="0000:00:1f.2" pci_type="0106 [8086:1d02] [0086:008c] 05" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Intel Corporation"/>
+            <info name="PCIDevice" value="C600/X79 series chipset 6-Port SATA AHCI Controller"/>
+          </object>
         </object>
       </object>
     </object>
@@ -238,464 +106,31 @@
       <object type="Socket" os_index="1" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz"/>
         <info name="CPUType" value="x86_64"/>
-        <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
-          <object type="Cache" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="0" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="1" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="2" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="3" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="4" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="5" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="6" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="7" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
+        <object type="Core" os_index="0" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-      </object>
-      <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0000:[80-81]">
-        <object type="Bridge" os_index="524336" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode" bridge_type="1-1" depth="0" bridge_pci="0000:[81-81]" pci_busid="0000:80:03.0" pci_type="0604 [8086:3c08] [0000:0000] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode"/>
+        <object type="Core" os_index="1" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524352" name="Intel Corporation Xeon E5/Core i7 DMA Channel 0" pci_busid="0000:80:04.0" pci_type="0880 [8086:3c20] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 0"/>
-          <object type="OSDev" name="dma8chan0" osdev_type="4"/>
+        <object type="Core" os_index="2" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524353" name="Intel Corporation Xeon E5/Core i7 DMA Channel 1" pci_busid="0000:80:04.1" pci_type="0880 [8086:3c21] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 1"/>
-          <object type="OSDev" name="dma9chan0" osdev_type="4"/>
+        <object type="Core" os_index="3" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524354" name="Intel Corporation Xeon E5/Core i7 DMA Channel 2" pci_busid="0000:80:04.2" pci_type="0880 [8086:3c22] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 2"/>
-          <object type="OSDev" name="dma10chan0" osdev_type="4"/>
+        <object type="Core" os_index="4" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524355" name="Intel Corporation Xeon E5/Core i7 DMA Channel 3" pci_busid="0000:80:04.3" pci_type="0880 [8086:3c23] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 3"/>
-          <object type="OSDev" name="dma11chan0" osdev_type="4"/>
+        <object type="Core" os_index="5" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524356" name="Intel Corporation Xeon E5/Core i7 DMA Channel 4" pci_busid="0000:80:04.4" pci_type="0880 [8086:3c24] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 4"/>
-          <object type="OSDev" name="dma12chan0" osdev_type="4"/>
+        <object type="Core" os_index="6" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524357" name="Intel Corporation Xeon E5/Core i7 DMA Channel 5" pci_busid="0000:80:04.5" pci_type="0880 [8086:3c25] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 5"/>
-          <object type="OSDev" name="dma13chan0" osdev_type="4"/>
+        <object type="Core" os_index="7" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524358" name="Intel Corporation Xeon E5/Core i7 DMA Channel 6" pci_busid="0000:80:04.6" pci_type="0880 [8086:3c26] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 6"/>
-          <object type="OSDev" name="dma14chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="524359" name="Intel Corporation Xeon E5/Core i7 DMA Channel 7" pci_busid="0000:80:04.7" pci_type="0880 [8086:3c27] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 7"/>
-          <object type="OSDev" name="dma15chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="524368" name="Intel Corporation Xeon E5/Core i7 Address Map, VTd_Misc, System Management" pci_busid="0000:80:05.0" pci_type="0880 [8086:3c28] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 Address Map, VTd_Misc, System Management"/>
-        </object>
-        <object type="PCIDev" os_index="524370" name="Intel Corporation Xeon E5/Core i7 Control Status and Global Errors" pci_busid="0000:80:05.2" pci_type="0880 [8086:3c2a] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 Control Status and Global Errors"/>
-        </object>
-        <object type="PCIDev" os_index="524372" name="Intel Corporation Xeon E5/Core i7 I/O APIC" pci_busid="0000:80:05.4" pci_type="0800 [8086:3c2c] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 I/O APIC"/>
-        </object>
-      </object>
-    </object>
-    <object type="Bridge" os_index="1" bridge_type="0-1" depth="0" bridge_pci="0000:[7f-7f]">
-      <object type="PCIDev" os_index="520320" name="Intel Corporation Xeon E5/Core i7 QPI Link 0" pci_busid="0000:7f:08.0" pci_type="0880 [8086:3c80] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 0"/>
-      </object>
-      <object type="PCIDev" os_index="520336" name="Intel Corporation Xeon E5/Core i7 QPI Link 1" pci_busid="0000:7f:09.0" pci_type="0880 [8086:3c90] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 1"/>
-      </object>
-      <object type="PCIDev" os_index="520352" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 0" pci_busid="0000:7f:0a.0" pci_type="0880 [8086:3cc0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 0"/>
-      </object>
-      <object type="PCIDev" os_index="520353" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 1" pci_busid="0000:7f:0a.1" pci_type="0880 [8086:3cc1] [0086:0000] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 1"/>
-      </object>
-      <object type="PCIDev" os_index="520354" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 2" pci_busid="0000:7f:0a.2" pci_type="0880 [8086:3cc2] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 2"/>
-      </object>
-      <object type="PCIDev" os_index="520355" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 3" pci_busid="0000:7f:0a.3" pci_type="0880 [8086:3cd0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 3"/>
-      </object>
-      <object type="PCIDev" os_index="520368" name="Intel Corporation Xeon E5/Core i7 Interrupt Control Registers" pci_busid="0000:7f:0b.0" pci_type="0880 [8086:3ce0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Interrupt Control Registers"/>
-      </object>
-      <object type="PCIDev" os_index="520371" name="Intel Corporation Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers" pci_busid="0000:7f:0b.3" pci_type="0880 [8086:3ce3] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers"/>
-      </object>
-      <object type="PCIDev" os_index="520384" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520385" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520386" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520387" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520390" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0" pci_busid="0000:7f:0c.6" pci_type="0880 [8086:3cf4] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0"/>
-      </object>
-      <object type="PCIDev" os_index="520391" name="Intel Corporation Xeon E5/Core i7 System Address Decoder" pci_busid="0000:7f:0c.7" pci_type="0880 [8086:3cf6] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 System Address Decoder"/>
-      </object>
-      <object type="PCIDev" os_index="520400" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520401" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520402" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520403" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520406" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1" pci_busid="0000:7f:0d.6" pci_type="0880 [8086:3cf5] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1"/>
-      </object>
-      <object type="PCIDev" os_index="520416" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent" pci_busid="0000:7f:0e.0" pci_type="0880 [8086:3ca0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent"/>
-      </object>
-      <object type="PCIDev" os_index="520417" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent Performance Monitoring" pci_busid="0000:7f:0e.1" pci_type="1101 [8086:3c46] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent Performance Monitoring"/>
-      </object>
-      <object type="PCIDev" os_index="520432" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Registers" pci_busid="0000:7f:0f.0" pci_type="0880 [8086:3ca8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Registers"/>
-      </object>
-      <object type="PCIDev" os_index="520433" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller RAS Registers" pci_busid="0000:7f:0f.1" pci_type="0880 [8086:3c71] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller RAS Registers"/>
-      </object>
-      <object type="PCIDev" os_index="520434" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0" pci_busid="0000:7f:0f.2" pci_type="0880 [8086:3caa] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0"/>
-      </object>
-      <object type="PCIDev" os_index="520435" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1" pci_busid="0000:7f:0f.3" pci_type="0880 [8086:3cab] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1"/>
-      </object>
-      <object type="PCIDev" os_index="520436" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2" pci_busid="0000:7f:0f.4" pci_type="0880 [8086:3cac] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2"/>
-      </object>
-      <object type="PCIDev" os_index="520437" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3" pci_busid="0000:7f:0f.5" pci_type="0880 [8086:3cad] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3"/>
-      </object>
-      <object type="PCIDev" os_index="520438" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4" pci_busid="0000:7f:0f.6" pci_type="0880 [8086:3cae] [0086:0000] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4"/>
-      </object>
-      <object type="PCIDev" os_index="520448" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0" pci_busid="0000:7f:10.0" pci_type="0880 [8086:3cb0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0"/>
-      </object>
-      <object type="PCIDev" os_index="520449" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1" pci_busid="0000:7f:10.1" pci_type="0880 [8086:3cb1] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1"/>
-      </object>
-      <object type="PCIDev" os_index="520450" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0" pci_busid="0000:7f:10.2" pci_type="0880 [8086:3cb2] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0"/>
-      </object>
-      <object type="PCIDev" os_index="520451" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1" pci_busid="0000:7f:10.3" pci_type="0880 [8086:3cb3] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1"/>
-      </object>
-      <object type="PCIDev" os_index="520452" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2" pci_busid="0000:7f:10.4" pci_type="0880 [8086:3cb4] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2"/>
-      </object>
-      <object type="PCIDev" os_index="520453" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3" pci_busid="0000:7f:10.5" pci_type="0880 [8086:3cb5] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3"/>
-      </object>
-      <object type="PCIDev" os_index="520454" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2" pci_busid="0000:7f:10.6" pci_type="0880 [8086:3cb6] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2"/>
-      </object>
-      <object type="PCIDev" os_index="520455" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3" pci_busid="0000:7f:10.7" pci_type="0880 [8086:3cb7] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3"/>
-      </object>
-      <object type="PCIDev" os_index="520464" name="Intel Corporation Xeon E5/Core i7 DDRIO" pci_busid="0000:7f:11.0" pci_type="0880 [8086:3cb8] [0086:0000] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 DDRIO"/>
-      </object>
-      <object type="PCIDev" os_index="520496" name="Intel Corporation Xeon E5/Core i7 R2PCIe" pci_busid="0000:7f:13.0" pci_type="0880 [8086:3ce4] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 R2PCIe"/>
-      </object>
-      <object type="PCIDev" os_index="520497" name="Intel Corporation Xeon E5/Core i7 Ring to PCI Express Performance Monitor" pci_busid="0000:7f:13.1" pci_type="1101 [8086:3c43] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to PCI Express Performance Monitor"/>
-      </object>
-      <object type="PCIDev" os_index="520500" name="Intel Corporation Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers" pci_busid="0000:7f:13.4" pci_type="1101 [8086:3ce6] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers"/>
-      </object>
-      <object type="PCIDev" os_index="520501" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor" pci_busid="0000:7f:13.5" pci_type="1101 [8086:3c44] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor"/>
-      </object>
-      <object type="PCIDev" os_index="520502" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor" pci_busid="0000:7f:13.6" pci_type="0880 [8086:3c45] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor"/>
-      </object>
-    </object>
-    <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0000:[ff-ff]">
-      <object type="PCIDev" os_index="1044608" name="Intel Corporation Xeon E5/Core i7 QPI Link 0" pci_busid="0000:ff:08.0" pci_type="0880 [8086:3c80] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044624" name="Intel Corporation Xeon E5/Core i7 QPI Link 1" pci_busid="0000:ff:09.0" pci_type="0880 [8086:3c90] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 1"/>
-      </object>
-      <object type="PCIDev" os_index="1044640" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 0" pci_busid="0000:ff:0a.0" pci_type="0880 [8086:3cc0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044641" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 1" pci_busid="0000:ff:0a.1" pci_type="0880 [8086:3cc1] [0086:0000] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 1"/>
-      </object>
-      <object type="PCIDev" os_index="1044642" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 2" pci_busid="0000:ff:0a.2" pci_type="0880 [8086:3cc2] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 2"/>
-      </object>
-      <object type="PCIDev" os_index="1044643" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 3" pci_busid="0000:ff:0a.3" pci_type="0880 [8086:3cd0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 3"/>
-      </object>
-      <object type="PCIDev" os_index="1044656" name="Intel Corporation Xeon E5/Core i7 Interrupt Control Registers" pci_busid="0000:ff:0b.0" pci_type="0880 [8086:3ce0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Interrupt Control Registers"/>
-      </object>
-      <object type="PCIDev" os_index="1044659" name="Intel Corporation Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers" pci_busid="0000:ff:0b.3" pci_type="0880 [8086:3ce3] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers"/>
-      </object>
-      <object type="PCIDev" os_index="1044672" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044673" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044674" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044675" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044678" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0" pci_busid="0000:ff:0c.6" pci_type="0880 [8086:3cf4] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044679" name="Intel Corporation Xeon E5/Core i7 System Address Decoder" pci_busid="0000:ff:0c.7" pci_type="0880 [8086:3cf6] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 System Address Decoder"/>
-      </object>
-      <object type="PCIDev" os_index="1044688" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044689" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044690" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044691" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044694" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1" pci_busid="0000:ff:0d.6" pci_type="0880 [8086:3cf5] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1"/>
-      </object>
-      <object type="PCIDev" os_index="1044704" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent" pci_busid="0000:ff:0e.0" pci_type="0880 [8086:3ca0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent"/>
-      </object>
-      <object type="PCIDev" os_index="1044705" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent Performance Monitoring" pci_busid="0000:ff:0e.1" pci_type="1101 [8086:3c46] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent Performance Monitoring"/>
-      </object>
-      <object type="PCIDev" os_index="1044720" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Registers" pci_busid="0000:ff:0f.0" pci_type="0880 [8086:3ca8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Registers"/>
-      </object>
-      <object type="PCIDev" os_index="1044721" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller RAS Registers" pci_busid="0000:ff:0f.1" pci_type="0880 [8086:3c71] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller RAS Registers"/>
-      </object>
-      <object type="PCIDev" os_index="1044722" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0" pci_busid="0000:ff:0f.2" pci_type="0880 [8086:3caa] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044723" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1" pci_busid="0000:ff:0f.3" pci_type="0880 [8086:3cab] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1"/>
-      </object>
-      <object type="PCIDev" os_index="1044724" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2" pci_busid="0000:ff:0f.4" pci_type="0880 [8086:3cac] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2"/>
-      </object>
-      <object type="PCIDev" os_index="1044725" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3" pci_busid="0000:ff:0f.5" pci_type="0880 [8086:3cad] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3"/>
-      </object>
-      <object type="PCIDev" os_index="1044726" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4" pci_busid="0000:ff:0f.6" pci_type="0880 [8086:3cae] [0086:0000] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4"/>
-      </object>
-      <object type="PCIDev" os_index="1044736" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0" pci_busid="0000:ff:10.0" pci_type="0880 [8086:3cb0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044737" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1" pci_busid="0000:ff:10.1" pci_type="0880 [8086:3cb1] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1"/>
-      </object>
-      <object type="PCIDev" os_index="1044738" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0" pci_busid="0000:ff:10.2" pci_type="0880 [8086:3cb2] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044739" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1" pci_busid="0000:ff:10.3" pci_type="0880 [8086:3cb3] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1"/>
-      </object>
-      <object type="PCIDev" os_index="1044740" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2" pci_busid="0000:ff:10.4" pci_type="0880 [8086:3cb4] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2"/>
-      </object>
-      <object type="PCIDev" os_index="1044741" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3" pci_busid="0000:ff:10.5" pci_type="0880 [8086:3cb5] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3"/>
-      </object>
-      <object type="PCIDev" os_index="1044742" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2" pci_busid="0000:ff:10.6" pci_type="0880 [8086:3cb6] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2"/>
-      </object>
-      <object type="PCIDev" os_index="1044743" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3" pci_busid="0000:ff:10.7" pci_type="0880 [8086:3cb7] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3"/>
-      </object>
-      <object type="PCIDev" os_index="1044752" name="Intel Corporation Xeon E5/Core i7 DDRIO" pci_busid="0000:ff:11.0" pci_type="0880 [8086:3cb8] [0086:0000] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 DDRIO"/>
-      </object>
-      <object type="PCIDev" os_index="1044784" name="Intel Corporation Xeon E5/Core i7 R2PCIe" pci_busid="0000:ff:13.0" pci_type="0880 [8086:3ce4] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 R2PCIe"/>
-      </object>
-      <object type="PCIDev" os_index="1044785" name="Intel Corporation Xeon E5/Core i7 Ring to PCI Express Performance Monitor" pci_busid="0000:ff:13.1" pci_type="1101 [8086:3c43] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to PCI Express Performance Monitor"/>
-      </object>
-      <object type="PCIDev" os_index="1044788" name="Intel Corporation Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers" pci_busid="0000:ff:13.4" pci_type="1101 [8086:3ce6] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers"/>
-      </object>
-      <object type="PCIDev" os_index="1044789" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor" pci_busid="0000:ff:13.5" pci_type="1101 [8086:3c44] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor"/>
-      </object>
-      <object type="PCIDev" os_index="1044790" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor" pci_busid="0000:ff:13.6" pci_type="0880 [8086:3c45] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor"/>
       </object>
     </object>
   </object>
 </topology>
-

--- a/t/data/hwloc-data/004N/exclusive/04-brokers/1.xml
+++ b/t/data/hwloc-data/004N/exclusive/04-brokers/1.xml
@@ -2,8 +2,6 @@
 <!DOCTYPE topology SYSTEM "hwloc.dtd">
 <topology>
   <object type="Machine" os_index="0" cpuset="0x0000ffff" complete_cpuset="0x0000ffff" online_cpuset="0x0000ffff" allowed_cpuset="0x0000ffff" nodeset="0x00000003" complete_nodeset="0x00000003" allowed_nodeset="0x00000003">
-    <page_type size="4096" count="0"/>
-    <page_type size="2097152" count="0"/>
     <info name="DMIProductName" value="appro-512x"/>
     <info name="DMIProductVersion" value="...................."/>
     <info name="DMIBoardVendor" value="Intel Corporation"/>
@@ -31,204 +29,74 @@
       <object type="Socket" os_index="0" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz"/>
         <info name="CPUType" value="x86_64"/>
-        <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
-          <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
+        <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-      </object>
-      <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-08]">
-        <object type="PCIDev" os_index="0" name="Intel Corporation Xeon E5/Core i7 DMI2" pci_busid="0000:00:00.0" pci_type="0600 [8086:3c00] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMI2"/>
+        <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="Bridge" os_index="16" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 1a" bridge_type="1-1" depth="0" bridge_pci="0000:[01-01]" pci_busid="0000:00:01.0" pci_type="0604 [8086:3c02] [0000:0000] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 1a"/>
+        <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="Bridge" os_index="32" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 2a" bridge_type="1-1" depth="0" bridge_pci="0000:[02-02]" pci_busid="0000:00:02.0" pci_type="0604 [8086:3c04] [0000:0000] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 2a"/>
-          <object type="PCIDev" os_index="8192" name="QLogic Corp. IBA7322 QDR InfiniBand HCA" pci_busid="0000:02:00.0" pci_type="0c06 [1077:7322] [0077:0022] 02" pci_link_speed="0.000000">
-            <info name="PCIVendor" value="QLogic Corp."/>
-            <info name="PCIDevice" value="IBA7322 QDR InfiniBand HCA"/>
-            <object type="OSDev" name="ib0" osdev_type="2">
-              <info name="Address" value="80:00:00:03:fe:80:00:00:00:00:00:00:00:11:75:00:00:77:27:d2"/>
-              <info name="Port" value="1"/>
-            </object>
-            <object type="OSDev" name="qib0" osdev_type="3"/>
-          </object>
+        <object type="Core" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="Bridge" os_index="48" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode" bridge_type="1-1" depth="0" bridge_pci="0000:[03-03]" pci_busid="0000:00:03.0" pci_type="0604 [8086:3c08] [0000:0000] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode"/>
+        <object type="Core" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="PCIDev" os_index="64" name="Intel Corporation Xeon E5/Core i7 DMA Channel 0" pci_busid="0000:00:04.0" pci_type="0880 [8086:3c20] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 0"/>
-          <object type="OSDev" name="dma0chan0" osdev_type="4"/>
+        <object type="Core" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="PCIDev" os_index="65" name="Intel Corporation Xeon E5/Core i7 DMA Channel 1" pci_busid="0000:00:04.1" pci_type="0880 [8086:3c21] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 1"/>
-          <object type="OSDev" name="dma1chan0" osdev_type="4"/>
+        <object type="Core" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="PCIDev" os_index="66" name="Intel Corporation Xeon E5/Core i7 DMA Channel 2" pci_busid="0000:00:04.2" pci_type="0880 [8086:3c22] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 2"/>
-          <object type="OSDev" name="dma2chan0" osdev_type="4"/>
+        <object type="Core" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="PCIDev" os_index="67" name="Intel Corporation Xeon E5/Core i7 DMA Channel 3" pci_busid="0000:00:04.3" pci_type="0880 [8086:3c23] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 3"/>
-          <object type="OSDev" name="dma3chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="68" name="Intel Corporation Xeon E5/Core i7 DMA Channel 4" pci_busid="0000:00:04.4" pci_type="0880 [8086:3c24] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 4"/>
-          <object type="OSDev" name="dma4chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="69" name="Intel Corporation Xeon E5/Core i7 DMA Channel 5" pci_busid="0000:00:04.5" pci_type="0880 [8086:3c25] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 5"/>
-          <object type="OSDev" name="dma5chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="70" name="Intel Corporation Xeon E5/Core i7 DMA Channel 6" pci_busid="0000:00:04.6" pci_type="0880 [8086:3c26] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 6"/>
-          <object type="OSDev" name="dma6chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="71" name="Intel Corporation Xeon E5/Core i7 DMA Channel 7" pci_busid="0000:00:04.7" pci_type="0880 [8086:3c27] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 7"/>
-          <object type="OSDev" name="dma7chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="80" name="Intel Corporation Xeon E5/Core i7 Address Map, VTd_Misc, System Management" pci_busid="0000:00:05.0" pci_type="0880 [8086:3c28] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 Address Map, VTd_Misc, System Management"/>
-        </object>
-        <object type="PCIDev" os_index="82" name="Intel Corporation Xeon E5/Core i7 Control Status and Global Errors" pci_busid="0000:00:05.2" pci_type="0880 [8086:3c2a] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 Control Status and Global Errors"/>
-        </object>
-        <object type="PCIDev" os_index="84" name="Intel Corporation Xeon E5/Core i7 I/O APIC" pci_busid="0000:00:05.4" pci_type="0800 [8086:3c2c] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 I/O APIC"/>
-        </object>
-        <object type="Bridge" os_index="272" name="Intel Corporation C600/X79 series chipset PCI Express Virtual Root Port" bridge_type="1-1" depth="0" bridge_pci="0000:[04-04]" pci_busid="0000:00:11.0" pci_type="0604 [8086:1d3e] [0000:0000] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset PCI Express Virtual Root Port"/>
-        </object>
-        <object type="PCIDev" os_index="352" name="Intel Corporation C600/X79 series chipset MEI Controller #1" pci_busid="0000:00:16.0" pci_type="0780 [8086:1d3a] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset MEI Controller #1"/>
-        </object>
-        <object type="PCIDev" os_index="353" name="Intel Corporation C600/X79 series chipset MEI Controller #2" pci_busid="0000:00:16.1" pci_type="0780 [8086:1d3b] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset MEI Controller #2"/>
-        </object>
-        <object type="PCIDev" os_index="416" name="Intel Corporation C600/X79 series chipset USB2 Enhanced Host Controller #2" pci_busid="0000:00:1a.0" pci_type="0c03 [8086:1d2d] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset USB2 Enhanced Host Controller #2"/>
-        </object>
-        <object type="Bridge" os_index="448" name="Intel Corporation C600/X79 series chipset PCI Express Root Port 1" bridge_type="1-1" depth="0" bridge_pci="0000:[05-06]" pci_busid="0000:00:1c.0" pci_type="0604 [8086:1d10] [0000:0000] b5" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset PCI Express Root Port 1"/>
-          <object type="PCIDev" os_index="20480" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:05:00.0" pci_type="0200 [8086:1521] [0086:008c] 01" pci_link_speed="0.000000">
+        <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-08]">
+          <object type="Bridge" os_index="32" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 2a" bridge_type="1-1" depth="1" bridge_pci="0000:[02-02]" pci_busid="0000:00:02.0" pci_type="0604 [8086:3c04] [0000:0000] 06" pci_link_speed="0.000000">
             <info name="PCIVendor" value="Intel Corporation"/>
-            <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
-            <object type="OSDev" name="eth0" osdev_type="2">
-              <info name="Address" value="00:1e:67:32:7e:05"/>
+            <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 2a"/>
+            <object type="PCIDev" os_index="8192" name="QLogic Corp. IBA7322 QDR InfiniBand HCA" pci_busid="0000:02:00.0" pci_type="0c06 [1077:7322] [0077:0022] 02" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="QLogic Corp."/>
+              <info name="PCIDevice" value="IBA7322 QDR InfiniBand HCA"/>
+              <object type="OSDev" name="ib0" osdev_type="2">
+                <info name="Address" value="80:00:00:03:fe:80:00:00:00:00:00:00:00:11:75:00:00:77:27:d2"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" name="qib0" osdev_type="3"/>
             </object>
           </object>
-          <object type="PCIDev" os_index="20481" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:05:00.1" pci_type="0200 [8086:1521] [0086:008c] 01" pci_link_speed="0.000000">
+          <object type="Bridge" os_index="448" name="Intel Corporation C600/X79 series chipset PCI Express Root Port 1" bridge_type="1-1" depth="1" bridge_pci="0000:[05-06]" pci_busid="0000:00:1c.0" pci_type="0604 [8086:1d10] [0000:0000] b5" pci_link_speed="0.000000">
             <info name="PCIVendor" value="Intel Corporation"/>
-            <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
-            <object type="OSDev" name="eth1" osdev_type="2">
-              <info name="Address" value="00:1e:67:32:7e:06"/>
+            <info name="PCIDevice" value="C600/X79 series chipset PCI Express Root Port 1"/>
+            <object type="PCIDev" os_index="20480" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:05:00.0" pci_type="0200 [8086:1521] [0086:008c] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Intel Corporation"/>
+              <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+              <object type="OSDev" name="eth0" osdev_type="2">
+                <info name="Address" value="00:1e:67:32:7e:05"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="20481" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:05:00.1" pci_type="0200 [8086:1521] [0086:008c] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Intel Corporation"/>
+              <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+              <object type="OSDev" name="eth1" osdev_type="2">
+                <info name="Address" value="00:1e:67:32:7e:06"/>
+              </object>
             </object>
           </object>
-        </object>
-        <object type="Bridge" os_index="455" name="Intel Corporation C600/X79 series chipset PCI Express Root Port 8" bridge_type="1-1" depth="0" bridge_pci="0000:[07-07]" pci_busid="0000:00:1c.7" pci_type="0604 [8086:1d1e] [0000:0000] b5" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset PCI Express Root Port 8"/>
-          <object type="PCIDev" os_index="28672" name="Matrox Electronics Systems Ltd. MGA G200e [Pilot] ServerEngines (SEP1)" pci_busid="0000:07:00.0" pci_type="0300 [102b:0522] [0086:0003] 04" pci_link_speed="0.000000">
-            <info name="PCIVendor" value="Matrox Electronics Systems Ltd."/>
-            <info name="PCIDevice" value="MGA G200e [Pilot] ServerEngines (SEP1)"/>
+          <object type="Bridge" os_index="455" name="Intel Corporation C600/X79 series chipset PCI Express Root Port 8" bridge_type="1-1" depth="1" bridge_pci="0000:[07-07]" pci_busid="0000:00:1c.7" pci_type="0604 [8086:1d1e] [0000:0000] b5" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Intel Corporation"/>
+            <info name="PCIDevice" value="C600/X79 series chipset PCI Express Root Port 8"/>
+            <object type="PCIDev" os_index="28672" name="Matrox Electronics Systems Ltd. MGA G200e [Pilot] ServerEngines (SEP1)" pci_busid="0000:07:00.0" pci_type="0300 [102b:0522] [0086:0003] 04" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Matrox Electronics Systems Ltd."/>
+              <info name="PCIDevice" value="MGA G200e [Pilot] ServerEngines (SEP1)"/>
+            </object>
           </object>
-        </object>
-        <object type="PCIDev" os_index="464" name="Intel Corporation C600/X79 series chipset USB2 Enhanced Host Controller #1" pci_busid="0000:00:1d.0" pci_type="0c03 [8086:1d26] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset USB2 Enhanced Host Controller #1"/>
-        </object>
-        <object type="Bridge" os_index="480" name="Intel Corporation 82801 PCI Bridge" bridge_type="1-1" depth="0" bridge_pci="0000:[08-08]" pci_busid="0000:00:1e.0" pci_type="0604 [8086:244e] [0000:0000] a5" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="82801 PCI Bridge"/>
-        </object>
-        <object type="PCIDev" os_index="496" name="Intel Corporation C600/X79 series chipset LPC Controller" pci_busid="0000:00:1f.0" pci_type="0601 [8086:1d41] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset LPC Controller"/>
-        </object>
-        <object type="PCIDev" os_index="498" name="Intel Corporation C600/X79 series chipset 6-Port SATA AHCI Controller" pci_busid="0000:00:1f.2" pci_type="0106 [8086:1d02] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset 6-Port SATA AHCI Controller"/>
-        </object>
-        <object type="PCIDev" os_index="499" name="Intel Corporation C600/X79 series chipset SMBus Host Controller" pci_busid="0000:00:1f.3" pci_type="0c05 [8086:1d22] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset SMBus Host Controller"/>
+          <object type="PCIDev" os_index="498" name="Intel Corporation C600/X79 series chipset 6-Port SATA AHCI Controller" pci_busid="0000:00:1f.2" pci_type="0106 [8086:1d02] [0086:008c] 05" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Intel Corporation"/>
+            <info name="PCIDevice" value="C600/X79 series chipset 6-Port SATA AHCI Controller"/>
+          </object>
         </object>
       </object>
     </object>
@@ -238,464 +106,31 @@
       <object type="Socket" os_index="1" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz"/>
         <info name="CPUType" value="x86_64"/>
-        <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
-          <object type="Cache" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="0" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="1" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="2" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="3" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="4" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="5" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="6" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="7" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
+        <object type="Core" os_index="0" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-      </object>
-      <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0000:[80-81]">
-        <object type="Bridge" os_index="524336" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode" bridge_type="1-1" depth="0" bridge_pci="0000:[81-81]" pci_busid="0000:80:03.0" pci_type="0604 [8086:3c08] [0000:0000] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode"/>
+        <object type="Core" os_index="1" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524352" name="Intel Corporation Xeon E5/Core i7 DMA Channel 0" pci_busid="0000:80:04.0" pci_type="0880 [8086:3c20] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 0"/>
-          <object type="OSDev" name="dma8chan0" osdev_type="4"/>
+        <object type="Core" os_index="2" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524353" name="Intel Corporation Xeon E5/Core i7 DMA Channel 1" pci_busid="0000:80:04.1" pci_type="0880 [8086:3c21] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 1"/>
-          <object type="OSDev" name="dma9chan0" osdev_type="4"/>
+        <object type="Core" os_index="3" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524354" name="Intel Corporation Xeon E5/Core i7 DMA Channel 2" pci_busid="0000:80:04.2" pci_type="0880 [8086:3c22] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 2"/>
-          <object type="OSDev" name="dma10chan0" osdev_type="4"/>
+        <object type="Core" os_index="4" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524355" name="Intel Corporation Xeon E5/Core i7 DMA Channel 3" pci_busid="0000:80:04.3" pci_type="0880 [8086:3c23] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 3"/>
-          <object type="OSDev" name="dma11chan0" osdev_type="4"/>
+        <object type="Core" os_index="5" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524356" name="Intel Corporation Xeon E5/Core i7 DMA Channel 4" pci_busid="0000:80:04.4" pci_type="0880 [8086:3c24] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 4"/>
-          <object type="OSDev" name="dma12chan0" osdev_type="4"/>
+        <object type="Core" os_index="6" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524357" name="Intel Corporation Xeon E5/Core i7 DMA Channel 5" pci_busid="0000:80:04.5" pci_type="0880 [8086:3c25] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 5"/>
-          <object type="OSDev" name="dma13chan0" osdev_type="4"/>
+        <object type="Core" os_index="7" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524358" name="Intel Corporation Xeon E5/Core i7 DMA Channel 6" pci_busid="0000:80:04.6" pci_type="0880 [8086:3c26] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 6"/>
-          <object type="OSDev" name="dma14chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="524359" name="Intel Corporation Xeon E5/Core i7 DMA Channel 7" pci_busid="0000:80:04.7" pci_type="0880 [8086:3c27] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 7"/>
-          <object type="OSDev" name="dma15chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="524368" name="Intel Corporation Xeon E5/Core i7 Address Map, VTd_Misc, System Management" pci_busid="0000:80:05.0" pci_type="0880 [8086:3c28] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 Address Map, VTd_Misc, System Management"/>
-        </object>
-        <object type="PCIDev" os_index="524370" name="Intel Corporation Xeon E5/Core i7 Control Status and Global Errors" pci_busid="0000:80:05.2" pci_type="0880 [8086:3c2a] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 Control Status and Global Errors"/>
-        </object>
-        <object type="PCIDev" os_index="524372" name="Intel Corporation Xeon E5/Core i7 I/O APIC" pci_busid="0000:80:05.4" pci_type="0800 [8086:3c2c] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 I/O APIC"/>
-        </object>
-      </object>
-    </object>
-    <object type="Bridge" os_index="1" bridge_type="0-1" depth="0" bridge_pci="0000:[7f-7f]">
-      <object type="PCIDev" os_index="520320" name="Intel Corporation Xeon E5/Core i7 QPI Link 0" pci_busid="0000:7f:08.0" pci_type="0880 [8086:3c80] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 0"/>
-      </object>
-      <object type="PCIDev" os_index="520336" name="Intel Corporation Xeon E5/Core i7 QPI Link 1" pci_busid="0000:7f:09.0" pci_type="0880 [8086:3c90] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 1"/>
-      </object>
-      <object type="PCIDev" os_index="520352" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 0" pci_busid="0000:7f:0a.0" pci_type="0880 [8086:3cc0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 0"/>
-      </object>
-      <object type="PCIDev" os_index="520353" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 1" pci_busid="0000:7f:0a.1" pci_type="0880 [8086:3cc1] [0086:0000] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 1"/>
-      </object>
-      <object type="PCIDev" os_index="520354" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 2" pci_busid="0000:7f:0a.2" pci_type="0880 [8086:3cc2] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 2"/>
-      </object>
-      <object type="PCIDev" os_index="520355" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 3" pci_busid="0000:7f:0a.3" pci_type="0880 [8086:3cd0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 3"/>
-      </object>
-      <object type="PCIDev" os_index="520368" name="Intel Corporation Xeon E5/Core i7 Interrupt Control Registers" pci_busid="0000:7f:0b.0" pci_type="0880 [8086:3ce0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Interrupt Control Registers"/>
-      </object>
-      <object type="PCIDev" os_index="520371" name="Intel Corporation Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers" pci_busid="0000:7f:0b.3" pci_type="0880 [8086:3ce3] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers"/>
-      </object>
-      <object type="PCIDev" os_index="520384" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520385" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520386" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520387" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520390" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0" pci_busid="0000:7f:0c.6" pci_type="0880 [8086:3cf4] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0"/>
-      </object>
-      <object type="PCIDev" os_index="520391" name="Intel Corporation Xeon E5/Core i7 System Address Decoder" pci_busid="0000:7f:0c.7" pci_type="0880 [8086:3cf6] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 System Address Decoder"/>
-      </object>
-      <object type="PCIDev" os_index="520400" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520401" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520402" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520403" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520406" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1" pci_busid="0000:7f:0d.6" pci_type="0880 [8086:3cf5] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1"/>
-      </object>
-      <object type="PCIDev" os_index="520416" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent" pci_busid="0000:7f:0e.0" pci_type="0880 [8086:3ca0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent"/>
-      </object>
-      <object type="PCIDev" os_index="520417" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent Performance Monitoring" pci_busid="0000:7f:0e.1" pci_type="1101 [8086:3c46] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent Performance Monitoring"/>
-      </object>
-      <object type="PCIDev" os_index="520432" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Registers" pci_busid="0000:7f:0f.0" pci_type="0880 [8086:3ca8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Registers"/>
-      </object>
-      <object type="PCIDev" os_index="520433" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller RAS Registers" pci_busid="0000:7f:0f.1" pci_type="0880 [8086:3c71] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller RAS Registers"/>
-      </object>
-      <object type="PCIDev" os_index="520434" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0" pci_busid="0000:7f:0f.2" pci_type="0880 [8086:3caa] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0"/>
-      </object>
-      <object type="PCIDev" os_index="520435" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1" pci_busid="0000:7f:0f.3" pci_type="0880 [8086:3cab] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1"/>
-      </object>
-      <object type="PCIDev" os_index="520436" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2" pci_busid="0000:7f:0f.4" pci_type="0880 [8086:3cac] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2"/>
-      </object>
-      <object type="PCIDev" os_index="520437" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3" pci_busid="0000:7f:0f.5" pci_type="0880 [8086:3cad] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3"/>
-      </object>
-      <object type="PCIDev" os_index="520438" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4" pci_busid="0000:7f:0f.6" pci_type="0880 [8086:3cae] [0086:0000] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4"/>
-      </object>
-      <object type="PCIDev" os_index="520448" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0" pci_busid="0000:7f:10.0" pci_type="0880 [8086:3cb0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0"/>
-      </object>
-      <object type="PCIDev" os_index="520449" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1" pci_busid="0000:7f:10.1" pci_type="0880 [8086:3cb1] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1"/>
-      </object>
-      <object type="PCIDev" os_index="520450" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0" pci_busid="0000:7f:10.2" pci_type="0880 [8086:3cb2] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0"/>
-      </object>
-      <object type="PCIDev" os_index="520451" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1" pci_busid="0000:7f:10.3" pci_type="0880 [8086:3cb3] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1"/>
-      </object>
-      <object type="PCIDev" os_index="520452" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2" pci_busid="0000:7f:10.4" pci_type="0880 [8086:3cb4] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2"/>
-      </object>
-      <object type="PCIDev" os_index="520453" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3" pci_busid="0000:7f:10.5" pci_type="0880 [8086:3cb5] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3"/>
-      </object>
-      <object type="PCIDev" os_index="520454" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2" pci_busid="0000:7f:10.6" pci_type="0880 [8086:3cb6] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2"/>
-      </object>
-      <object type="PCIDev" os_index="520455" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3" pci_busid="0000:7f:10.7" pci_type="0880 [8086:3cb7] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3"/>
-      </object>
-      <object type="PCIDev" os_index="520464" name="Intel Corporation Xeon E5/Core i7 DDRIO" pci_busid="0000:7f:11.0" pci_type="0880 [8086:3cb8] [0086:0000] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 DDRIO"/>
-      </object>
-      <object type="PCIDev" os_index="520496" name="Intel Corporation Xeon E5/Core i7 R2PCIe" pci_busid="0000:7f:13.0" pci_type="0880 [8086:3ce4] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 R2PCIe"/>
-      </object>
-      <object type="PCIDev" os_index="520497" name="Intel Corporation Xeon E5/Core i7 Ring to PCI Express Performance Monitor" pci_busid="0000:7f:13.1" pci_type="1101 [8086:3c43] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to PCI Express Performance Monitor"/>
-      </object>
-      <object type="PCIDev" os_index="520500" name="Intel Corporation Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers" pci_busid="0000:7f:13.4" pci_type="1101 [8086:3ce6] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers"/>
-      </object>
-      <object type="PCIDev" os_index="520501" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor" pci_busid="0000:7f:13.5" pci_type="1101 [8086:3c44] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor"/>
-      </object>
-      <object type="PCIDev" os_index="520502" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor" pci_busid="0000:7f:13.6" pci_type="0880 [8086:3c45] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor"/>
-      </object>
-    </object>
-    <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0000:[ff-ff]">
-      <object type="PCIDev" os_index="1044608" name="Intel Corporation Xeon E5/Core i7 QPI Link 0" pci_busid="0000:ff:08.0" pci_type="0880 [8086:3c80] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044624" name="Intel Corporation Xeon E5/Core i7 QPI Link 1" pci_busid="0000:ff:09.0" pci_type="0880 [8086:3c90] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 1"/>
-      </object>
-      <object type="PCIDev" os_index="1044640" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 0" pci_busid="0000:ff:0a.0" pci_type="0880 [8086:3cc0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044641" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 1" pci_busid="0000:ff:0a.1" pci_type="0880 [8086:3cc1] [0086:0000] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 1"/>
-      </object>
-      <object type="PCIDev" os_index="1044642" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 2" pci_busid="0000:ff:0a.2" pci_type="0880 [8086:3cc2] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 2"/>
-      </object>
-      <object type="PCIDev" os_index="1044643" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 3" pci_busid="0000:ff:0a.3" pci_type="0880 [8086:3cd0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 3"/>
-      </object>
-      <object type="PCIDev" os_index="1044656" name="Intel Corporation Xeon E5/Core i7 Interrupt Control Registers" pci_busid="0000:ff:0b.0" pci_type="0880 [8086:3ce0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Interrupt Control Registers"/>
-      </object>
-      <object type="PCIDev" os_index="1044659" name="Intel Corporation Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers" pci_busid="0000:ff:0b.3" pci_type="0880 [8086:3ce3] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers"/>
-      </object>
-      <object type="PCIDev" os_index="1044672" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044673" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044674" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044675" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044678" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0" pci_busid="0000:ff:0c.6" pci_type="0880 [8086:3cf4] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044679" name="Intel Corporation Xeon E5/Core i7 System Address Decoder" pci_busid="0000:ff:0c.7" pci_type="0880 [8086:3cf6] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 System Address Decoder"/>
-      </object>
-      <object type="PCIDev" os_index="1044688" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044689" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044690" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044691" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044694" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1" pci_busid="0000:ff:0d.6" pci_type="0880 [8086:3cf5] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1"/>
-      </object>
-      <object type="PCIDev" os_index="1044704" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent" pci_busid="0000:ff:0e.0" pci_type="0880 [8086:3ca0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent"/>
-      </object>
-      <object type="PCIDev" os_index="1044705" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent Performance Monitoring" pci_busid="0000:ff:0e.1" pci_type="1101 [8086:3c46] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent Performance Monitoring"/>
-      </object>
-      <object type="PCIDev" os_index="1044720" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Registers" pci_busid="0000:ff:0f.0" pci_type="0880 [8086:3ca8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Registers"/>
-      </object>
-      <object type="PCIDev" os_index="1044721" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller RAS Registers" pci_busid="0000:ff:0f.1" pci_type="0880 [8086:3c71] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller RAS Registers"/>
-      </object>
-      <object type="PCIDev" os_index="1044722" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0" pci_busid="0000:ff:0f.2" pci_type="0880 [8086:3caa] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044723" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1" pci_busid="0000:ff:0f.3" pci_type="0880 [8086:3cab] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1"/>
-      </object>
-      <object type="PCIDev" os_index="1044724" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2" pci_busid="0000:ff:0f.4" pci_type="0880 [8086:3cac] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2"/>
-      </object>
-      <object type="PCIDev" os_index="1044725" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3" pci_busid="0000:ff:0f.5" pci_type="0880 [8086:3cad] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3"/>
-      </object>
-      <object type="PCIDev" os_index="1044726" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4" pci_busid="0000:ff:0f.6" pci_type="0880 [8086:3cae] [0086:0000] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4"/>
-      </object>
-      <object type="PCIDev" os_index="1044736" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0" pci_busid="0000:ff:10.0" pci_type="0880 [8086:3cb0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044737" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1" pci_busid="0000:ff:10.1" pci_type="0880 [8086:3cb1] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1"/>
-      </object>
-      <object type="PCIDev" os_index="1044738" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0" pci_busid="0000:ff:10.2" pci_type="0880 [8086:3cb2] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044739" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1" pci_busid="0000:ff:10.3" pci_type="0880 [8086:3cb3] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1"/>
-      </object>
-      <object type="PCIDev" os_index="1044740" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2" pci_busid="0000:ff:10.4" pci_type="0880 [8086:3cb4] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2"/>
-      </object>
-      <object type="PCIDev" os_index="1044741" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3" pci_busid="0000:ff:10.5" pci_type="0880 [8086:3cb5] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3"/>
-      </object>
-      <object type="PCIDev" os_index="1044742" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2" pci_busid="0000:ff:10.6" pci_type="0880 [8086:3cb6] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2"/>
-      </object>
-      <object type="PCIDev" os_index="1044743" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3" pci_busid="0000:ff:10.7" pci_type="0880 [8086:3cb7] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3"/>
-      </object>
-      <object type="PCIDev" os_index="1044752" name="Intel Corporation Xeon E5/Core i7 DDRIO" pci_busid="0000:ff:11.0" pci_type="0880 [8086:3cb8] [0086:0000] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 DDRIO"/>
-      </object>
-      <object type="PCIDev" os_index="1044784" name="Intel Corporation Xeon E5/Core i7 R2PCIe" pci_busid="0000:ff:13.0" pci_type="0880 [8086:3ce4] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 R2PCIe"/>
-      </object>
-      <object type="PCIDev" os_index="1044785" name="Intel Corporation Xeon E5/Core i7 Ring to PCI Express Performance Monitor" pci_busid="0000:ff:13.1" pci_type="1101 [8086:3c43] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to PCI Express Performance Monitor"/>
-      </object>
-      <object type="PCIDev" os_index="1044788" name="Intel Corporation Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers" pci_busid="0000:ff:13.4" pci_type="1101 [8086:3ce6] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers"/>
-      </object>
-      <object type="PCIDev" os_index="1044789" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor" pci_busid="0000:ff:13.5" pci_type="1101 [8086:3c44] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor"/>
-      </object>
-      <object type="PCIDev" os_index="1044790" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor" pci_busid="0000:ff:13.6" pci_type="0880 [8086:3c45] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor"/>
       </object>
     </object>
   </object>
 </topology>
-

--- a/t/data/hwloc-data/004N/exclusive/04-brokers/2.xml
+++ b/t/data/hwloc-data/004N/exclusive/04-brokers/2.xml
@@ -2,8 +2,6 @@
 <!DOCTYPE topology SYSTEM "hwloc.dtd">
 <topology>
   <object type="Machine" os_index="0" cpuset="0x0000ffff" complete_cpuset="0x0000ffff" online_cpuset="0x0000ffff" allowed_cpuset="0x0000ffff" nodeset="0x00000003" complete_nodeset="0x00000003" allowed_nodeset="0x00000003">
-    <page_type size="4096" count="0"/>
-    <page_type size="2097152" count="0"/>
     <info name="DMIProductName" value="appro-512x"/>
     <info name="DMIProductVersion" value="...................."/>
     <info name="DMIBoardVendor" value="Intel Corporation"/>
@@ -31,204 +29,74 @@
       <object type="Socket" os_index="0" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz"/>
         <info name="CPUType" value="x86_64"/>
-        <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
-          <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
+        <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-      </object>
-      <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-08]">
-        <object type="PCIDev" os_index="0" name="Intel Corporation Xeon E5/Core i7 DMI2" pci_busid="0000:00:00.0" pci_type="0600 [8086:3c00] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMI2"/>
+        <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="Bridge" os_index="16" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 1a" bridge_type="1-1" depth="0" bridge_pci="0000:[01-01]" pci_busid="0000:00:01.0" pci_type="0604 [8086:3c02] [0000:0000] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 1a"/>
+        <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="Bridge" os_index="32" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 2a" bridge_type="1-1" depth="0" bridge_pci="0000:[02-02]" pci_busid="0000:00:02.0" pci_type="0604 [8086:3c04] [0000:0000] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 2a"/>
-          <object type="PCIDev" os_index="8192" name="QLogic Corp. IBA7322 QDR InfiniBand HCA" pci_busid="0000:02:00.0" pci_type="0c06 [1077:7322] [0077:0022] 02" pci_link_speed="0.000000">
-            <info name="PCIVendor" value="QLogic Corp."/>
-            <info name="PCIDevice" value="IBA7322 QDR InfiniBand HCA"/>
-            <object type="OSDev" name="ib0" osdev_type="2">
-              <info name="Address" value="80:00:00:03:fe:80:00:00:00:00:00:00:00:11:75:00:00:77:27:54"/>
-              <info name="Port" value="1"/>
-            </object>
-            <object type="OSDev" name="qib0" osdev_type="3"/>
-          </object>
+        <object type="Core" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="Bridge" os_index="48" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode" bridge_type="1-1" depth="0" bridge_pci="0000:[03-03]" pci_busid="0000:00:03.0" pci_type="0604 [8086:3c08] [0000:0000] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode"/>
+        <object type="Core" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="PCIDev" os_index="64" name="Intel Corporation Xeon E5/Core i7 DMA Channel 0" pci_busid="0000:00:04.0" pci_type="0880 [8086:3c20] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 0"/>
-          <object type="OSDev" name="dma0chan0" osdev_type="4"/>
+        <object type="Core" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="PCIDev" os_index="65" name="Intel Corporation Xeon E5/Core i7 DMA Channel 1" pci_busid="0000:00:04.1" pci_type="0880 [8086:3c21] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 1"/>
-          <object type="OSDev" name="dma1chan0" osdev_type="4"/>
+        <object type="Core" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="PCIDev" os_index="66" name="Intel Corporation Xeon E5/Core i7 DMA Channel 2" pci_busid="0000:00:04.2" pci_type="0880 [8086:3c22] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 2"/>
-          <object type="OSDev" name="dma2chan0" osdev_type="4"/>
+        <object type="Core" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="PCIDev" os_index="67" name="Intel Corporation Xeon E5/Core i7 DMA Channel 3" pci_busid="0000:00:04.3" pci_type="0880 [8086:3c23] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 3"/>
-          <object type="OSDev" name="dma3chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="68" name="Intel Corporation Xeon E5/Core i7 DMA Channel 4" pci_busid="0000:00:04.4" pci_type="0880 [8086:3c24] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 4"/>
-          <object type="OSDev" name="dma4chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="69" name="Intel Corporation Xeon E5/Core i7 DMA Channel 5" pci_busid="0000:00:04.5" pci_type="0880 [8086:3c25] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 5"/>
-          <object type="OSDev" name="dma5chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="70" name="Intel Corporation Xeon E5/Core i7 DMA Channel 6" pci_busid="0000:00:04.6" pci_type="0880 [8086:3c26] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 6"/>
-          <object type="OSDev" name="dma6chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="71" name="Intel Corporation Xeon E5/Core i7 DMA Channel 7" pci_busid="0000:00:04.7" pci_type="0880 [8086:3c27] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 7"/>
-          <object type="OSDev" name="dma7chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="80" name="Intel Corporation Xeon E5/Core i7 Address Map, VTd_Misc, System Management" pci_busid="0000:00:05.0" pci_type="0880 [8086:3c28] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 Address Map, VTd_Misc, System Management"/>
-        </object>
-        <object type="PCIDev" os_index="82" name="Intel Corporation Xeon E5/Core i7 Control Status and Global Errors" pci_busid="0000:00:05.2" pci_type="0880 [8086:3c2a] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 Control Status and Global Errors"/>
-        </object>
-        <object type="PCIDev" os_index="84" name="Intel Corporation Xeon E5/Core i7 I/O APIC" pci_busid="0000:00:05.4" pci_type="0800 [8086:3c2c] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 I/O APIC"/>
-        </object>
-        <object type="Bridge" os_index="272" name="Intel Corporation C600/X79 series chipset PCI Express Virtual Root Port" bridge_type="1-1" depth="0" bridge_pci="0000:[04-04]" pci_busid="0000:00:11.0" pci_type="0604 [8086:1d3e] [0000:0000] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset PCI Express Virtual Root Port"/>
-        </object>
-        <object type="PCIDev" os_index="352" name="Intel Corporation C600/X79 series chipset MEI Controller #1" pci_busid="0000:00:16.0" pci_type="0780 [8086:1d3a] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset MEI Controller #1"/>
-        </object>
-        <object type="PCIDev" os_index="353" name="Intel Corporation C600/X79 series chipset MEI Controller #2" pci_busid="0000:00:16.1" pci_type="0780 [8086:1d3b] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset MEI Controller #2"/>
-        </object>
-        <object type="PCIDev" os_index="416" name="Intel Corporation C600/X79 series chipset USB2 Enhanced Host Controller #2" pci_busid="0000:00:1a.0" pci_type="0c03 [8086:1d2d] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset USB2 Enhanced Host Controller #2"/>
-        </object>
-        <object type="Bridge" os_index="448" name="Intel Corporation C600/X79 series chipset PCI Express Root Port 1" bridge_type="1-1" depth="0" bridge_pci="0000:[05-06]" pci_busid="0000:00:1c.0" pci_type="0604 [8086:1d10] [0000:0000] b5" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset PCI Express Root Port 1"/>
-          <object type="PCIDev" os_index="20480" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:05:00.0" pci_type="0200 [8086:1521] [0086:008c] 01" pci_link_speed="0.000000">
+        <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-08]">
+          <object type="Bridge" os_index="32" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 2a" bridge_type="1-1" depth="1" bridge_pci="0000:[02-02]" pci_busid="0000:00:02.0" pci_type="0604 [8086:3c04] [0000:0000] 06" pci_link_speed="0.000000">
             <info name="PCIVendor" value="Intel Corporation"/>
-            <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
-            <object type="OSDev" name="eth0" osdev_type="2">
-              <info name="Address" value="00:1e:67:32:7d:9c"/>
+            <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 2a"/>
+            <object type="PCIDev" os_index="8192" name="QLogic Corp. IBA7322 QDR InfiniBand HCA" pci_busid="0000:02:00.0" pci_type="0c06 [1077:7322] [0077:0022] 02" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="QLogic Corp."/>
+              <info name="PCIDevice" value="IBA7322 QDR InfiniBand HCA"/>
+              <object type="OSDev" name="ib0" osdev_type="2">
+                <info name="Address" value="80:00:00:03:fe:80:00:00:00:00:00:00:00:11:75:00:00:77:27:54"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" name="qib0" osdev_type="3"/>
             </object>
           </object>
-          <object type="PCIDev" os_index="20481" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:05:00.1" pci_type="0200 [8086:1521] [0086:008c] 01" pci_link_speed="0.000000">
+          <object type="Bridge" os_index="448" name="Intel Corporation C600/X79 series chipset PCI Express Root Port 1" bridge_type="1-1" depth="1" bridge_pci="0000:[05-06]" pci_busid="0000:00:1c.0" pci_type="0604 [8086:1d10] [0000:0000] b5" pci_link_speed="0.000000">
             <info name="PCIVendor" value="Intel Corporation"/>
-            <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
-            <object type="OSDev" name="eth1" osdev_type="2">
-              <info name="Address" value="00:1e:67:32:7d:9d"/>
+            <info name="PCIDevice" value="C600/X79 series chipset PCI Express Root Port 1"/>
+            <object type="PCIDev" os_index="20480" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:05:00.0" pci_type="0200 [8086:1521] [0086:008c] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Intel Corporation"/>
+              <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+              <object type="OSDev" name="eth0" osdev_type="2">
+                <info name="Address" value="00:1e:67:32:7d:9c"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="20481" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:05:00.1" pci_type="0200 [8086:1521] [0086:008c] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Intel Corporation"/>
+              <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+              <object type="OSDev" name="eth1" osdev_type="2">
+                <info name="Address" value="00:1e:67:32:7d:9d"/>
+              </object>
             </object>
           </object>
-        </object>
-        <object type="Bridge" os_index="455" name="Intel Corporation C600/X79 series chipset PCI Express Root Port 8" bridge_type="1-1" depth="0" bridge_pci="0000:[07-07]" pci_busid="0000:00:1c.7" pci_type="0604 [8086:1d1e] [0000:0000] b5" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset PCI Express Root Port 8"/>
-          <object type="PCIDev" os_index="28672" name="Matrox Electronics Systems Ltd. MGA G200e [Pilot] ServerEngines (SEP1)" pci_busid="0000:07:00.0" pci_type="0300 [102b:0522] [0086:0003] 04" pci_link_speed="0.000000">
-            <info name="PCIVendor" value="Matrox Electronics Systems Ltd."/>
-            <info name="PCIDevice" value="MGA G200e [Pilot] ServerEngines (SEP1)"/>
+          <object type="Bridge" os_index="455" name="Intel Corporation C600/X79 series chipset PCI Express Root Port 8" bridge_type="1-1" depth="1" bridge_pci="0000:[07-07]" pci_busid="0000:00:1c.7" pci_type="0604 [8086:1d1e] [0000:0000] b5" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Intel Corporation"/>
+            <info name="PCIDevice" value="C600/X79 series chipset PCI Express Root Port 8"/>
+            <object type="PCIDev" os_index="28672" name="Matrox Electronics Systems Ltd. MGA G200e [Pilot] ServerEngines (SEP1)" pci_busid="0000:07:00.0" pci_type="0300 [102b:0522] [0086:0003] 04" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Matrox Electronics Systems Ltd."/>
+              <info name="PCIDevice" value="MGA G200e [Pilot] ServerEngines (SEP1)"/>
+            </object>
           </object>
-        </object>
-        <object type="PCIDev" os_index="464" name="Intel Corporation C600/X79 series chipset USB2 Enhanced Host Controller #1" pci_busid="0000:00:1d.0" pci_type="0c03 [8086:1d26] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset USB2 Enhanced Host Controller #1"/>
-        </object>
-        <object type="Bridge" os_index="480" name="Intel Corporation 82801 PCI Bridge" bridge_type="1-1" depth="0" bridge_pci="0000:[08-08]" pci_busid="0000:00:1e.0" pci_type="0604 [8086:244e] [0000:0000] a5" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="82801 PCI Bridge"/>
-        </object>
-        <object type="PCIDev" os_index="496" name="Intel Corporation C600/X79 series chipset LPC Controller" pci_busid="0000:00:1f.0" pci_type="0601 [8086:1d41] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset LPC Controller"/>
-        </object>
-        <object type="PCIDev" os_index="498" name="Intel Corporation C600/X79 series chipset 6-Port SATA AHCI Controller" pci_busid="0000:00:1f.2" pci_type="0106 [8086:1d02] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset 6-Port SATA AHCI Controller"/>
-        </object>
-        <object type="PCIDev" os_index="499" name="Intel Corporation C600/X79 series chipset SMBus Host Controller" pci_busid="0000:00:1f.3" pci_type="0c05 [8086:1d22] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset SMBus Host Controller"/>
+          <object type="PCIDev" os_index="498" name="Intel Corporation C600/X79 series chipset 6-Port SATA AHCI Controller" pci_busid="0000:00:1f.2" pci_type="0106 [8086:1d02] [0086:008c] 05" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Intel Corporation"/>
+            <info name="PCIDevice" value="C600/X79 series chipset 6-Port SATA AHCI Controller"/>
+          </object>
         </object>
       </object>
     </object>
@@ -238,464 +106,31 @@
       <object type="Socket" os_index="1" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz"/>
         <info name="CPUType" value="x86_64"/>
-        <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
-          <object type="Cache" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="0" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="1" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="2" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="3" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="4" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="5" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="6" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="7" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
+        <object type="Core" os_index="0" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-      </object>
-      <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0000:[80-81]">
-        <object type="Bridge" os_index="524336" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode" bridge_type="1-1" depth="0" bridge_pci="0000:[81-81]" pci_busid="0000:80:03.0" pci_type="0604 [8086:3c08] [0000:0000] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode"/>
+        <object type="Core" os_index="1" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524352" name="Intel Corporation Xeon E5/Core i7 DMA Channel 0" pci_busid="0000:80:04.0" pci_type="0880 [8086:3c20] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 0"/>
-          <object type="OSDev" name="dma8chan0" osdev_type="4"/>
+        <object type="Core" os_index="2" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524353" name="Intel Corporation Xeon E5/Core i7 DMA Channel 1" pci_busid="0000:80:04.1" pci_type="0880 [8086:3c21] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 1"/>
-          <object type="OSDev" name="dma9chan0" osdev_type="4"/>
+        <object type="Core" os_index="3" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524354" name="Intel Corporation Xeon E5/Core i7 DMA Channel 2" pci_busid="0000:80:04.2" pci_type="0880 [8086:3c22] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 2"/>
-          <object type="OSDev" name="dma10chan0" osdev_type="4"/>
+        <object type="Core" os_index="4" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524355" name="Intel Corporation Xeon E5/Core i7 DMA Channel 3" pci_busid="0000:80:04.3" pci_type="0880 [8086:3c23] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 3"/>
-          <object type="OSDev" name="dma11chan0" osdev_type="4"/>
+        <object type="Core" os_index="5" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524356" name="Intel Corporation Xeon E5/Core i7 DMA Channel 4" pci_busid="0000:80:04.4" pci_type="0880 [8086:3c24] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 4"/>
-          <object type="OSDev" name="dma12chan0" osdev_type="4"/>
+        <object type="Core" os_index="6" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524357" name="Intel Corporation Xeon E5/Core i7 DMA Channel 5" pci_busid="0000:80:04.5" pci_type="0880 [8086:3c25] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 5"/>
-          <object type="OSDev" name="dma13chan0" osdev_type="4"/>
+        <object type="Core" os_index="7" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524358" name="Intel Corporation Xeon E5/Core i7 DMA Channel 6" pci_busid="0000:80:04.6" pci_type="0880 [8086:3c26] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 6"/>
-          <object type="OSDev" name="dma14chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="524359" name="Intel Corporation Xeon E5/Core i7 DMA Channel 7" pci_busid="0000:80:04.7" pci_type="0880 [8086:3c27] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 7"/>
-          <object type="OSDev" name="dma15chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="524368" name="Intel Corporation Xeon E5/Core i7 Address Map, VTd_Misc, System Management" pci_busid="0000:80:05.0" pci_type="0880 [8086:3c28] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 Address Map, VTd_Misc, System Management"/>
-        </object>
-        <object type="PCIDev" os_index="524370" name="Intel Corporation Xeon E5/Core i7 Control Status and Global Errors" pci_busid="0000:80:05.2" pci_type="0880 [8086:3c2a] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 Control Status and Global Errors"/>
-        </object>
-        <object type="PCIDev" os_index="524372" name="Intel Corporation Xeon E5/Core i7 I/O APIC" pci_busid="0000:80:05.4" pci_type="0800 [8086:3c2c] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 I/O APIC"/>
-        </object>
-      </object>
-    </object>
-    <object type="Bridge" os_index="1" bridge_type="0-1" depth="0" bridge_pci="0000:[7f-7f]">
-      <object type="PCIDev" os_index="520320" name="Intel Corporation Xeon E5/Core i7 QPI Link 0" pci_busid="0000:7f:08.0" pci_type="0880 [8086:3c80] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 0"/>
-      </object>
-      <object type="PCIDev" os_index="520336" name="Intel Corporation Xeon E5/Core i7 QPI Link 1" pci_busid="0000:7f:09.0" pci_type="0880 [8086:3c90] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 1"/>
-      </object>
-      <object type="PCIDev" os_index="520352" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 0" pci_busid="0000:7f:0a.0" pci_type="0880 [8086:3cc0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 0"/>
-      </object>
-      <object type="PCIDev" os_index="520353" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 1" pci_busid="0000:7f:0a.1" pci_type="0880 [8086:3cc1] [0086:0000] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 1"/>
-      </object>
-      <object type="PCIDev" os_index="520354" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 2" pci_busid="0000:7f:0a.2" pci_type="0880 [8086:3cc2] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 2"/>
-      </object>
-      <object type="PCIDev" os_index="520355" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 3" pci_busid="0000:7f:0a.3" pci_type="0880 [8086:3cd0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 3"/>
-      </object>
-      <object type="PCIDev" os_index="520368" name="Intel Corporation Xeon E5/Core i7 Interrupt Control Registers" pci_busid="0000:7f:0b.0" pci_type="0880 [8086:3ce0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Interrupt Control Registers"/>
-      </object>
-      <object type="PCIDev" os_index="520371" name="Intel Corporation Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers" pci_busid="0000:7f:0b.3" pci_type="0880 [8086:3ce3] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers"/>
-      </object>
-      <object type="PCIDev" os_index="520384" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520385" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520386" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520387" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520390" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0" pci_busid="0000:7f:0c.6" pci_type="0880 [8086:3cf4] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0"/>
-      </object>
-      <object type="PCIDev" os_index="520391" name="Intel Corporation Xeon E5/Core i7 System Address Decoder" pci_busid="0000:7f:0c.7" pci_type="0880 [8086:3cf6] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 System Address Decoder"/>
-      </object>
-      <object type="PCIDev" os_index="520400" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520401" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520402" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520403" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520406" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1" pci_busid="0000:7f:0d.6" pci_type="0880 [8086:3cf5] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1"/>
-      </object>
-      <object type="PCIDev" os_index="520416" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent" pci_busid="0000:7f:0e.0" pci_type="0880 [8086:3ca0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent"/>
-      </object>
-      <object type="PCIDev" os_index="520417" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent Performance Monitoring" pci_busid="0000:7f:0e.1" pci_type="1101 [8086:3c46] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent Performance Monitoring"/>
-      </object>
-      <object type="PCIDev" os_index="520432" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Registers" pci_busid="0000:7f:0f.0" pci_type="0880 [8086:3ca8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Registers"/>
-      </object>
-      <object type="PCIDev" os_index="520433" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller RAS Registers" pci_busid="0000:7f:0f.1" pci_type="0880 [8086:3c71] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller RAS Registers"/>
-      </object>
-      <object type="PCIDev" os_index="520434" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0" pci_busid="0000:7f:0f.2" pci_type="0880 [8086:3caa] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0"/>
-      </object>
-      <object type="PCIDev" os_index="520435" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1" pci_busid="0000:7f:0f.3" pci_type="0880 [8086:3cab] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1"/>
-      </object>
-      <object type="PCIDev" os_index="520436" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2" pci_busid="0000:7f:0f.4" pci_type="0880 [8086:3cac] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2"/>
-      </object>
-      <object type="PCIDev" os_index="520437" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3" pci_busid="0000:7f:0f.5" pci_type="0880 [8086:3cad] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3"/>
-      </object>
-      <object type="PCIDev" os_index="520438" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4" pci_busid="0000:7f:0f.6" pci_type="0880 [8086:3cae] [0086:0000] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4"/>
-      </object>
-      <object type="PCIDev" os_index="520448" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0" pci_busid="0000:7f:10.0" pci_type="0880 [8086:3cb0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0"/>
-      </object>
-      <object type="PCIDev" os_index="520449" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1" pci_busid="0000:7f:10.1" pci_type="0880 [8086:3cb1] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1"/>
-      </object>
-      <object type="PCIDev" os_index="520450" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0" pci_busid="0000:7f:10.2" pci_type="0880 [8086:3cb2] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0"/>
-      </object>
-      <object type="PCIDev" os_index="520451" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1" pci_busid="0000:7f:10.3" pci_type="0880 [8086:3cb3] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1"/>
-      </object>
-      <object type="PCIDev" os_index="520452" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2" pci_busid="0000:7f:10.4" pci_type="0880 [8086:3cb4] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2"/>
-      </object>
-      <object type="PCIDev" os_index="520453" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3" pci_busid="0000:7f:10.5" pci_type="0880 [8086:3cb5] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3"/>
-      </object>
-      <object type="PCIDev" os_index="520454" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2" pci_busid="0000:7f:10.6" pci_type="0880 [8086:3cb6] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2"/>
-      </object>
-      <object type="PCIDev" os_index="520455" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3" pci_busid="0000:7f:10.7" pci_type="0880 [8086:3cb7] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3"/>
-      </object>
-      <object type="PCIDev" os_index="520464" name="Intel Corporation Xeon E5/Core i7 DDRIO" pci_busid="0000:7f:11.0" pci_type="0880 [8086:3cb8] [0086:0000] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 DDRIO"/>
-      </object>
-      <object type="PCIDev" os_index="520496" name="Intel Corporation Xeon E5/Core i7 R2PCIe" pci_busid="0000:7f:13.0" pci_type="0880 [8086:3ce4] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 R2PCIe"/>
-      </object>
-      <object type="PCIDev" os_index="520497" name="Intel Corporation Xeon E5/Core i7 Ring to PCI Express Performance Monitor" pci_busid="0000:7f:13.1" pci_type="1101 [8086:3c43] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to PCI Express Performance Monitor"/>
-      </object>
-      <object type="PCIDev" os_index="520500" name="Intel Corporation Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers" pci_busid="0000:7f:13.4" pci_type="1101 [8086:3ce6] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers"/>
-      </object>
-      <object type="PCIDev" os_index="520501" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor" pci_busid="0000:7f:13.5" pci_type="1101 [8086:3c44] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor"/>
-      </object>
-      <object type="PCIDev" os_index="520502" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor" pci_busid="0000:7f:13.6" pci_type="0880 [8086:3c45] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor"/>
-      </object>
-    </object>
-    <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0000:[ff-ff]">
-      <object type="PCIDev" os_index="1044608" name="Intel Corporation Xeon E5/Core i7 QPI Link 0" pci_busid="0000:ff:08.0" pci_type="0880 [8086:3c80] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044624" name="Intel Corporation Xeon E5/Core i7 QPI Link 1" pci_busid="0000:ff:09.0" pci_type="0880 [8086:3c90] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 1"/>
-      </object>
-      <object type="PCIDev" os_index="1044640" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 0" pci_busid="0000:ff:0a.0" pci_type="0880 [8086:3cc0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044641" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 1" pci_busid="0000:ff:0a.1" pci_type="0880 [8086:3cc1] [0086:0000] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 1"/>
-      </object>
-      <object type="PCIDev" os_index="1044642" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 2" pci_busid="0000:ff:0a.2" pci_type="0880 [8086:3cc2] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 2"/>
-      </object>
-      <object type="PCIDev" os_index="1044643" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 3" pci_busid="0000:ff:0a.3" pci_type="0880 [8086:3cd0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 3"/>
-      </object>
-      <object type="PCIDev" os_index="1044656" name="Intel Corporation Xeon E5/Core i7 Interrupt Control Registers" pci_busid="0000:ff:0b.0" pci_type="0880 [8086:3ce0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Interrupt Control Registers"/>
-      </object>
-      <object type="PCIDev" os_index="1044659" name="Intel Corporation Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers" pci_busid="0000:ff:0b.3" pci_type="0880 [8086:3ce3] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers"/>
-      </object>
-      <object type="PCIDev" os_index="1044672" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044673" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044674" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044675" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044678" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0" pci_busid="0000:ff:0c.6" pci_type="0880 [8086:3cf4] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044679" name="Intel Corporation Xeon E5/Core i7 System Address Decoder" pci_busid="0000:ff:0c.7" pci_type="0880 [8086:3cf6] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 System Address Decoder"/>
-      </object>
-      <object type="PCIDev" os_index="1044688" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044689" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044690" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044691" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044694" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1" pci_busid="0000:ff:0d.6" pci_type="0880 [8086:3cf5] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1"/>
-      </object>
-      <object type="PCIDev" os_index="1044704" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent" pci_busid="0000:ff:0e.0" pci_type="0880 [8086:3ca0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent"/>
-      </object>
-      <object type="PCIDev" os_index="1044705" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent Performance Monitoring" pci_busid="0000:ff:0e.1" pci_type="1101 [8086:3c46] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent Performance Monitoring"/>
-      </object>
-      <object type="PCIDev" os_index="1044720" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Registers" pci_busid="0000:ff:0f.0" pci_type="0880 [8086:3ca8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Registers"/>
-      </object>
-      <object type="PCIDev" os_index="1044721" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller RAS Registers" pci_busid="0000:ff:0f.1" pci_type="0880 [8086:3c71] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller RAS Registers"/>
-      </object>
-      <object type="PCIDev" os_index="1044722" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0" pci_busid="0000:ff:0f.2" pci_type="0880 [8086:3caa] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044723" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1" pci_busid="0000:ff:0f.3" pci_type="0880 [8086:3cab] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1"/>
-      </object>
-      <object type="PCIDev" os_index="1044724" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2" pci_busid="0000:ff:0f.4" pci_type="0880 [8086:3cac] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2"/>
-      </object>
-      <object type="PCIDev" os_index="1044725" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3" pci_busid="0000:ff:0f.5" pci_type="0880 [8086:3cad] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3"/>
-      </object>
-      <object type="PCIDev" os_index="1044726" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4" pci_busid="0000:ff:0f.6" pci_type="0880 [8086:3cae] [0086:0000] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4"/>
-      </object>
-      <object type="PCIDev" os_index="1044736" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0" pci_busid="0000:ff:10.0" pci_type="0880 [8086:3cb0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044737" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1" pci_busid="0000:ff:10.1" pci_type="0880 [8086:3cb1] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1"/>
-      </object>
-      <object type="PCIDev" os_index="1044738" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0" pci_busid="0000:ff:10.2" pci_type="0880 [8086:3cb2] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044739" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1" pci_busid="0000:ff:10.3" pci_type="0880 [8086:3cb3] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1"/>
-      </object>
-      <object type="PCIDev" os_index="1044740" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2" pci_busid="0000:ff:10.4" pci_type="0880 [8086:3cb4] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2"/>
-      </object>
-      <object type="PCIDev" os_index="1044741" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3" pci_busid="0000:ff:10.5" pci_type="0880 [8086:3cb5] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3"/>
-      </object>
-      <object type="PCIDev" os_index="1044742" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2" pci_busid="0000:ff:10.6" pci_type="0880 [8086:3cb6] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2"/>
-      </object>
-      <object type="PCIDev" os_index="1044743" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3" pci_busid="0000:ff:10.7" pci_type="0880 [8086:3cb7] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3"/>
-      </object>
-      <object type="PCIDev" os_index="1044752" name="Intel Corporation Xeon E5/Core i7 DDRIO" pci_busid="0000:ff:11.0" pci_type="0880 [8086:3cb8] [0086:0000] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 DDRIO"/>
-      </object>
-      <object type="PCIDev" os_index="1044784" name="Intel Corporation Xeon E5/Core i7 R2PCIe" pci_busid="0000:ff:13.0" pci_type="0880 [8086:3ce4] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 R2PCIe"/>
-      </object>
-      <object type="PCIDev" os_index="1044785" name="Intel Corporation Xeon E5/Core i7 Ring to PCI Express Performance Monitor" pci_busid="0000:ff:13.1" pci_type="1101 [8086:3c43] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to PCI Express Performance Monitor"/>
-      </object>
-      <object type="PCIDev" os_index="1044788" name="Intel Corporation Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers" pci_busid="0000:ff:13.4" pci_type="1101 [8086:3ce6] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers"/>
-      </object>
-      <object type="PCIDev" os_index="1044789" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor" pci_busid="0000:ff:13.5" pci_type="1101 [8086:3c44] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor"/>
-      </object>
-      <object type="PCIDev" os_index="1044790" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor" pci_busid="0000:ff:13.6" pci_type="0880 [8086:3c45] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor"/>
       </object>
     </object>
   </object>
 </topology>
-

--- a/t/data/hwloc-data/004N/exclusive/04-brokers/3.xml
+++ b/t/data/hwloc-data/004N/exclusive/04-brokers/3.xml
@@ -2,8 +2,6 @@
 <!DOCTYPE topology SYSTEM "hwloc.dtd">
 <topology>
   <object type="Machine" os_index="0" cpuset="0x0000ffff" complete_cpuset="0x0000ffff" online_cpuset="0x0000ffff" allowed_cpuset="0x0000ffff" nodeset="0x00000003" complete_nodeset="0x00000003" allowed_nodeset="0x00000003">
-    <page_type size="4096" count="0"/>
-    <page_type size="2097152" count="0"/>
     <info name="DMIProductName" value="gb812x-cn"/>
     <info name="DMIProductVersion" value="...................."/>
     <info name="DMIBoardVendor" value="Intel Corporation"/>
@@ -31,204 +29,74 @@
       <object type="Socket" os_index="0" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz"/>
         <info name="CPUType" value="x86_64"/>
-        <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
-          <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
-                <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
-              </object>
-            </object>
-          </object>
+        <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-      </object>
-      <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-08]">
-        <object type="PCIDev" os_index="0" name="Intel Corporation Xeon E5/Core i7 DMI2" pci_busid="0000:00:00.0" pci_type="0600 [8086:3c00] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMI2"/>
+        <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="Bridge" os_index="16" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 1a" bridge_type="1-1" depth="0" bridge_pci="0000:[01-01]" pci_busid="0000:00:01.0" pci_type="0604 [8086:3c02] [0000:0000] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 1a"/>
+        <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="Bridge" os_index="32" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 2a" bridge_type="1-1" depth="0" bridge_pci="0000:[02-02]" pci_busid="0000:00:02.0" pci_type="0604 [8086:3c04] [0000:0000] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 2a"/>
-          <object type="PCIDev" os_index="8192" name="QLogic Corp. IBA7322 QDR InfiniBand HCA" pci_busid="0000:02:00.0" pci_type="0c06 [1077:7322] [0077:0022] 02" pci_link_speed="0.000000">
-            <info name="PCIVendor" value="QLogic Corp."/>
-            <info name="PCIDevice" value="IBA7322 QDR InfiniBand HCA"/>
-            <object type="OSDev" name="ib0" osdev_type="2">
-              <info name="Address" value="80:00:00:03:fe:80:00:00:00:00:00:00:00:11:75:00:00:77:ca:e8"/>
-              <info name="Port" value="1"/>
-            </object>
-            <object type="OSDev" name="qib0" osdev_type="3"/>
-          </object>
+        <object type="Core" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="Bridge" os_index="48" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode" bridge_type="1-1" depth="0" bridge_pci="0000:[03-03]" pci_busid="0000:00:03.0" pci_type="0604 [8086:3c08] [0000:0000] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode"/>
+        <object type="Core" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="PCIDev" os_index="64" name="Intel Corporation Xeon E5/Core i7 DMA Channel 0" pci_busid="0000:00:04.0" pci_type="0880 [8086:3c20] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 0"/>
-          <object type="OSDev" name="dma0chan0" osdev_type="4"/>
+        <object type="Core" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="PCIDev" os_index="65" name="Intel Corporation Xeon E5/Core i7 DMA Channel 1" pci_busid="0000:00:04.1" pci_type="0880 [8086:3c21] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 1"/>
-          <object type="OSDev" name="dma1chan0" osdev_type="4"/>
+        <object type="Core" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="PCIDev" os_index="66" name="Intel Corporation Xeon E5/Core i7 DMA Channel 2" pci_busid="0000:00:04.2" pci_type="0880 [8086:3c22] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 2"/>
-          <object type="OSDev" name="dma2chan0" osdev_type="4"/>
+        <object type="Core" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+          <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
         </object>
-        <object type="PCIDev" os_index="67" name="Intel Corporation Xeon E5/Core i7 DMA Channel 3" pci_busid="0000:00:04.3" pci_type="0880 [8086:3c23] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 3"/>
-          <object type="OSDev" name="dma3chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="68" name="Intel Corporation Xeon E5/Core i7 DMA Channel 4" pci_busid="0000:00:04.4" pci_type="0880 [8086:3c24] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 4"/>
-          <object type="OSDev" name="dma4chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="69" name="Intel Corporation Xeon E5/Core i7 DMA Channel 5" pci_busid="0000:00:04.5" pci_type="0880 [8086:3c25] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 5"/>
-          <object type="OSDev" name="dma5chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="70" name="Intel Corporation Xeon E5/Core i7 DMA Channel 6" pci_busid="0000:00:04.6" pci_type="0880 [8086:3c26] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 6"/>
-          <object type="OSDev" name="dma6chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="71" name="Intel Corporation Xeon E5/Core i7 DMA Channel 7" pci_busid="0000:00:04.7" pci_type="0880 [8086:3c27] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 7"/>
-          <object type="OSDev" name="dma7chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="80" name="Intel Corporation Xeon E5/Core i7 Address Map, VTd_Misc, System Management" pci_busid="0000:00:05.0" pci_type="0880 [8086:3c28] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 Address Map, VTd_Misc, System Management"/>
-        </object>
-        <object type="PCIDev" os_index="82" name="Intel Corporation Xeon E5/Core i7 Control Status and Global Errors" pci_busid="0000:00:05.2" pci_type="0880 [8086:3c2a] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 Control Status and Global Errors"/>
-        </object>
-        <object type="PCIDev" os_index="84" name="Intel Corporation Xeon E5/Core i7 I/O APIC" pci_busid="0000:00:05.4" pci_type="0800 [8086:3c2c] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 I/O APIC"/>
-        </object>
-        <object type="Bridge" os_index="272" name="Intel Corporation C600/X79 series chipset PCI Express Virtual Root Port" bridge_type="1-1" depth="0" bridge_pci="0000:[04-04]" pci_busid="0000:00:11.0" pci_type="0604 [8086:1d3e] [0000:0000] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset PCI Express Virtual Root Port"/>
-        </object>
-        <object type="PCIDev" os_index="352" name="Intel Corporation C600/X79 series chipset MEI Controller #1" pci_busid="0000:00:16.0" pci_type="0780 [8086:1d3a] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset MEI Controller #1"/>
-        </object>
-        <object type="PCIDev" os_index="353" name="Intel Corporation C600/X79 series chipset MEI Controller #2" pci_busid="0000:00:16.1" pci_type="0780 [8086:1d3b] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset MEI Controller #2"/>
-        </object>
-        <object type="PCIDev" os_index="416" name="Intel Corporation C600/X79 series chipset USB2 Enhanced Host Controller #2" pci_busid="0000:00:1a.0" pci_type="0c03 [8086:1d2d] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset USB2 Enhanced Host Controller #2"/>
-        </object>
-        <object type="Bridge" os_index="448" name="Intel Corporation C600/X79 series chipset PCI Express Root Port 1" bridge_type="1-1" depth="0" bridge_pci="0000:[05-06]" pci_busid="0000:00:1c.0" pci_type="0604 [8086:1d10] [0000:0000] b5" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset PCI Express Root Port 1"/>
-          <object type="PCIDev" os_index="20480" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:05:00.0" pci_type="0200 [8086:1521] [0086:008c] 01" pci_link_speed="0.000000">
+        <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-08]">
+          <object type="Bridge" os_index="32" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 2a" bridge_type="1-1" depth="1" bridge_pci="0000:[02-02]" pci_busid="0000:00:02.0" pci_type="0604 [8086:3c04] [0000:0000] 06" pci_link_speed="0.000000">
             <info name="PCIVendor" value="Intel Corporation"/>
-            <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
-            <object type="OSDev" name="eth0" osdev_type="2">
-              <info name="Address" value="00:1e:67:34:e1:d3"/>
+            <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 2a"/>
+            <object type="PCIDev" os_index="8192" name="QLogic Corp. IBA7322 QDR InfiniBand HCA" pci_busid="0000:02:00.0" pci_type="0c06 [1077:7322] [0077:0022] 02" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="QLogic Corp."/>
+              <info name="PCIDevice" value="IBA7322 QDR InfiniBand HCA"/>
+              <object type="OSDev" name="ib0" osdev_type="2">
+                <info name="Address" value="80:00:00:03:fe:80:00:00:00:00:00:00:00:11:75:00:00:77:ca:e8"/>
+                <info name="Port" value="1"/>
+              </object>
+              <object type="OSDev" name="qib0" osdev_type="3"/>
             </object>
           </object>
-          <object type="PCIDev" os_index="20481" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:05:00.1" pci_type="0200 [8086:1521] [0086:008c] 01" pci_link_speed="0.000000">
+          <object type="Bridge" os_index="448" name="Intel Corporation C600/X79 series chipset PCI Express Root Port 1" bridge_type="1-1" depth="1" bridge_pci="0000:[05-06]" pci_busid="0000:00:1c.0" pci_type="0604 [8086:1d10] [0000:0000] b5" pci_link_speed="0.000000">
             <info name="PCIVendor" value="Intel Corporation"/>
-            <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
-            <object type="OSDev" name="eth1" osdev_type="2">
-              <info name="Address" value="00:1e:67:34:e1:d4"/>
+            <info name="PCIDevice" value="C600/X79 series chipset PCI Express Root Port 1"/>
+            <object type="PCIDev" os_index="20480" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:05:00.0" pci_type="0200 [8086:1521] [0086:008c] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Intel Corporation"/>
+              <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+              <object type="OSDev" name="eth0" osdev_type="2">
+                <info name="Address" value="00:1e:67:34:e1:d3"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="20481" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:05:00.1" pci_type="0200 [8086:1521] [0086:008c] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Intel Corporation"/>
+              <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+              <object type="OSDev" name="eth1" osdev_type="2">
+                <info name="Address" value="00:1e:67:34:e1:d4"/>
+              </object>
             </object>
           </object>
-        </object>
-        <object type="Bridge" os_index="455" name="Intel Corporation C600/X79 series chipset PCI Express Root Port 8" bridge_type="1-1" depth="0" bridge_pci="0000:[07-07]" pci_busid="0000:00:1c.7" pci_type="0604 [8086:1d1e] [0000:0000] b5" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset PCI Express Root Port 8"/>
-          <object type="PCIDev" os_index="28672" name="Matrox Electronics Systems Ltd. MGA G200e [Pilot] ServerEngines (SEP1)" pci_busid="0000:07:00.0" pci_type="0300 [102b:0522] [0086:0003] 04" pci_link_speed="0.000000">
-            <info name="PCIVendor" value="Matrox Electronics Systems Ltd."/>
-            <info name="PCIDevice" value="MGA G200e [Pilot] ServerEngines (SEP1)"/>
+          <object type="Bridge" os_index="455" name="Intel Corporation C600/X79 series chipset PCI Express Root Port 8" bridge_type="1-1" depth="1" bridge_pci="0000:[07-07]" pci_busid="0000:00:1c.7" pci_type="0604 [8086:1d1e] [0000:0000] b5" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Intel Corporation"/>
+            <info name="PCIDevice" value="C600/X79 series chipset PCI Express Root Port 8"/>
+            <object type="PCIDev" os_index="28672" name="Matrox Electronics Systems Ltd. MGA G200e [Pilot] ServerEngines (SEP1)" pci_busid="0000:07:00.0" pci_type="0300 [102b:0522] [0086:0003] 04" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Matrox Electronics Systems Ltd."/>
+              <info name="PCIDevice" value="MGA G200e [Pilot] ServerEngines (SEP1)"/>
+            </object>
           </object>
-        </object>
-        <object type="PCIDev" os_index="464" name="Intel Corporation C600/X79 series chipset USB2 Enhanced Host Controller #1" pci_busid="0000:00:1d.0" pci_type="0c03 [8086:1d26] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset USB2 Enhanced Host Controller #1"/>
-        </object>
-        <object type="Bridge" os_index="480" name="Intel Corporation 82801 PCI Bridge" bridge_type="1-1" depth="0" bridge_pci="0000:[08-08]" pci_busid="0000:00:1e.0" pci_type="0604 [8086:244e] [0000:0000] a5" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="82801 PCI Bridge"/>
-        </object>
-        <object type="PCIDev" os_index="496" name="Intel Corporation C600/X79 series chipset LPC Controller" pci_busid="0000:00:1f.0" pci_type="0601 [8086:1d41] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset LPC Controller"/>
-        </object>
-        <object type="PCIDev" os_index="498" name="Intel Corporation C600/X79 series chipset 6-Port SATA AHCI Controller" pci_busid="0000:00:1f.2" pci_type="0106 [8086:1d02] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset 6-Port SATA AHCI Controller"/>
-        </object>
-        <object type="PCIDev" os_index="499" name="Intel Corporation C600/X79 series chipset SMBus Host Controller" pci_busid="0000:00:1f.3" pci_type="0c05 [8086:1d22] [0086:008c] 05" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="C600/X79 series chipset SMBus Host Controller"/>
+          <object type="PCIDev" os_index="498" name="Intel Corporation C600/X79 series chipset 6-Port SATA AHCI Controller" pci_busid="0000:00:1f.2" pci_type="0106 [8086:1d02] [0086:008c] 05" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Intel Corporation"/>
+            <info name="PCIDevice" value="C600/X79 series chipset 6-Port SATA AHCI Controller"/>
+          </object>
         </object>
       </object>
     </object>
@@ -238,464 +106,31 @@
       <object type="Socket" os_index="1" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz"/>
         <info name="CPUType" value="x86_64"/>
-        <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
-          <object type="Cache" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="0" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="1" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="2" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="3" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="4" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="5" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="6" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
-          <object type="Cache" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
-            <object type="Cache" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
-              <object type="Core" os_index="7" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
-                <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
-              </object>
-            </object>
-          </object>
+        <object type="Core" os_index="0" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-      </object>
-      <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0000:[80-81]">
-        <object type="Bridge" os_index="524336" name="Intel Corporation Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode" bridge_type="1-1" depth="0" bridge_pci="0000:[81-81]" pci_busid="0000:80:03.0" pci_type="0604 [8086:3c08] [0000:0000] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 IIO PCI Express Root Port 3a in PCI Express Mode"/>
+        <object type="Core" os_index="1" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524352" name="Intel Corporation Xeon E5/Core i7 DMA Channel 0" pci_busid="0000:80:04.0" pci_type="0880 [8086:3c20] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 0"/>
-          <object type="OSDev" name="dma8chan0" osdev_type="4"/>
+        <object type="Core" os_index="2" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524353" name="Intel Corporation Xeon E5/Core i7 DMA Channel 1" pci_busid="0000:80:04.1" pci_type="0880 [8086:3c21] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 1"/>
-          <object type="OSDev" name="dma9chan0" osdev_type="4"/>
+        <object type="Core" os_index="3" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524354" name="Intel Corporation Xeon E5/Core i7 DMA Channel 2" pci_busid="0000:80:04.2" pci_type="0880 [8086:3c22] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 2"/>
-          <object type="OSDev" name="dma10chan0" osdev_type="4"/>
+        <object type="Core" os_index="4" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524355" name="Intel Corporation Xeon E5/Core i7 DMA Channel 3" pci_busid="0000:80:04.3" pci_type="0880 [8086:3c23] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 3"/>
-          <object type="OSDev" name="dma11chan0" osdev_type="4"/>
+        <object type="Core" os_index="5" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524356" name="Intel Corporation Xeon E5/Core i7 DMA Channel 4" pci_busid="0000:80:04.4" pci_type="0880 [8086:3c24] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 4"/>
-          <object type="OSDev" name="dma12chan0" osdev_type="4"/>
+        <object type="Core" os_index="6" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524357" name="Intel Corporation Xeon E5/Core i7 DMA Channel 5" pci_busid="0000:80:04.5" pci_type="0880 [8086:3c25] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 5"/>
-          <object type="OSDev" name="dma13chan0" osdev_type="4"/>
+        <object type="Core" os_index="7" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+          <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
         </object>
-        <object type="PCIDev" os_index="524358" name="Intel Corporation Xeon E5/Core i7 DMA Channel 6" pci_busid="0000:80:04.6" pci_type="0880 [8086:3c26] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 6"/>
-          <object type="OSDev" name="dma14chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="524359" name="Intel Corporation Xeon E5/Core i7 DMA Channel 7" pci_busid="0000:80:04.7" pci_type="0880 [8086:3c27] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 DMA Channel 7"/>
-          <object type="OSDev" name="dma15chan0" osdev_type="4"/>
-        </object>
-        <object type="PCIDev" os_index="524368" name="Intel Corporation Xeon E5/Core i7 Address Map, VTd_Misc, System Management" pci_busid="0000:80:05.0" pci_type="0880 [8086:3c28] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 Address Map, VTd_Misc, System Management"/>
-        </object>
-        <object type="PCIDev" os_index="524370" name="Intel Corporation Xeon E5/Core i7 Control Status and Global Errors" pci_busid="0000:80:05.2" pci_type="0880 [8086:3c2a] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 Control Status and Global Errors"/>
-        </object>
-        <object type="PCIDev" os_index="524372" name="Intel Corporation Xeon E5/Core i7 I/O APIC" pci_busid="0000:80:05.4" pci_type="0800 [8086:3c2c] [0086:008c] 06" pci_link_speed="0.000000">
-          <info name="PCIVendor" value="Intel Corporation"/>
-          <info name="PCIDevice" value="Xeon E5/Core i7 I/O APIC"/>
-        </object>
-      </object>
-    </object>
-    <object type="Bridge" os_index="1" bridge_type="0-1" depth="0" bridge_pci="0000:[7f-7f]">
-      <object type="PCIDev" os_index="520320" name="Intel Corporation Xeon E5/Core i7 QPI Link 0" pci_busid="0000:7f:08.0" pci_type="0880 [8086:3c80] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 0"/>
-      </object>
-      <object type="PCIDev" os_index="520336" name="Intel Corporation Xeon E5/Core i7 QPI Link 1" pci_busid="0000:7f:09.0" pci_type="0880 [8086:3c90] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 1"/>
-      </object>
-      <object type="PCIDev" os_index="520352" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 0" pci_busid="0000:7f:0a.0" pci_type="0880 [8086:3cc0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 0"/>
-      </object>
-      <object type="PCIDev" os_index="520353" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 1" pci_busid="0000:7f:0a.1" pci_type="0880 [8086:3cc1] [0086:0000] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 1"/>
-      </object>
-      <object type="PCIDev" os_index="520354" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 2" pci_busid="0000:7f:0a.2" pci_type="0880 [8086:3cc2] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 2"/>
-      </object>
-      <object type="PCIDev" os_index="520355" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 3" pci_busid="0000:7f:0a.3" pci_type="0880 [8086:3cd0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 3"/>
-      </object>
-      <object type="PCIDev" os_index="520368" name="Intel Corporation Xeon E5/Core i7 Interrupt Control Registers" pci_busid="0000:7f:0b.0" pci_type="0880 [8086:3ce0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Interrupt Control Registers"/>
-      </object>
-      <object type="PCIDev" os_index="520371" name="Intel Corporation Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers" pci_busid="0000:7f:0b.3" pci_type="0880 [8086:3ce3] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers"/>
-      </object>
-      <object type="PCIDev" os_index="520384" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520385" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520386" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520387" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0c.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520390" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0" pci_busid="0000:7f:0c.6" pci_type="0880 [8086:3cf4] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0"/>
-      </object>
-      <object type="PCIDev" os_index="520391" name="Intel Corporation Xeon E5/Core i7 System Address Decoder" pci_busid="0000:7f:0c.7" pci_type="0880 [8086:3cf6] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 System Address Decoder"/>
-      </object>
-      <object type="PCIDev" os_index="520400" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520401" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520402" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520403" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:7f:0d.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="520406" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1" pci_busid="0000:7f:0d.6" pci_type="0880 [8086:3cf5] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1"/>
-      </object>
-      <object type="PCIDev" os_index="520416" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent" pci_busid="0000:7f:0e.0" pci_type="0880 [8086:3ca0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent"/>
-      </object>
-      <object type="PCIDev" os_index="520417" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent Performance Monitoring" pci_busid="0000:7f:0e.1" pci_type="1101 [8086:3c46] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent Performance Monitoring"/>
-      </object>
-      <object type="PCIDev" os_index="520432" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Registers" pci_busid="0000:7f:0f.0" pci_type="0880 [8086:3ca8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Registers"/>
-      </object>
-      <object type="PCIDev" os_index="520433" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller RAS Registers" pci_busid="0000:7f:0f.1" pci_type="0880 [8086:3c71] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller RAS Registers"/>
-      </object>
-      <object type="PCIDev" os_index="520434" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0" pci_busid="0000:7f:0f.2" pci_type="0880 [8086:3caa] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0"/>
-      </object>
-      <object type="PCIDev" os_index="520435" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1" pci_busid="0000:7f:0f.3" pci_type="0880 [8086:3cab] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1"/>
-      </object>
-      <object type="PCIDev" os_index="520436" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2" pci_busid="0000:7f:0f.4" pci_type="0880 [8086:3cac] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2"/>
-      </object>
-      <object type="PCIDev" os_index="520437" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3" pci_busid="0000:7f:0f.5" pci_type="0880 [8086:3cad] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3"/>
-      </object>
-      <object type="PCIDev" os_index="520438" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4" pci_busid="0000:7f:0f.6" pci_type="0880 [8086:3cae] [0086:0000] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4"/>
-      </object>
-      <object type="PCIDev" os_index="520448" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0" pci_busid="0000:7f:10.0" pci_type="0880 [8086:3cb0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0"/>
-      </object>
-      <object type="PCIDev" os_index="520449" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1" pci_busid="0000:7f:10.1" pci_type="0880 [8086:3cb1] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1"/>
-      </object>
-      <object type="PCIDev" os_index="520450" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0" pci_busid="0000:7f:10.2" pci_type="0880 [8086:3cb2] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0"/>
-      </object>
-      <object type="PCIDev" os_index="520451" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1" pci_busid="0000:7f:10.3" pci_type="0880 [8086:3cb3] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1"/>
-      </object>
-      <object type="PCIDev" os_index="520452" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2" pci_busid="0000:7f:10.4" pci_type="0880 [8086:3cb4] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2"/>
-      </object>
-      <object type="PCIDev" os_index="520453" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3" pci_busid="0000:7f:10.5" pci_type="0880 [8086:3cb5] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3"/>
-      </object>
-      <object type="PCIDev" os_index="520454" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2" pci_busid="0000:7f:10.6" pci_type="0880 [8086:3cb6] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2"/>
-      </object>
-      <object type="PCIDev" os_index="520455" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3" pci_busid="0000:7f:10.7" pci_type="0880 [8086:3cb7] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3"/>
-      </object>
-      <object type="PCIDev" os_index="520464" name="Intel Corporation Xeon E5/Core i7 DDRIO" pci_busid="0000:7f:11.0" pci_type="0880 [8086:3cb8] [0086:0000] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 DDRIO"/>
-      </object>
-      <object type="PCIDev" os_index="520496" name="Intel Corporation Xeon E5/Core i7 R2PCIe" pci_busid="0000:7f:13.0" pci_type="0880 [8086:3ce4] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 R2PCIe"/>
-      </object>
-      <object type="PCIDev" os_index="520497" name="Intel Corporation Xeon E5/Core i7 Ring to PCI Express Performance Monitor" pci_busid="0000:7f:13.1" pci_type="1101 [8086:3c43] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to PCI Express Performance Monitor"/>
-      </object>
-      <object type="PCIDev" os_index="520500" name="Intel Corporation Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers" pci_busid="0000:7f:13.4" pci_type="1101 [8086:3ce6] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers"/>
-      </object>
-      <object type="PCIDev" os_index="520501" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor" pci_busid="0000:7f:13.5" pci_type="1101 [8086:3c44] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor"/>
-      </object>
-      <object type="PCIDev" os_index="520502" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor" pci_busid="0000:7f:13.6" pci_type="0880 [8086:3c45] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor"/>
-      </object>
-    </object>
-    <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0000:[ff-ff]">
-      <object type="PCIDev" os_index="1044608" name="Intel Corporation Xeon E5/Core i7 QPI Link 0" pci_busid="0000:ff:08.0" pci_type="0880 [8086:3c80] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044624" name="Intel Corporation Xeon E5/Core i7 QPI Link 1" pci_busid="0000:ff:09.0" pci_type="0880 [8086:3c90] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 QPI Link 1"/>
-      </object>
-      <object type="PCIDev" os_index="1044640" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 0" pci_busid="0000:ff:0a.0" pci_type="0880 [8086:3cc0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044641" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 1" pci_busid="0000:ff:0a.1" pci_type="0880 [8086:3cc1] [0086:0000] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 1"/>
-      </object>
-      <object type="PCIDev" os_index="1044642" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 2" pci_busid="0000:ff:0a.2" pci_type="0880 [8086:3cc2] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 2"/>
-      </object>
-      <object type="PCIDev" os_index="1044643" name="Intel Corporation Xeon E5/Core i7 Power Control Unit 3" pci_busid="0000:ff:0a.3" pci_type="0880 [8086:3cd0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Power Control Unit 3"/>
-      </object>
-      <object type="PCIDev" os_index="1044656" name="Intel Corporation Xeon E5/Core i7 Interrupt Control Registers" pci_busid="0000:ff:0b.0" pci_type="0880 [8086:3ce0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Interrupt Control Registers"/>
-      </object>
-      <object type="PCIDev" os_index="1044659" name="Intel Corporation Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers" pci_busid="0000:ff:0b.3" pci_type="0880 [8086:3ce3] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Semaphore and Scratchpad Configuration Registers"/>
-      </object>
-      <object type="PCIDev" os_index="1044672" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044673" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044674" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044675" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0c.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044678" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0" pci_busid="0000:ff:0c.6" pci_type="0880 [8086:3cf4] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044679" name="Intel Corporation Xeon E5/Core i7 System Address Decoder" pci_busid="0000:ff:0c.7" pci_type="0880 [8086:3cf6] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 System Address Decoder"/>
-      </object>
-      <object type="PCIDev" os_index="1044688" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.0" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044689" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.1" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044690" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.2" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044691" name="Intel Corporation Xeon E5/Core i7 Unicast Register 0" pci_busid="0000:ff:0d.3" pci_type="0880 [8086:3ce8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Unicast Register 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044694" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1" pci_busid="0000:ff:0d.6" pci_type="0880 [8086:3cf5] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller System Address Decoder 1"/>
-      </object>
-      <object type="PCIDev" os_index="1044704" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent" pci_busid="0000:ff:0e.0" pci_type="0880 [8086:3ca0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent"/>
-      </object>
-      <object type="PCIDev" os_index="1044705" name="Intel Corporation Xeon E5/Core i7 Processor Home Agent Performance Monitoring" pci_busid="0000:ff:0e.1" pci_type="1101 [8086:3c46] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Processor Home Agent Performance Monitoring"/>
-      </object>
-      <object type="PCIDev" os_index="1044720" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Registers" pci_busid="0000:ff:0f.0" pci_type="0880 [8086:3ca8] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Registers"/>
-      </object>
-      <object type="PCIDev" os_index="1044721" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller RAS Registers" pci_busid="0000:ff:0f.1" pci_type="0880 [8086:3c71] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller RAS Registers"/>
-      </object>
-      <object type="PCIDev" os_index="1044722" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0" pci_busid="0000:ff:0f.2" pci_type="0880 [8086:3caa] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044723" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1" pci_busid="0000:ff:0f.3" pci_type="0880 [8086:3cab] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 1"/>
-      </object>
-      <object type="PCIDev" os_index="1044724" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2" pci_busid="0000:ff:0f.4" pci_type="0880 [8086:3cac] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 2"/>
-      </object>
-      <object type="PCIDev" os_index="1044725" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3" pci_busid="0000:ff:0f.5" pci_type="0880 [8086:3cad] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 3"/>
-      </object>
-      <object type="PCIDev" os_index="1044726" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4" pci_busid="0000:ff:0f.6" pci_type="0880 [8086:3cae] [0086:0000] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Target Address Decoder 4"/>
-      </object>
-      <object type="PCIDev" os_index="1044736" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0" pci_busid="0000:ff:10.0" pci_type="0880 [8086:3cb0] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044737" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1" pci_busid="0000:ff:10.1" pci_type="0880 [8086:3cb1] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 1"/>
-      </object>
-      <object type="PCIDev" os_index="1044738" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0" pci_busid="0000:ff:10.2" pci_type="0880 [8086:3cb2] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 0"/>
-      </object>
-      <object type="PCIDev" os_index="1044739" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1" pci_busid="0000:ff:10.3" pci_type="0880 [8086:3cb3] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 1"/>
-      </object>
-      <object type="PCIDev" os_index="1044740" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2" pci_busid="0000:ff:10.4" pci_type="0880 [8086:3cb4] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 2"/>
-      </object>
-      <object type="PCIDev" os_index="1044741" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3" pci_busid="0000:ff:10.5" pci_type="0880 [8086:3cb5] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller Channel 0-3 Thermal Control 3"/>
-      </object>
-      <object type="PCIDev" os_index="1044742" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2" pci_busid="0000:ff:10.6" pci_type="0880 [8086:3cb6] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 2"/>
-      </object>
-      <object type="PCIDev" os_index="1044743" name="Intel Corporation Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3" pci_busid="0000:ff:10.7" pci_type="0880 [8086:3cb7] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Integrated Memory Controller ERROR Registers 3"/>
-      </object>
-      <object type="PCIDev" os_index="1044752" name="Intel Corporation Xeon E5/Core i7 DDRIO" pci_busid="0000:ff:11.0" pci_type="0880 [8086:3cb8] [0086:0000] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 DDRIO"/>
-      </object>
-      <object type="PCIDev" os_index="1044784" name="Intel Corporation Xeon E5/Core i7 R2PCIe" pci_busid="0000:ff:13.0" pci_type="0880 [8086:3ce4] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 R2PCIe"/>
-      </object>
-      <object type="PCIDev" os_index="1044785" name="Intel Corporation Xeon E5/Core i7 Ring to PCI Express Performance Monitor" pci_busid="0000:ff:13.1" pci_type="1101 [8086:3c43] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to PCI Express Performance Monitor"/>
-      </object>
-      <object type="PCIDev" os_index="1044788" name="Intel Corporation Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers" pci_busid="0000:ff:13.4" pci_type="1101 [8086:3ce6] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 QuickPath Interconnect Agent Ring Registers"/>
-      </object>
-      <object type="PCIDev" os_index="1044789" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor" pci_busid="0000:ff:13.5" pci_type="1101 [8086:3c44] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 0 Performance Monitor"/>
-      </object>
-      <object type="PCIDev" os_index="1044790" name="Intel Corporation Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor" pci_busid="0000:ff:13.6" pci_type="0880 [8086:3c45] [0086:008c] 06" pci_link_speed="0.000000">
-        <info name="PCIVendor" value="Intel Corporation"/>
-        <info name="PCIDevice" value="Xeon E5/Core i7 Ring to QuickPath Interconnect Link 1 Performance Monitor"/>
       </object>
     </object>
   </object>
 </topology>
-

--- a/t/sharness.d/sched-sharness.sh
+++ b/t/sharness.d/sched-sharness.sh
@@ -125,13 +125,8 @@ remove_resource () {
 # Usage: load_test_resources hwloc-dir
 #   where hwloc-dir contains <rank>.xml files
 load_test_resources () {
-    flux kvs get --waitcreate resource.hwloc.by_rank &&
-        flux module remove resource &&
-        flux kvs unlink -R resource
-        flux hwloc reload $1 &&
-        flux kvs eventlog append resource.eventlog \
-            hwloc-discover-finish "{\"loaded\":true}" &&
-        flux module load resource monitor-force-up
+    flux resource reload --xml $1 &&
+        flux kvs get resource.R
 }
 
 # N.B. this assumes that a scheduler is loaded

--- a/t/t1001-qmanager-basic.t
+++ b/t/t1001-qmanager-basic.t
@@ -5,8 +5,8 @@ test_description='Test qmanager service in simulated mode'
 . `dirname $0`/sharness.sh
 
 hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
-# 4 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
-excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers"
+# 1 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
+excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers"
 
 skip_all_unless_have jq
 
@@ -26,7 +26,7 @@ test_expect_success 'qmanager: generate jobspec for a simple test job' '
 '
 
 test_expect_success 'load test resources' '
-    load_test_resources ${excl_4N4B}
+    load_test_resources ${excl_1N1B}
 '
 
 test_expect_success 'qmanager: loading resource and qmanager modules works' '

--- a/t/t1002-qmanager-reload.t
+++ b/t/t1002-qmanager-reload.t
@@ -5,8 +5,8 @@ test_description='Test qmanager service reloading'
 . `dirname $0`/sharness.sh
 
 hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
-# 4 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
-excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers"
+# 1 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
+excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers"
 
 skip_all_unless_have jq
 
@@ -27,7 +27,7 @@ test_expect_success 'qmanager: generate jobspec for a simple test job' '
 '
 
 test_expect_success 'load test resources' '
-    load_test_resources ${excl_4N4B}
+    load_test_resources ${excl_1N1B}
 '
 
 test_expect_success 'qmanager: loading resource and qmanager modules works' '

--- a/t/t1003-qmanager-policy.t
+++ b/t/t1003-qmanager-policy.t
@@ -5,8 +5,8 @@ test_description='Test the correctness of different queuing policies'
 . `dirname $0`/sharness.sh
 
 hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
-# 4 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
-excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers"
+# 1 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
+excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers"
 
 skip_all_unless_have jq
 
@@ -30,7 +30,7 @@ test_expect_success 'qmanager: generate jobspecs of varying requirements' '
 '
 
 test_expect_success 'load test resources' '
-    load_test_resources ${excl_4N4B}
+    load_test_resources ${excl_1N1B}
 '
 
 test_expect_success 'qmanager: loading qmanager (queue-policy=easy)' '

--- a/t/t1004-qmanager-optimize.t
+++ b/t/t1004-qmanager-optimize.t
@@ -5,8 +5,8 @@ test_description='Test the correctness of various queuing optimization'
 . `dirname $0`/sharness.sh
 
 hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
-# 4 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
-excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers"
+# 1 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
+excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers"
 
 skip_all_unless_have jq
 
@@ -30,7 +30,7 @@ test_expect_success 'qmanager: generate jobspecs of varying requirements' '
 '
 
 test_expect_success 'load test resources' '
-    load_test_resources ${excl_4N4B}
+    load_test_resources ${excl_1N1B}
 '
 
 test_expect_success 'qmanager: loading with easy+queue-depth=5' '

--- a/t/t1007-recovery-full.t
+++ b/t/t1007-recovery-full.t
@@ -10,8 +10,8 @@ Full recovery case --
 . `dirname $0`/sharness.sh
 
 hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
-# 4 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
-excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers"
+# 1 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
+excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers"
 
 export FLUX_SCHED_MODULE=none
 test_under_flux 1
@@ -21,7 +21,7 @@ test_expect_success 'recovery: generate a test jobspec' '
 '
 
 test_expect_success 'load test resources' '
-    load_test_resources ${excl_4N4B}
+    load_test_resources ${excl_1N1B}
 '
 
 test_expect_success 'recovery: loading flux-sched modules works (rv1)' '

--- a/t/t1007-recovery-full.t
+++ b/t/t1007-recovery-full.t
@@ -25,7 +25,6 @@ test_expect_success 'load test resources' '
 '
 
 test_expect_success 'recovery: loading flux-sched modules works (rv1)' '
-    flux module reload -f resource &&
     load_resource load-allowlist=node,core,gpu match-format=rv1 &&
     load_qmanager
 '

--- a/t/t1008-recovery-none.t
+++ b/t/t1008-recovery-none.t
@@ -10,8 +10,8 @@ resource-recovery-on-load=false)
 . `dirname $0`/sharness.sh
 
 hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
-# 4 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
-excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers"
+# 1 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
+excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers"
 
 export FLUX_SCHED_MODULE=none
 test_under_flux 1
@@ -21,7 +21,7 @@ test_expect_success 'recovery: generate a test jobspec' '
 '
 
 test_expect_success 'load test resources' '
-    load_test_resources ${excl_4N4B}
+    load_test_resources ${excl_1N1B}
 '
 
 test_expect_success 'recovery: loading flux-sched modules works (rv1_nosched)' '

--- a/t/t1009-recovery-multiqueue.t
+++ b/t/t1009-recovery-multiqueue.t
@@ -5,8 +5,8 @@ test_description='Test the full state recovery of qmanager for multiple queues'
 . `dirname $0`/sharness.sh
 
 hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
-# 4 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
-excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers"
+# 1 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
+excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers"
 
 export FLUX_SCHED_MODULE=none
 test_under_flux 1
@@ -33,7 +33,7 @@ test_expect_success 'recovery: generate test jobspecs' '
 '
 
 test_expect_success 'load test resources' '
-    load_test_resources ${excl_4N4B}
+    load_test_resources ${excl_1N1B}
 '
 
 test_expect_success 'recovery: loading flux-sched modules with two queues' '

--- a/t/t1013-exclusion.t
+++ b/t/t1013-exclusion.t
@@ -45,14 +45,16 @@ test_expect_success 'exclusion: all jobs are rejected on satisfiability' '
     flux job eventlog ${jobid1} | grep unsatisfiable &&
     flux job eventlog ${jobid2} | grep unsatisfiable
 '
-
+test_expect_success 'exclusion: removing fluxion modules' '
+    remove_qmanager &&
+    remove_resource
+'
 test_expect_success 'exclusion: reloading resource with a config file' '
     cat >resource.toml <<-EOF &&
 	[resource]
 	exclude = "2-3"
 EOF
-    flux config reload &&
-    flux module reload resource noverify
+    flux config reload
 '
 
 test_expect_success 'exclusion: loading fluxion modules works' '

--- a/t/t1013-exclusion.t
+++ b/t/t1013-exclusion.t
@@ -52,7 +52,7 @@ test_expect_success 'exclusion: reloading resource with a config file' '
 	exclude = "2-3"
 EOF
     flux config reload &&
-    flux module reload resource
+    flux module reload resource noverify
 '
 
 test_expect_success 'exclusion: loading fluxion modules works' '

--- a/t/t1013-qmanager-priority.t
+++ b/t/t1013-qmanager-priority.t
@@ -6,7 +6,7 @@ test_description='Fluxion takes into account priority and t_submit'
 
 hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 1 node, 2 sockets, 44 cores (22 per socket), 4 gpus (2 per socket)
-excl_1N1B="${hwloc_basepath}/004N/exclusive/04-brokers-sierra2"
+excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers-sierra2"
 
 skip_all_unless_have jq
 

--- a/t/t1014-annotation.t
+++ b/t/t1014-annotation.t
@@ -5,8 +5,8 @@ test_description='Test job annotation'
 . `dirname $0`/sharness.sh
 
 hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
-# 4 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
-excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers"
+# 1 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
+excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers"
 
 skip_all_unless_have jq
 
@@ -44,7 +44,7 @@ print_t_estimate() {
 }
 
 test_expect_success 'load test resources' '
-    load_test_resources ${excl_4N4B}
+    load_test_resources ${excl_1N1B}
 '
 
 test_expect_success 'annotation: loading qmanager (queue-policy=easy)' '

--- a/t/t4009-match-update.t
+++ b/t/t4009-match-update.t
@@ -17,8 +17,8 @@ ORIG_HOME=${HOME}
 HOME=${ORIG_HOME}
 
 hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
-# 4 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
-excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers"
+# 1 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
+excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers"
 
 #
 # test_under_flux is under sharness.d/
@@ -31,7 +31,7 @@ test_expect_success 'update: generate jobspec for a simple test job' '
 '
 
 test_expect_success 'update: load test resources' '
-    load_test_resources ${excl_4N4B}
+    load_test_resources ${excl_1N1B}
 '
 
 test_expect_success 'update: loading sched-fluxion-resource works' '

--- a/t/t6002-graph-hwloc.t
+++ b/t/t6002-graph-hwloc.t
@@ -31,6 +31,7 @@ test_expect_success 'qmanager: loading resource and qmanager modules works' '
 
 test_expect_success 'qmanager: graph stat as expected' '
     flux ion-resource stat > stat.out &&
+    test_debug "cat stat.out" &&
     verify stat.out
 '
 


### PR DESCRIPTION
This is tracking changes in flux-framework/flux-core#3265 to the way that dummy resources are loaded in test.

That PR is still undergoing development and this one should wait until it is merged.