### PR TITLE
sharness: update flux start options

### DIFF
--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -132,7 +132,7 @@ test_under_flux() {
     logopts="-o -Slog-filename=${log_file},-Slog-forward-level=7"
     TEST_UNDER_FLUX_ACTIVE=t \
     TERM=${ORIGINAL_TERM} \
-      exec flux start --bootstrap=selfpmi --size=${size} \
+      exec flux start -s${size} \
                       ${RC1_PATH+-o -Sbroker.rc1_path=${RC1_PATH}} \
                       ${RC3_PATH+-o -Sbroker.rc3_path=${RC3_PATH}} \
                       ${logopts} \


### PR DESCRIPTION
Problem: flux-start options have changed in flux-core
so sharness script for starting an instance is out of date.

Change flux start --size to -s, and drop --bootstrap=selfpmi
which was superfluous anyway.

The flux-core change is proposed in flux-framework/flux-core#3605.  This should be merged first.