### PR TITLE
Globally rename "administrative priority" to "urgency"

### DIFF
--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -153,9 +153,9 @@ int qmanager_cb_t::jobmanager_hello_cb (flux_t *h,
     queue_name = qn_attr? qn_attr : ctx->opts.get_opt ().get_default_queue ();
     json_decref (o);
     queue = ctx->queues.at (queue_name);
-    // Note that RFC27 defines 31 as the max priority. Because our queue policy
+    // Note that RFC27 defines 31 as the max urgency. Because our queue policy
     // layer sorts the pending jobs in lexicographical order
-    // (<priority, t_submit, ...> and lower the better, we adjust priority.
+    // (<urgency, t_submit, ...> and lower the better, we adjust urgency.
     running_job = std::make_shared<job_t> (job_state_kind_t::RUNNING,
                                                    id, uid, 31 - prio, ts, R);
 
@@ -183,15 +183,15 @@ void qmanager_cb_t::jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
 
     if (jobspec_obj.attributes.system.queue != "")
         queue_name = jobspec_obj.attributes.system.queue;
-    if (schedutil_alloc_request_decode (msg, &job->id, &job->priority,
+    if (schedutil_alloc_request_decode (msg, &job->id, &job->urgency,
                                         &job->userid, &job->t_submit) < 0) {
         flux_log_error (h, "%s: schedutil_alloc_request_decode", __FUNCTION__);
         return;
     }
-    // Note that RFC27 defines 31 as the max priority. Because our queue policy
+    // Note that RFC27 defines 31 as the max urgency. Because our queue policy
     // layer sorts the pending jobs in lexicographical order
-    // (<priority, t_submit, ...> and lower the better, we adjust the priority.
-    job->priority = 31 - job->priority;
+    // (<urgency, t_submit, ...> and lower the better, we adjust the urgency.
+    job->urgency = 31 - job->urgency;
     if (ctx->queues.find (queue_name) == ctx->queues.end ()) {
         if (schedutil_alloc_respond_deny (ctx->schedutil, msg, NULL) < 0)
             flux_log_error (h, "%s: schedutil_alloc_respond_deny",

--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -85,9 +85,9 @@ public:
     ~job_t () { flux_msg_destroy (msg); }
     job_t () = default;
     job_t (job_state_kind_t s, flux_jobid_t jid,
-           uint32_t uid, int p, double t_s, const std::string &R)
+           uint32_t uid, int u, double t_s, const std::string &R)
 	   : state (s), id (jid), userid (uid),
-	     priority (p), t_submit (t_s), schedule (R) { }
+	     urgency (u), t_submit (t_s), schedule (R) { }
     job_t (job_t &&j) = default;
     job_t (const job_t &j) = default;
     job_t& operator= (job_t &&s) = default;
@@ -99,7 +99,7 @@ public:
     job_state_kind_t state = job_state_kind_t::INIT;
     flux_jobid_t id = 0;
     uint32_t userid = 0;
-    int priority = 0;
+    int urgency = 0;
     double t_submit = 0.0f;;
     std::string jobspec = "";
     std::string note = "";

--- a/qmanager/policies/base/queue_policy_base_impl.hpp
+++ b/qmanager/policies/base/queue_policy_base_impl.hpp
@@ -416,7 +416,7 @@ std::shared_ptr<job_t> queue_policy_base_impl_t::pending_pop ()
     flux_jobid_t id;
 
     if (m_pending.empty ())
-        return nullptr; 
+        return nullptr;
     id = m_pending.begin ()->second;
     if (m_jobs.find (id) == m_jobs.end ())
         return nullptr;

--- a/qmanager/policies/base/queue_policy_base_impl.hpp
+++ b/qmanager/policies/base/queue_policy_base_impl.hpp
@@ -253,7 +253,7 @@ int queue_policy_base_impl_t::insert (std::shared_ptr<job_t> job)
     job->state = job_state_kind_t::PENDING;
     job->t_stamps.pending_ts = m_pq_cnt++;
     m_pending.insert (std::pair<std::vector<double>, flux_jobid_t> (
-        {static_cast<double> (job->priority),
+        {static_cast<double> (job->urgency),
          static_cast<double> (job->t_submit),
          static_cast<double> (job->t_stamps.pending_ts)}, job->id));
     m_jobs.insert (std::pair<flux_jobid_t, std::shared_ptr<job_t>> (job->id,
@@ -276,7 +276,7 @@ int queue_policy_base_impl_t::remove (flux_jobid_t id)
     job = m_jobs[id];
     switch (job->state) {
     case job_state_kind_t::PENDING:
-        m_pending.erase ({static_cast<double> (job->priority),
+        m_pending.erase ({static_cast<double> (job->urgency),
                           static_cast<double> (job->t_submit),
                           static_cast<double> (job->t_stamps.pending_ts)});
         job->state = job_state_kind_t::CANCELED;
@@ -421,7 +421,7 @@ std::shared_ptr<job_t> queue_policy_base_impl_t::pending_pop ()
     if (m_jobs.find (id) == m_jobs.end ())
         return nullptr;
     job = m_jobs[id];
-    m_pending.erase ({static_cast<double> (job->priority),
+    m_pending.erase ({static_cast<double> (job->urgency),
                       static_cast<double> (job->t_submit),
                       static_cast<double> (job->t_stamps.pending_ts)});
     m_jobs.erase (id);

--- a/t/t1013-qmanager-priority.t
+++ b/t/t1013-qmanager-priority.t
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-test_description='Fluxion takes into account priority and t_submit'
+test_description='Fluxion takes into account urgency and t_submit'
 
 . `dirname $0`/sharness.sh
 
@@ -24,15 +24,15 @@ test_expect_success 'priority: loading fluxion modules works' '
 
 test_expect_success 'priority: a full-size job can be scheduled and run' '
     jobid1=$(flux mini submit -N 1 -n 1 -c 44 -g 4 -t 1h \
---priority 16 sleep 3600) &&
+--urgency 16 sleep 3600) &&
     flux job wait-event -t 10 ${jobid1} start
 '
 
-test_expect_success 'priority: 2 jobs with higher priority will not run' '
+test_expect_success 'priority: 2 jobs with higher urgency will not run' '
     jobid2=$(flux mini submit -N 1 -n 1 -c 44 -g 4 -t 1h \
---priority 17 sleep 3600) &&
+--urgency 17 sleep 3600) &&
     jobid3=$(flux mini submit -N 1 -n 1 -c 44 -g 4 -t 1h \
---priority 18 sleep 3600) &&
+--urgency 18 sleep 3600) &&
     test_must_fail flux job wait-event -t 1 ${jobid2} start
 '
 


### PR DESCRIPTION
Per RFC21 update (flux-framework/rfc#277) the "administrative priority" has been renamed to "urgency".

Globally update flux-sched for this change. This is built on and dependent on https://github.com/flux-framework/flux-core/pull/3394

