### PR TITLE
update configs for travis-ci.com migration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,7 @@ pull_request_rules:
   - name: rebase and merge when passing all checks
     conditions:
       - base=master
-      - status-success=continuous-integration/travis-ci/pr
+      - status-success=Travis CI - Pull Request
       - status-success="validate commits"
       - label="merge-when-passing"
       - label!="work-in-progress"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 services: docker
 dist: trusty
 language: c


### PR DESCRIPTION
flux-sched has be migrated from travis-ci.org to travis-ci.com. Update mergify config accordingly (also, remove one deprecated key in the .travis.yml config)