### PR TITLE
Add minor C++ safety improvements

### DIFF
--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -345,6 +345,7 @@ private:
                     std::unordered_map<std::string, std::string> &p_map);
     int set_param (std::string &kv,
                    std::unordered_map<std::string, std::string> &p_map);
+    bool is_number (const std::string &num_str);
 
     std::map<std::vector<double>, flux_jobid_t>::iterator m_pending_iter;
     bool m_iter_valid = false;

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -2377,7 +2377,14 @@ extern "C" int mod_main (flux_t *h, int argc, char **argv)
         }
     }
     catch (std::exception &e) {
-        flux_log_error (h, "%s: %s", __FUNCTION__, e.what ());
+        errno = ENOSYS;
+        flux_log (h, LOG_ERR, "%s: %s", __FUNCTION__, e.what ());
+        return -1;
+    }
+    catch (...) {
+        errno = ENOSYS;
+        flux_log (h, LOG_ERR, "%s: caught unknown exception", __FUNCTION__);
+        return -1;
     }
 
 done:


### PR DESCRIPTION
This PR adds minor safety enhancements that can work around some issues caused by potentially buggy C++ compilers and/or other unexpected faults. 

- Add pre-check on the input strings that are passed to `std::stoi`
- Add catch-all exception handling for the `sched-fluxion-resource` module scope.
