### PR TITLE
Add support to use RV1+JGF to populate graph data store

### DIFF
--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -606,7 +606,67 @@ ret:
     return rc;
 }
 
-static int unpack_resobj (json_t *resobj, std::vector<resobj_t> &out)
+/* Given 'resobj' in Rv1 form, decode the set of execution target ranks
+ * contained in it as well as r_lite key.
+ */
+static int unpack_resources (json_t *resobj,
+                             struct idset **idset,
+                             json_t **r_lite_p, json_t **jgf_p)
+{
+    int rc = 0;
+    struct idset *ids;
+    int version;
+    json_t *r_lite = NULL;
+    json_t *jgf = NULL;
+    size_t index;
+    json_t *val;
+
+    if (!(ids = idset_create (0, IDSET_FLAG_AUTOGROW)))
+        return -1;
+    if (resobj) {
+        if (json_unpack (resobj,
+                         "{s:i s:{s:o} s?:o}",
+                         "version", &version,
+                         "execution",
+                           "R_lite", &r_lite,
+                         "scheduling", &jgf) < 0)
+            goto inval;
+        if (version != 1)
+            goto inval;
+        json_array_foreach (r_lite, index, val) {
+            struct idset *r_ids;
+            unsigned long id;
+            const char *rank;
+
+            if (json_unpack (val, "{s:s}", "rank", &rank) < 0)
+                goto inval;
+            if (!(r_ids = idset_decode (rank)))
+                goto error;
+            id = idset_first (r_ids);
+            while (id != IDSET_INVALID_ID) {
+                if (idset_set (ids, id) < 0) {
+                    idset_destroy (r_ids);
+                    goto error;
+                }
+                id = idset_next (r_ids, id);
+            }
+            idset_destroy (r_ids);
+        }
+    }
+    *idset = ids;
+    *r_lite_p = r_lite;
+    *jgf_p = jgf;
+    return 0;
+inval:
+    errno = EINVAL;
+error:
+    idset_destroy (ids);
+    return -1;
+}
+
+static int unpack_resobj (json_t *resobj,
+                          std::map<const distinct_range_t,
+                                   std::shared_ptr<resobj_t>> &out)
 {
     if (!resobj)
         goto inval;
@@ -615,7 +675,7 @@ static int unpack_resobj (json_t *resobj, std::vector<resobj_t> &out)
         json_t *val;
 
         json_array_foreach (resobj, index, val) {
-            std::string exec_target_range;
+            std::string range;
             std::istringstream istr;
             const char *rank = NULL, *core = NULL, *gpu = NULL;
             if (json_unpack (val, "{s:s s:{s?:s s?:s}}",
@@ -624,21 +684,40 @@ static int unpack_resobj (json_t *resobj, std::vector<resobj_t> &out)
                                       "core", &core,
                                       "gpu", &gpu) < 0)
                 goto inval;
+            // Split the rank idset in resobj, convert each entry into
+            // distict_range_t and use it as the key to std::map.
+            // The value is the pointer to resobj_t.
+            // The distinct_range_t class provides ordering logic such that
+            // you will be able to iterate through ranges in strictly
+            // ascending order.
             istr.str (rank);
-            while (std::getline (istr, exec_target_range, ',')) {
-                resobj_t robj;
-                robj.exec_target_range = exec_target_range;
-                if (core && expand_ids (core, robj.core) < 0)
+            while (std::getline (istr, range, ',')) {
+                uint64_t low, high;
+                std::pair<std::map<const distinct_range_t,
+                                   std::shared_ptr<resobj_t>>::iterator, bool> res;
+                std::shared_ptr<resobj_t> robj = std::make_shared<resobj_t> ();
+                if (distinct_range_t::get_low_high (range, low, high) < 0)
                     goto error;
-                if (gpu && expand_ids (gpu, robj.gpu) < 0)
+                robj->exec_target_range = range;
+                if (core && expand_ids (core, robj->core) < 0)
                     goto error;
-                out.push_back (robj);
+                if (gpu && expand_ids (gpu, robj->gpu) < 0)
+                    goto error;
+                res = out.insert (std::pair<const distinct_range_t,
+                                  std::shared_ptr<resobj_t>> (
+                                      distinct_range_t{low, high}, robj));
+                if (res.second == false) {
+                    errno = EEXIST;
+                    goto error;
+                }
             }
         }
         return 0;
     } catch (std::bad_alloc &) {
         errno = ENOMEM;
         goto error;
+    } catch (std::invalid_argument &) {
+        goto inval;
     }
 inval:
     errno = EINVAL;
@@ -649,29 +728,90 @@ error:
 static int remap_hwloc_namespace (std::shared_ptr<resource_ctx_t> &ctx,
                                   json_t *r_lite)
 {
-    std::vector<resobj_t> resobjs;
+    std::map<const distinct_range_t, std::shared_ptr<resobj_t>> resobjs;
     if (unpack_resobj (r_lite, resobjs) < 0)
         return -1;
-    for (auto &resobj : resobjs) {
+    for (auto &kv : resobjs) {
         /* hwloc reader only needs to remap gpu IDs */
         size_t logical;
-        for (logical = 0; logical < resobj.gpu.size (); logical++) {
-            if (ctx->reader->namespace_remapper.add (resobj.exec_target_range,
-                                                     "gpu",
-                                                     logical,
-                                                     resobj.gpu[logical]) < 0)
+        for (logical = 0; logical < kv.second->gpu.size (); logical++) {
+            if (ctx->reader->namespace_remapper.add (
+                                 kv.second->exec_target_range,
+                                 "gpu",
+                                 logical,
+                                 kv.second->gpu[logical]) < 0)
                 return -1;
         }
     }
     return 0;
 }
 
+static int remap_jgf_namespace (std::shared_ptr<resource_ctx_t> &ctx,
+                                json_t *resobj, json_t *p_resobj)
+{
+    size_t i, j;
+    uint64_t cur_rank = 0;
+    std::map<const distinct_range_t, std::shared_ptr<resobj_t>> robjs, p_robjs;
+
+    if (unpack_resobj (resobj, robjs) < 0)
+        goto error;
+    if (unpack_resobj (p_resobj, p_robjs) < 0)
+        goto error;
+
+    try {
+        // Add remap rule for rank and compute core Ids. JGF reader only
+        // needs to remap them (e.g., GPU uses Id in global scope).
+        // This loop iterates through the distinct rank ranges of R_lite in
+        // the parent's namespace in ascending order.
+        // We first translate the ascending rank range sequence into
+        // 0-based monotonically increasing rank range sequence, for example
+        // A: <"3", "5", "6", "20-21"> --> B: <"1", "2", "3", "4-5">.
+        // Now, per core resource.acquire's remapping rule, for each range found
+        // in the parent namespace's R_lite, you should be able to find a
+        // corresponding range in the current namespace's R_lite.
+        // The current R_lite's range sequence for the above example might
+        // be C: <"1-2", "3", "4-5">. Then, B's "1" and "2" will be resolved
+        // to C's "1-2" range. B's "3" to C's "3". And B's "4-5" to C's "4-5".
+        for (auto kv : p_robjs) {
+            distinct_range_t new_range{cur_rank,
+                                       kv.first.get_high ()
+                                           - kv.first.get_low () + cur_rank};
+            std::shared_ptr<resobj_t> entry = nullptr;
+            std::shared_ptr<resobj_t> p_entry = kv.second;
+            if (robjs.find (new_range) == robjs.end ()) {
+                // Can't find the rank range in the current namespace
+                // corresponding to the (remapped) range of the parent namespace!
+                errno = ENOENT;
+                goto error;
+            }
+            entry = robjs[new_range];
+            if (ctx->reader->namespace_remapper.add_exec_target_range (
+                                                    p_entry->exec_target_range,
+                                                    new_range) < 0)
+                goto error;
+            for (j = 0; j < p_entry->core.size (); j++) {
+                if (ctx->reader->namespace_remapper.add (
+                                     p_entry->exec_target_range, "core",
+                                     p_entry->core[j], entry->core[j]) < 0)
+                    goto error;
+            }
+            cur_rank += (kv.first.get_high () - kv.first.get_low () + 1);
+        }
+    } catch (std::invalid_argument &) {
+        errno = EINVAL;
+        goto error;
+    }
+    return 0;
+error:
+    return -1;
+}
+
 /* Grow resources for execution targets 'ids', fetching resource
  * details in hwloc XML form from the core resource module.
  * If 'ids' is the empty set, an empty resource vertex will be instantiated.
  */
-static int grow_resource_db (std::shared_ptr<resource_ctx_t> &ctx,
-                             struct idset *ids, json_t *resobj)
+static int grow_resource_db_hwloc (std::shared_ptr<resource_ctx_t> &ctx,
+                                   struct idset *ids, json_t *resobj)
 {
     int rc = -1;
     resource_graph_db_t &db = *(ctx->db);
@@ -685,12 +825,6 @@ static int grow_resource_db (std::shared_ptr<resource_ctx_t> &ctx,
         goto done;
     if (flux_rpc_get_unpack (f, "{s:o}", "xml", &xml_array) < 0)
         goto done;
-    if (ctx->reader == nullptr
-        && create_reader (ctx, "hwloc", ctx->args.load_allowlist) < 0) {
-        flux_log (ctx->h, LOG_ERR, "%s: can't create hwloc reader",
-                  __FUNCTION__);
-        goto done;
-    }
     if (db.metadata.roots.find ("containment") == db.metadata.roots.end ()) {
         if (rank != IDSET_INVALID_ID) {
             if (!(hwloc_xml = get_array_string (xml_array, rank)))
@@ -728,6 +862,166 @@ static int grow_resource_db (std::shared_ptr<resource_ctx_t> &ctx,
 
 done:
     flux_future_destroy (f);
+    return rc;
+}
+
+static int get_parent_job_resources (std::shared_ptr<resource_ctx_t> &ctx,
+                                     json_t **resobj_p)
+{
+    int rc = -1;
+    json_t *resobj;
+    json_error_t json_err;
+    flux_jobid_t id;
+    flux_future_t *f = NULL;
+    flux_t *parent_h = NULL;
+    const char *uri, *jobid, *resobj_str;
+
+    if ( !(uri = flux_attr_get (ctx->h, "parent-uri")))
+        return 0;
+    if ( !(jobid = flux_attr_get (ctx->h, "jobid")))
+        return 0;
+    if (flux_job_id_parse (jobid, &id) < 0) {
+        flux_log_error (ctx->h, "%s: parsing jobid %s", __FUNCTION__, jobid);
+        return -1;
+    }
+    if ( !(parent_h = flux_open (uri, 0))) {
+        flux_log_error (ctx->h, "%s: flux_open (%s)", __FUNCTION__, uri);
+        goto done;
+    }
+    if ( !(f = flux_rpc_pack (parent_h, "job-info.lookup", FLUX_NODEID_ANY, 0,
+                                          "{s:I s:[s] s:i}",
+                                            "id", id,
+                                            "keys", "R",
+                                            "flags", 0))) {
+        flux_log_error (ctx->h, "%s: flux_rpc_pack (R)", __FUNCTION__);
+        goto done;
+    }
+    if (flux_rpc_get_unpack (f, "{s:s}", "R", &resobj_str) < 0) {
+        flux_log_error (ctx->h, "%s: flux_rpc_get_unpack (R)", __FUNCTION__);
+        goto done;
+    }
+    if ( !(resobj = json_loads (resobj_str, 0, &json_err))) {
+        errno = ENOMEM;
+        flux_log (ctx->h, LOG_ERR, "%s: json_loads", __FUNCTION__);
+        goto done;
+    }
+    *resobj_p = resobj;
+    rc = 0;
+done:
+    flux_future_destroy (f);
+    flux_close (parent_h);
+    return rc;
+}
+
+static int unpack_parent_job_resources (std::shared_ptr<resource_ctx_t> &ctx,
+                                        json_t **p_r_lite_p)
+{
+    int rc = 0;
+    int saved_errno;
+    json_t *p_jgf = NULL;
+    json_t *p_r_lite = NULL;
+    json_t *p_resources = NULL;
+    struct idset *p_grow_set = NULL;
+    if ( (rc = get_parent_job_resources (ctx, &p_resources)) < 0
+         || !p_resources)
+        goto done;
+    if ( (rc = unpack_resources (p_resources,
+                                 &p_grow_set, &p_r_lite, &p_jgf)) < 0)
+        goto done;
+    if (!p_grow_set || !p_r_lite || !p_jgf) {
+        errno = EINVAL;
+        rc = -1;
+        goto done;
+    }
+    if ( (*p_r_lite_p = json_deep_copy (p_r_lite)) == NULL) {
+        errno = ENOMEM;
+        rc = -1;
+        goto done;
+    }
+    rc = 0;
+done:
+    saved_errno = errno;
+    json_decref (p_resources);
+    idset_destroy (p_grow_set);
+    errno = saved_errno;
+    return rc;
+}
+
+static int grow_resource_db_jgf (std::shared_ptr<resource_ctx_t> &ctx,
+                                 json_t *r_lite, json_t *jgf)
+{
+    int rc = -1;
+    int saved_errno;
+    json_t *p_r_lite = NULL;
+    resource_graph_db_t &db = *(ctx->db);
+    char *jgf_str = NULL;
+    vtx_t v = boost::graph_traits<resource_graph_t>::null_vertex ();
+
+    if ( (rc = unpack_parent_job_resources (ctx, &p_r_lite)) < 0) {
+        flux_log_error (ctx->h, "%s: unpack_parent_job_resources",
+                        __FUNCTION__);
+        goto done;
+    }
+    if (db.metadata.roots.find ("containment") == db.metadata.roots.end ()) {
+        if ( p_r_lite
+             && (rc = remap_jgf_namespace (ctx, r_lite, p_r_lite)) < 0) {
+            flux_log_error (ctx->h, "%s: remap_jgf_namespace", __FUNCTION__);
+            goto done;
+        }
+        if ( (jgf_str = json_dumps (jgf, JSON_INDENT (0))) == NULL) {
+            rc = -1;
+            errno = ENOMEM;
+            goto done;
+        }
+        if ( (rc = db.load (jgf_str, ctx->reader, -1)) < 0) {
+            flux_log_error (ctx->h, "%s: db.load: %s",
+                            __FUNCTION__, ctx->reader->err_message ().c_str ());
+            goto done;
+        }
+    }
+done:
+    saved_errno = errno;
+    json_decref (p_r_lite);
+    free (jgf_str);
+    errno = saved_errno;
+    return rc;
+}
+
+static int grow_resource_db (std::shared_ptr<resource_ctx_t> &ctx,
+                             json_t *resources)
+{
+    int rc = 0;
+    struct idset *grow_set = NULL;
+    json_t *r_lite = NULL;
+    json_t *jgf = NULL;
+
+    if ( (rc = unpack_resources (resources,
+                                 &grow_set, &r_lite, &jgf)) < 0) {
+        flux_log_error (ctx->h, "%s: unpack_resources", __FUNCTION__);
+        goto done;
+    }
+    if (jgf) {
+        if (ctx->reader == nullptr
+            && (rc = create_reader (ctx, "jgf",
+                                    ctx->args.load_allowlist)) < 0) {
+            flux_log (ctx->h, LOG_ERR, "%s: can't create jgf reader",
+                      __FUNCTION__);
+            goto done;
+        }
+        rc = grow_resource_db_jgf (ctx, r_lite, jgf);
+    } else {
+        if (ctx->reader == nullptr
+            && (rc = create_reader (ctx, "hwloc",
+                                    ctx->args.load_allowlist)) < 0) {
+            flux_log (ctx->h, LOG_ERR, "%s: can't create hwloc reader",
+                      __FUNCTION__);
+            goto done;
+        }
+        rc = grow_resource_db_hwloc (ctx, grow_set, r_lite);
+   }
+
+done:
+    idset_destroy (grow_set);
     return rc;
 }
 
@@ -833,11 +1127,11 @@ static int mark (std::shared_ptr<resource_ctx_t> &ctx,
 }
 
 static int update_resource_db (std::shared_ptr<resource_ctx_t> &ctx,
-                               struct idset *grow_set, json_t *resobj,
+                               json_t *resources,
                                const char *up, const char *down)
 {
     int rc = 0;
-    if (grow_set && (rc = grow_resource_db (ctx, grow_set, resobj)) < 0) {
+    if (resources && (rc = grow_resource_db (ctx, resources)) < 0) {
         flux_log_error (ctx->h, "%s: grow_resource_db", __FUNCTION__);
         goto done;
     }
@@ -853,68 +1147,12 @@ done:
     return rc;
 }
 
-/* Given 'resobj' in Rv1 form, decode the set of execution target ranks
- * contained in it as well as r_lite key.
- */
-static int unpack_resources (json_t *resobj,
-                             struct idset **idset, json_t **r_lite_p)
-{
-    int rc = 0;
-    struct idset *ids;
-    int version;
-    json_t *r_lite;
-    size_t index;
-    json_t *val;
-
-    if (!(ids = idset_create (0, IDSET_FLAG_AUTOGROW)))
-        return -1;
-    if (resobj) {
-        if (json_unpack (resobj,
-                         "{s:i s:{s:o}}",
-                         "version", &version,
-                         "execution",
-                           "R_lite", &r_lite) < 0)
-            goto inval;
-        if (version != 1)
-            goto inval;
-        json_array_foreach (r_lite, index, val) {
-            struct idset *r_ids;
-            unsigned long id;
-            const char *rank;
-
-            if (json_unpack (val, "{s:s}", "rank", &rank) < 0)
-                goto inval;
-            if (!(r_ids = idset_decode (rank)))
-                goto error;
-            id = idset_first (r_ids);
-            while (id != IDSET_INVALID_ID) {
-                if (idset_set (ids, id) < 0) {
-                    idset_destroy (r_ids);
-                    goto error;
-                }
-                id = idset_next (r_ids, id);
-            }
-            idset_destroy (r_ids);
-        }
-    }
-    *idset = ids;
-    *r_lite_p = r_lite;
-    return 0;
-inval:
-    errno = EINVAL;
-error:
-    idset_destroy (ids);
-    return -1;
-}
-
 static void update_resource (flux_future_t *f, void *arg)
 {
     int rc = -1;
     const char *up = NULL;
     const char *down = NULL;
     json_t *resources = NULL;
-    json_t *r_lite = NULL;
-    struct idset *grow_set = NULL;
     std::shared_ptr<resource_ctx_t> ctx = getctx ((flux_t *)arg);
 
     if ( (rc = flux_rpc_get_unpack (f, "{s?:o s?:s s?:s}",
@@ -926,14 +1164,7 @@ static void update_resource (flux_future_t *f, void *arg)
         flux_reactor_stop (flux_get_reactor (ctx->h));
         goto done;
     }
-    if (resources) {
-        if ( (rc = unpack_resources (resources, &grow_set, &r_lite)) < 0) {
-            rc = -1;
-            flux_log_error (ctx->h, "%s: unpack_resources", __FUNCTION__);
-            goto done;
-        }
-    }
-    if ( (rc = update_resource_db (ctx, grow_set, r_lite, up, down)) < 0) {
+    if ( (rc = update_resource_db (ctx, resources, up, down)) < 0) {
         flux_log_error (ctx->h, "%s: update_resource_db", __FUNCTION__);
         goto done;
     }
@@ -943,12 +1174,11 @@ static void update_resource (flux_future_t *f, void *arg)
         }
     }
 done:
-    idset_destroy (grow_set);
     flux_future_reset (f);
     ctx->set_update_rc (rc);
 }
 
-static int populate_resource_db_kvs (std::shared_ptr<resource_ctx_t> &ctx)
+static int populate_resource_db_acquire (std::shared_ptr<resource_ctx_t> &ctx)
 {
     int rc = -1;
     json_t *o = NULL;
@@ -992,13 +1222,14 @@ static int populate_resource_db (std::shared_ptr<resource_ctx_t> &ctx)
         flux_log (ctx->h, LOG_INFO, "%s: loaded resources from %s",
                   __FUNCTION__,  ctx->args.load_file.c_str ());
     } else {
-        if (populate_resource_db_kvs (ctx) < 0) {
-            flux_log (ctx->h, LOG_ERR, "%s: loading resources from the KVS",
+        if (populate_resource_db_acquire (ctx) < 0) {
+            flux_log (ctx->h, LOG_ERR,
+                      "%s: loading resources using resource.acquire",
                       __FUNCTION__);
             goto done;
         }
         flux_log (ctx->h, LOG_INFO,
-                  "%s: loaded resources from hwloc in the KVS",
+                  "%s: loaded resources from core's resource.acquire",
                   __FUNCTION__);
     }
     if ( (rc = gettimeofday (&et, NULL)) < 0) {

--- a/resource/readers/resource_namespace_remapper.cpp
+++ b/resource/readers/resource_namespace_remapper.cpp
@@ -42,58 +42,52 @@ using namespace Flux::resource_model;
 
 /********************************************************************************
  *                                                                              *
- *                   Private Resource Namespace Remapper API                    *
+ *                    Public Resource Namespace Remapper API                    *
  *                                                                              *
  ********************************************************************************/
 
-resource_namespace_remapper_t
-    ::distinct_range_t::distinct_range_t (uint64_t point)
+distinct_range_t::distinct_range_t (uint64_t point)
 {
     m_low = point;
     m_high = point;
 }
 
-resource_namespace_remapper_t
-    ::distinct_range_t::distinct_range_t (uint64_t lo, uint64_t hi)
+distinct_range_t::distinct_range_t (uint64_t lo, uint64_t hi)
 {
     m_low = lo;
     m_high = hi;
+    if (lo > hi)
+        throw std::invalid_argument ("distinct_range_t: low > than high");
 }
 
-uint64_t resource_namespace_remapper_t
-             ::distinct_range_t::get_low () const
+uint64_t distinct_range_t::get_low () const
 {
     return m_low;
 }
 
-uint64_t resource_namespace_remapper_t
-             ::distinct_range_t::get_high () const
+uint64_t distinct_range_t::get_high () const
 {
     return m_high;
 }
 
-bool resource_namespace_remapper_t
-         ::distinct_range_t::is_point () const
+bool distinct_range_t::is_point () const
 {
     return m_low == m_high;
 }
 
-bool resource_namespace_remapper_t
-         ::distinct_range_t::operator< (const distinct_range_t &o) const {
+bool distinct_range_t::operator< (const distinct_range_t &o) const {
     // this class is used as key for std::map, which relies on the following
     // x and y are equivalent if !(x < y) && !(y < x)
     return m_high < o.m_low;
 }
 
-bool resource_namespace_remapper_t
-         ::distinct_range_t::operator== (const distinct_range_t &o) const {
+bool distinct_range_t::operator== (const distinct_range_t &o) const {
     // x and y are equal if and only if both high and low
     // of the operands are equal
     return m_high == o.m_high && m_low == o.m_low;
 }
 
-bool resource_namespace_remapper_t
-         ::distinct_range_t::operator!= (const distinct_range_t &o) const {
+bool distinct_range_t::operator!= (const distinct_range_t &o) const {
     // x and y are not equal if either high or low is not equal
     return m_high != o.m_high || m_low != o.m_low;
 }
@@ -109,8 +103,6 @@ int resource_namespace_remapper_t::add (const uint64_t low, const uint64_t high,
                                         const std::string &name_type,
                                         uint64_t ref_id, uint64_t remapped_id)
 {
-    if (low > high)
-        goto inval;
     try {
         const distinct_range_t exec_target_range{low, high};
         auto m_remap_iter = m_remap.find (exec_target_range);
@@ -135,6 +127,8 @@ int resource_namespace_remapper_t::add (const uint64_t low, const uint64_t high,
     } catch (std::bad_alloc &) {
         errno = ENOMEM;
         goto error;
+    } catch (std::invalid_argument &) {
+        goto inval;
     }
     return 0;
 inval:

--- a/resource/readers/resource_namespace_remapper.cpp
+++ b/resource/readers/resource_namespace_remapper.cpp
@@ -92,9 +92,8 @@ bool distinct_range_t::operator!= (const distinct_range_t &o) const {
     return m_high != o.m_high || m_low != o.m_low;
 }
 
-int resource_namespace_remapper_t::get_low_high (
-                                       const std::string &exec_target_range,
-                                       uint64_t &low, uint64_t &high) const
+int distinct_range_t::get_low_high (const std::string &exec_target_range,
+                                    uint64_t &low, uint64_t &high)
 {
     try {
         long int n;
@@ -180,7 +179,7 @@ int resource_namespace_remapper_t::add (const std::string &exec_target_range,
 {
     try {
         uint64_t low, high;
-        if (get_low_high (exec_target_range, low, high) < 0)
+        if (distinct_range_t::get_low_high (exec_target_range, low, high) < 0)
             goto error;
         return add (low, high, name_type, ref_id, remapped_id);
     } catch (std::bad_alloc &) {
@@ -194,17 +193,17 @@ error:
 
 int resource_namespace_remapper_t::add_exec_target_range (
         const std::string &exec_target_range,
-        const std::string &remapped_exec_target_range)
+        const distinct_range_t &remapped_exec_target_range)
 {
     try {
         uint64_t low, high, r_low, r_high, i, j;
-        if (get_low_high (exec_target_range, low, high) < 0)
+        if (distinct_range_t::get_low_high (exec_target_range, low, high) < 0)
             goto error;
-        if (get_low_high (remapped_exec_target_range, r_low, r_high) < 0)
-            goto error;
+        r_low = remapped_exec_target_range.get_low ();
+        r_high = remapped_exec_target_range.get_high ();
         if ((high - low) != (r_high - r_low))
             goto inval;
-        for (i = low, j = r_low; i <= high; i++, j++) {
+        for (i = low, j = r_low; i <= high && j <= r_high; i++, j++) {
             if (add (exec_target_range, "exec-target", i, j) < 0)
                 goto error;
         }

--- a/resource/readers/resource_namespace_remapper.hpp
+++ b/resource/readers/resource_namespace_remapper.hpp
@@ -59,9 +59,13 @@ public:
     int add (const std::string &exec_target_range,
              const std::string &name_type,
              uint64_t ref_id, uint64_t remapped_id);
+    int add_exec_target_range (const std::string &exec_target_range,
+                               const std::string &remapped_exec_target_range);
     int query (const uint64_t exec_target,
                const std::string &name_type,
                uint64_t ref_id, uint64_t &remapped_id_out) const;
+    int query_exec_target (const uint64_t exec_target,
+                           uint64_t &remapped_exec_target) const;
     bool is_remapped () const;
 
 private:

--- a/resource/readers/resource_namespace_remapper.hpp
+++ b/resource/readers/resource_namespace_remapper.hpp
@@ -65,22 +65,9 @@ public:
     bool is_remapped () const;
 
 private:
-    class distinct_range_t {
-    public:
-        explicit distinct_range_t (uint64_t point);
-        distinct_range_t (uint64_t lo, uint64_t hi);
 
-        uint64_t get_low () const;
-        uint64_t get_high () const;
-        bool is_point () const;
-        bool operator< (const distinct_range_t &o) const;
-        bool operator== (const distinct_range_t &o) const;
-        bool operator!= (const distinct_range_t &o) const;
-
-    private:
-        uint64_t m_low;
-        uint64_t m_high;
-    };
+    int get_low_high (const std::string &exec_target_range,
+                      uint64_t &low, uint64_t &high) const;
 
     std::map<const distinct_range_t,
              std::map<const std::string,

--- a/resource/readers/resource_namespace_remapper.hpp
+++ b/resource/readers/resource_namespace_remapper.hpp
@@ -32,6 +32,24 @@
 namespace Flux {
 namespace resource_model {
 
+class distinct_range_t {
+public:
+    explicit distinct_range_t (uint64_t point);
+    distinct_range_t (uint64_t lo, uint64_t hi);
+
+    uint64_t get_low () const;
+    uint64_t get_high () const;
+    bool is_point () const;
+    bool operator< (const distinct_range_t &o) const;
+    bool operator== (const distinct_range_t &o) const;
+    bool operator!= (const distinct_range_t &o) const;
+
+private:
+    uint64_t m_low;
+    uint64_t m_high;
+};
+
+
 class resource_namespace_remapper_t {
 public:
     int add (const uint64_t exec_target_high,

--- a/resource/readers/resource_namespace_remapper.hpp
+++ b/resource/readers/resource_namespace_remapper.hpp
@@ -44,6 +44,9 @@ public:
     bool operator== (const distinct_range_t &o) const;
     bool operator!= (const distinct_range_t &o) const;
 
+    static int get_low_high (const std::string &exec_target_range,
+                             uint64_t &low, uint64_t &high);
+
 private:
     uint64_t m_low;
     uint64_t m_high;
@@ -59,8 +62,9 @@ public:
     int add (const std::string &exec_target_range,
              const std::string &name_type,
              uint64_t ref_id, uint64_t remapped_id);
-    int add_exec_target_range (const std::string &exec_target_range,
-                               const std::string &remapped_exec_target_range);
+    int add_exec_target_range (
+            const std::string &exec_target_range,
+            const distinct_range_t &remapped_exec_target_range);
     int query (const uint64_t exec_target,
                const std::string &name_type,
                uint64_t ref_id, uint64_t &remapped_id_out) const;

--- a/resource/readers/resource_reader_base.cpp
+++ b/resource/readers/resource_reader_base.cpp
@@ -90,6 +90,11 @@ int resource_reader_base_t::set_allowlist (const std::string &csl)
     return rc;
 }
 
+bool resource_reader_base_t::is_allowlist_set ()
+{
+    return !allowlist.empty ();
+}
+
 const std::string &resource_reader_base_t::err_message () const
 {
     return m_err_msg;

--- a/resource/readers/resource_reader_base.hpp
+++ b/resource/readers/resource_reader_base.hpp
@@ -92,6 +92,12 @@ public:
      */
     int set_allowlist (const std::string &csl);
 
+    /*! Is the allowlist set
+     *
+     * \return       true when supported
+     */
+    virtual bool is_allowlist_set ();
+
     /*! Is the selected reader format support allowlist
      *
      * \return       true when supported

--- a/resource/readers/resource_reader_jgf.cpp
+++ b/resource/readers/resource_reader_jgf.cpp
@@ -242,7 +242,7 @@ int resource_reader_jgf_t::fetch_jgf (const std::string &str, json_t **jgf_p,
     json_error_t json_err;
 
     if ( (*jgf_p = json_loads (str.c_str (), 0, &json_err)) == NULL) {
-        errno = EPROTO;
+        errno = EINVAL;
         m_err_msg += __FUNCTION__;
         m_err_msg += ": json_loads returned an error: ";
         m_err_msg += std::string (json_err.text) + std::string (": ");
@@ -252,19 +252,19 @@ int resource_reader_jgf_t::fetch_jgf (const std::string &str, json_t **jgf_p,
         goto done;
     }
     if ( (graph = json_object_get (*jgf_p, "graph" )) == NULL) {
-        errno = EPROTO;
+        errno = EINVAL;
         m_err_msg += __FUNCTION__;
         m_err_msg += ": JGF does not contain a required key (graph).\n";
         goto done;
     }
     if ( (*nodes_p = json_object_get (graph, "nodes" )) == NULL) {
-        errno = EPROTO;
+        errno = EINVAL;
         m_err_msg += __FUNCTION__;
         m_err_msg += ": JGF does not contain a required key (nodes).\n";
         goto done;
     }
     if ( (*edges_p = json_object_get (graph, "edges" )) == NULL) {
-        errno = EPROTO;
+        errno = EINVAL;
         m_err_msg += __FUNCTION__;
         m_err_msg += ": JGF does not contain a required key (edges).\n";
         goto done;
@@ -378,13 +378,13 @@ int resource_reader_jgf_t::fill_fetcher (json_t *element, fetch_helper_t &f,
     json_t *metadata = NULL;
 
     if ( (json_unpack (element, "{ s:s }", "id", &f.vertex_id) < 0)) {
-        errno = EPROTO;
+        errno = EINVAL;
         m_err_msg += __FUNCTION__;
         m_err_msg += ": JGF vertex id key is not found in a node.\n";
         goto done;
     }
     if ( (metadata = json_object_get (element, "metadata")) == NULL) {
-        errno = EPROTO;
+        errno = EINVAL;
         m_err_msg += __FUNCTION__;
         m_err_msg += ": key (metadata) is not found in an JGF node for ";
         m_err_msg += std::string (f.vertex_id) + ".\n";
@@ -396,14 +396,14 @@ int resource_reader_jgf_t::fill_fetcher (json_t *element, fetch_helper_t &f,
                                  "uniq_id", &f.uniq_id, "rank", &f.rank,
                                  "status", &f.status, "exclusive", &f.exclusive,
                                  "unit", &f.unit, "size", &f.size)) < 0) {
-        errno = EPROTO;
+        errno = EINVAL;
         m_err_msg += __FUNCTION__;
         m_err_msg += ": malformed metadata in an JGF node for ";
         m_err_msg += std::string (f.vertex_id) + "\n";
         goto done;
     }
     if ( (p = json_object_get (metadata, "paths")) == NULL) {
-        errno = EPROTO;
+        errno = EINVAL;
         m_err_msg += __FUNCTION__;
         m_err_msg += ": key (paths) does not exist in an JGF node for ";
         m_err_msg += std::string (f.vertex_id) + ".\n";
@@ -525,7 +525,7 @@ int resource_reader_jgf_t::add_vtx (resource_graph_t &g,
     vtx_t v = boost::graph_traits<resource_graph_t>::null_vertex ();
 
     if (vmap.find (fetcher.vertex_id) != vmap.end ()) {
-        errno = EPROTO;
+        errno = EINVAL;
         m_err_msg += __FUNCTION__;
         m_err_msg += ": found duplicate JGF node id for ";
         m_err_msg += std::string (fetcher.vertex_id) + ".\n";
@@ -565,7 +565,7 @@ int resource_reader_jgf_t::find_vtx (resource_graph_t &g,
     v = nullvtx;
 
     if (vmap.find (fetcher.vertex_id) != vmap.end ()) {
-        errno = EPROTO;
+        errno = EINVAL;
         m_err_msg += __FUNCTION__;
         m_err_msg += ": found duplicate JGF node id for ";
         m_err_msg += std::string (fetcher.vertex_id) + ".\n";
@@ -576,7 +576,7 @@ int resource_reader_jgf_t::find_vtx (resource_graph_t &g,
         try {
             vtx_t u = m.by_path.at (kv.second);
             if (v != nullvtx && u != v) {
-                errno = EPROTO;
+                errno = EINVAL;
                 m_err_msg += __FUNCTION__;
                 m_err_msg += ": inconsistent input vertex for " + kv.second;
                 m_err_msg += " (id=" + std::string (fetcher.vertex_id) + ").\n";
@@ -595,7 +595,7 @@ int resource_reader_jgf_t::find_vtx (resource_graph_t &g,
     }
 
     if (g[v] != fetcher) {
-        errno = EPROTO;
+        errno = EINVAL;
         m_err_msg += __FUNCTION__;
         m_err_msg += ": inconsistent input vertex for ";
         m_err_msg += std::string (fetcher.vertex_id) + ".\n";
@@ -680,7 +680,7 @@ int resource_reader_jgf_t::update_vtx (resource_graph_t &g,
                             static_cast<unsigned int> (fetcher.size),
                             static_cast<unsigned int> (fetcher.exclusive)});
     if (!ptr.second) {
-        errno = EPROTO;
+        errno = EINVAL;
         m_err_msg += __FUNCTION__;
         m_err_msg += ": can't insert into vmap.\n";
         rc = -1;
@@ -795,7 +795,7 @@ int resource_reader_jgf_t::unpack_edge (json_t *element,
 
     if ( (json_unpack (element, "{ s:s s:s }", "source", &src,
                                                "target", &tgt)) < 0) {
-        errno = EPROTO;
+        errno = EINVAL;
         m_err_msg += __FUNCTION__;
         m_err_msg += ": encountered a malformed edge.\n";
         goto done;
@@ -804,21 +804,21 @@ int resource_reader_jgf_t::unpack_edge (json_t *element,
     target = tgt;
     if (vmap.find (source) == vmap.end ()
         || vmap.find (target) == vmap.end ()) {
-        errno = EPROTO;
+        errno = EINVAL;
         m_err_msg += __FUNCTION__;
         m_err_msg += ": source and/or target vertex not found";
         m_err_msg += source + std::string (" -> ") + target + ".\n";
         goto done;
     }
     if ( (metadata = json_object_get (element, "metadata")) == NULL) {
-        errno = EPROTO;
+        errno = EINVAL;
         m_err_msg += __FUNCTION__;
         m_err_msg += ": metadata key not found in an edge for ";
         m_err_msg += source + std::string (" -> ") + target + ".\n";
         goto done;
     }
     if ( (*name = json_object_get (metadata, "name")) == NULL) {
-        errno = EPROTO;
+        errno = EINVAL;
         m_err_msg += __FUNCTION__;
         m_err_msg += ": name key not found in edge metadata.\n";
         goto done;
@@ -852,7 +852,7 @@ int resource_reader_jgf_t::unpack_edges (resource_graph_t &g,
             goto done;
         tie (e, inserted) = add_edge (vmap[source].v, vmap[target].v, g);
         if (inserted == false) {
-            errno = EPROTO;
+            errno = EINVAL;
             m_err_msg += __FUNCTION__;
             m_err_msg += ": couldn't add an edge to the graph for ";
             m_err_msg += source + std::string (" -> ") + target + ".\n";
@@ -914,13 +914,13 @@ int resource_reader_jgf_t::update_tgt_edge (resource_graph_t &g,
          }
     }
     if (!found) {
-        errno = EPROTO;
+        errno = EINVAL;
         m_err_msg += __FUNCTION__;
         m_err_msg += ": JGF edge not found in resource graph.\n";
         goto done;
     }
     if (!(vmap[target].is_roots.empty ())) {
-        errno = EPROTO;
+        errno = EINVAL;
         m_err_msg += __FUNCTION__;
         m_err_msg += ": an edge into a root detected!\n";
         goto done;

--- a/resource/readers/resource_reader_jgf.cpp
+++ b/resource/readers/resource_reader_jgf.cpp
@@ -38,12 +38,36 @@ extern "C" {
 using namespace Flux;
 using namespace Flux::resource_model;
 
-struct fetch_helper_t {
-    int64_t id = 0;
-    int64_t rank = 0;
-    int64_t size = 0;
-    int64_t uniq_id = 0;
-    int exclusive = 0;
+class fetch_remap_support_t {
+public:
+    int64_t get_remapped_id () const;
+    int64_t get_remapped_rank () const;
+    const std::string &get_remapped_name () const;
+    void set_remapped_id (int64_t i);
+    void set_remapped_rank (int64_t r);
+    void set_remapped_name (const std::string &n);
+    bool is_name_remapped () const;
+    bool is_id_remapped () const;
+    bool is_rank_remapped () const;
+    void clear ();
+
+private:
+    int64_t m_remapped_id = -1;
+    int64_t m_remapped_rank = -1;
+    std::string m_remapped_name = "";
+};
+
+struct fetch_helper_t : public fetch_remap_support_t {
+    const char *get_proper_name () const;
+    int64_t get_proper_id () const;
+    int64_t get_proper_rank () const;
+    void scrub ();
+
+    int64_t id = -1;
+    int64_t rank = -1;
+    int64_t size = -1;
+    int64_t uniq_id = -1;
+    int exclusive = -1;
     resource_pool_t::status_t status = resource_pool_t::status_t::UP;
     const char *type = NULL;
     const char *name = NULL;
@@ -53,6 +77,91 @@ struct fetch_helper_t {
     std::map<std::string, std::string> properties;
     std::map<std::string, std::string> paths;
 };
+
+int64_t fetch_remap_support_t::get_remapped_id () const
+{
+    return m_remapped_id;
+}
+
+int64_t fetch_remap_support_t::get_remapped_rank () const
+{
+    return m_remapped_rank;
+}
+
+const std::string &fetch_remap_support_t::get_remapped_name () const
+{
+    return m_remapped_name;
+}
+
+void fetch_remap_support_t::set_remapped_id (int64_t i)
+{
+    m_remapped_id = i;
+}
+
+void fetch_remap_support_t::set_remapped_rank (int64_t r)
+{
+    m_remapped_rank = r;
+}
+
+void fetch_remap_support_t::set_remapped_name (const std::string &n)
+{
+    m_remapped_name = n;
+}
+
+bool fetch_remap_support_t::is_name_remapped () const
+{
+    return m_remapped_name != "";
+}
+
+bool fetch_remap_support_t::is_id_remapped () const
+{
+    return m_remapped_id != -1;
+}
+
+bool fetch_remap_support_t::is_rank_remapped () const
+{
+    return m_remapped_rank != -1;
+}
+
+void fetch_remap_support_t::clear ()
+{
+    m_remapped_id = -1;
+    m_remapped_rank = -1;
+    m_remapped_name = "";
+}
+
+const char *fetch_helper_t::get_proper_name () const
+{
+    return (is_name_remapped ())? get_remapped_name ().c_str () : name;
+}
+
+int64_t fetch_helper_t::get_proper_id () const
+{
+    return (is_id_remapped ())? get_remapped_id () : id;
+}
+
+int64_t fetch_helper_t::get_proper_rank () const
+{
+    return (is_rank_remapped ())? get_remapped_rank () : rank;
+}
+
+void fetch_helper_t::scrub ()
+{
+    id = -1;
+    rank = -1;
+    size = -1;
+    uniq_id = -1;
+    exclusive = -1;
+    type = NULL;
+    name = NULL;
+    unit = NULL;
+    basename = NULL;
+    vertex_id = NULL;
+    properties.clear ();
+    paths.clear ();
+    clear ();
+}
+
 
 struct vmap_val_t {
     vtx_t v;

--- a/resource/readers/resource_reader_jgf.hpp
+++ b/resource/readers/resource_reader_jgf.hpp
@@ -96,6 +96,12 @@ public:
 private:
     int fetch_jgf (const std::string &str,
                    json_t **jgf_p, json_t **nodes_p, json_t **edges_p);
+    int unpack_and_remap_vtx (fetch_helper_t &f,
+                              json_t *paths, json_t *properties);
+    int remap_aware_unpack_vtx (fetch_helper_t &f,
+                                json_t *paths, json_t *properties);
+    int fill_fetcher (json_t *element, fetch_helper_t &f,
+                      json_t **path, json_t **properties);
     int unpack_vtx (json_t *element, fetch_helper_t &f);
     vtx_t create_vtx (resource_graph_t &g, const fetch_helper_t &fetcher);
     bool is_root (const std::string &path);

--- a/resource/readers/resource_spec_grug.cpp
+++ b/resource/readers/resource_spec_grug.cpp
@@ -171,7 +171,7 @@ int resource_gen_spec_t::read_graphml (std::istream &in)
     try {
         boost::read_graphml (in, g, dp);
     } catch (boost::exception &e) {
-        errno = EPROTO;
+        errno = EINVAL;
         rc = -1;
     }
     return rc;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -40,6 +40,7 @@ TESTS = \
     t1015-find-format.t \
     t1016-nest-namespace.t \
     t1017-rv1-bootstrap.t \
+    t1018-rv1-bootstrap2.t \
     t2000-tree-basic.t \
     t2001-tree-real.t \
     t3000-jobspec.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -39,6 +39,7 @@ TESTS = \
     t1014-annotation.t \
     t1015-find-format.t \
     t1016-nest-namespace.t \
+    t1017-rv1-bootstrap.t \
     t2000-tree-basic.t \
     t2001-tree-real.t \
     t3000-jobspec.t \

--- a/t/scripts/flux-ion-R.py
+++ b/t/scripts/flux-ion-R.py
@@ -1,0 +1,132 @@
+#!/bin/false
+#
+#  Run script as `flux ion-R ` with properly configured
+#   FLUX_EXEC_PATH or `flux python flux-ion-R` if not to
+#   avoid python version mismatch
+#
+
+import sys
+import json
+from flux.idset import IDset
+from flux.hostlist import Hostlist
+from jsongraph.objects.graph import Graph, Node, Edge
+
+def idset_expand(s):
+    return list(IDset(s))
+
+uniqId = 0
+def tick_uniq_id():
+    global uniqId
+    uniqId += 1
+
+def get_uniq_id():
+    global uniqId
+    return uniqId
+
+def postfix_digits(s):
+    res = [int(i) for i in s.split() if i.isdigit()]
+
+def extract_id_from_hn(s):
+    import re
+    global uniqId
+    postfix = re.findall(r"(\d+$)", s)
+    if len(postfix) == 1:
+        return int(postfix[0])
+    else:
+        return uniqId
+
+rv1 = json.loads(sys.stdin.read())
+R_lite = rv1['execution']['R_lite']
+nodeList = Hostlist(rv1['execution']['nodelist'])
+graph = Graph()
+
+#
+# Create a cluster graph node
+#
+clusterNode = Node(get_uniq_id(),
+                   metadata={ 'type': 'cluster',
+                              'basename': 'cluster',
+                              'name': 'cluster0',
+                              'id' : get_uniq_id(),
+                              'uniq_id' : get_uniq_id(),
+                              'rank' : -1,
+                              'exclusive' : True,
+                              'unit' : '',
+                              'size' : 1,
+                              'paths' : {
+                                  'containment': '/cluster0'
+                              }
+                            }
+                   )
+graph.add_node(clusterNode)
+tick_uniq_id()
+
+h = -1
+for entry in R_lite:
+    for rank in idset_expand(entry['rank']):
+        #
+        # Create a compute-node graph node
+        #
+        h += 1
+        nodePath=f"/cluster0/{nodeList[h]}"
+        node = Node(get_uniq_id(),
+                    metadata={ 'type': 'node',
+                               'basename': 'node',
+                               'name': nodeList[h],
+                               'id' : extract_id_from_hn (nodeList[h]),
+                               'uniq_id' : get_uniq_id(),
+                               'rank' : rank,
+                               'exclusive' : True,
+                               'unit' : '',
+                               'size' : 1,
+                               'paths' : {
+                                   'containment': nodePath
+                               }
+                             }
+                       )
+        graph.add_node(node)
+        edge = Edge(clusterNode.get_id(),
+                    node.get_id(),
+                    directed=True,
+                    metadata={ 'name' : { 'containment' : 'contains' }},
+                    )
+        graph.add_edge(edge)
+        tick_uniq_id()
+
+        for k,v in entry['children'].items():
+            for i in idset_expand(v):
+                #
+                # Create a core or gpu graph node
+                #
+                resourceType = str(k)
+                childNodePath = f"{nodePath}/{resourceType}{i}"
+                childNode=Node(uniqId,
+                               metadata={ 'type': resourceType,
+                                          'basename': resourceType,
+                                          'name': resourceType + str(i),
+                                          'id' : i,
+                                          'uniq_id' : uniqId,
+                                          'rank' : rank,
+                                          'exclusive' : True,
+                                          'unit' : '',
+                                          'size' : 1,
+                                          'paths' : {
+                                              'containment': childNodePath
+                                          }
+                                        }
+                              )
+                graph.add_node(childNode)
+                edge = Edge(node.get_id(),
+                            childNode.get_id(),
+                            directed=True,
+                            metadata={ 'name' : { 'containment' : 'contains' }}
+                           )
+                graph.add_edge (edge)
+                tick_uniq_id()
+
+rv1['scheduling'] = graph.to_JSON()
+print (json.dumps(rv1))
+
+#
+# vi: ts=4 sw=4 expandtab
+#

--- a/t/scripts/jsongraph/LICENSE
+++ b/t/scripts/jsongraph/LICENSE
@@ -1,0 +1,21 @@
+Copyright 2014 William Hayes
+https://github.com/jsongraph/jsongraph.rb
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/t/scripts/jsongraph/objects/edge.py
+++ b/t/scripts/jsongraph/objects/edge.py
@@ -1,0 +1,231 @@
+import json
+import unittest
+
+class Edge:
+    """Edge class representing a edge in the JSON Graph Format."""
+
+    SOURCE = 'source'
+    TARGET = 'target'
+    RELATION = 'relation'
+    DIRECTED = 'directed'
+    METADATA = 'metadata'
+
+    def __init__(self, source, target, relation=None, directed=None, metadata=None):
+        """Constructor of the Edge class.
+
+        Arguments:
+            source -- string        the id of the source-node
+            target -- string        the is of the target-node
+            relation -- string      (optionally) the name of the relationship of the edge (default None)
+            directed -- bool        (optionally) boolean indicating whether the edge is directed (default None)
+            metadata -- dictionary  (optionally) a dictionary representing the metadata that belongs to the node (default None)
+
+        Returns:
+            Edge     Edge object initialized with the provided arguments.
+        """
+        self.set_source(source)
+        self.set_target(target)
+        self._relation = None
+        if relation != None:
+            self.set_relation(relation)
+        self._directed = None
+        if directed != None:
+            self.set_directed(directed)
+        self._metadata = None
+        if metadata != None:
+            self.set_metadata(metadata)
+
+
+    def _isJsonSerializable(self, dictionay):
+        try:
+            json.dumps(dictionay)
+            return True
+        except Exception:
+            return False
+
+    def set_source(self, source):
+        """Method to the set source of the edge.
+
+        Arguments:
+            source -- string    the id of the source-node to set
+        """
+        if source == None:
+            raise ValueError('Source of Edge can not be None')
+        if isinstance(source, str):
+            self._source = source
+        else:
+            try:
+                stringSource = str(source)
+                self._source = stringSource
+            except Exception as excecption:
+                raise TypeError("Type of source in Edge needs to be a string (or string castable): " + str(exception))
+
+
+    def set_target(self, target):
+        """Method to set the target of the edge.
+
+        Arguments:
+            target -- string    the id of the target-node to set
+        """
+        if target == None:
+            raise ValueError('Target of Edge can not be None')
+        if isinstance(target, str):
+            self._target = target
+        else:
+            try:
+                stringTarget = str(target)
+                self._target = stringTarget
+            except Exception as excecption:
+                raise TypeError("Type of target in Edge needs to be a string (or string castable): " + str(exception))
+
+
+    def set_relation(self, relation):
+        """Method to set the name of the relationship of the edge.
+
+        Arguments:
+            relation -- string      the name of the relationship
+        """
+        if relation == None:
+            self._relation = None
+        else:
+            if isinstance(relation, str):
+                self._relation = relation
+            else:
+                try:
+                    stringLabel = str(label)
+                    self._label = stringLabel
+                except Exception as excecption:
+                    raise TypeError("Type of label in Node object needs to be a string (or string castable): " + str(exception))
+
+
+    def set_directed(self, directed):
+        """Method to set the edge directed or not.
+
+        Arguments:
+            directed -- bool    boolean indicating whether the edge is directed or not
+        """
+        if directed == None:
+            self._directed = None
+        else:
+            if isinstance(directed, bool):
+                self._directed = directed
+            else:
+                try:
+                    boolDirected = bool(target)
+                    self._directed = boolDirected
+                except Exception as excecption:
+                    raise TypeError("Type of directed in Edge needs to be a boolean (or boolean castable): " + str(exception))
+
+
+    def set_metadata(self, metadata):
+        """Method to set the metadata of the edge.
+
+        Arguments:
+            metadata -- dictionary      the metadata to set on the edge
+        """
+        if metadata == None:
+            self._metadata = None
+        else:
+            if isinstance(metadata, dict) and self._isJsonSerializable(metadata):
+                self._metadata = metadata
+            else:
+                raise TypeError("metadata in Edge object needs to be json serializable")
+
+    def get_source(self):
+        """Get source of the edge.
+
+        Returns:
+            string      the id of the source-node set
+        """
+        return self._source
+
+
+    def get_target(self):
+        """Get target of the edge.
+
+        Returns:
+            string      the id of the target-node set
+        """
+        return self._target
+
+
+    def get_relation(self):
+        """Get relationname of the edge.
+
+        Returns:
+            string      the name of the relationship if set, else None
+        """
+        return self._relation
+
+
+    def is_directed(self):
+        """Get boolean indicating whether edge is directed.
+
+        Returns:
+            bool    True if edge is directed, if nothing set None
+        """
+        return self._directed
+
+
+    def get_metadata(self):
+        """Get the metadata of the edge.
+
+        Returns:
+            dictionary      the metadata of the edge if set, else None
+        """
+        return self._metadata
+
+    def to_JSON(self):
+        """Convert the edge to JSON.
+
+        Creates a dictionary object of the edge comforming the JSON Graph Format.
+
+        Returns:
+            dictionary      the edge as dictionary ready to serialize
+        """
+        json = {Edge.SOURCE: self._source, Edge.TARGET: self._target}
+        if self._relation != None:
+            json[Edge.RELATION] = self._relation #TODO change in original
+        if self._directed != None:
+            json[Edge.DIRECTED] = self._directed
+        if self._metadata != None:
+            json[Edge.METADATA] = self._metadata
+        return json
+
+
+
+
+class TestEdgeClass(unittest.TestCase):
+
+    def test_base(self):
+        edge = Edge('from', 'to', 'relation', True, {'metaNumber': 11, 'metaString': 'hello world'})
+
+        self.assertEqual(edge.get_source(), 'from')
+        self.assertEqual(edge.get_target(), 'to')
+        self.assertEqual(edge.get_relation(), 'relation')
+        self.assertTrue(edge.is_directed())
+        self.assertEqual(edge.get_metadata()['metaNumber'], 11)
+        self.assertEqual(edge.get_metadata()['metaString'], 'hello world')
+
+    def test_setters(self):
+        edge = Edge('from', 'to', 'relation', True, {'metaNumber': 11, 'metaString': 'hello world'})
+        edge.set_source('new_from')
+        edge.set_target('new_to')
+        edge.set_relation('new_relation')
+        edge.set_directed(False)
+        edge.set_metadata({'new_metaNumber': 13, 'new_metaString': 'world hello'})
+
+        self.assertEqual(edge.get_source(), 'new_from')
+        self.assertEqual(edge.get_target(), 'new_to')
+        self.assertEqual(edge.get_relation(), 'new_relation')
+        self.assertFalse(edge.is_directed())
+        self.assertEqual(edge.get_metadata()['new_metaNumber'], 13)
+        self.assertEqual(edge.get_metadata()['new_metaString'], 'world hello')
+        #TODO unittest error handling
+
+    def test_to_JSON(self):
+        self.assertEqual("TODO", "TODO")
+        #TODO unittest json result
+
+if __name__ == '__main__':
+    unittest.main()

--- a/t/scripts/jsongraph/objects/graph.py
+++ b/t/scripts/jsongraph/objects/graph.py
@@ -1,0 +1,316 @@
+from .node import Node
+from .edge import Edge
+import json
+import unittest
+
+class Graph:
+    """Graph class representing a single graph in the JSON Graph Format."""
+
+    GRAPH = 'graph'
+    NODES = 'nodes'
+    EDGES = 'edges'
+    TYPE = 'type'
+    LABEL = 'label'
+    DIRECTED = 'directed'
+    METADATA = 'metadata'
+
+    def __init__(self, nodes=[], edges=[], type=None, label=None, directed=True, metadata=None):
+        """Constructor of the Graph class.
+
+        Arguments:
+            nodes -- [Nodes]        list of nodes that are a part of the graph
+            edges -- [Edges]        list of edges that are a part of the graph
+            type -- string          (optionally) the typename of the graph (default None)
+            lable -- string         (optionally) the label of the graph (default None)
+            directed -- bool        (optionally) boolean indicating whether the graph is directed or not (default True)
+            metadata -- dictionary  (optionally) a dictionary representing the metadata that belongs to the graph (default None)
+
+        Returns:
+            Graph     Graph object initialized with the provided arguments.
+        """
+        self._directed = None
+        self.set_directed(directed)
+        self._nodes = []
+        self._edges = []
+        self.set_nodes(nodes)
+        self.set_edges(edges)
+        self._type = None
+        if type != None:
+            self.set_type(type)
+        self._label = None
+        if label != None:
+            self.set_label(label)
+        self._metadata = None
+        if metadata != None:
+            self.set_metadata(metadata)
+
+
+
+    def _isJsonSerializable(self, dictionay):
+        try:
+            json.dumps(dictionay)
+            return True
+        except Exception:
+            return False
+
+    def add_node(self, node):
+        """Method to add one node to the graph.
+
+        Arguments:
+            node -- Node    the node to add
+        """
+        if node == None:
+            return
+        if isinstance(node, Node):
+            self._nodes.append(node)
+        else:
+            raise TypeError("Adding node to graph failed: node must of type Node")
+
+
+    def add_edge(self, edge, force_direction=False):#TODO check existence of node ids when adding
+        """Method to add one edge to the graph.
+
+        Arguments:
+            edge -- Edge                the edge to add
+            force_direction -- bool     (optionally) boolean indicating whether the direction-value (of the graph) needs to be enforced on the edge (default False)
+        """
+        if edge == None:
+            return
+        if isinstance(edge, Edge):
+            if self._directed:
+                if edge.is_directed() == None:
+                    edge.is_directed(True)
+                if not edge.is_directed() and not force_direction:
+                    ValueError("Adding undirected edge to directed graph")
+                if not edge.is_directed() and force_direction:
+                    edge.set_directed(True)
+            self._edges.append(edge)
+        else:
+            raise TypeError("Adding edge to graph failed: edge must be of type Edge")
+
+
+    def set_nodes(self, nodes):
+        """Method to add a list of nodes to the graph.
+
+        Arguments:
+            nodes -- [Node]     array of nodes that need to be added
+        """
+        for node in nodes:
+            self.add_node(node)
+
+
+    def set_edges(self, edges, force_direction=False):
+        """Method to add a list of edges to the graph.
+
+        Arguments:
+            edges -- [edge]             array of nodes that need to be added
+            force_direction -- bool     (optionally) boolean indicating whether the direction-value (of the graph) needs to be enforced on the edge (default False)
+        """
+        for edge in edges:
+            self.add_edge(edge, force_direction)
+
+
+    def set_type(self, type):
+        """Method to set the type of the graph.
+
+        Arguments:
+            type -- string      the typename of the graph to set
+        """
+        if type == None:
+            self._type = None
+        else:
+            if isinstance(type, str):
+                self._type = type
+            else:
+                try:
+                    stringType = str(type)
+                    self._type = stringType
+                except Exception as excecption:
+                    raise TypeError("Type of type in Graph object needs to be a string (or string castable): " + str(exception))
+
+
+    def set_label(self, label):
+        """Method to set the label of the graph.
+
+        Arguments:
+            label -- string     the labelname of the graph to set
+        """
+        if label == None:
+            self._label = None
+        else:
+            if isinstance(label, str):
+                self._label = label
+            else:
+                try:
+                    stringLabel = str(label)
+                    self._label = stringLabel
+                except Exception as excecption:
+                    raise TypeError("Type of label in Graph object needs to be a string (or string castable): " + str(exception))
+
+
+    def set_directed(self, directed=True):
+        """Method to make the graph (un)directed.
+
+        Arguments:
+            directed -- bool    (optionally) boolean to indicate whether the graph is directed (default True)
+        """
+        if directed == None:
+            self._directed = None
+        else:
+            if isinstance(directed, bool):
+                self._directed = directed
+            else:
+                try:
+                    boolDirected = bool(target)
+                    self._directed = boolDirected
+                except Exception as excecption:
+                    raise TypeError("Type of directed in Graph needs to be a boolean (or boolean castable): " + str(exception))
+
+
+    def set_metadata(self, metadata):
+        """Method to set the metadata of the graph.
+
+        Arguments:
+            metadata -- dictionary      the metadata to set on the graph
+        """
+        if metadata == None:
+            self._metadata = None
+        else:
+            if isinstance(metadata, dict) and self._isJsonSerializable(metadata):
+                self._metadata = metadata
+            else:
+                raise TypeError("metadata in Graph object needs to be json serializable")
+
+
+    def get_nodes(self):
+        """Method to get a list of the nodes in the graph.
+
+        Returns:
+            [Node]      the list of all nodes in the graph
+        """
+        return self._nodes
+
+
+    def get_edges(self):
+        """Method to get a list of the edges in the graph.
+
+        Returns:
+            [Edge]      the list of all edges in the graph
+        """
+        return self._edges
+
+
+    def get_type(self):
+        """Method to get the type of the graph.
+
+        Returns:
+            string      the typename of the graph if set, else None
+        """
+        return self._type
+
+
+    def get_label(self):
+        """Method to get the label of the graph.
+
+        Returns:
+            string      the label of the graph if set, else None
+        """
+        return self._label
+
+    def is_directed(self):
+        """Method to see whehter the graph is directed or not.
+
+        Returns:
+            bool        True if the graph directed, else False
+        """
+        return self._directed
+
+
+    def get_metadata(self):
+        """"Get the metadata of the graph.
+
+        Returns:
+            dictionary      the metadata of the graph if set, else None
+        """
+        return self._metadata
+
+    def to_JSON(self, asString=False):
+        """Convert the graph to JSON.
+
+        Creates a dictionary object of the graph comforming the JSON Graph Format.
+
+        Arguments:
+            asString -- bool    if set to True the method returns the JSON as string
+
+        Returns:
+            dictionary      the graph as dictionary ready to serialize
+        """
+        graph = {}
+        if self._label != None:
+            graph[Graph.LABEL] = self._label
+        if self._type != None:
+            graph[Graph.TYPE] = self._type
+        if self._directed != None:
+            graph[Graph.DIRECTED] = self._directed
+        if self._metadata != None:
+            graph[Graph.METADATA] = self._metadata
+        if len(self._nodes) > 0:
+            nodes = []
+            for node in self._nodes:
+                nodes.append(node.to_JSON())
+            graph[Graph.NODES] = nodes
+        if len(self._edges) > 0:
+            edges = []
+            for edge in self._edges:
+                edges.append(edge.to_JSON())
+            graph[Graph.EDGES] = edges
+        if asString:
+            return json.dumps({Graph.GRAPH: graph})
+        else:
+            return {Graph.GRAPH: graph}
+
+
+
+
+
+class TestGraphClass(unittest.TestCase):
+
+    def test_base(self):
+        node = Node('nodeId', 'nodeLabel', {'metaNumber': 11, 'metaString': 'hello world'})
+        edge = Edge('from', 'to', 'relation', True, {'metaNumber': 11, 'metaString': 'hello world'})
+        graph = Graph([node], [edge], 'graphType', 'graphLabel', True, {'metaNumber': 11, 'metaString': 'hello world'})
+
+        self.assertEqual(graph.get_type(), 'graphType')
+        self.assertEqual(graph.get_label(), 'graphLabel')
+        self.assertTrue(graph.is_directed())
+        self.assertEqual(graph.get_metadata()['metaNumber'], 11)
+        self.assertEqual(graph.get_metadata()['metaString'], 'hello world')
+        self.assertEqual(graph.get_nodes()[0], node)
+        self.assertEqual(graph.get_edges()[0], edge)
+
+    def test_setters(self):
+        node = Node('nodeId', 'nodeLabel', {'metaNumber': 11, 'metaString': 'hello world'})
+        edge = Edge('from', 'to', 'relation', False, {'metaNumber': 11, 'metaString': 'hello world'})
+        graph = Graph([], [], 'graphType', 'graphLabel', True, {'metaNumber': 11, 'metaString': 'hello world'})
+        graph.set_directed(False)
+        graph.set_label('new_graphLabel')
+        graph.set_type('new_graphType')
+        graph.set_metadata({'new_metaNumber': 13, 'new_metaString': 'world hello'})
+        graph.set_nodes([node])
+        graph.set_edges([edge])
+
+        self.assertEqual(graph.get_type(), 'new_graphType')
+        self.assertEqual(graph.get_label(), 'new_graphLabel')
+        self.assertFalse(graph.is_directed())
+        self.assertEqual(graph.get_metadata()['new_metaNumber'], 13)
+        self.assertEqual(graph.get_metadata()['new_metaString'], 'world hello')
+        self.assertEqual(graph.get_nodes()[0], node)
+        self.assertEqual(graph.get_edges()[0], edge)
+        #TODO make unit test complete
+
+    def test_to_JSON(self):
+        self.assertEqual("TODO", "TODO")
+        #TODO unittest json result
+
+if __name__ == '__main__':
+    unittest.main()

--- a/t/scripts/jsongraph/objects/multigraph.py
+++ b/t/scripts/jsongraph/objects/multigraph.py
@@ -1,0 +1,217 @@
+from .graph import Graph
+import json
+import unittest
+
+class Multigraph:
+
+    GRAPHS = 'graphs'
+    TYPE = 'type'
+    LABEL = 'label'
+    METADATA = 'metadata'
+
+    def __init__(self, graphs=[], type=None, label=None, metadata=None):
+        """Constructor of the Multigraph class.
+
+        Arguments:
+            graphs -- [Graph]       list of Graph objects that are part of the multigraph (default [])
+            type -- string          (optionally) the typename of the multigraph (default None)
+            label -- string         (optionally) the label of the multigraph (default None)
+            metadata -- dictionary  (optionally) a dictionary representing the metadata that belongs to the multigraph (default None)
+        """
+        self._graphs = []
+        self.set_graphs(graphs)
+        self._type = None
+        if type != None:
+            self.set_type(type)
+        self._label = None
+        if label != None:
+            self.set_label(label)
+        self._metadata = None
+        if metadata != None:
+            self.set_metadata(metadata)
+
+
+    def _isJsonSerializable(self, dictionay):
+        try:
+            json.dumps(dictionay)
+            return True
+        except Exception:
+            return False
+
+    def add_graph(self, graph):
+        """Method to add a graph to the multigraph.
+
+        Arguments:
+            graph -- Graph      the graph to add
+        """
+        if graph == None:
+            return
+        if isinstance(graph, Graph):
+            self._graphs.append(graph)
+        else:
+            raise TypeError("Adding graph to Multigraph failed: graph must of type Graph")
+
+
+    def set_graphs(self, graphs):
+        """Method to add a list of graphs.
+
+        Arguments:
+            graphs -- [Graph]   the list of graphs that need to be added
+        """
+        for graph in graphs:
+            self.add_graph(graph)
+
+
+    def set_type(self, type):
+        """Method to set the type of the multigraph.
+
+        Arguments:
+            type -- string      the typename of the multigraph to set
+        """
+        if type == None:
+            self._type = None
+        else:
+            if isinstance(type, str):
+                self._type = type
+            else:
+                try:
+                    stringType = str(type)
+                    self._type = stringType
+                except Exception as excecption:
+                    raise TypeError("Type of type in Multigraph object needs to be a string (or string castable): " + str(exception))
+
+
+    def set_label(self, label):
+        """Method to set the label of the multigraph.
+
+        Arguments:
+            label -- string     the labelname of the multigraph to set
+        """
+        if label == None:
+            self._label = None
+        else:
+            if isinstance(label, str):
+                self._label = label
+            else:
+                try:
+                    stringLabel = str(label)
+                    self._label = stringLabel
+                except Exception as excecption:
+                    raise TypeError("Type of label in Multigraph object needs to be a string (or string castable): " + str(exception))
+
+
+    def set_metadata(self, metadata):
+        """Method to set the metadata of the multigraph.
+
+        Arguments:
+            metadata -- dictionary      the metadata to set on the multigraph
+        """
+        if metadata == None:
+            self._metadata = None
+        else:
+            if isinstance(metadata, dict) and self._isJsonSerializable(metadata):
+                self._metadata = metadata
+            else:
+                raise TypeError("metadata in Multigraph object needs to be json serializable")
+
+
+    def get_graphs(self):
+        """Method to get a list of all graphs in the multigraph.
+
+        Returns:
+            [Graph]     list of graphs present in the multigraph
+        """
+        return self._graphs
+
+
+    def get_type(self):
+        """Method to get the type of the multigraph.
+
+        Returns:
+            string      the typename of the multigraph if set, else None
+        """
+        return self._type
+
+
+    def get_label(self):
+        """Method to get the label of the multigraph.
+
+        Returns:
+            string      the label of the multigraph if set, else None
+        """
+        return self._label
+
+
+    def get_metadata(self):
+        """"Get the metadata of the multigraph.
+
+        Returns:
+            dictionary      the metadata of the multigraph if set, else None
+        """
+        return self._metadata
+
+
+    def to_JSON(self, asString=False):
+        """Convert the multigraph to JSON.
+
+        Creates a dictionary object of the multigraph comforming the JSON Graph Format.
+
+        Arguments:
+            asString -- bool    if set to True the method returns the JSON as string
+
+        Returns:
+            dictionary      the multigraph as dictionary ready to serialize
+        """
+        result = {}
+        if self._label != None:
+            result[Multigraph.LABEL] = self._label
+        if self._type != None:
+            result[Multigraph.TYPE] = self._type
+        if self._metadata != None:
+            result[Multigraph.METADATA] = self._metadata
+        graphs = []
+        for graph in self._graphs:
+            graphs.append(graph.to_JSON())
+        result[Multigraph.GRAPHS] = graphs
+        if asString:
+            return json.dumps(result)
+        else:
+            return result
+
+
+
+
+
+class TestMultigraphClass(unittest.TestCase):
+
+    def test_base(self):
+        graph = Graph([], [], 'graphType', 'graphLabel', True, {'metaNumber': 11, 'metaString': 'hello world'})
+        mgraph = Multigraph([graph], 'multigraphType', 'multigraphLabel', {'metaNumber': 11, 'metaString': 'hello world'})
+
+        self.assertEqual(mgraph.get_type(), 'multigraphType')
+        self.assertEqual(mgraph.get_label(), 'multigraphLabel')
+        self.assertEqual(mgraph.get_metadata()['metaNumber'], 11)
+        self.assertEqual(mgraph.get_metadata()['metaString'], 'hello world')
+        self.assertEqual(mgraph.get_graphs()[0], graph)
+
+    def test_setters(self):
+        graph = Graph([], [], 'graphType', 'graphLabel', True, {'metaNumber': 11, 'metaString': 'hello world'})
+        mgraph = Multigraph([], 'multigraphType', 'multigraphLabel', {'metaNumber': 11, 'metaString': 'hello world'})
+        mgraph.set_label('new_multigraphLabel')
+        mgraph.set_type('new_multigraphType')
+        mgraph.set_metadata({'new_metaNumber': 13, 'new_metaString': 'world hello'})
+        mgraph.set_graphs([graph])
+
+        self.assertEqual(mgraph.get_type(), 'new_multigraphType')
+        self.assertEqual(mgraph.get_label(), 'new_multigraphLabel')
+        self.assertEqual(mgraph.get_metadata()['new_metaNumber'], 13)
+        self.assertEqual(mgraph.get_metadata()['new_metaString'], 'world hello')
+        self.assertEqual(mgraph.get_graphs()[0], graph)
+        #TODO make unit test complete
+
+    def test_to_JSON(self):
+        self.assertEqual("TODO", "TODO")
+        #TODO unittest json result
+
+if __name__ == '__main__':
+    unittest.main()

--- a/t/scripts/jsongraph/objects/node.py
+++ b/t/scripts/jsongraph/objects/node.py
@@ -1,0 +1,159 @@
+import json
+import unittest
+
+class Node:
+    """Node class representing a node in the JSON Graph Format."""
+
+    ID = 'id'
+    LABEL = 'label'
+    METADATA = "metadata"
+
+    def __init__(self, id, label=None, metadata=None):
+        """Constructor of the Node class.
+
+        Arguments:
+            id -- string            the id of the node
+            label -- string         (optionally) the label for the node (default None)
+            metadata -- dictionary  (optionally) a dictionary representing the metadata that belongs to the node (default None)
+
+        Returns:
+            Node    Node object initialized with the provided arguments.
+        """
+        self.set_id(id)
+        self._label = None
+        if label != None:
+            self.set_label(label)
+        self._metadata = None
+        if metadata != None:
+            self.set_metadata(metadata)
+
+
+    def _isJsonSerializable(self, dictionary):
+        try:
+            json.dumps(dictionary)
+            return True
+        except Exception:
+            return False
+
+    def set_id(self, id):
+        """Method to set the id of the node.
+
+        Arguments:
+            id -- string    the id to set
+        """
+        if id == None:
+            raise ValueError('Id of Node can not be None')
+        if isinstance(id, str):
+            self._id = id
+        else:
+            try:
+                stringId = str(id)
+                self._id = stringId
+            except Exception as excecption:
+                raise TypeError("Type of id in Node needs to be a string (or string castable): " + str(exception))
+
+
+    def set_label(self, label):
+        """Method to set the label of the node.
+
+        Arguments:
+            label -- string     the label to set.
+        """
+        if label == None:
+            self._label = None
+        else:
+            if isinstance(label, str):
+                self._label = label
+            else:
+                try:
+                    stringLabel = str(label)
+                    self._label = stringLabel
+                except Exception as excecption:
+                    raise TypeError("Type of label in Node object needs to be a string (or string castable): " + str(exception))
+
+
+    def set_metadata(self, metadata):
+        """Method to set the metadata of the node.
+
+        Arguments:
+            metadata -- dictionary      the metadata to set.
+        """
+        if metadata == None:
+            self._metadata = None
+        else:
+            if isinstance(metadata, dict) and self._isJsonSerializable(metadata):
+                self._metadata = metadata
+            else:
+                raise TypeError("metadata in Node object needs to be json serializable")
+
+
+    def get_id(self):
+        """Get the id of the node.
+
+        Returns:
+            string      id of the node
+        """
+        return self._id
+
+    def get_label(self):
+        """Get the label of the node.
+
+        Returns:
+            string      label of the node if set, else None
+        """
+        return self._label
+
+    def get_metadata(self):
+        """Get the metadata of the node.
+
+        Returns:
+            dictionary      the metadata of the node if set, else None
+        """
+        return self._metadata
+
+    def to_JSON(self):
+        """Convert the node to JSON.
+
+        Creates a dictionary object of the node comforming the JSON Graph Format.
+
+        Returns:
+            dictionary      the node as dictionary ready to serialize
+        """
+        json = {Node.ID: self._id}
+        if self._label != None:
+            json[Node.LABEL] = self._label
+        if self._metadata != None:
+            json[Node.METADATA] = self._metadata
+        return json
+
+
+
+
+class TestNodeClass(unittest.TestCase):
+
+    def test_base(self):
+        node = Node('nodeId', 'nodeLabel', {'metaNumber': 11, 'metaString': 'hello world'})
+
+        self.assertEqual(node.get_id(), 'nodeId')
+        self.assertEqual(node.get_label(), 'nodeLabel')
+        self.assertEqual(node.get_metadata()['metaNumber'], 11)
+        self.assertEqual(node.get_metadata()['metaString'], 'hello world')
+
+    def test_setters(self):
+        node = Node('nodeId', 'nodeLabel', {'metaNumber': 11, 'metaString': 'hello world'})
+        node.set_id('new_nodeId')
+        node.set_label('new_nodeLabel')
+        node.set_metadata({'new_metaNumber': 13, 'new_metaString': 'world hello'})
+
+        self.assertEqual(node.get_id(), 'new_nodeId')
+        self.assertEqual(node.get_label(), 'new_nodeLabel')
+        self.assertEqual(node.get_metadata()['new_metaNumber'], 13)
+        self.assertEqual(node.get_metadata()['new_metaString'], 'world hello')
+        #TODO unittest error handling
+
+    def test_to_JSON(self):
+        self.assertEqual("TODO", "TODO")
+        #TODO unittest json result
+
+if __name__ == '__main__':
+    unittest.main()

--- a/t/scripts/waitfile.lua
+++ b/t/scripts/waitfile.lua
@@ -1,0 +1,237 @@
+#!/usr/bin/env lua
+
+-------------------------------------------------------------
+-- Copyright 2014 Lawrence Livermore National Security, LLC
+-- (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+--
+-- This file is part of the Flux resource manager framework.
+-- For details, see https://github.com/flux-framework.
+--
+-- SPDX-License-Identifier: LGPL-3.0
+-------------------------------------------------------------
+
+--
+--  waitfile.lua : Wait until a named file appears and contains a pattern
+--
+local usage = [[
+Usage: waitfile.lua [OPTIONS] FILE
+Wait for FILE to appear with optional pattern and number of lines.
+Options:
+ -h, --help       Display this message
+ -q, --quiet      Do not print file lines on stdout
+ -v, --verbose    Print extra information about program operation
+ -p, --pattern=P  Only match lines with Lua pattern P. Default is the
+                  empty pattern (therefore anything or nothing matches)
+ -c, --count=N    Wait until pattern has matched on N lines (Default: 1)
+ -t, --timeout=T  Timeout and exit with nonzero status after T seconds.
+                  (Default is to wait forever)
+ -P, --plugin=F   Load a plugin from file F or stdin if F is `-'. The plugin
+                  can register its own callbacks with flux handle `f'
+]]
+
+local getopt = require 'flux.alt_getopt' .get_opts
+local posix  = require 'flux.posix'
+local flux   = require 'flux'
+local timer  = require 'flux.timer'
+local loadstring = loadstring or load
+
+local opts, optind = getopt (arg, "hvqc:t:p:P:",
+                             { timeout = 't',
+                               pattern = 'p',
+                               plugin = 'P',
+                               count = 'c',
+                               quiet = 'q',
+                               verbose = 'v',
+                               help = 'h'
+                             })
+if opts.h then print (usage); os.exit (0) end
+
+local f, err = flux.new()
+if not f then error (err) end
+
+local timeout = tonumber (opts.t or 0)
+local pattern = opts.p or ""
+local count = opts.c or 1
+local file = arg[optind]
+local plugin = opts.P
+
+local tt = timer.new()
+
+local function printf (m, ...)
+    io.stderr:write (string.format ("waitfile: %s: %4.03fs: "..m, file, tt:get0(), ...))
+end
+
+local function log_verbose (m, ...)
+    if opts.v then
+        printf (m, ...)
+    end
+end
+
+if not timeout or not pattern or not file then
+    io.stderr:write (usage)
+    os.exit (1)
+end
+
+local filewatcher = {}
+filewatcher.__index = filewatcher
+
+function filewatcher:check_line (line)
+    if line:match (self.pattern) then
+        self.nmatch = self.nmatch + 1
+        log_verbose ("Got match (%d/%d)\n", self.nmatch, self.count)
+        return self.nmatch == self.count
+    end
+    return false
+end
+
+function filewatcher:checklines ()
+    if self.st.st_size == 0 then
+        -- Check if empty file is a match
+        return self:check_line ("")
+    end
+
+    local fp, err = io.open (self.filename, "r")
+    if not fp then return nil, err end
+    local p, err = fp:seek ("set", self.position)
+    log_verbose ("%s seek set to %d\n", self.filename, self.position)
+    for line in fp:lines() do
+        if self.printlines then io.stdout:write (line.."\n") end
+        if self:check_line (line) then
+            return true
+        end
+    end
+    self.position = fp:seek()
+    log_verbose ("leaving checklines() position=%d\n", self.position)
+    return false
+end
+
+-- Make older posix stat table look like new
+local stat = {
+ __index = function (t, k)
+    local k2 = k:match ("st_(.+)")
+    local v = rawget (t, k)
+    return v and v or rawget (t, k2)
+ end
+}
+
+function filewatcher:changed ()
+    local st = self.st
+    local prev = self.prev
+    if not st then
+        log_verbose ("No file yet\n")
+        return false
+    end
+    if not prev then
+        log_verbose ("File appeared with size %d\n", st.st_size)
+        return true
+    end
+    log_verbose ("File changed size %d\n", st.st_size)
+    if st.st_size < prev.st_size then
+        printf ("truncated!\n")
+        self.position = 0 -- reread
+    end
+    return true
+end
+
+function filewatcher:check ()
+    if self:changed () and self:checklines () then
+        log_verbose ("Got match. Calling self:on_match()\n")
+        self:on_match ()
+        return true
+    end
+    self.prev = self.st
+    return false
+end
+
+function filewatcher:start ()
+    self.flux:statwatcher {
+        path = self.filename,
+        interval = self.interval,
+        handler = function (w, st, prev)
+            log_verbose ("wakeup\n")
+            self.st = setmetatable (st, stat)
+            self:check ()
+            log_verbose ("back to sleep\n")
+        end
+    }
+    --  Be sure to call initial stat(2) *after*
+    --  statwatcher is started above, to avoid any race
+    local st = posix.stat (self.filename)
+    if st then
+        self.st = setmetatable (st, stat)
+    end
+    self:check ()
+end
+
+setmetatable (filewatcher, { __call = function (t, arg)
+    if not arg.filename or not arg.pattern then
+        return nil, "Error: required argument missing"
+    end
+    if not arg.flux then
+        return nil, "Error: flux handle missing"
+    end
+    local w = {
+        flux =     arg.flux,
+        filename = arg.filename,
+        pattern  = arg.pattern,
+	    count    = tonumber (arg.count) or 1,
+        interval = arg.interval and arg.interval or .25,
+        on_match = arg.on_match,
+        position = 0,
+        nmatch   = 0,
+        printlines =  not arg.quiet,
+    }
+    setmetatable (w, filewatcher)
+    if not w.on_match then
+        w.on_match = function ()
+	    log_verbose ("Exiting\n")
+            os.exit (0)
+        end
+    end
+    return w
+end
+})
+
+local fw, err = filewatcher { flux = f,
+                              filename = file,
+                              pattern = pattern,
+                              count = count,
+                              quiet = opts.q }
+if not fw then printf ("%s\n", err); os.exit (1) end
+
+-- Exit with non-zero status after timeout:
+--
+if timeout > 0 then
+    f:timer {
+      timeout = timeout * 1000,
+      handler = function ()
+        printf ("Timeout after %ds\n", timeout)
+        os.execute ("ls -l "..file)
+        os.exit (1)
+      end
+    }
+end
+
+
+-- open and execute a plugin file provided on cmdline
+if plugin then
+    local file
+    if plugin == "-" then
+        file = io.stdin
+    else
+        local f,err = io.open (plugin, "r")
+        if not f then error (err) end
+        file = f
+    end
+    local code = file:read ("*a")
+    local fn, err = loadstring ("local f, printf = ...; " .. code);
+    if not fn then error (err) end
+    local r, v = pcall (fn, f, printf)
+    if not r then error (v) end
+end
+
+-- Start reactor to do the work. It is an error if we exit the reactor.
+fw:start ()
+f:reactor ()
+printf ("Unexpectedly exited reactor\n")
+os.exit (1)

--- a/t/t1017-rv1-bootstrap.t
+++ b/t/t1017-rv1-bootstrap.t
@@ -1,0 +1,213 @@
+#!/bin/sh
+
+test_description='Test Bootstrapping from RV1 Object'
+
+. `dirname $0`/sharness.sh
+
+hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+# 4 brokers: 1 node, 2 sockets, 44 cores 4 gpus
+excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers-sierra2"
+export WAITFILE="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
+
+skip_all_unless_have jq
+
+export FLUX_SCHED_MODULE=none
+
+test_under_flux 4
+
+# Usage: remap_rv1_resource_type file resource_type rank_rebase id_rebase
+#   Remap rank and Id of the given resource type based on rank_rebase
+#   and id_rebase. If the rebase refactors are not passed in, don't remap.
+#   Print the remapped info into a CSV file with heading:
+#   Name, Rank, Id, Id-in-paths
+#
+remap_rv1_resource_type() {
+    local json=${1} &&
+    local type=${2} &&
+    local rank_rebase=${3:-0} &&
+    local id_rebase=${4:-0} &&
+    local path_prefix=$(expr 21 + ${#type})
+
+    # jq filter
+    local filter=".scheduling.graph.nodes[].metadata | \
+select(.type == \"${type}\") | .name |= .[${#type}:] | \
+.paths.containment |= .[${path_prefix}:] | \
+[ (.name | tonumber - ${id_rebase}), \
+.rank - ${rank_rebase}, .id - ${id_rebase}, \
+(.paths.containment | tonumber - ${id_rebase}) ] | @csv" &&
+    echo Name,Rank,Id,Id-in-paths &&
+    jq -r " ${filter} " ${json}
+}
+
+test_expect_success 'rv1-bootstrap: load test resources' '
+    load_test_resources ${excl_4N4B}
+'
+
+test_expect_success 'rv1-bootstrap: loading resource/qmanager modules works' '
+    load_resource load-allowlist=cluster,node,gpu,core \
+match-format=rv1 policy=high &&
+    load_qmanager
+'
+
+test_expect_success 'rv1-bootstrap: creating a nested batch script' '
+    cat >nest.sh <<-EOF &&
+#!/bin/sh
+	flux module load sched-fluxion-resource \
+load-allowlist=cluster,node,gpu,core match-format=rv1 policy=\$1
+	flux module load sched-fluxion-qmanager
+	nested_jobid=\$(flux mini submit -n\$2 -N\$3 -c\$4 -g\$5 sleep 0)
+	flux job info \${nested_jobid} R > \$6
+	sleep inf
+EOF
+    chmod u+x nest.sh
+'
+
+# Idempotency check
+test_expect_success 'rv1-bootstrap: resource idempotency preserved' '
+    JOBID=$(flux mini batch -n4 -N4 -c44 -g4 \
+	./nest.sh high 4 4 44 4 nest.json) &&
+    $WAITFILE -t 10 -v -p \"R_lite\" nest.json &&
+    jq " del(.execution.starttime, .execution.expiration) " \
+	nest.json > nest.norm.json &&
+    flux job info ${JOBID} R | \
+	jq " del(.execution.starttime, .execution.expiration) " \
+	> job.norm.json &&
+    test_cmp job.norm.json nest.norm.json
+'
+
+# Cancel jobs
+test_expect_success 'rv1-bootstrap: killing a nested job works' '
+    flux job cancel ${JOBID} &&
+    flux job wait-event ${JOBID} release
+'
+
+# 2 full nodes are scheduled for a nest flux instnace -- requiring no remap
+test_expect_success 'rv1-bootstrap: 2N nesting works (policy=high)' '
+    JOBID1=$(flux mini batch -n2 -N2 -c44 -g4 \
+	./nest.sh high 2 2 44 4 nest1.json) &&
+    $WAITFILE -t 10 -v -p \"R_lite\" nest1.json &&
+    remap_rv1_resource_type nest1.json core > nest1.csv &&
+    remap_rv1_resource_type nest1.json gpu > nest1.gpu.csv &&
+    flux job info ${JOBID1} R | jq . > job1.json &&
+    remap_rv1_resource_type job1.json core > job1.csv &&
+    remap_rv1_resource_type job1.json gpu > job1.gpu.csv &&
+    test_cmp job1.csv nest1.csv &&
+    test_cmp job1.gpu.csv nest1.gpu.csv
+'
+
+# 2 nodes each with partial resource set using match policy=high
+test_expect_success 'rv1-bootstrap: 2 partial node nesting works (high)' '
+    JOBID2=$(flux mini batch -n2 -N2 -c10 -g2 \
+	./nest.sh high 2 2 10 2 nest2.json) &&
+    $WAITFILE -t 10 -v -p \"R_lite\" nest2.json &&
+    flux job info ${JOBID2} R | jq . > job2.json &&
+    remap_rv1_resource_type nest2.json core > nest2.csv &&
+    remap_rv1_resource_type nest2.json gpu > nest2.gpu.csv &&
+    remap_rv1_resource_type job2.json core 2 34 > job2.csv &&
+    remap_rv1_resource_type job2.json gpu 2 > job2.gpu.csv &&
+    test_cmp job2.csv nest2.csv &&
+    test_cmp job2.gpu.csv nest2.gpu.csv &&
+    flux jobs -a > before
+'
+
+# Cancel jobs
+test_expect_success 'rv1-bootstrap: killing nested jobs works' '
+    flux job cancel ${JOBID1} &&
+    flux job cancel ${JOBID2} &&
+    flux job wait-event -t10 ${JOBID1} release &&
+    flux job wait-event -t10 ${JOBID2} release
+'
+
+test_expect_success 'rv1-bootstrap: remove fluxion schedulers' '
+    remove_qmanager &&
+    remove_resource
+'
+
+test_expect_success 'rv1-bootstrap: loading fluxion modules works (pol=low)' '
+    load_resource load-allowlist=cluster,node,gpu,core \
+match-format=rv1 policy=low &&
+    load_qmanager
+'
+
+# 2 full nodes are scheduled for a nest flux instnace -- requiring no remap
+test_expect_success 'rv1-bootstrap: 2N nesting works (policy=low)' '
+    JOBID3=$(flux mini batch -n2 -N2 -c44 -g4 \
+	./nest.sh low 2 2 44 4 nest3.json) &&
+    $WAITFILE -t 10 -v -p \"R_lite\" nest3.json &&
+    remap_rv1_resource_type nest3.json core > nest3.csv &&
+    remap_rv1_resource_type nest3.json gpu > nest3.gpu.csv &&
+    flux job info ${JOBID3} R | jq . > job3.json &&
+    remap_rv1_resource_type job3.json core > job3.csv &&
+    remap_rv1_resource_type job3.json gpu > job3.gpu.csv &&
+    test_cmp job3.csv nest3.csv &&
+    test_cmp job3.gpu.csv nest3.gpu.csv
+'
+
+test_expect_success 'rv1-bootstrap: 2 partial node nesting works (low)' '
+    JOBID4=$(flux mini batch -n2 -N2 -c10 -g2 \
+	./nest.sh low 2 2 10 2 nest4.json) &&
+    $WAITFILE -t 10 -v -p \"R_lite\" nest4.json &&
+    flux job info ${JOBID4} R | jq . > job4.json &&
+    remap_rv1_resource_type nest4.json core > nest4.csv &&
+    remap_rv1_resource_type nest4.json gpu > nest4.gpu.csv &&
+    remap_rv1_resource_type job4.json core 2 0 > job4.csv &&
+    remap_rv1_resource_type job4.json gpu 2 > job4.gpu.csv &&
+    test_cmp job4.csv nest4.csv &&
+    test_cmp job4.gpu.csv nest4.gpu.csv
+'
+
+# Cancel jobs
+test_expect_success 'rv1-bootstrap: killing nested jobs works' '
+    flux job cancel ${JOBID3} &&
+    flux job cancel ${JOBID4} &&
+    flux job wait-event -t 10 ${JOBID3} release &&
+    flux job wait-event -t 10 ${JOBID4} release
+'
+
+test_expect_success 'rv1-bootstrap: creating doubly nested batch script' '
+    cat >dnest.sh <<-EOF &&
+#!/bin/sh
+	flux module load sched-fluxion-resource \
+load-allowlist=cluster,node,gpu,core match-format=rv1 policy=\$1
+	flux module load sched-fluxion-qmanager
+	hc=\$(expr \$4 / 2)
+	hg=\$(expr \$5 / 2)
+	job1=\$(flux mini batch -n\$2 -N\$3 -c\${hc} -g\${hg} \
+		./nest.sh \$1 \$2 \$3 \${hc} \${hg} \$8)
+	job2=\$(flux mini batch -n\$2 -N\$3 -c\${hc} -g\${hg} \
+		./nest.sh \$1 \$2 \$3 \${hc} \${hg} \$9)
+	\$WAITFILE -t 10 -v -p \"R_lite\" \$8
+	flux job info \${job1} R > \$6
+	\$WAITFILE -t 10 -v -p \"R_lite\" \$9
+	flux job info \${job2} R > \$7
+	sleep inf
+EOF
+    chmod u+x dnest.sh
+'
+
+test_expect_success 'rv1-bootstrap: double nesting works' '
+    JOBID5=$(flux mini batch -n2 -N2 -c10 -g2 ./dnest.sh low 2 2 10 2 \
+	job5.1.json job5.2.json nest5.1.json nest5.2.json) &&
+    $WAITFILE -t 10 -v -p \"R_lite\" job5.1.json &&
+    $WAITFILE -t 10 -v -p \"R_lite\" job5.2.json &&
+    remap_rv1_resource_type nest5.1.json core > nest5.1.csv &&
+    remap_rv1_resource_type nest5.1.json gpu > nest5.1.gpu.csv &&
+    remap_rv1_resource_type nest5.2.json core > nest5.2.csv &&
+    remap_rv1_resource_type nest5.2.json gpu > nest5.2.gpu.csv &&
+    remap_rv1_resource_type job5.1.json core > job5.1.csv &&
+    remap_rv1_resource_type job5.1.json gpu > job5.1.gpu.csv &&
+    remap_rv1_resource_type job5.2.json core 0 5 > job5.2.csv &&
+    remap_rv1_resource_type job5.2.json gpu > job5.2.gpu.csv
+'
+
+# Cancel jobs
+test_expect_success 'rv1-bootstrap: killing doubly nested jobs works' '
+    flux job cancel ${JOBID5} &&
+    flux job wait-event -t 10 ${JOBID5} release
+'
+
+test_expect_success 'rv1-bootstrap: removing resource/qmanager modules' '
+    remove_resource
+'
+
+test_done

--- a/t/t1018-rv1-bootstrap2.t
+++ b/t/t1018-rv1-bootstrap2.t
@@ -1,0 +1,191 @@
+#!/bin/sh
+
+test_description='Test Bootstrapping from Configured RV1 Object'
+
+. `dirname $0`/sharness.sh
+
+skip_all_unless_have jq
+
+export WAITFILE="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
+export FLUX_SCHED_MODULE=none
+
+test_under_flux 4
+
+# Purposefully create the same configuration as with t1017-rv1-bootstrap.t
+# However, node selections are different this time as node Ids are filled
+test_expect_success 'rv1-bootstrap2: create test R with unlikely core count' '
+    flux R encode --hosts=sierra[3682,3179,3683,3178] --cores=0-43 --gpu=0-3 \
+	| flux ion-R > sierra.R.test
+'
+
+test_expect_success 'rv1-bootstrap2: reload the configured R' '
+    flux resource reload $(pwd)/sierra.R.test
+'
+
+test_expect_success 'rv1-bootstrap2: loading resource/qmanager modules works' '
+    load_resource load-allowlist=cluster,node,gpu,core \
+match-format=rv1 policy=high &&
+    load_qmanager
+'
+
+test_expect_success 'rv1-bootstrap2: creating a nested batch script' '
+    cat >nest.sh <<-EOF &&
+	#!/bin/sh
+	flux module load sched-fluxion-resource \
+load-allowlist=cluster,node,gpu,core match-format=rv1 policy=\$1
+	flux module load sched-fluxion-qmanager
+	nested_jobid=\$(flux mini submit -n\$2 -N\$3 -c\$4 -g\$5 sleep 0)
+	flux job info \${nested_jobid} R > \$6
+	sleep inf
+EOF
+    chmod u+x nest.sh
+'
+
+# Idempotency check
+test_expect_success 'rv1-bootstrap: resource idempotency preserved' '
+    JOBID=$(flux mini batch -n4 -N4 -c44 -g4 \
+	./nest.sh high 4 4 44 4 nest.json) &&
+    $WAITFILE -t 10 -v -p \"R_lite\" nest.json &&
+    jq " del(.execution.starttime, .execution.expiration) " \
+	nest.json > nest.norm.json &&
+    flux job info ${JOBID} R | \
+	jq " del(.execution.starttime, .execution.expiration) " \
+	> job.norm.json &&
+    test_cmp job.norm.json nest.norm.json
+'
+
+# Cancel jobs
+test_expect_success 'rv1-bootstrap2: killing a nested job works' '
+    flux job cancel ${JOBID} &&
+    flux job wait-event ${JOBID} release
+'
+
+# 2 full nodes are scheduled for a nest flux instnace -- requiring no remap
+test_expect_success 'rv1-bootstrap2: 2N nesting works (policy=high)' '
+    JOBID1=$(flux mini batch -n2 -N2 -c44 -g4 \
+	./nest.sh high 2 2 44 4 nest1.json) &&
+    $WAITFILE -t 10 -v -p \"R_lite\" nest1.json &&
+    remap_rv1_resource_type nest1.json core > nest1.csv &&
+    remap_rv1_resource_type nest1.json gpu > nest1.gpu.csv &&
+    flux job info ${JOBID1} R | jq . > job1.json &&
+    remap_rv1_resource_type job1.json core 0 0 0 1 0 > job1.csv &&
+    remap_rv1_resource_type job1.json gpu 0 0 0 1 0 > job1.gpu.csv &&
+    test_cmp job1.csv nest1.csv &&
+    test_cmp job1.gpu.csv nest1.gpu.csv
+'
+
+# 2 nodes each with partial resource set using match policy=high
+test_expect_success 'rv1-bootstrap2: 2 partial node nesting works (high)' '
+    JOBID2=$(flux mini batch -n2 -N2 -c10 -g2 \
+	./nest.sh high 2 2 10 2 nest2.json) &&
+    $WAITFILE -t 10 -v -p \"R_lite\" nest2.json &&
+    flux job info ${JOBID2} R | jq . > job2.json &&
+    remap_rv1_resource_type nest2.json core > nest2.csv &&
+    remap_rv1_resource_type nest2.json gpu > nest2.gpu.csv &&
+    remap_rv1_resource_type job2.json core 34 0 1 0 2 > job2.csv &&
+    remap_rv1_resource_type job2.json gpu 0 0 1 0 2 > job2.gpu.csv &&
+    test_cmp job2.csv nest2.csv &&
+    test_cmp job2.gpu.csv nest2.gpu.csv
+'
+
+# Cancel jobs
+test_expect_success 'rv1-bootstrap2: killing nested jobs works' '
+    flux job cancel ${JOBID1} &&
+    flux job cancel ${JOBID2} &&
+    flux job wait-event -t10 ${JOBID1} release &&
+    flux job wait-event -t10 ${JOBID2} release
+'
+
+test_expect_success 'rv1-bootstrap2: remove fluxion schedulers' '
+    remove_qmanager &&
+    remove_resource
+'
+
+test_expect_success 'rv1-bootstrap2: loading fluxion modules works (pol=low)' '
+    load_resource load-allowlist=cluster,node,gpu,core \
+match-format=rv1 policy=low &&
+    load_qmanager
+'
+
+# 2 full nodes are scheduled for a nest flux instnace -- requiring no remap
+test_expect_success 'rv1-bootstrap2: 2N nesting works (policy=low)' '
+    JOBID3=$(flux mini batch -n2 -N2 -c44 -g4 \
+	./nest.sh low 2 2 44 4 nest3.json) &&
+    $WAITFILE -t 10 -v -p \"R_lite\" nest3.json &&
+    remap_rv1_resource_type nest3.json core > nest3.csv &&
+    remap_rv1_resource_type nest3.json gpu > nest3.gpu.csv &&
+    flux job info ${JOBID3} R | jq . > job3.json &&
+    remap_rv1_resource_type job3.json core 0 0 1 0 2 > job3.csv &&
+    remap_rv1_resource_type job3.json gpu 0 0 1 0 2 > job3.gpu.csv &&
+    test_cmp job3.csv nest3.csv &&
+    test_cmp job3.gpu.csv nest3.gpu.csv
+'
+
+test_expect_success 'rv1-bootstrap2: 2 partial node nesting works (low)' '
+    JOBID4=$(flux mini batch -n2 -N2 -c10 -g2 \
+	./nest.sh low 2 2 10 2 nest4.json) &&
+    $WAITFILE -t 10 -v -p \"R_lite\" nest4.json &&
+    flux job info ${JOBID4} R | jq . > job4.json &&
+    remap_rv1_resource_type nest4.json core > nest4.csv &&
+    remap_rv1_resource_type nest4.json gpu > nest4.gpu.csv &&
+    remap_rv1_resource_type job4.json core 0 0 0 1 0 > job4.csv &&
+    remap_rv1_resource_type job4.json gpu 0 0 0 1 0 > job4.gpu.csv &&
+    test_cmp job4.csv nest4.csv &&
+    test_cmp job4.gpu.csv nest4.gpu.csv
+'
+
+# Cancel jobs
+test_expect_success 'rv1-bootstrap2: killing nested jobs works' '
+    flux job cancel ${JOBID3} &&
+    flux job cancel ${JOBID4} &&
+    flux job wait-event -t 10 ${JOBID3} release &&
+    flux job wait-event -t 10 ${JOBID4} release
+'
+
+test_expect_success 'rv1-bootstrap2: creating doubly nested batch script' '
+    cat >dnest.sh <<-EOF &&
+#!/bin/sh
+	flux module load sched-fluxion-resource \
+load-allowlist=cluster,node,gpu,core match-format=rv1 policy=\$1
+	flux module load sched-fluxion-qmanager
+	hc=\$(expr \$4 / 2)
+	hg=\$(expr \$5 / 2)
+	job1=\$(flux mini batch -n\$2 -N\$3 -c\${hc} -g\${hg} \
+		./nest.sh \$1 \$2 \$3 \${hc} \${hg} \$8)
+	job2=\$(flux mini batch -n\$2 -N\$3 -c\${hc} -g\${hg} \
+		./nest.sh \$1 \$2 \$3 \${hc} \${hg} \$9)
+	\$WAITFILE -t 10 -v -p \"R_lite\" \$8
+	flux job info \${job1} R > \$6
+	\$WAITFILE -t 10 -v -p \"R_lite\" \$9
+	flux job info \${job2} R > \$7
+	sleep inf
+EOF
+    chmod u+x dnest.sh
+'
+
+test_expect_success 'rv1-bootstrap2: double nesting works' '
+    JOBID5=$(flux mini batch -n2 -N2 -c10 -g2 ./dnest.sh low 2 2 10 2 \
+	job5.1.json job5.2.json nest5.1.json nest5.2.json) &&
+    $WAITFILE -t 10 -v -p \"R_lite\" job5.1.json &&
+    $WAITFILE -t 10 -v -p \"R_lite\" job5.2.json &&
+    remap_rv1_resource_type nest5.1.json core > nest5.1.csv &&
+    remap_rv1_resource_type nest5.1.json gpu > nest5.1.gpu.csv &&
+    remap_rv1_resource_type nest5.2.json core > nest5.2.csv &&
+    remap_rv1_resource_type nest5.2.json gpu > nest5.2.gpu.csv &&
+    remap_rv1_resource_type job5.1.json core > job5.1.csv &&
+    remap_rv1_resource_type job5.1.json gpu > job5.1.gpu.csv &&
+    remap_rv1_resource_type job5.2.json core 0 5 > job5.2.csv &&
+    remap_rv1_resource_type job5.2.json gpu > job5.2.gpu.csv
+'
+
+# Cancel jobs
+test_expect_success 'rv1-bootstrap2: killing doubly nested jobs works' '
+    flux job cancel ${JOBID5} &&
+    flux job wait-event -t 10 ${JOBID5} release
+'
+
+test_expect_success 'rv1-bootstrap2: removing resource/qmanager modules' '
+    remove_resource
+'
+
+test_done


### PR DESCRIPTION
This PR adds support to use RV1+JGF to populate graph data store.

- Extend the JGF reader to make use of namespace remapper in order
to remap the rank field of all of the resources as well as the Id fields
of the compute core resources.

- Delay creating the reader object within `sched-fluxion-resource` so
that this service can pick the right resource reader type depending
on the condition (e.g., if JGF is embedded in RV1, use the JGF reader.)

- Fetch the job RV1 from the parent if exists and use it in combination
with the RV1 received from core's resource.acquire to remap the
JGF information.

- Add test cases based on nested Flux instances. 

- Add `flux-ion-R.py` which takes in a RV1 JSON as input, generates JGF
and adds it to the `scheduling` key. This is currently a test-aiding internal
command. (Vendor the jsongraph package as this command depends
on it). 

- Use `flux-ion-R.py` to test the new logic based on a generated
RV1+JGF. 
