### PR TITLE
testsuite: fix logging test in t7000-shell-datastaging.t

### DIFF
--- a/t/t7000-shell-datastaging.t
+++ b/t/t7000-shell-datastaging.t
@@ -142,7 +142,7 @@ test_expect_success 'datastaging logging is not overly verbose by default' '
 
 test_expect_success 'datastaging logging can be access with verbose option' '
     flux mini run -o verbose=2 hostname 2> verbose-run.err &&
-        grep -q " DEBUG: Jobspec does not contain data-staging attributes. "\
+        grep -q " DEBUG:.* Jobspec does not contain data-staging attributes. "\
 "No staging necessary." verbose-run.err
 '
 


### PR DESCRIPTION
Unfortunately I was lazy and didn't test #864 after application of flux-framework/flux-core#3879. It turns out one of the datastaging tests fails after those changes since now a prefix will appear in the logging output of the shell.

This updates the test to (hopefully) work with or without flux-framework/flux-core#3879.

(This time tested against the changes above)

Sorry!