### PR TITLE
Add bug fix for by_subplan pruning

### DIFF
--- a/resource/traversers/dfu.hpp
+++ b/resource/traversers/dfu.hpp
@@ -54,6 +54,8 @@ public:
     const std::shared_ptr<const resource_graph_db_t> get_graph_db () const;
     const std::shared_ptr<const dfu_match_cb_t> get_match_cb () const;
     const std::string &err_message () const;
+    const unsigned int get_total_preorder_count () const;
+    const unsigned int get_total_postorder_count () const;
 
     void set_graph (std::shared_ptr<f_resource_graph_t> g);
     void set_graph_db (std::shared_ptr<resource_graph_db_t> db);
@@ -200,6 +202,8 @@ private:
                   bool x, match_op_t op, vtx_t root,
                   std::unordered_map<std::string, int64_t> &dfv);
     bool m_initialized = false;
+    unsigned int m_total_preorder = 0;
+    unsigned int m_total_postorder = 0;
 };
 
 } // namespace resource_model

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -211,10 +211,11 @@ int dfu_impl_t::prune (const jobmeta_t &meta, bool exclusive,
     if ( (rc = by_avail (meta, s, u, resources)) == -1)
         goto done;
     for (auto &resource : resources) {
-        if ((*m_graph)[u].type != resource.type)
+        if ((*m_graph)[u].type != resource.type && resource.type != "slot")
             continue;
         // Prune by exclusivity checker
-        if ( (rc = by_excl (meta, s, u, exclusive, resource)) == -1)
+        if (resource.type != "slot"
+            && (rc = by_excl (meta, s, u, exclusive, resource)) == -1)
             break;
         // Prune by the subtree planner quantities
         if ( (rc = by_subplan (meta, s, u, resource)) == -1)

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -173,12 +173,12 @@ int dfu_impl_t::by_subplan (const jobmeta_t &meta, const std::string &s, vtx_t u
     int saved_errno = errno;
     planner_multi_t *p = (*m_graph)[u].idata.subplans[s];
 
-    count_relevant_types (p, resource.user_data, aggs);
-    if (aggs.empty ()) {
+    if (resource.user_data.empty ()) {
+        // If user_data is empty, no data is available to prune with.
         rc = 0;
         goto done;
     }
-
+    count_relevant_types (p, resource.user_data, aggs);
     errno = 0;
     len = aggs.size ();
     if ((rc = planner_multi_avail_during (p, at, d, &(aggs[0]), len)) == -1) {

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -576,6 +576,7 @@ int dfu_impl_t::dom_dfv (const jobmeta_t &meta, vtx_t u,
     const std::string &dom = m_match->dom_subsystem ();
     const std::vector<Resource> &next = test (u, resources, check_pres, sm);
 
+    m_preorder++;
     if (sm == match_kind_t::NONE_MATCH)
         goto done;
     if ((prune (meta, x_in, dom, u, resources) == -1)
@@ -618,6 +619,7 @@ int dfu_impl_t::dom_dfv (const jobmeta_t &meta, vtx_t u,
             }
         }
     }
+    m_postorder++;
 done:
     return rc;
 }
@@ -845,6 +847,16 @@ const std::string &dfu_impl_t::err_message () const
     return m_err_msg;
 }
 
+const unsigned int dfu_impl_t::get_preorder_count () const
+{
+    return m_preorder;
+}
+
+const unsigned int dfu_impl_t::get_postorder_count () const
+{
+    return m_postorder;
+}
+
 void dfu_impl_t::set_graph (std::shared_ptr<f_resource_graph_t> g)
 {
     m_graph = g;
@@ -943,6 +955,8 @@ int dfu_impl_t::select (Jobspec::Jobspec &j, vtx_t root, jobmeta_t &meta,
     const std::string &dom = m_match->dom_subsystem ();
 
     tick ();
+    m_preorder = 0;
+    m_postorder = 0;
     rc = dom_dfv (meta, root, j.resources, true, &x_in, dfu);
     if (rc == 0) {
         unsigned int needs = 0;

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -118,6 +118,8 @@ public:
     const std::shared_ptr<const dfu_match_cb_t> get_match_cb () const;
     const std::string &err_message () const;
     const expr_eval_api_t &get_expr_eval () const;
+    const unsigned int get_preorder_count () const;
+    const unsigned int get_postorder_count () const;
 
     void set_graph (std::shared_ptr<f_resource_graph_t> g);
     void set_graph_db (std::shared_ptr<resource_graph_db_t> db);
@@ -444,6 +446,8 @@ private:
     color_t m_color;
     uint64_t m_best_k_cnt = 0;
     unsigned int m_trav_level = 0;
+    unsigned int m_preorder = 0;
+    unsigned int m_postorder = 0;
     std::shared_ptr<std::map<subsystem_t, vtx_t>> m_roots = nullptr;
     std::shared_ptr<f_resource_graph_t> m_graph = nullptr;
     std::shared_ptr<resource_graph_db_t> m_graph_db = nullptr;

--- a/resource/traversers/dfu_impl_update.cpp
+++ b/resource/traversers/dfu_impl_update.cpp
@@ -179,11 +179,13 @@ int dfu_impl_t::accum_to_parent (vtx_t u, const subsystem_t &subsystem,
 {
     // Build up the new aggregates that will be used by subtree
     // aggregate pruning filter. If exclusive, none of the vertex's resource
-    // is available (0). If not, all will be available (needs).
+    // is available (size). If not, all will be available (size - needs).
     if (excl)
-        accum_if (subsystem, (*m_graph)[u].type, 0, to_parent);
+        accum_if (subsystem,
+                  (*m_graph)[u].type, (*m_graph)[u].size, to_parent);
     else
-        accum_if (subsystem, (*m_graph)[u].type, needs, to_parent);
+        accum_if (subsystem,
+                  (*m_graph)[u].type, (*m_graph)[u].size - needs, to_parent);
 
     // Pass up the new subtree aggregates collected so far to the parent.
     for (auto &kv : dfu)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -73,6 +73,7 @@ TESTS = \
     t3026-resource-sibling.t \
     t3027-resource-RV.t \
     t3028-resource-grow.t \
+    t3029-resource-prune.t \
     t4000-match-params.t \
     t4001-match-allocate.t \
     t4002-match-reserve.t \

--- a/t/data/resource/commands/pruning/cmds01.in
+++ b/t/data/resource/commands/pruning/cmds01.in
@@ -1,0 +1,6 @@
+# 4x node[1]->slot[1]->socket[1]->core[1]
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/pruning/test001.yaml
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/pruning/test001.yaml
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/pruning/test001.yaml
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/pruning/test001.yaml
+quit

--- a/t/data/resource/commands/pruning/cmds02.in
+++ b/t/data/resource/commands/pruning/cmds02.in
@@ -1,0 +1,6 @@
+# 4x node[1]->slot[1]->socket[1]->core[1]
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/pruning/test002.yaml
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/pruning/test002.yaml
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/pruning/test002.yaml
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/pruning/test002.yaml
+quit

--- a/t/data/resource/commands/pruning/cmds03.in
+++ b/t/data/resource/commands/pruning/cmds03.in
@@ -1,0 +1,6 @@
+# 4x slot[1]->core[1]
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/pruning/test003.yaml
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/pruning/test003.yaml
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/pruning/test003.yaml
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/pruning/test003.yaml
+quit

--- a/t/data/resource/jobspecs/pruning/test001.yaml
+++ b/t/data/resource/jobspecs/pruning/test001.yaml
@@ -1,0 +1,24 @@
+version: 9999
+resources:
+  - type: node
+    count: 1
+    with:
+      - type: socket
+        count: 1
+        with:
+          - type: slot
+            count: 1
+            label: default
+            with:
+              - type: core
+                count: 18
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: [ "app" ]
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/data/resource/jobspecs/pruning/test002.yaml
+++ b/t/data/resource/jobspecs/pruning/test002.yaml
@@ -1,0 +1,26 @@
+version: 9999
+resources:
+  - type: node
+    count: 1
+    with:
+      - type: socket
+        count: 1
+        with:
+          - type: slot
+            count: 1
+            label: default
+            with:
+              - type: core
+                count: 1
+              - type: gpu
+                count: 1
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: [ "app" ]
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/data/resource/jobspecs/pruning/test003.yaml
+++ b/t/data/resource/jobspecs/pruning/test003.yaml
@@ -1,0 +1,19 @@
+version: 9999
+resources:
+  - type: slot
+    count: 1
+    label: default
+    with:
+      - type: core
+        count: 18
+
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: [ "app" ]
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/t3029-resource-prune.t
+++ b/t/t3029-resource-prune.t
@@ -1,0 +1,121 @@
+#!/bin/sh
+
+test_description='Test Scheduling On Tiny Machine Configuration'
+
+. $(dirname $0)/sharness.sh
+
+cmd_dir="${SHARNESS_TEST_SRCDIR}/data/resource/commands/pruning"
+exp_dir="${SHARNESS_TEST_SRCDIR}/data/resource/expected/basics"
+grugs="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/tiny.graphml"
+query="../../resource/utilities/resource-query"
+
+# tiny machine has a total of 100 resource vertices:
+#     cluster[1]->rack[1]->node[2]->socket[2]->core[18],memory[4],gpu[1]
+#
+# jobspec is node[1]->socket[1]->slot[1]->core[18]
+#
+# Thus, the baseline preorder visit count (e.g., machine with no job allocated)
+# should be 100.
+# At the socket level, non-core resource vertices underneath it will not incur
+# postorder visits so the baseline postorder visit count should be 80.
+#
+# As each job gets allocated, a socket's subtree resources will
+# be allocated and won't lead to postorder visits. Plus, because of
+# the default "ALL:core" pruning filter, preorder visit won't occur
+# for those subtree resources under each socket either.
+#
+# There are further pruning at even higher level resources
+# like compute node vertices.
+# But in general, the preorder visit count should be reduced
+# by O(23) starting from 100 each time. The postorder visit count
+# starts from 80 and then should be reduced by O(18) each time.
+#
+cmds01="${cmd_dir}/cmds01.in"
+test_expect_success 'prune: default core-level pruning works' '
+    cat <<-EOF >cmp01 &&
+	INFO: PREORDER VISIT COUNT=100
+	INFO: POSTORDER VISIT COUNT=80
+	INFO: PREORDER VISIT COUNT=77
+	INFO: POSTORDER VISIT COUNT=61
+	INFO: PREORDER VISIT COUNT=52
+	INFO: POSTORDER VISIT COUNT=41
+	INFO: PREORDER VISIT COUNT=29
+	INFO: POSTORDER VISIT COUNT=22
+	EOF
+    sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds01} > cmds01 &&
+    ${query} -L ${grugs} -S CA -P high -t 001.R.out -e < cmds01 > out01 &&
+    cat out01 | grep ORDER > visit_count.out01 &&
+    test_cmp cmp01 visit_count.out01
+'
+
+# jobspec is node[1]->socket[1]->slot[1]->core[1],gpu[1]
+# See the comment with the first test for reasoning.
+# The default core-level pruning won't be that helpful as you don't
+# saturate core resources at all
+#
+cmds02="${cmd_dir}/cmds02.in"
+test_expect_success 'prune: default core-level pruning works with gpu jobspec' '
+    cat <<-EOF >cmp02 &&
+	INFO: PREORDER VISIT COUNT=100
+	INFO: POSTORDER VISIT COUNT=84
+	INFO: PREORDER VISIT COUNT=100
+	INFO: POSTORDER VISIT COUNT=81
+	INFO: PREORDER VISIT COUNT=100
+	INFO: POSTORDER VISIT COUNT=77
+	INFO: PREORDER VISIT COUNT=100
+	INFO: POSTORDER VISIT COUNT=74
+	EOF
+    sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds02} > cmds02 &&
+    ${query} -L ${grugs} -S CA -P high -t 002.R.out -e < cmds02 > out02 &&
+    cat out02 | grep ORDER > visit_count.out02 &&
+    test_cmp cmp02 visit_count.out02
+'
+
+# jobspec is node[1]->socket[1]->slot[1]->core[1],gpu[1]
+# See the comment with the first test for reasoning.
+# Adding an additional pruning filter with GPU significantly
+# helps in this case.
+cmds03="${cmd_dir}/cmds02.in"
+test_expect_success 'prune: using additional for faster gpu-level pruning' '
+    cat <<-EOF >cmp03 &&
+	INFO: PREORDER VISIT COUNT=100
+	INFO: POSTORDER VISIT COUNT=84
+	INFO: PREORDER VISIT COUNT=77
+	INFO: POSTORDER VISIT COUNT=64
+	INFO: PREORDER VISIT COUNT=52
+	INFO: POSTORDER VISIT COUNT=43
+	INFO: PREORDER VISIT COUNT=29
+	INFO: POSTORDER VISIT COUNT=23
+	EOF
+    sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds03} > cmds03 &&
+    ${query} -L ${grugs} -S CA -P high -p ALL:gpu -t 003.R.out -e < cmds03 > out03 &&
+    cat out03 | grep ORDER > visit_count.out03 &&
+    test_cmp cmp03 visit_count.out03
+'
+
+# jobspec is slot[1]->core[18]
+# See the comment with the first test for reasoning.
+# Notice the minor difference in the 3rd preorder
+# visit count with the one above. Pruning could not be done at
+# the node level because this jobspec doesn't have the aggregate
+# core count requirement info at the node level.
+cmds04="${cmd_dir}/cmds03.in"
+test_expect_success 'prune: default core-level pruning works on w/ headless spec' '
+    cat <<-EOF >cmp04 &&
+	INFO: PREORDER VISIT COUNT=100
+	INFO: POSTORDER VISIT COUNT=80
+	INFO: PREORDER VISIT COUNT=77
+	INFO: POSTORDER VISIT COUNT=61
+	INFO: PREORDER VISIT COUNT=54
+	INFO: POSTORDER VISIT COUNT=42
+	INFO: PREORDER VISIT COUNT=29
+	INFO: POSTORDER VISIT COUNT=22
+	EOF
+    sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds04} > cmds04 &&
+    ${query} -L ${grugs} -S CA -P high -t 004.R.out -e < cmds04 > out04 &&
+    cat out04 | grep ORDER > visit_count.out04 &&
+    test_cmp cmp04 visit_count.out04
+'
+
+test_done
+


### PR DESCRIPTION
This PR adds a bug fix for `by_subplan` pruning. The problem was discovered as I analyzed the performance of Fluxion against the MuMMI workflow @ ORNL Summit.

- Fix the main bug where the pruning filter state was miscalculated, which led to higher numbers of graph visits than necessary: For aggregate-based pruning, `accum_to_parent()` should propagate to the parent resource vertex the amount of resources that will become "unavailable" after each allocation. But code was propagating the new (reduced) available resource amount after the allocation.
- Improve performance by enabling `by_subplan` pruning filter for "headless" jobspecs, the class of jobspecs whose first resource type in the resource section is `slot`. 
- Add graph visit count reporting support into our traverser
- Add tests that use the visit counts to check the correctness of pruning filters.

Note that this is just a precursor to ultimate match performance important via introducing ultrafast first-match policy later.