### PR TITLE
Fix cancel race

### DIFF
--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -77,6 +77,7 @@ struct t_stamps_t {
     uint64_t running_ts = 0;
     uint64_t rejected_ts = 0;
     uint64_t complete_ts = 0;
+    uint64_t canceled_ts = 0;
 };
 
 /*! Type to store a job's attributes.
@@ -121,11 +122,12 @@ public:
     bool is_scheduled ();
     void reset_scheduled ();
     bool is_sched_loop_active ();
-    void set_sched_loop_active (bool active);
+    int set_sched_loop_active (bool active);
 
 protected:
     int reconstruct_queue (std::shared_ptr<job_t> running_job);
     int pending_reprioritize (flux_jobid_t id, unsigned int priority);
+    int process_provisional_cancel ();
     int insert_pending_job (std::shared_ptr<job_t> &job, bool into_provisional);
     int erase_pending_job (std::shared_ptr<job_t> &job, bool &found_in_prov);
     std::shared_ptr<job_t> pending_pop ();
@@ -133,6 +135,7 @@ protected:
     std::shared_ptr<job_t> rejected_pop ();
     std::shared_ptr<job_t> complete_pop ();
     std::shared_ptr<job_t> reserved_pop ();
+    std::shared_ptr<job_t> canceled_pop ();
     std::map<std::vector<double>, flux_jobid_t>::iterator to_running (
         std::map<std::vector<double>,
                  flux_jobid_t>::iterator pending_iter,
@@ -152,14 +155,17 @@ protected:
     uint64_t m_dq_cnt = 0;
     uint64_t m_cq_cnt = 0;
     uint64_t m_oq_cnt = 0;
+    uint64_t m_cancel_cnt = 0;
     unsigned int m_queue_depth = DEFAULT_QUEUE_DEPTH;
     unsigned int m_max_queue_depth = MAX_QUEUE_DEPTH;
     std::map<std::vector<double>, flux_jobid_t> m_pending;
     std::map<std::vector<double>, flux_jobid_t> m_pending_provisional;
+    std::map<uint64_t, flux_jobid_t> m_pending_cancel_provisional;
     std::map<uint64_t, flux_jobid_t> m_running;
     std::map<uint64_t, flux_jobid_t> m_alloced;
     std::map<uint64_t, flux_jobid_t> m_complete;
     std::map<uint64_t, flux_jobid_t> m_rejected;
+    std::map<uint64_t, flux_jobid_t> m_canceled;
     std::map<flux_jobid_t, std::shared_ptr<job_t>> m_jobs;
     std::unordered_map<std::string, std::string> m_qparams;
     std::unordered_map<std::string, std::string> m_pparams;
@@ -368,6 +374,13 @@ public:
      */
     std::shared_ptr<job_t> complete_pop ();
 
+    /*! Pop the first job from the internal canceled job queue.
+     *  The popped is completely graduated from the queue policy layer.
+     *  \return          a shared pointer pointing to a job_t object
+     *                   on success; nullptr when the queue is empty.
+     */
+    std::shared_ptr<job_t> canceled_pop ();
+
     /*! Return true if this queue has become schedulable since
      *  its state had been reset with set_schedulability (false).
      *  "Being schedulable" means one or more job or resource events
@@ -403,8 +416,15 @@ public:
     /*! Implement queue_adapter_base_t's pure virtual method
      *  so that this queue can be adapted for use within high-level
      *  resource API. Set the state of the scheduling loop.
+     *  \param active    true when the scheduling loop becomes
+     *                   active; false when becomes inactive.
+     *  \return          0 on success; otherwise -1 an error with errno set
+     *                   (Note: when the scheduling loop becomes inactive,
+     *                    internal queueing can occur and an error can arise):
+     *                       - ENOENT (job is not found from some queue)
+     *                       - EEXIST (enqueue fails due to an existent entry)
      */
