### PR TITLE
Add resource Id remapping support

### DIFF
--- a/resource/Makefile.am
+++ b/resource/Makefile.am
@@ -31,6 +31,7 @@ libresource_la_SOURCES = \
     traversers/dfu_impl_update.cpp \
     policies/base/dfu_match_cb.cpp \
     policies/base/matcher.cpp \
+    readers/resource_namespace_remapper.cpp \
     readers/resource_reader_base.cpp \
     readers/resource_spec_grug.cpp \
     readers/resource_reader_grug.cpp \
@@ -61,6 +62,7 @@ libresource_la_SOURCES = \
     traversers/dfu_impl.hpp \
     policies/base/dfu_match_cb.hpp \
     policies/base/matcher.hpp \
+    readers/resource_namespace_remapper.hpp \
     readers/resource_reader_base.hpp \
     readers/resource_spec_grug.hpp \
     readers/resource_reader_grug.hpp \

--- a/resource/readers/resource_namespace_remapper.cpp
+++ b/resource/readers/resource_namespace_remapper.cpp
@@ -1,0 +1,207 @@
+/*****************************************************************************\
+ *  Copyright (c) 2020 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+ \*****************************************************************************/
+
+#include <vector>
+#include <iostream>
+#include <cerrno>
+#include <cstdlib>
+#include <sstream>
+#include <algorithm>
+#include <stdexcept>
+#include "resource/readers/resource_namespace_remapper.hpp"
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+}
+
+using namespace Flux::resource_model;
+
+
+/********************************************************************************
+ *                                                                              *
+ *                   Private Resource Namespace Remapper API                    *
+ *                                                                              *
+ ********************************************************************************/
+
+resource_namespace_remapper_t
+    ::distinct_range_t::distinct_range_t (uint64_t point)
+{
+    m_low = point;
+    m_high = point;
+}
+
+resource_namespace_remapper_t
+    ::distinct_range_t::distinct_range_t (uint64_t lo, uint64_t hi)
+{
+    m_low = lo;
+    m_high = hi;
+}
+
+uint64_t resource_namespace_remapper_t
+             ::distinct_range_t::get_low () const
+{
+    return m_low;
+}
+
+uint64_t resource_namespace_remapper_t
+             ::distinct_range_t::get_high () const
+{
+    return m_high;
+}
+
+bool resource_namespace_remapper_t
+         ::distinct_range_t::is_point () const
+{
+    return m_low == m_high;
+}
+
+bool resource_namespace_remapper_t
+         ::distinct_range_t::operator< (const distinct_range_t &o) const {
+    // this class is used as key for std::map, which relies on the following
+    // x and y are equivalent if !(x < y) && !(y < x)
+    return m_high < o.m_low;
+}
+
+bool resource_namespace_remapper_t
+         ::distinct_range_t::operator== (const distinct_range_t &o) const {
+    // x and y are equal if and only if both high and low
+    // of the operands are equal
+    return m_high == o.m_high && m_low == o.m_low;
+}
+
+bool resource_namespace_remapper_t
+         ::distinct_range_t::operator!= (const distinct_range_t &o) const {
+    // x and y are not equal if either high or low is not equal
+    return m_high != o.m_high || m_low != o.m_low;
+}
+
+
+/********************************************************************************
+ *                                                                              *
+ *                    Public Resource Namespace Remapper API                    *
+ *                                                                              *
+ ********************************************************************************/
+
+int resource_namespace_remapper_t::add (const uint64_t low, const uint64_t high,
+                                        const std::string &name_type,
+                                        uint64_t ref_id, uint64_t remapped_id)
+{
+    if (low > high)
+        goto inval;
+    try {
+        const distinct_range_t exec_target_range{low, high};
+        auto m_remap_iter = m_remap.find (exec_target_range);
+
+        if (m_remap_iter == m_remap.end ()) {
+            m_remap.emplace (exec_target_range,
+                             std::map<const std::string,
+                                      std::map<uint64_t, uint64_t>> ());
+        } else if (exec_target_range != m_remap_iter->first)
+            goto inval; // key must be exact
+
+        if (m_remap[exec_target_range].find (name_type)
+            == m_remap[exec_target_range].end ())
+            m_remap[exec_target_range][name_type] = std::map<uint64_t,
+                                                             uint64_t> ();
+        if (m_remap[exec_target_range][name_type].find (ref_id)
+            != m_remap[exec_target_range][name_type].end ()) {
+            errno = EEXIST;
+            goto error;
+        }
+        m_remap[exec_target_range][name_type][ref_id] = remapped_id;
+    } catch (std::bad_alloc &) {
+        errno = ENOMEM;
+        goto error;
+    }
+    return 0;
+inval:
+    errno = EINVAL;
+error:
+    return -1;
+}
+
+int resource_namespace_remapper_t::add (const std::string &exec_target_range,
+                                        const std::string &name_type,
+                                        uint64_t ref_id, uint64_t remapped_id)
+{
+    try {
+        long int n;
+        size_t ndash;
+        std::string exec_target;
+        std::istringstream istr{exec_target_range};
+        std::vector<uint64_t> targets;
+
+        if ( (ndash = std::count (exec_target_range.begin (),
+                                  exec_target_range.end (), '-')) > 1)
+            goto inval;
+        while (std::getline (istr, exec_target, '-')) {
+            if ( (n = std::stol (exec_target)) < 0)
+                goto inval;
+            targets.push_back (static_cast<uint64_t> (n));
+        }
+        return (targets.size () == 2) ? add (targets[0], targets[1],
+                                             name_type, ref_id, remapped_id)
+                                      : add (targets[0], targets[0],
+                                             name_type, ref_id, remapped_id);
+    } catch (std::invalid_argument &) {
+        goto inval;
+    } catch (std::out_of_range &) {
+        errno = ERANGE;
+        goto error;
+    } catch (std::bad_alloc &) {
+        errno = ENOMEM;
+        goto error;
+    }
+    return 0;
+inval:
+    errno = EINVAL;
+error:
+    return -1;
+}
+
+int resource_namespace_remapper_t::query (const uint64_t exec_target,
+                                          const std::string &name_type,
+                                          uint64_t ref_id,
+                                          uint64_t &remapped_id_out) const
+{
+    try {
+        remapped_id_out = m_remap.at (distinct_range_t{exec_target})
+                                         .at (name_type). at (ref_id);
+        return 0;
+    } catch (std::out_of_range &) {
+        errno = ENOENT;
+        return -1;
+    }
+}
+
+bool resource_namespace_remapper_t::is_remapped () const
+{
+    return !m_remap.empty ();
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/readers/resource_namespace_remapper.hpp
+++ b/resource/readers/resource_namespace_remapper.hpp
@@ -1,0 +1,80 @@
+/*****************************************************************************\
+ *  Copyright (c) 2020 Lawrence Livermore National Security, LLC.  Produced at
+ *  the Lawrence Livermore National Laboratory (cf, AUTHORS, DISCLAIMER.LLNS).
+ *  LLNL-CODE-658032 All rights reserved.
+ *
+ *  This file is part of the Flux resource manager framework.
+ *  For details, see https://github.com/flux-framework.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the license, or (at your option)
+ *  any later version.
+ *
+ *  Flux is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the terms and conditions of the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ *  See also:  http://www.gnu.org/licenses/
+ \*****************************************************************************/
+
+#ifndef RESOURCE_NAMESPACE_REMAPPER_HPP
+#define RESOURCE_NAMESPACE_REMAPPER_HPP
+
+#include <map>
+#include <string>
+#include <cstdint>
+
+namespace Flux {
+namespace resource_model {
+
+class resource_namespace_remapper_t {
+public:
+    int add (const uint64_t exec_target_high,
+             const uint64_t exec_target_low,
+             const std::string &name_type,
+             uint64_t ref_id, uint64_t remapped_id);
+    int add (const std::string &exec_target_range,
+             const std::string &name_type,
+             uint64_t ref_id, uint64_t remapped_id);
+    int query (const uint64_t exec_target,
+               const std::string &name_type,
+               uint64_t ref_id, uint64_t &remapped_id_out) const;
+    bool is_remapped () const;
+
+private:
+    class distinct_range_t {
+    public:
+        explicit distinct_range_t (uint64_t point);
+        distinct_range_t (uint64_t lo, uint64_t hi);
+
+        uint64_t get_low () const;
+        uint64_t get_high () const;
+        bool is_point () const;
+        bool operator< (const distinct_range_t &o) const;
+        bool operator== (const distinct_range_t &o) const;
+        bool operator!= (const distinct_range_t &o) const;
+
+    private:
+        uint64_t m_low;
+        uint64_t m_high;
+    };
+
+    std::map<const distinct_range_t,
+             std::map<const std::string,
+                      std::map<uint64_t, uint64_t>>> m_remap;
+};
+
+} // namesapce resource_model
+} // namespace Flux
+
+
+#endif // RESOURCE_NAMESPACE_REMAPPER_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/readers/resource_reader_base.hpp
+++ b/resource/readers/resource_reader_base.hpp
@@ -30,6 +30,7 @@
 #include <cerrno>
 #include "resource/schema/resource_graph.hpp"
 #include "resource/store/resource_graph_store.hpp"
+#include "resource/readers/resource_namespace_remapper.hpp"
 
 namespace Flux {
 namespace resource_model {
@@ -104,6 +105,10 @@ public:
     /*! Clear the error message string.
      */
     void clear_err_message ();
+
+    /*! Expose resource_namespace_remapper_t interface
+     */
+    resource_namespace_remapper_t namespace_remapper;
 
 protected:
     bool in_allowlist (const std::string &resource);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -38,6 +38,7 @@ TESTS = \
     t1013-qmanager-priority.t \
     t1014-annotation.t \
     t1015-find-format.t \
+    t1016-nest-namespace.t \
     t2000-tree-basic.t \
     t2001-tree-real.t \
     t3000-jobspec.t \

--- a/t/scripts/flux-ion-resource.py
+++ b/t/scripts/flux-ion-resource.py
@@ -207,7 +207,7 @@ def find_action (args):
     print (json.dumps (resp['R']))
 
 """
-    Action for find sub-command
+    Action for status sub-command
 """
 def status_action (args):
     r = ResourceModuleInterface ()

--- a/t/scripts/flux-ion-resource.py
+++ b/t/scripts/flux-ion-resource.py
@@ -83,6 +83,10 @@ class ResourceModuleInterface:
 
     def rpc_status (self):
         return self.f.rpc ("sched-fluxion-resource.status").get ()
+
+    def rpc_namespace_info (self, rank, type_name, identity):
+        payload = {'rank' : rank, 'type-name' : type_name, 'id' : identity}
+        return self.f.rpc ("sched-fluxion-resource.ns-info", payload).get ()
     
 
 """
@@ -221,6 +225,14 @@ def status_action (args):
     print (json.dumps (resp))
 
 """
+    Action for ns-info sub-command
+"""
+def namespace_info_action (args):
+    r = ResourceModuleInterface ()
+    resp = r.rpc_namespace_info (args.rank, args.type, args.Id)
+    print (resp['id'])
+
+"""
     Main entry point
 """
 def main ():
@@ -250,6 +262,7 @@ def main ():
     ststr = "Display resource status"
     pstr = "Set property-key=value for specified resource."
     gstr = "Get value for specified resource and property-key."
+    nstr = "Get remapped ID given raw ID seen by the selected reader."
     parser_m = subpar.add_parser ('match', help=mstr, description=mstr)
     parser_u = subpar.add_parser ('update', help=ustr, description=ustr)
     parser_i = subpar.add_parser ('info', help=istr, description=istr)
@@ -259,6 +272,7 @@ def main ():
     parser_st = subpar.add_parser ('status', help=ststr, description=ststr)
     parser_sp = subpar.add_parser ('set-property', help=pstr, description=pstr)
     parser_gp = subpar.add_parser ('get-property', help=gstr, description=gstr)
+    parser_n = subpar.add_parser ('ns-info', help=nstr, description=nstr)
 
     #
     # Add subparser for the match sub-command
@@ -352,6 +366,16 @@ def main ():
     parser_gp.add_argument ('gp_key', metavar='PropertyKey', type=str,
                             help='get-property resource_path property-key')
     parser_gp.set_defaults (func=get_property_action)
+
+    # Positional argument for ns-info sub-command
+    #
+    parser_n.add_argument ('rank', metavar='Rank', type=int,
+                           help='execution target')
+    parser_n.add_argument ('type', metavar='Type', type=str,
+                           help='type: e.g., core, gpu, or rank')
+    parser_n.add_argument ('Id', metavar='Id', type=int,
+                           help='raw Id seen by the reader')
+    parser_n.set_defaults (func=namespace_info_action)
 
     #
     # Parse the args and call an action routine as part of that

--- a/t/t1016-nest-namespace.t
+++ b/t/t1016-nest-namespace.t
@@ -1,0 +1,91 @@
+#!/bin/sh
+
+test_description='Test Id Namespace Remapping for Nested Instances'
+
+. `dirname $0`/sharness.sh
+
+hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+# 1 brokers: 1 node, 2 sockets, 44 cores 4 gpus
+excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers-sierra2"
+
+export FLUX_SCHED_MODULE=none
+
+test_under_flux 1
+
+test_expect_success 'namespace: load test resources' '
+    load_test_resources ${excl_1N1B}
+'
+
+test_expect_success 'namespace: loading resource and qmanager modules works' '
+    load_resource load-allowlist=cluster,node,gpu,core policy=high &&
+    load_qmanager
+'
+
+test_expect_success 'namespace: gpu id remapping works with hwloc (pol=hi)' '
+    cat >nest.sh <<-EOF &&
+	#!/bin/sh
+	flux module load sched-fluxion-resource load-allowlist=cluster,node,gpu,core
+	flux module load sched-fluxion-qmanager
+	flux resource list
+	flux ion-resource ns-info 0 gpu 0
+	flux ion-resource ns-info 0 gpu 1
+	echo \${CUDA_VISIBLE_DEVICES}
+EOF
+    cat >exp1 <<-EOF &&
+	2
+	3
+	2,3
+EOF
+    chmod u+x nest.sh &&
+    jobid=$(flux mini batch --output=kvs -n1 -N1 -c22 -g2 ./nest.sh) &&
+    flux job wait-event -t10 ${jobid} release &&
+    flux job attach ${jobid} > out1.a &&
+    tail -3 out1.a > out1.a.fin &&
+    diff out1.a.fin exp1
+'
+
+test_expect_success 'namespace: parent CUDA_VISIBLE_DEVICES has no effect' '
+    export CUDA_VISIBLE_DEVICES="0,1,2,3" &&
+    jobid=$(flux mini batch --output=kvs -n1 -N1 -c22 -g2 ./nest.sh) &&
+    flux job wait-event -t10 ${jobid} release &&
+    flux job attach ${jobid} > out1.b &&
+    tail -3 out1.b > out1.b.fin &&
+    diff out1.b.fin exp1
+'
+
+test_expect_success 'namespace: removing resource and qmanager modules' '
+    remove_resource
+'
+
+test_expect_success 'namespace: loading resource and qmanager modules works' '
+    load_resource load-allowlist=cluster,node,gpu,core policy=low &&
+    load_qmanager
+'
+
+test_expect_success 'namespace: gpu id remapping works with hwloc (pol=low)' '
+    cat >exp2 <<-EOF &&
+	0
+	1
+	0,1
+EOF
+    jobid=$(flux mini batch --output=kvs -n1 -N1 -c22 -g2 ./nest.sh) &&
+    flux job wait-event -t10 ${jobid} release &&
+    flux job attach ${jobid} > out2.a &&
+    tail -3 out2.a > out2.a.fin &&
+    diff out2.a.fin exp2
+'
+
+test_expect_success 'namespace: parent CUDA_VISIBLE_DEVICES has no effect' '
+    export CUDA_VISIBLE_DEVICES=-1 &&
+    jobid=$(flux mini batch --output=kvs -n1 -N1 -c22 -g2 ./nest.sh) &&
+    flux job wait-event -t10 ${jobid} release &&
+    flux job attach ${jobid} > out2.b &&
+    tail -3 out2.b > out2.b.fin &&
+    diff out2.b.fin exp2
+'
+
+test_expect_success 'namespace: removing resource and qmanager modules' '
+    remove_resource
+'
+
+test_done


### PR DESCRIPTION
This PR adds basic support for resource Id namespace remapping and solves hwloc GPU ID remapping.  

* Add initial support to aid in remapping resource Id and rank efficiently for nested instances (i.e., `class resource_namespace_remapper_t`)
* Integrate it into the base resource reader class to make it available for all of the reader classes
* Fix incorrect GPU numbering of our hwloc reader using this support
* Modify `sched-fluxion-resource` to establish correct GPU remapping for hwloc reader. The hwloc reader of a nested flux instance discovers the GPU resources using hwloc. However, hwloc uses the logical Id space for each discovered GPU resource, which does not work with GPU affinity at execution time (i.e., `CUDA_VISIBLE_DEVICES`).

 