### PR TITLE
testsuite: fix shell path discovery in datastaging test

### DIFF
--- a/t/scripts/flux-builtin-conf.py
+++ b/t/scripts/flux-builtin-conf.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+##############################################################
+# Copyright 2021 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+import sys
+from flux.core.inner import raw
+from flux.constants import FLUX_CONF_AUTO;
+print(raw.flux_conf_builtin_get(sys.argv[1], FLUX_CONF_AUTO).decode("utf-8"))

--- a/t/t7000-shell-datastaging.t
+++ b/t/t7000-shell-datastaging.t
@@ -7,9 +7,12 @@ test_description='Test data-staging job shell plugin'
 shell_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/shell`
 shell_plugin_path="$(readlink -e ${SHARNESS_BUILD_DIRECTORY}/src/shell/.libs)"
 jobspec_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/`
-flux_shell="$(pkg-config --variable=prefix flux-core)/libexec/flux/flux-shell"
+
 
 test_under_flux 2
+
+flux_shell=$(flux builtin-conf shell_path)
+test_debug "echo flux_shell=$flux_shell"
 
 test_expect_success 'node-local storage allocation staging rank 0' '
 	cat <<-EOT >test-initrc.lua &&


### PR DESCRIPTION
Use a more foolproof method of discovering the default flux-shell path from the enclosing flux instance in `t7000-datastaging.t`. Without this, `make check` for flux-sched built against a side-installed flux-core may fail since the test could use the flux-shell from the system instance unless PKG_CONFIG_PATH happens to be set appropriately.