### PR TITLE
Replace GNU readline with editline

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ boost-graph               | libboost-graph-dev      | == 1.53 or > 1.58 | *1*
 boost-system              | libboost-system-dev     | == 1.53 or > 1.58 | *1*
 boost-filesystem          | libboost-filesystem-dev | == 1.53 or > 1.58 | *1*
 boost-regex               | libboost-regex-dev      | == 1.53 or > 1.58 | *1*
-readline-devel            |                         | >= 6.2-11         |
+libedit-devel             | libedit-dev             | >= 3.0            |
 libxml2-devel             | libxml2-dev             | >= 2.9.1          |
 python3-pyyaml            | python3-yaml            | >= 3.10           |
 yaml-cpp-devel            | libyaml-cpp-dev         | >= 0.5.1          |
@@ -92,14 +92,14 @@ jq                | jq                |
 
 ##### Installing RedHat/CentOS Packages
 ```
-sudo yum install hwloc-devel boost-devel boost-graph boost-system boost-filesystem boost-regex readline-devel libxml2-devel python3-pyyaml yaml-cpp-devel
+sudo yum install hwloc-devel boost-devel boost-graph boost-system boost-filesystem boost-regex libedit-devel libxml2-devel python3-pyyaml yaml-cpp-devel
 ```
 
 ##### Installing Ubuntu Packages
 
 ```
 sudo apt-get update
-sudo apt install libhwloc-dev libboost-dev libboost-system-dev libboost-filesystem-dev libboost-graph-dev libboost-regex-dev libxml2-dev libyaml-cpp-dev python3-yaml
+sudo apt install libhwloc-dev libboost-dev libboost-system-dev libboost-filesystem-dev libboost-graph-dev libboost-regex-dev libedit-dev libxml2-dev libyaml-cpp-dev python3-yaml
 ```
 
 Clone flux-sched, the repo name for Fluxion, from an upstream repo and prepare for configure:

--- a/configure.ac
+++ b/configure.ac
@@ -61,11 +61,7 @@ AX_BOOST_SYSTEM
 AX_BOOST_FILESYSTEM
 AX_BOOST_GRAPH
 AX_BOOST_REGEX
-AC_CHECK_LIB([readline], [readline],
-             [AC_SUBST([READLINE_LIBS], ["-lreadline"])
-              AC_DEFINE([HAVE_LIBREADLINE], [1],
-                        [Define if you have libreadline])],
-             [AC_MSG_ERROR([Please install GNU readline])])
+PKG_CHECK_MODULES(LIBEDIT, libedit)
 
 #  Set PYTHON_VERSION to FLUX_PYTHON_VERSION here
 PYTHON_VERSION=${PYTHON_VERSION:-$FLUX_PYTHON_VERSION}

--- a/resource/utilities/Makefile.am
+++ b/resource/utilities/Makefile.am
@@ -35,7 +35,7 @@ resource_query_CXXFLAGS = \
     $(FLUX_HOSTLIST_CFLAGS)
 resource_query_LDADD = \
     ../libresource.la \
-    $(READLINE_LIBS) \
+    $(LIBEDIT_LIBS) \
     $(FLUX_HOSTLIST_LIBS) \
     $(BOOST_LDFLAGS) \
     $(BOOST_SYSTEM_LIB) \

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -31,8 +31,7 @@
 #include <iterator>
 #include <limits>
 #include <memory>
-#include <readline/readline.h>
-#include <readline/history.h>
+#include <editline/readline.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 #include "resource/utilities/command.hpp"

--- a/src/test/docker/bionic/Dockerfile
+++ b/src/test/docker/bionic/Dockerfile
@@ -12,7 +12,8 @@ RUN sudo apt-get -qq install -y --no-install-recommends \
 	libboost-regex-dev \
 	libxml2-dev \
 	python-yaml \
-	libyaml-cpp-dev
+	libyaml-cpp-dev \
+	libedit-dev
 
 # Add configured user to image with sudo access:
 #

--- a/src/test/docker/centos7/Dockerfile
+++ b/src/test/docker/centos7/Dockerfile
@@ -10,9 +10,9 @@ RUN sudo yum -y install \
 	libboost-filesystem-devel \
 	libboost-regex-devel \
 	libxml2-devel \
-	readline-devel \
 	python-yaml \
-	yaml-cpp-devel
+	yaml-cpp-devel \
+	libedit-devel
 
 # Add configured user to image with sudo access:
 #

--- a/src/test/docker/centos8/Dockerfile
+++ b/src/test/docker/centos8/Dockerfile
@@ -13,7 +13,8 @@ RUN sudo yum -y install \
 	libxml2-devel \
 	readline-devel \
 	python3-pyyaml \
-	yaml-cpp-devel
+	yaml-cpp-devel \
+	libedit-devel
 
 # Add configured user to image with sudo access:
 #

--- a/src/test/docker/fedora33/Dockerfile
+++ b/src/test/docker/fedora33/Dockerfile
@@ -17,6 +17,7 @@ RUN sudo yum -y update \
 	readline-devel \
 	python3-pyyaml \
 	yaml-cpp-devel \
+	libedit-devel \
  && sudo yum clean all
 
 # Add configured user to image with sudo access:

--- a/src/test/docker/focal/Dockerfile
+++ b/src/test/docker/focal/Dockerfile
@@ -12,7 +12,8 @@ RUN sudo apt-get -qq install -y --no-install-recommends \
 	libboost-regex-dev \
 	libxml2-dev \
 	python-yaml \
-	libyaml-cpp-dev
+	libyaml-cpp-dev \
+	libedit-dev
 
 # Add configured user to image with sudo access:
 #


### PR DESCRIPTION
This PR adds support for the editline library
and deprecates the use of GNU readline within
Fluxion.

Editline uses a BSD style license which is
much more compatible with more permissive
licensing including LGPL.

This PR does not yet include new LICENSE
term changes for Fluxion yet because PR #846 
still needs to be merged in before we can do that.

Terms will change in the near future at once
after both this PR and PR #846 will be merged. 

