### PR TITLE
Default policy changes

### DIFF
--- a/qmanager/config/queue_system_defaults.hpp
+++ b/qmanager/config/queue_system_defaults.hpp
@@ -28,7 +28,7 @@
 namespace Flux {
 namespace queue_manager {
     const unsigned int MAX_QUEUE_DEPTH = 1000000;
-    const unsigned int DEFAULT_QUEUE_DEPTH = 8192;
+    const unsigned int DEFAULT_QUEUE_DEPTH = 32;
     const unsigned int MAX_RESERVATION_DEPTH = 100000;
     const unsigned int HYBRID_RESERVATION_DEPTH = 64;
 } // namespace resource_model

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -323,7 +323,7 @@ static void set_default_args (resource_args_t &args)
     args.load_format = "hwloc";
     args.load_allowlist = "";
     args.match_subsystems = "containment";
-    args.match_policy = "high";
+    args.match_policy = "first";
     args.prune_filters = "ALL:core";
     args.match_format = "rv1_nosched";
     args.reserve_vtx_vec = 0;

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -146,7 +146,7 @@ static void usage (int code)
 "                locality: Select contiguous resources first in their ID space\n"
 "                variation: Allocate resources based on performance classes.\n"
 "				 (perf_class must be set using set-property).\n"
-"            	 (default=high).\n"
+"            	 (default=first).\n"
 "\n"
 "    -F, --match-format=<simple|pretty_simple|jgf|rlite|rv1|rv1_nosched>\n"
 "            Specify the emit format of the matched resource set.\n"
@@ -198,7 +198,7 @@ static void set_default_params (std::shared_ptr<resource_context_t> &ctx)
     ctx->params.load_format = "grug";
     ctx->params.load_allowlist = "";
     ctx->params.matcher_name = "CA";
-    ctx->params.matcher_policy = "high";
+    ctx->params.matcher_policy = "first";
     ctx->params.o_fname = "";
     ctx->params.r_fname = "";
     ctx->params.o_fext = "dot";

--- a/t/t1005-qmanager-conf.t
+++ b/t/t1005-qmanager-conf.t
@@ -30,7 +30,8 @@ start_qmanager () {
     echo $QMANAGER_OPTIONS > options
     flux broker --config-path=${config} bash -c \
 "flux dmesg -C && "\
-"flux module reload -f sched-fluxion-resource load-whitelist=node,core,gpu && "\
+"flux module reload -f sched-fluxion-resource load-whitelist=node,core,gpu "\
+"policy=high && "\
 "flux module reload -f sched-fluxion-qmanager ${QMANAGER_OPTIONS} && "\
 "flux dmesg"
 }
@@ -38,7 +39,8 @@ start_qmanager_noconfig () {
     QMANAGER_OPTIONS=$*
     flux broker bash -c \
 "flux dmesg -C && "\
-"flux module reload -f sched-fluxion-resource load-whitelist=node,core,gpu && "\
+"flux module reload -f sched-fluxion-resource load-whitelist=node,core,gpu "\
+"policy=high && "\
 "flux module reload -f sched-fluxion-qmanager ${QMANAGER_OPTIONS} && "\
 "flux dmesg"
 }

--- a/t/t1007-recovery-full.t
+++ b/t/t1007-recovery-full.t
@@ -25,7 +25,7 @@ test_expect_success 'load test resources' '
 '
 
 test_expect_success 'recovery: loading flux-sched modules works (rv1)' '
-    load_resource load-allowlist=node,core,gpu match-format=rv1 &&
+    load_resource load-allowlist=node,core,gpu match-format=rv1 policy=high &&
     load_qmanager
 '
 
@@ -55,7 +55,7 @@ test_expect_success 'recovery: cancel one running job without fluxion' '
 # flux module stats commands ensure a proper sync between
 # flux ion-resource info and the rest of fluxion module loads
 test_expect_success 'recovery: works when both modules restart (rv1)' '
-    reload_resource load-allowlist=node,core,gpu match-format=rv1 &&
+    reload_resource load-allowlist=node,core,gpu match-format=rv1 policy=high &&
     reload_qmanager &&
     flux module stats sched-fluxion-qmanager &&
     flux module stats sched-fluxion-resource &&
@@ -90,7 +90,8 @@ test_expect_success 'recovery: a cancel leads to a job schedule (rv1)' '
 '
 
 test_expect_success 'recovery: both modules restart (rv1->rv1_nosched)' '
-    reload_resource load-allowlist=node,core,gpu match-format=rv1_nosched &&
+    reload_resource load-allowlist=node,core,gpu match-format=rv1_nosched \
+    policy=high &&
     reload_qmanager &&
     flux module stats sched-fluxion-qmanager &&
     flux module stats sched-fluxion-resource &&
@@ -121,7 +122,8 @@ test_expect_success 'recovery: cancel all jobs (rv1_nosched)' '
 '
 
 test_expect_success 'recovery: restart w/ no running jobs (rv1_nosched)' '
-    reload_resource load-allowlist=node,core,gpu match-format=rv1_nosched &&
+    reload_resource load-allowlist=node,core,gpu match-format=rv1_nosched
+    policy=high &&
     reload_qmanager &&
     flux module stats sched-fluxion-qmanager &&
     flux module stats sched-fluxion-resource

--- a/t/t1007-recovery-full.t
+++ b/t/t1007-recovery-full.t
@@ -122,7 +122,7 @@ test_expect_success 'recovery: cancel all jobs (rv1_nosched)' '
 '
 
 test_expect_success 'recovery: restart w/ no running jobs (rv1_nosched)' '
-    reload_resource load-allowlist=node,core,gpu match-format=rv1_nosched
+    reload_resource load-allowlist=node,core,gpu match-format=rv1_nosched \
     policy=high &&
     reload_qmanager &&
     flux module stats sched-fluxion-qmanager &&

--- a/t/t1009-recovery-multiqueue.t
+++ b/t/t1009-recovery-multiqueue.t
@@ -37,7 +37,7 @@ test_expect_success 'load test resources' '
 '
 
 test_expect_success 'recovery: loading flux-sched modules with two queues' '
-    load_resource load-allowlist=node,core,gpu match-format=rv1 &&
+    load_resource load-allowlist=node,core,gpu match-format=rv1 policy=high &&
     load_qmanager "queues=batch debug"
 '
 
@@ -53,7 +53,7 @@ test_expect_success 'recovery: submit to occupy resources fully (rv1)' '
 
 test_expect_success 'recovery: works when both modules restart (rv1)' '
     flux dmesg -C &&
-    reload_resource load-allowlist=node,core,gpu match-format=rv1 &&
+    reload_resource load-allowlist=node,core,gpu match-format=rv1 policy=high &&
     reload_qmanager "queues=batch debug" &&
     flux module stats sched-fluxion-qmanager &&
     flux module stats sched-fluxion-resource &&

--- a/t/t1010-sync-modules.t
+++ b/t/t1010-sync-modules.t
@@ -29,7 +29,7 @@ test_expect_success 'remove sched-simple' '
 
 # sched-simple releases the exclusive access to resource.
 test_expect_success 'sync: fluxion-resource loads w/ sched-simple unloaded' '
-    load_resource load-allowlist=node,socket,core,gpu
+    load_resource load-allowlist=node,socket,core,gpu policy=high
 '
 
 test_expect_success 'sync: qmanager loads w/ sched-fluxion-resource loaded' '
@@ -56,7 +56,7 @@ test_expect_success 'sync: remove sched-simple' '
 '
 
 test_expect_success 'sync: qmanager will not prematurely proceed' '
-    load_resource load-allowlist=node,socket,core,gpu &&
+    load_resource load-allowlist=node,socket,core,gpu policy=high &&
     flux dmesg -C &&
     load_qmanager &&
     flux module stats sched-fluxion-qmanager &&

--- a/t/t1012-find-status.t
+++ b/t/t1012-find-status.t
@@ -40,7 +40,7 @@ test_expect_success 'load test resources' '
 '
 
 test_expect_success 'find/status: loading fluxion modules works' '
-    load_resource load-allowlist=cluster,node,core,gpu &&
+    load_resource load-allowlist=cluster,node,core,gpu policy=high &&
     load_qmanager queue-policy=easy
 '
 

--- a/t/t1013-exclusion.t
+++ b/t/t1013-exclusion.t
@@ -32,7 +32,7 @@ test_expect_success 'load test resources' '
 '
 
 test_expect_success 'exclusion: loading fluxion modules works' '
-    load_resource load-allowlist=cluster,node,core,gpu &&
+    load_resource load-allowlist=cluster,node,core,gpu policy=high &&
     load_qmanager
 '
 

--- a/t/t1016-nest-namespace.t
+++ b/t/t1016-nest-namespace.t
@@ -24,7 +24,7 @@ test_expect_success 'namespace: loading resource and qmanager modules works' '
 test_expect_success 'namespace: gpu id remapping works with hwloc (pol=hi)' '
     cat >nest.sh <<-EOF &&
 	#!/bin/sh
-	flux module load sched-fluxion-resource load-allowlist=cluster,node,gpu,core
+	flux module load sched-fluxion-resource load-allowlist=cluster,node,gpu,core policy=high
 	flux module load sched-fluxion-qmanager
 	flux resource list
 	flux ion-resource ns-info 0 gpu 0

--- a/t/t3027-resource-RV.t
+++ b/t/t3027-resource-RV.t
@@ -17,7 +17,7 @@ test_expect_success 'RV1 is correct on rank and node ID order match' '
 	match allocate ${full_job}
 	quit
 EOF
-    ${query} -L ${jgf_orig} -f jgf -F rv1_nosched -t R1.out < cmds001 &&
+    ${query} -L ${jgf_orig} -f jgf -F rv1_nosched -t R1.out -P high < cmds001 &&
     test_cmp R1.out ${exp_dir}/R1.out
 '
 
@@ -26,7 +26,7 @@ test_expect_success 'RV1 is correct on core ID modified' '
 	match allocate ${full_job}
 	quit
 EOF
-    ${query} -L ${jgf_mod1} -f jgf -F rv1_nosched -t R2.out < cmds002 &&
+    ${query} -L ${jgf_mod1} -f jgf -F rv1_nosched -t R2.out -P high < cmds002 &&
     test_cmp R2.out ${exp_dir}/R2.out
 '
 
@@ -35,7 +35,7 @@ test_expect_success 'RV1 correct on rank/node ID mismatch + core ID modified' '
 	match allocate ${full_job}
 	quit
 EOF
-    ${query} -L ${jgf_mod2} -f jgf -F rv1_nosched -t R3.out < cmds003 &&
+    ${query} -L ${jgf_mod2} -f jgf -F rv1_nosched -t R3.out -P high < cmds003 &&
     test_cmp R3.out ${exp_dir}/R3.out
 '
 

--- a/t/t4000-match-params.t
+++ b/t/t4000-match-params.t
@@ -47,25 +47,25 @@ unload_resource() {
 test_expect_success 'loading resource module with a tiny machine GRUG works' '
     unload_resource &&
     load_resource load-file=${grug} \
-load-format=grug prune-filters=ALL:core
+load-format=grug prune-filters=ALL:core policy=high
 '
 
 test_expect_success 'loading resource module with an XML works' '
     unload_resource &&
     load_resource load-file=${xml} \
-load-format=hwloc prune-filters=ALL:core
+load-format=hwloc prune-filters=ALL:core policy=high
 '
 
 test_expect_success 'loading resource module with no option works' '
     unload_resource &&
-    load_resource prune-filters=ALL:core
+    load_resource prune-filters=ALL:core policy=high
 '
 
 test_expect_success 'loading resource module with a nonexistent GRUG fails' '
     unload_resource &&
     flux dmesg -C &&
     load_resource load-file=${ne_grug} load-format=grug \
-prune-filters=ALL:core &&
+prune-filters=ALL:core policy=high &&
     test_must_fail flux module stats sched-fluxion-resource &&
     flux dmesg > error1 &&
     test_must_fail grep -i Success error1
@@ -75,7 +75,7 @@ test_expect_success 'loading resource module with a nonexistent XML fails' '
     unload_resource &&
     flux dmesg -C &&
     load_resource load-file=${ne_xml} load-format=hwloc \
-prune-filters=ALL:core &&
+prune-filters=ALL:core policy=high &&
     test_must_fail flux module stats sched-fluxion-resource &&
     flux dmesg > error2 &&
     test_must_fail grep -i Success error2
@@ -85,7 +85,7 @@ test_expect_success 'loading resource module with incorrect reader fails' '
     unload_resource &&
     flux dmesg -C &&
     load_resource load-file=${xml} load-format=grug \
-prune-filters=ALL:core &&
+prune-filters=ALL:core policy=high &&
     test_must_fail flux module stats sched-fluxion-resource &&
     flux dmesg > error3 &&
     grep -i "Invalid argument" error3
@@ -96,6 +96,8 @@ test_expect_success 'loading resource module with known policies works' '
     load_resource policy=high &&
     remove_resource &&
     load_resource policy=low &&
+    remove_resource &&
+    load_resource policy=first &&
     remove_resource &&
     load_resource policy=locality
 '

--- a/t/t4009-match-update.t
+++ b/t/t4009-match-update.t
@@ -35,7 +35,7 @@ test_expect_success 'update: load test resources' '
 '
 
 test_expect_success 'update: loading sched-fluxion-resource works' '
-    load_resource load-allowlist=node,core,gpu match-format=rv1
+    load_resource load-allowlist=node,core,gpu match-format=rv1 policy=high
 '
 
 test_expect_success 'update: resource.match-allocate works with a jobspec' '
@@ -51,7 +51,7 @@ awk "NR==5{ print; }" > R4
 
 test_expect_success 'update: reloading sched-fluxion-resource works' '
     remove_resource &&
-    load_resource load-allowlist=node,core,gpu match-format=rv1
+    load_resource load-allowlist=node,core,gpu match-format=rv1 policy=high
 '
 
 test_expect_success 'update: sched-fluxion-resource.update works with R1' '

--- a/t/t5000-valgrind.t
+++ b/t/t5000-valgrind.t
@@ -37,7 +37,7 @@ VALGRIND_NBROKERS=${VALGRIND_NBROKERS:-2}
 
 test_expect_success \
   "valgrind reports no new errors on $VALGRIND_NBROKERS broker run" '
-	run_timeout 300 \
+	run_timeout 400 \
 	flux start -s ${VALGRIND_NBROKERS} \
 		--killer-timeout=120 \
 		--wrap=libtool,e,${VALGRIND} \

--- a/t/t6000-graph-size.t
+++ b/t/t6000-graph-size.t
@@ -103,8 +103,8 @@ out5.txt &&
 
 test_expect_success LONGTEST "--reserve-vtx-vec improves loading performance" '
     echo "quit" > input6.txt &&
-    ${query} -L ${large_grug} -e -r 400000 < input6.txt > out6A.txt &&
-    ${query} -L ${large_grug} -e < input6.txt > out6B.txt &&
+    ${query} -L ${large_grug} -e -r 400000 -P high < input6.txt > out6A.txt &&
+    ${query} -L ${large_grug} -e -P high < input6.txt > out6B.txt &&
     with=$(grep "Graph" out6A.txt | sed "s/INFO: Graph Load Time: //") &&
     without=$(grep "Graph" out6B.txt | sed "s/INFO: Graph Load Time: //") &&
     test $(awk "BEGIN{ print $with<$without }") -eq 1

--- a/t/t6001-match-formats.t
+++ b/t/t6001-match-formats.t
@@ -22,7 +22,7 @@ query="../../resource/utilities/resource-query"
 test_expect_success "R emitted with -F jgf validates against schema" '
     echo "match allocate ${jobspec}" > in1.txt &&
     echo "quit" >> in1.txt &&
-    ${query} -L ${tiny_grug} -F jgf -d -t o1 < in1.txt &&
+    ${query} -L ${tiny_grug} -F jgf -d -t o1 -P high < in1.txt &&
     cat o1 | grep -v "INFO:" > o1.json &&
     flux jsonschemalint -v ${schema} o1.json
 '
@@ -30,7 +30,7 @@ test_expect_success "R emitted with -F jgf validates against schema" '
 test_expect_success LONGTEST "Large R emitted with -F jgf validates" '
     echo "match allocate ${jobspec2}" > in3.txt &&
     echo "quit" >> in3.txt &&
-    ${query} -L ${large_grug} -r 400000 -F jgf -d -t o3 < in3.txt &&
+    ${query} -L ${large_grug} -r 400000 -F jgf -d -t o3 -P high < in3.txt &&
     cat o3 | grep -v "INFO:" > o3.json &&
     flux jsonschemalint -v ${schema} o3.json
 '
@@ -38,7 +38,7 @@ test_expect_success LONGTEST "Large R emitted with -F jgf validates" '
 test_expect_success HAVE_JQ "--match-format=rv1 works" '
     echo "match allocate ${jobspec}" > in5.txt &&
     echo "quit" >> in5.txt &&
-    ${query} -L ${tiny_grug} -F rv1 -d -t o5 < in5.txt &&
+    ${query} -L ${tiny_grug} -F rv1 -d -t o5 -P high < in5.txt &&
     cat o5 | grep -v "INFO:" | jq ".scheduling" > o5.json &&
     flux jsonschemalint -v ${schema} o5.json
 '
@@ -46,8 +46,8 @@ test_expect_success HAVE_JQ "--match-format=rv1 works" '
 test_expect_success HAVE_JQ "--match-format=rv1_nosched and =rlite works" '
     echo "match allocate ${jobspec}" > in7.txt &&
     echo "quit" >> in7.txt &&
-    ${query} -L ${tiny_grug} -F rv1_nosched -d -t o7 < in7.txt &&
-    ${query} -L ${tiny_grug} -F rlite -d -t o8 < in7.txt &&
+    ${query} -L ${tiny_grug} -F rv1_nosched -d -t o7 -P high < in7.txt &&
+    ${query} -L ${tiny_grug} -F rlite -d -t o8 -P high < in7.txt &&
     cat o7 | grep -v "INFO:" | jq ".execution.R_lite" > o7.json &&
     cat o8 | grep -v "INFO:" | jq "" > o8.json &&
     diff o7.json o8.json
@@ -56,7 +56,7 @@ test_expect_success HAVE_JQ "--match-format=rv1_nosched and =rlite works" '
 test_expect_success "--match-format=pretty_simple works" '
     echo "match allocate ${jobspec}" > in9.txt &&
     echo "quit" >> in9.txt &&
-    ${query} -L ${tiny_grug} -F pretty_simple -d -t o9 < in9.txt &&
+    ${query} -L ${tiny_grug} -F pretty_simple -d -t o9 -P high < in9.txt &&
     cat o9 | grep -v "INFO:" > o9.simple &&
     test -s o9.simple
 '
@@ -64,7 +64,7 @@ test_expect_success "--match-format=pretty_simple works" '
 test_expect_success HAVE_JQ "rv1 contains starttime and expiration keys" '
     echo "match allocate ${jobspec}" > in10.txt &&
     echo "quit" >> in10.txt &&
-    ${query} -L ${tiny_grug} -F rv1_nosched -d -t o10 < in10.txt &&
+    ${query} -L ${tiny_grug} -F rv1_nosched -d -t o10 -P high < in10.txt &&
     starttime=$(cat o10 | grep -v "INFO:" | jq ".execution.starttime") &&
     expiration=$(cat o10 | grep -v "INFO:" | jq ".execution.expiration") &&
     test ${starttime} -eq 0 &&
@@ -74,7 +74,7 @@ test_expect_success HAVE_JQ "rv1 contains starttime and expiration keys" '
 test_expect_success HAVE_JQ "rv1_nosched contains starttime and expiration keys" '
     echo "match allocate ${jobspec}" > in11.txt &&
     echo "quit" >> in11.txt &&
-    ${query} -L ${tiny_grug} -F rv1 -d -t o11 < in11.txt &&
+    ${query} -L ${tiny_grug} -F rv1 -d -t o11 -P high < in11.txt &&
     starttime=$(cat o11 | grep -v "INFO:" | jq ".execution.starttime") &&
     expiration=$(cat o11 | grep -v "INFO:" | jq ".execution.expiration") &&
     test ${starttime} -eq 0 &&


### PR DESCRIPTION
This PR changes the default match policy to "first match" and the default queue-depth to 32. Given that many of the current users require high throughput scheduling and it would make sense the default values are tuned for them. For system-instance, the policies will be configured and set differently through configuration and rc files.

Fixes #827, #830.