### PR TITLE
shell: reduce logging verbosity of datastaging plugin

### DIFF
--- a/src/shell/data-staging.cpp
+++ b/src/shell/data-staging.cpp
@@ -36,7 +36,7 @@ static jobspec_state_t validate_jobspec (json &jobspec)
         storage_attrs = \
             jobspec.at ("/attributes/system/data-staging"_json_pointer);
     } catch (json::out_of_range& e) {
-        shell_log ("Jobspec does not contain data-staging attributes. "
+        shell_debug ("Jobspec does not contain data-staging attributes. "
                    "No staging necessary.");
         return jobspec_state_t::VALID_NO_STAGING;
     }
@@ -131,7 +131,7 @@ static std::map<std::string, json> find_storage_resources (json &R, int rank)
                 } else {
                     auto name = metadata.at ("name").get_ref<
                         const std::string&>();
-                    shell_log ("Storage resource in R without a label: %s",
+                    shell_debug ("Storage resource in R without a label: %s",
                                name.c_str ());
                 }
             }
@@ -149,14 +149,14 @@ static int stage_data (json &jobspec, json &R, int rank)
     auto data_staging_key = "/attributes/system/data-staging"_json_pointer;
     json data_staging_list = jobspec.at (data_staging_key);
     auto storage_resources = find_storage_resources (R, rank);
-    shell_log ("Found %d storage resources", (int) storage_resources.size ());
+    shell_debug ("Found %d storage resources", (int) storage_resources.size ());
 
     for (const json &data_staging : data_staging_list) {
         // If the filesystem is job-level then only the first rank needs to do
         // the staging
         std::string granularity = data_staging.at ("granularity");
         if ((granularity == "job") && (rank > 0)) {
-            shell_log ("Rank %d skipping staging to a job granularity storage",
+            shell_debug ("Rank %d skipping staging to a job granularity storage",
                        rank);
             continue;
         }
@@ -190,7 +190,7 @@ static int stage_data (json &jobspec, json &R, int rank)
         try {
             test = data_staging.at ("test").get<bool>();
              if (test) {
-                shell_log ("Rank %d staging from %s to %s",
+                shell_debug ("Rank %d staging from %s to %s",
                            rank,
                            source.c_str (),
                            destination.c_str ());

--- a/t/t7000-shell-datastaging.t
+++ b/t/t7000-shell-datastaging.t
@@ -132,6 +132,17 @@ test_expect_success 'submitting combined storage jobspec succeeded' '
             combined-endtoend.err
 '
 
+test_expect_success 'datastaging logging is not overly verbose by default' '
+    flux mini run hostname 2> non-verbose.err &&
+        test_must_be_empty non-verbose.err
+'
+
+test_expect_success 'datastaging logging can be access with verbose option' '
+    flux mini run -o verbose=2 hostname 2> verbose-run.err &&
+        grep -q " DEBUG: Jobspec does not contain data-staging attributes. "\
+"No staging necessary." verbose-run.err
+'
+
 test_expect_success 'removing resource and qmanager modules' '
     remove_qmanager &&
     remove_resource


### PR DESCRIPTION
Problem: when running a job without staging requirements, the shell logs
information that is high-enough level to be printed to the job's stdout
by default:

```
herbein1@4dd0461cee30:/usr/src$ flux mini run -N1 -n1 hostname
0.038s: flux-shell[0]: Jobspec does not contain data-staging attributes. No staging necessary.
4dd0461cee30
```

Solution: change `shell_log` to `shell_debug` to decrease the verbosity
of most messages enough that the datastaging shell plugin does not print
to stdout by default on non-staged jobs:

```
herbein1@4dd0461cee30:/usr/src$ flux mini run -N1 -n1 hostname
4dd0461cee30
```

You can still get access to the logging via a verbose option to the
job shell:

```
herbein1@4dd0461cee30:/usr/src$ flux mini run -N1 -n1 -o verbose=2 hostname
0.032s: flux-shell[0]: DEBUG: 0: task_count=1 slot_count=1 cores_per_slot=1 slots_per_node=1
0.032s: flux-shell[0]: DEBUG: 0: tasks [0] on cores 0
0.034s: flux-shell[0]: DEBUG: Loading /etc/flux/shell/initrc.lua
0.034s: flux-shell[0]: DEBUG: Jobspec does not contain data-staging attributes. No staging necessary.
0.041s: flux-shell[0]: DEBUG: output: batch timeout = 0.500s
4dd0461cee30
0.051s: flux-shell[0]: TRACE: 0: C: pmi EOF
0.051s: flux-shell[0]: DEBUG: task 0 complete status=0
0.062s: flux-shell[0]: DEBUG: exit 0
```

Closes #777