### PR TITLE
Globally standardize spelling of "canceled"

### DIFF
--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -286,7 +286,7 @@ void qmanager_cb_t::jobmanager_cancel_cb (flux_t *h, flux_jobid_t id,
         flux_log_error (h, "%s: schedutil_alloc_respond_cancel", __FUNCTION__);
         return;
     }
-    flux_log (h, LOG_DEBUG, "%s (id=%jd)", "alloc cancelled",
+    flux_log (h, LOG_DEBUG, "%s (id=%jd)", "alloc canceled",
              static_cast<intmax_t> (id));
 }
 

--- a/resource/jobinfo/jobinfo.cpp
+++ b/resource/jobinfo/jobinfo.cpp
@@ -53,8 +53,8 @@ void get_jobstate_str (job_lifecycle_t state, std::string &status)
     case job_lifecycle_t::RESERVED:
         status = "RESERVED";
         break;
-    case job_lifecycle_t::CANCELLED:
-        status = "CANCELLED";
+    case job_lifecycle_t::CANCELED:
+        status = "CANCELED";
         break;
     case job_lifecycle_t::ERROR:
         status = "ERROR";

--- a/resource/jobinfo/jobinfo.hpp
+++ b/resource/jobinfo/jobinfo.hpp
@@ -30,7 +30,7 @@
 namespace Flux {
 namespace resource_model {
 
-enum class job_lifecycle_t { INIT, ALLOCATED, RESERVED, CANCELLED, ERROR };
+enum class job_lifecycle_t { INIT, ALLOCATED, RESERVED, CANCELED, ERROR };
 
 struct job_info_t {
     job_info_t (uint64_t j, job_lifecycle_t s, int64_t at,

--- a/resource/utilities/command.cpp
+++ b/resource/utilities/command.cpp
@@ -80,7 +80,7 @@ static int do_remove (std::shared_ptr<resource_context_t> &ctx, int64_t jobid)
     if ((rc = ctx->traverser->remove ((int64_t)jobid)) == 0) {
         if (ctx->jobs.find (jobid) != ctx->jobs.end ()) {
            std::shared_ptr<job_info_t> info = ctx->jobs[jobid];
-           info->state = job_lifecycle_t::CANCELLED;
+           info->state = job_lifecycle_t::CANCELED;
         }
     } else {
         std::cout << ctx->traverser->err_message ();

--- a/t/t4003-cancel-info.t
+++ b/t/t4003-cancel-info.t
@@ -49,7 +49,7 @@ test_expect_success 'resource-cancel works' '
     flux ion-resource cancel 0
 '
 
-test_expect_success 'resource-info will not report for cancelled jobs' '
+test_expect_success 'resource-info will not report for canceled jobs' '
     test_must_fail flux ion-resource info 0
 '
 


### PR DESCRIPTION
Problem: The spelling of "canceled" is inconsistently
used in flux.  Sometimes the British spelling "cancelled" is
used and othertimes the American spelling "canceled" is used.

Solution: Change all spellings of "cancelled" to "canceled".

Fixes #795