### PR TITLE
Using static_cast to ensure type compatibility in readers.

### DIFF
--- a/resource/readers/resource_reader_hwloc.cpp
+++ b/resource/readers/resource_reader_hwloc.cpp
@@ -282,7 +282,8 @@ int resource_reader_hwloc_t::walk_hwloc (resource_graph_t &g,
                     rc = -1;
                     break;
                 }
-                if (remap_id > std::numeric_limits<int>::max ()) {
+                if (remap_id 
+                        > static_cast<uint64_t> (std::numeric_limits<int>::max ())) {
                     errno = EOVERFLOW;
                     m_err_msg += "Remapped gpu id too large; ";
                     rc = -1;

--- a/resource/readers/resource_reader_jgf.cpp
+++ b/resource/readers/resource_reader_jgf.cpp
@@ -282,7 +282,8 @@ int resource_reader_jgf_t::unpack_and_remap_vtx (fetch_helper_t &f,
         m_err_msg += std::to_string (f.rank) + ".\n";
         goto error;
     }
-    if (remap_rank > std::numeric_limits<int64_t>::max ()) {
+    if (remap_rank 
+            > static_cast<uint64_t> (std::numeric_limits<int64_t>::max ())) {
         errno = EOVERFLOW;
         m_err_msg += __FUNCTION__;
         m_err_msg += ": remapped rank too large.\n";
@@ -297,7 +298,8 @@ int resource_reader_jgf_t::unpack_and_remap_vtx (fetch_helper_t &f,
             m_err_msg += " rank=" + std::to_string (f.rank) + ".\n";
             goto error;
         }
-        if (remap_id > std::numeric_limits<int>::max ()) {
+        if (remap_id 
+                > static_cast<uint64_t> (std::numeric_limits<int>::max ())) {
             errno = EOVERFLOW;
             m_err_msg += __FUNCTION__;
             m_err_msg += ": remapped id too large.\n";


### PR DESCRIPTION
Potential fix for #856. Cannot currently compile master version of flux-sched, and instead have compiled 0.16.0 with this change. There is a slight difference between these versions in the readers, but the bug remains the same -- regardless, the change to this particular version is untested. However, to the best of my knowledge, this will ensure that type differences do not prevent compilation on platforms using GCC. 