### PR TITLE
qmanager: update per libschedutil API changes

### DIFF
--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -231,10 +231,7 @@ static int handshake_jobmanager (std::shared_ptr<qmanager_ctx_t> &ctx)
     int rc = -1;
     int queue_depth = 0;  /* Not implemented in job-manager */
 
-    if (schedutil_hello (ctx->schedutil,
-                         &qmanager_safe_cb_t::jobmanager_hello_cb,
-                         std::static_pointer_cast<
-			     qmanager_cb_ctx_t> (ctx).get ()) < 0) {
+    if (schedutil_hello (ctx->schedutil) < 0) {
         flux_log_error (ctx->h, "%s: schedutil_hello", __FUNCTION__);
         goto out;
     }
@@ -408,6 +405,13 @@ static int handshake (std::shared_ptr<qmanager_ctx_t> &ctx)
     return rc;
 }
 
+const struct schedutil_ops ops = {
+    .hello  = &qmanager_safe_cb_t::jobmanager_hello_cb,
+    .alloc  = &qmanager_safe_cb_t::jobmanager_alloc_cb,
+    .free   = &qmanager_safe_cb_t::jobmanager_free_cb,
+    .cancel = &qmanager_safe_cb_t::jobmanager_cancel_cb,
+};
+
 static std::shared_ptr<qmanager_ctx_t> qmanager_new (flux_t *h)
 {
     std::shared_ptr<qmanager_ctx_t> ctx = nullptr;
@@ -416,9 +420,7 @@ static std::shared_ptr<qmanager_ctx_t> qmanager_new (flux_t *h)
         ctx->h = h;
         set_default (ctx);
         if (!(ctx->schedutil = schedutil_create (ctx->h,
-                                   &qmanager_safe_cb_t::jobmanager_alloc_cb,
-                                   &qmanager_safe_cb_t::jobmanager_free_cb,
-                                   &qmanager_safe_cb_t::jobmanager_cancel_cb,
+                                   &ops,
                                    std::static_pointer_cast<
                                        qmanager_cb_ctx_t> (ctx).get ()))) {
             flux_log_error (ctx->h, "%s: schedutil_create", __FUNCTION__);

--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -410,6 +410,7 @@ const struct schedutil_ops ops = {
     .alloc  = &qmanager_safe_cb_t::jobmanager_alloc_cb,
     .free   = &qmanager_safe_cb_t::jobmanager_free_cb,
     .cancel = &qmanager_safe_cb_t::jobmanager_cancel_cb,
+    .prioritize = NULL,
 };
 
 static std::shared_ptr<qmanager_ctx_t> qmanager_new (flux_t *h)

--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -421,6 +421,7 @@ static std::shared_ptr<qmanager_ctx_t> qmanager_new (flux_t *h)
         ctx->h = h;
         set_default (ctx);
         if (!(ctx->schedutil = schedutil_create (ctx->h,
+                                   SCHEDUTIL_FREE_NOLOOKUP,
                                    &ops,
                                    std::static_pointer_cast<
                                        qmanager_cb_ctx_t> (ctx).get ()))) {

--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -184,9 +184,13 @@ void qmanager_cb_t::jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
 
     if (jobspec_obj.attributes.system.queue != "")
         queue_name = jobspec_obj.attributes.system.queue;
-    if (schedutil_alloc_request_decode (msg, &job->id, &job->urgency,
-                                        &job->userid, &job->t_submit) < 0) {
-        flux_log_error (h, "%s: schedutil_alloc_request_decode", __FUNCTION__);
+    if (flux_request_unpack (msg, NULL,
+                             "{s:I s:i s:i s:f}",
+                             "id", &job->id,
+                             "priority", &job->urgency,
+                             "userid", &job->userid,
+                             "t_submit", &job->t_submit) < 0) {
+        flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
         return;
     }
     // Note that RFC27 defines 31 as the max urgency. Because our queue policy
@@ -230,8 +234,8 @@ void qmanager_cb_t::jobmanager_free_cb (flux_t *h, const flux_msg_t *msg,
     std::shared_ptr<queue_policy_base_t> queue;
     std::string queue_name;
 
-    if (schedutil_free_request_decode (msg, &id) < 0) {
-        flux_log_error (h, "%s: schedutil_free_request_decode", __FUNCTION__);
+    if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0) {
+        flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
         return;
     }
     if (ctx->find_queue (id, queue_name, queue) < 0) {

--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -117,8 +117,9 @@ out:
 }
 
 int qmanager_cb_t::jobmanager_hello_cb (flux_t *h,
-                                        flux_jobid_t id, int prio, uint32_t uid,
-                                        double ts, const char *R, void *arg)
+                                        flux_jobid_t id, unsigned int prio,
+                                        uint32_t uid, double ts, const char *R,
+                                        void *arg)
 
 {
     int rc = 0;
@@ -291,7 +292,7 @@ void qmanager_cb_t::jobmanager_cancel_cb (flux_t *h, flux_jobid_t id,
 }
 
 int qmanager_safe_cb_t::jobmanager_hello_cb (flux_t *h,
-                                             flux_jobid_t id, int prio,
+                                             flux_jobid_t id, unsigned int prio,
                                              uint32_t uid, double ts,
                                              const char *R, void *arg)
 {

--- a/qmanager/modules/qmanager_callbacks.hpp
+++ b/qmanager/modules/qmanager_callbacks.hpp
@@ -48,8 +48,9 @@ struct qmanager_cb_ctx_t {
 class qmanager_cb_t {
 protected:
     static int jobmanager_hello_cb (flux_t *h,
-                                    flux_jobid_t id, int prio, uint32_t uid,
-                                    double ts, const char *R, void *arg);
+                                    flux_jobid_t id, unsigned int prio,
+                                    uint32_t uid, double ts, const char *R,
+                                    void *arg);
     static void jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
                                      const char *jobspec, void *arg);
     static void jobmanager_free_cb (flux_t *h, const flux_msg_t *msg,
@@ -64,8 +65,9 @@ protected:
 
 struct qmanager_safe_cb_t : public qmanager_cb_t {
     static int jobmanager_hello_cb (flux_t *h,
-                                    flux_jobid_t id, int prio, uint32_t uid,
-                                    double ts, const char *R, void *arg);
+                                    flux_jobid_t id, unsigned int prio,
+                                    uint32_t uid, double ts, const char *R,
+                                    void *arg);
     static void jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
                                      const char *jobspec, void *arg);
     static void jobmanager_free_cb (flux_t *h, const flux_msg_t *msg,

--- a/qmanager/modules/qmanager_callbacks.hpp
+++ b/qmanager/modules/qmanager_callbacks.hpp
@@ -55,7 +55,7 @@ protected:
                                      void *arg);
     static void jobmanager_free_cb (flux_t *h, const flux_msg_t *msg,
                                     const char *R, void *arg);
-    static void jobmanager_cancel_cb (flux_t *h, flux_jobid_t id,
+    static void jobmanager_cancel_cb (flux_t *h, const flux_msg_t *msg,
                                       void *arg);
     static int post_sched_loop (flux_t *h,
         schedutil_t *schedutil,
@@ -72,7 +72,7 @@ struct qmanager_safe_cb_t : public qmanager_cb_t {
                                      void *arg);
     static void jobmanager_free_cb (flux_t *h, const flux_msg_t *msg,
                                     const char *R, void *arg);
-    static void jobmanager_cancel_cb (flux_t *h, flux_jobid_t id,
+    static void jobmanager_cancel_cb (flux_t *h, const flux_msg_t *msg,
                                       void *arg);
     static int post_sched_loop (flux_t *h,
         schedutil_t *schedutil,

--- a/qmanager/modules/qmanager_callbacks.hpp
+++ b/qmanager/modules/qmanager_callbacks.hpp
@@ -52,7 +52,7 @@ protected:
                                     uint32_t uid, double ts, const char *R,
                                     void *arg);
     static void jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
-                                     const char *jobspec, void *arg);
+                                     void *arg);
     static void jobmanager_free_cb (flux_t *h, const flux_msg_t *msg,
                                     const char *R, void *arg);
     static void jobmanager_cancel_cb (flux_t *h, flux_jobid_t id,
@@ -69,7 +69,7 @@ struct qmanager_safe_cb_t : public qmanager_cb_t {
                                     uint32_t uid, double ts, const char *R,
                                     void *arg);
     static void jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
-                                     const char *jobspec, void *arg);
+                                     void *arg);
     static void jobmanager_free_cb (flux_t *h, const flux_msg_t *msg,
                                     const char *R, void *arg);
     static void jobmanager_cancel_cb (flux_t *h, flux_jobid_t id,

--- a/qmanager/modules/qmanager_callbacks.hpp
+++ b/qmanager/modules/qmanager_callbacks.hpp
@@ -47,10 +47,8 @@ struct qmanager_cb_ctx_t {
 
 class qmanager_cb_t {
 protected:
-    static int jobmanager_hello_cb (flux_t *h,
-                                    flux_jobid_t id, unsigned int prio,
-                                    uint32_t uid, double ts, const char *R,
-                                    void *arg);
+    static int jobmanager_hello_cb (flux_t *h, const flux_msg_t *msg,
+                                    const char *R, void *arg);
     static void jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
                                      void *arg);
     static void jobmanager_free_cb (flux_t *h, const flux_msg_t *msg,
@@ -64,10 +62,8 @@ protected:
 };
 
 struct qmanager_safe_cb_t : public qmanager_cb_t {
-    static int jobmanager_hello_cb (flux_t *h,
-                                    flux_jobid_t id, unsigned int prio,
-                                    uint32_t uid, double ts, const char *R,
-                                    void *arg);
+    static int jobmanager_hello_cb (flux_t *h, const flux_msg_t *msg,
+                                    const char *R, void *arg);
     static void jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
                                      void *arg);
     static void jobmanager_free_cb (flux_t *h, const flux_msg_t *msg,

--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -85,7 +85,7 @@ public:
     ~job_t () { flux_msg_destroy (msg); }
     job_t () = default;
     job_t (job_state_kind_t s, flux_jobid_t jid,
-           uint32_t uid, int u, double t_s, const std::string &R)
+           uint32_t uid, unsigned int u, double t_s, const std::string &R)
 	   : state (s), id (jid), userid (uid),
 	     urgency (u), t_submit (t_s), schedule (R) { }
     job_t (job_t &&j) = default;
@@ -99,7 +99,7 @@ public:
     job_state_kind_t state = job_state_kind_t::INIT;
     flux_jobid_t id = 0;
     uint32_t userid = 0;
-    int urgency = 0;
+    unsigned int urgency = 0;
     double t_submit = 0.0f;;
     std::string jobspec = "";
     std::string note = "";

--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -85,9 +85,9 @@ public:
     ~job_t () { flux_msg_destroy (msg); }
     job_t () = default;
     job_t (job_state_kind_t s, flux_jobid_t jid,
-           uint32_t uid, unsigned int u, double t_s, const std::string &R)
+           uint32_t uid, unsigned int p, double t_s, const std::string &R)
 	   : state (s), id (jid), userid (uid),
-	     urgency (u), t_submit (t_s), schedule (R) { }
+	     priority (p), t_submit (t_s), schedule (R) { }
     job_t (job_t &&j) = default;
     job_t (const job_t &j) = default;
     job_t& operator= (job_t &&s) = default;
@@ -99,7 +99,7 @@ public:
     job_state_kind_t state = job_state_kind_t::INIT;
     flux_jobid_t id = 0;
     uint32_t userid = 0;
-    unsigned int urgency = 0;
+    unsigned int priority = 0;
     double t_submit = 0.0f;;
     std::string jobspec = "";
     std::string note = "";

--- a/qmanager/policies/base/queue_policy_base_impl.hpp
+++ b/qmanager/policies/base/queue_policy_base_impl.hpp
@@ -253,7 +253,7 @@ int queue_policy_base_impl_t::insert (std::shared_ptr<job_t> job)
     job->state = job_state_kind_t::PENDING;
     job->t_stamps.pending_ts = m_pq_cnt++;
     m_pending.insert (std::pair<std::vector<double>, flux_jobid_t> (
-        {static_cast<double> (job->urgency),
+        {static_cast<double> (job->priority),
          static_cast<double> (job->t_submit),
          static_cast<double> (job->t_stamps.pending_ts)}, job->id));
     m_jobs.insert (std::pair<flux_jobid_t, std::shared_ptr<job_t>> (job->id,
@@ -276,7 +276,7 @@ int queue_policy_base_impl_t::remove (flux_jobid_t id)
     job = m_jobs[id];
     switch (job->state) {
     case job_state_kind_t::PENDING:
-        m_pending.erase ({static_cast<double> (job->urgency),
+        m_pending.erase ({static_cast<double> (job->priority),
                           static_cast<double> (job->t_submit),
                           static_cast<double> (job->t_stamps.pending_ts)});
         job->state = job_state_kind_t::CANCELED;
@@ -421,7 +421,7 @@ std::shared_ptr<job_t> queue_policy_base_impl_t::pending_pop ()
     if (m_jobs.find (id) == m_jobs.end ())
         return nullptr;
     job = m_jobs[id];
-    m_pending.erase ({static_cast<double> (job->urgency),
+    m_pending.erase ({static_cast<double> (job->priority),
                       static_cast<double> (job->t_submit),
                       static_cast<double> (job->t_stamps.pending_ts)});
     m_jobs.erase (id);


### PR DESCRIPTION
Changes per `libschedutil` changes in https://github.com/flux-framework/flux-core/pull/3447

We should wait for changes upstream to be accepted before merging this of course.

These commits could be collapsed into fewer ones if desired.