### PR TITLE
datastaging: add -avoid-version to LDFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -156,8 +156,8 @@ AC_SUBST(fluxionpylinkdir)
 fluxmod_ldflags="-Wl,--no-undefined -avoid-version -export-symbols-regex '^mod_(main|name|service)\$\$' --disable-static -shared -export-dynamic"
 AC_SUBST(fluxmod_ldflags)
 
-shellplugin_ldflags="-Wl,--no-undefined -avoid-version -export-symbols-regex '^flux_plugin_init\$\$' --disable-static -shared -export-dynamic"
-AC_SUBST(shellplugin_ldflags)
+fluxplugin_ldflags="-avoid-version -export-symbols-regex '^flux_plugin_init\$\$' --disable-static -shared -export-dynamic"
+AC_SUBST(fluxplugin_ldflags)
 
 fluxlib_ldflags="-shared -export-dynamic --disable-static -Wl,--no-undefined"
 AC_SUBST(fluxlib_ldflags)

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -22,6 +22,7 @@ datastaging_la_SOURCES = \
 
 datastaging_la_LDFLAGS = \
 	$(AM_LDFLAGS) \
+	$(fluxplugin_ldflags) \
 	-module
 
 datastaging_la_LIBADD= \


### PR DESCRIPTION
Currently, the datastaging shell plugin is being built as a versioned shared library, such that `datastaging.so` is a link to `datastaging.so.0` which is a link to `datastaging.so.0.0.0`. Unfortunately, this means that the current RPM built for flux-sched v0.16 is broken, since only `datastaging.so` was packaged :facepalm:

This PR replaces the unused `shellplugin_ldflags` in `configure.ac` with `fluxplugin_ldflags` from flux-framework/flux-core#3647 and uses it when building the datastaging plugin so that only `datastaging.so` is built.

Fixes #796