### PR TITLE
NEWS.md: Add release notes for v0.18.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+flux-sched version 0.18.0 - 2021-09-04
+--------------------------------------
+
+This version of Fluxion includes updates required for compatibility
+with flux-core v0.29.0.
+
+### Fixes
+
+ * resource: update for libflux API change (#852)
+
 flux-sched version 0.17.0 - 2021-07-01
 --------------------------------------
 


### PR DESCRIPTION
We recently tagged flux-core v0.29.0, but there was one API change that required an update to flux-sched, so we'll need a Fluxion release as well.

This PR adds an entry to the NEWS.md for flux-sched v0.18.0. (there was only a that single compatibility change)