### PR TITLE
resource: fix 'namespace' spelling

### DIFF
--- a/resource/readers/resource_namespace_remapper.hpp
+++ b/resource/readers/resource_namespace_remapper.hpp
@@ -82,7 +82,7 @@ private:
                       std::map<uint64_t, uint64_t>>> m_remap;
 };
 
-} // namesapce resource_model
+} // namespace resource_model
 } // namespace Flux
 
 

--- a/resource/readers/resource_reader_base.hpp
+++ b/resource/readers/resource_reader_base.hpp
@@ -122,7 +122,7 @@ protected:
     std::string m_err_msg = "";
 };
 
-} // namesapce resource_model
+} // namespace resource_model
 } // namespace Flux
 
 


### PR DESCRIPTION
I was looking at the `resource` directory for some example code of the `reader` class and I happened to notice a tiny misspelling of "namespace" in a couple of the `.hpp` files in the directory.

This PR fixes the spelling of "namespace" in **resource_namespace_remapper.hpp** and **resource_reader_base.hpp**.