-    virtual void set_sched_loop_active (bool active);
+    virtual int set_sched_loop_active (bool active);
 
     /*! Implement queue_adapter_base_t's pure virtual method
      *  so that this queue can be adapted for use within high-level

--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -126,6 +126,8 @@ public:
 protected:
     int reconstruct_queue (std::shared_ptr<job_t> running_job);
     int pending_reprioritize (flux_jobid_t id, unsigned int priority);
+    int insert_pending_job (std::shared_ptr<job_t> &job, bool into_provisional);
+    int erase_pending_job (std::shared_ptr<job_t> &job, bool &found_in_prov);
     std::shared_ptr<job_t> pending_pop ();
     std::shared_ptr<job_t> alloced_pop ();
     std::shared_ptr<job_t> rejected_pop ();

--- a/qmanager/policies/base/queue_policy_base_impl.hpp
+++ b/qmanager/policies/base/queue_policy_base_impl.hpp
@@ -230,9 +230,9 @@ bool queue_policy_base_t::is_sched_loop_active ()
     return detail::queue_policy_base_impl_t::is_sched_loop_active ();
 }
 
-void queue_policy_base_t::set_sched_loop_active (bool active)
+int queue_policy_base_t::set_sched_loop_active (bool active)
 {
-    detail::queue_policy_base_impl_t::set_sched_loop_active (active);
+    return detail::queue_policy_base_impl_t::set_sched_loop_active (active);
 }
 
 int queue_policy_base_t::handle_match_success (
@@ -322,6 +322,11 @@ std::shared_ptr<job_t> queue_policy_base_t::complete_pop ()
     return detail::queue_policy_base_impl_t::complete_pop ();
 }
 
+std::shared_ptr<job_t> queue_policy_base_t::canceled_pop ()
+{
+    return detail::queue_policy_base_impl_t::canceled_pop ();
+}
+
 namespace detail {
 
 int queue_policy_base_impl_t::insert (std::shared_ptr<job_t> job)
@@ -348,7 +353,6 @@ out:
 int queue_policy_base_impl_t::remove (flux_jobid_t id)
 {
     int rc = -1;
-    bool found_in_provisional = false;
     std::shared_ptr<job_t> job = nullptr;
 
     if (m_jobs.find (id) == m_jobs.end ()) {
@@ -359,10 +363,32 @@ int queue_policy_base_impl_t::remove (flux_jobid_t id)
     job = m_jobs[id];
     switch (job->state) {
     case job_state_kind_t::PENDING:
-        if (erase_pending_job (job, found_in_provisional) < 0)
-             goto out;
-        job->state = job_state_kind_t::CANCELED;
-        m_jobs.erase (id);
+        job->t_stamps.canceled_ts = m_cancel_cnt++;
+        if (is_sched_loop_active ()) {
+            // if sched-loop is active, the job's pending state
+            // cannot be determined. There is "MAYBE pending state" where
+            // a request has sent out to the match service.
+            auto res = m_pending_cancel_provisional.insert (
+                           std::pair<uint64_t, flux_jobid_t> (
+                               job->t_stamps.canceled_ts, job->id));
+            if (!res.second) {
+                errno = EEXIST;
+                goto out;
+            }
+        } else {
+            bool found_in_provisional = false;
+            if (erase_pending_job (job, found_in_provisional) < 0)
+                goto out;
+            job->state = job_state_kind_t::CANCELED;
+            auto res = m_canceled.insert (
+                           std::pair<uint64_t, flux_jobid_t> (
+                                job->t_stamps.canceled_ts, job->id));
+            if (!res.second) {
+                errno = EEXIST;
+                goto out;
+            }
+            m_schedulable = true;
+        }
         break;
     case job_state_kind_t::ALLOC_RUNNING:
         m_alloced.erase (job->t_stamps.running_ts);
@@ -371,14 +397,15 @@ int queue_policy_base_impl_t::remove (flux_jobid_t id)
         m_running.erase (job->t_stamps.running_ts);
         job->t_stamps.complete_ts = m_cq_cnt++;
         job->state = job_state_kind_t::COMPLETE;
-        m_complete.insert (std::pair<uint64_t, flux_jobid_t> (
-                               job->t_stamps.complete_ts, job->id));
+        m_complete.insert (std::pair<uint64_t,
+                                    flux_jobid_t> (job->t_stamps.complete_ts,
+                                                   job->id));
+        m_schedulable = true;
         break;
     default:
         break;
     }
 
-    m_schedulable = true;
     rc = 0;
 out:
     return rc;
@@ -409,9 +436,14 @@ bool queue_policy_base_impl_t::is_sched_loop_active ()
     return m_sched_loop_active;
 }
 
-void queue_policy_base_impl_t::set_sched_loop_active (bool active)
+int queue_policy_base_impl_t::set_sched_loop_active (bool active)
 {
+    int rc = 0;
+    bool prev = m_sched_loop_active;
     m_sched_loop_active = active;
+    if (prev && !m_sched_loop_active)
+        rc = process_provisional_cancel ();
+    return rc;
 }
 
 const std::shared_ptr<job_t> queue_policy_base_impl_t::lookup (flux_jobid_t id)
@@ -553,20 +585,44 @@ int queue_policy_base_impl_t::pending_reprioritize (flux_jobid_t id,
         errno = ENOENT;
         return -1;
     }
-
     job = m_jobs[id];
-
     if (job->state != job_state_kind_t::PENDING) {
         errno = EINVAL;
         return -1;
     }
-
     if (erase_pending_job (job, found_in_prov) < 0)
         return -1;
     job->priority = priority;
     if (insert_pending_job (job, found_in_prov) < 0)
         return -1;
     m_schedulable = true;
+    return 0;
+}
+
+int queue_policy_base_impl_t::process_provisional_cancel ()
+{
+    for (auto kv : m_pending_cancel_provisional) {
+        auto id = kv.second;
+        if (m_jobs.find (id) == m_jobs.end ()) {
+            errno = ENOENT;
+            return -1;
+        }
+        auto job = m_jobs[id];
+        if (job->state == job_state_kind_t::PENDING) {
+            bool found_in_provisional = false;
+            if (erase_pending_job (job, found_in_provisional) < 0)
+                return -1;
+            job->state = job_state_kind_t::CANCELED;
+            auto res = m_canceled.insert (
+                           std::pair<uint64_t, flux_jobid_t> (
+                               job->t_stamps.canceled_ts, job->id));
+            if (!res.second) {
+                errno = EEXIST;
+                return -1;
+            }
+            m_schedulable = true;
+        }
+    }
     return 0;
 }
 
@@ -678,6 +734,21 @@ std::shared_ptr<job_t> queue_policy_base_impl_t::complete_pop ()
         return nullptr;
     job = m_jobs[id];
     m_complete.erase (job->t_stamps.complete_ts);
+    m_jobs.erase (id);
+    return job;
+}
+
+std::shared_ptr<job_t> queue_policy_base_impl_t::canceled_pop ()
+{
+    std::shared_ptr<job_t> job;
+    flux_jobid_t id;
+    if (m_canceled.empty ())
+        return nullptr;
+    id = m_canceled.begin ()->second;
+    if (m_jobs.find (id) == m_jobs.end ())
+        return nullptr;
+    job = m_jobs[id];
+    m_canceled.erase (job->t_stamps.canceled_ts);
     m_jobs.erase (id);
     return job;
 }

--- a/resource/hlapi/bindings/c++/reapi.hpp
+++ b/resource/hlapi/bindings/c++/reapi.hpp
@@ -88,8 +88,15 @@ public:
     virtual bool is_sched_loop_active () = 0;
 
     /*! Set the state of the scheduling loop.
+     *  \param active    true when the scheduling loop becomes
+     *                   active; false when becomes inactive.
+     *  \return          0 on success; otherwise -1 an error with errno set
+     *                   (Note: when the scheduling loop becomes inactive,
+     *                    internal queueing can occur and an error can arise):
+     *                       - ENOENT (job is not found from some queue)
+     *                       - EEXIST (enqueue fails due to an existent entry)
      */
