### PR TITLE
ci: drop unnecessary flux keygen

### DIFF
--- a/src/test/docker/bionic/Dockerfile
+++ b/src/test/docker/bionic/Dockerfile
@@ -26,4 +26,3 @@ RUN \
 
 USER $USER
 WORKDIR /home/$USER
-RUN flux keygen

--- a/src/test/docker/centos7/Dockerfile
+++ b/src/test/docker/centos7/Dockerfile
@@ -26,4 +26,3 @@ RUN \
 
 USER $USER
 WORKDIR /home/$USER
-RUN flux keygen

--- a/src/test/docker/centos8/Dockerfile
+++ b/src/test/docker/centos8/Dockerfile
@@ -27,4 +27,3 @@ RUN \
 
 USER $USER
 WORKDIR /home/$USER
-RUN flux keygen

--- a/src/test/docker/focal/Dockerfile
+++ b/src/test/docker/focal/Dockerfile
@@ -26,4 +26,3 @@ RUN \
 
 USER $USER
 WORKDIR /home/$USER
-RUN flux keygen

--- a/src/test/travis_run.sh
+++ b/src/test/travis_run.sh
@@ -68,7 +68,6 @@ if test "$COVERAGE" = "t"; then
 elif test "$TEST_INSTALL" = "t"; then
     ARGS="$ARGS --prefix=/usr --sysconfdir=/etc"
     MAKECMDS="make -j $JOBS && sudo make install && \
-              /usr/bin/flux keygen --force && \
               FLUX_TEST_INSTALLED_PATH=/usr/bin \
               FLUX_SCHED_TEST_INSTALLED=t make -j $JOBS check"
 fi
@@ -87,10 +86,6 @@ export DISTCHECK_CONFIGURE_FLAGS="${ARGS}"
 
 if test "$CPPCHECK" = "t"; then
     sh -x src/test/cppcheck.sh
-fi
-
-if ! test -d $HOME/.flux/curve; then
-    travis_fold "flux_keygen" "flux keygen ..." flux keygen
 fi
 
 echo "Starting MUNGE"


### PR DESCRIPTION
Problem: flux-core no longer requires user CURVE keys to run Flux,
but flux-sched still generates them in ci scripts.

Drop flux keygen from Dockerfiles and travis_run.sh.