### PR TITLE
github: fix ci builds on master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,9 @@ jobs:
        fetch-depth: 0
 
     - name: fetch annotated tag
-      if: matrix.create_release || matrix.docker_tag
+      if: >
+        (matrix.create_release || matrix.docker_tag) &&
+        github.ref != 'refs/heads/master'
       run: |
         # Ensure git-describe works on a tag.
         #  (checkout@v2 action may have left current tag as


### PR DESCRIPTION
Problem: The "fetch annotated tag" step of Github fails on master
because the command  `git fetch -f origin master:master` reports

  fatal: Refusing to fetch into current branch refs/heads/master
         of non-bare repository

which in turn causes the CI overall to fail.

Skip this step on the master branch

Fixes #847