### PR TITLE
qmanager: support re-prioritization of jobs

### DIFF
--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -410,7 +410,7 @@ const struct schedutil_ops ops = {
     .alloc  = &qmanager_safe_cb_t::jobmanager_alloc_cb,
     .free   = &qmanager_safe_cb_t::jobmanager_free_cb,
     .cancel = &qmanager_safe_cb_t::jobmanager_cancel_cb,
-    .prioritize = NULL,
+    .prioritize = &qmanager_safe_cb_t::jobmanager_prioritize_cb,
 };
 
 static std::shared_ptr<qmanager_ctx_t> qmanager_new (flux_t *h)

--- a/qmanager/modules/qmanager_callbacks.hpp
+++ b/qmanager/modules/qmanager_callbacks.hpp
@@ -55,6 +55,8 @@ protected:
                                     const char *R, void *arg);
     static void jobmanager_cancel_cb (flux_t *h, const flux_msg_t *msg,
                                       void *arg);
+    static void jobmanager_prioritize_cb (flux_t *h, const flux_msg_t *msg,
+                                          void *arg);
     static int post_sched_loop (flux_t *h,
         schedutil_t *schedutil,
         std::map<std::string, std::shared_ptr<
@@ -70,6 +72,8 @@ struct qmanager_safe_cb_t : public qmanager_cb_t {
                                     const char *R, void *arg);
     static void jobmanager_cancel_cb (flux_t *h, const flux_msg_t *msg,
                                       void *arg);
+    static void jobmanager_prioritize_cb (flux_t *h, const flux_msg_t *msg,
+                                          void *arg);
     static int post_sched_loop (flux_t *h,
         schedutil_t *schedutil,
         std::map<std::string, std::shared_ptr<

--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -118,6 +118,7 @@ public:
 
 protected:
     int reconstruct_queue (std::shared_ptr<job_t> running_job);
+    int pending_reprioritize (flux_jobid_t id, unsigned int priority);
     std::shared_ptr<job_t> pending_pop ();
     std::shared_ptr<job_t> alloced_pop ();
     std::shared_ptr<job_t> rejected_pop ();
@@ -285,6 +286,16 @@ public:
      *                       ENOTSUP: job->schedule.R has unsupported feature.
      */
     int reconstruct (void *h, std::shared_ptr<job_t> job, std::string &R_out);
+
+    /*! Reprioritize a job with a new priority.
+     *
+     *  \param id        jobid of flux_jobid_t type.
+     *  \param priority  new job priority
+     *  \return          0 on success; -1 on error.
+     *                       ENOENT: unknown id.
+     *                       EINVAL: job not pending
+     */
+    int pending_reprioritize (flux_jobid_t id, unsigned int priority);
 
     /*! Pop the first job from the pending job queue. The popped
      *  job is completely graduated from the queue policy layer.

--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -293,6 +293,7 @@ public:
      *  \param priority  new job priority
      *  \return          0 on success; -1 on error.
      *                       ENOENT: unknown id.
+     *                       EEXIST: id already exists
      *                       EINVAL: job not pending
      */
     int pending_reprioritize (flux_jobid_t id, unsigned int priority);

--- a/qmanager/policies/base/queue_policy_base_impl.hpp
+++ b/qmanager/policies/base/queue_policy_base_impl.hpp
@@ -269,7 +269,7 @@ int queue_policy_base_impl_t::remove (flux_jobid_t id)
     std::shared_ptr<job_t> job = nullptr;
 
     if (m_jobs.find (id) == m_jobs.end ()) {
-        errno = EINVAL;
+        errno = ENOENT;
         goto out;
     }
 


### PR DESCRIPTION
Support re-prioritization of pending jobs by adding a prioritize callback through `libschedutil`.

Built on top of PR #801 