-    virtual void set_sched_loop_active (bool active) = 0;
+    virtual int set_sched_loop_active (bool active) = 0;
 };
 
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -41,6 +41,7 @@ TESTS = \
     t1016-nest-namespace.t \
     t1017-rv1-bootstrap.t \
     t1018-rv1-bootstrap2.t \
+    t1019-qmanager-async.t \
     t2000-tree-basic.t \
     t2001-tree-real.t \
     t3000-jobspec.t \

--- a/t/t1019-qmanager-async.t
+++ b/t/t1019-qmanager-async.t
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+test_description='Coverage for async RPC between fluxion modules'
+
+. `dirname $0`/sharness.sh
+
+hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+# 1 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
+excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers"
+
+export FLUX_SCHED_MODULE=none
+test_under_flux 1
+
+submit_jobs() {
+    for i in `seq 1 $1`
+    do
+        flux job submit $2
+    done
+}
+
+test_expect_success 'qmanager: generate jobspec for a simple test job' '
+    flux mini submit -n16 -t 100 --dry-run sleep 100 > basic.json
+'
+
+test_expect_success 'load test resources' '
+    load_test_resources ${excl_1N1B}
+'
+
+test_expect_success 'qmanager: loading resource and qmanager modules works' '
+    flux module load sched-fluxion-resource prune-filters=ALL:core \
+subsystems=containment policy=low load-allowlist=node,core &&
+    load_qmanager
+'
+
+test_expect_success 'qmanager: many basic job submitted' '
+    jobid=$(flux job submit basic.json) &&
+    flux job wait-event -t 10 ${jobid} start &&
+    submit_jobs 30 basic.json
+'
+
+# Statistically speaking some cancels hit qmanager
+# when its sched-loop is active (with 30 jobs pending).
+# We don't use flux queue stop because that can lead
+# to duplicate cancel requests
+test_expect_success 'qmanager: rapidly cancel all jobs' '
+    flux job cancelall -f &&
+    flux queue idle
+'
+
+test_expect_success 'removing resource and qmanager modules' '
+    remove_qmanager &&
+    remove_resource
+'
+
+test_done


### PR DESCRIPTION
This PR adds provisional cancel support into the base queue policy layer to fix a cancel race introduced by the FCFS async support PR (PR #826).

Problem: The `sched.cancel` request handling semantics used to be that when a request is received by `qmanager`, the pending job state was deterministic. The job is either pending or not. It is no longer true because there is a *maybe-pending* state: a match request could have been sent out to `sched-fluxion-resource` and the corresponding stream RPC has not been received. Because the mishandling, an intermittent crash occurs. 

Introduce a provisional cancel request queue and handle a request received during the *maybe pending* state when the schedule loop invocation completes.

Fixes Issue #836. I ran `t1009-recovery-multiqueue.t` 30 times on the docker on my Mac laptop and didn't see the crash. 