### PR TITLE
t5000-valgrind.t: do not run valgrind test by default

### DIFF
--- a/src/test/checks_run.sh
+++ b/src/test/checks_run.sh
@@ -156,6 +156,8 @@ export FLUX_TEST_MPI=t
 export FLUX_TESTS_LOGFILE=t
 export DISTCHECK_CONFIGURE_FLAGS="${ARGS}"
 
+# Force enable valgrind test
+export FLUX_ENABLE_VALGRIND_TEST=t
 
 if test "$CPPCHECK" = "t"; then
     sh -x src/test/cppcheck.sh

--- a/t/t5000-valgrind.t
+++ b/t/t5000-valgrind.t
@@ -6,6 +6,14 @@ test_description='Run broker under valgrind with a small workload'
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 . `dirname $0`/sharness.sh
 
+#  Do not run valgrind test by default unless FLUX_ENABLE_VALGRIND_TEST
+#   is set in environment (e.g. by CI), or the test run run with -d, --debug
+#
+if test -z "$FLUX_ENABLE_VALGRIND_TEST" && test "$debug" = ""; then
+    skip_all='skipping valgrind tests since FLUX_ENABLE_VALGRIND_TEST not set'
+    test_done
+fi
+
 if ! which valgrind >/dev/null; then
     skip_all='skipping valgrind tests since no valgrind executable found'
     test_done


### PR DESCRIPTION
Problem: The t5000-valgrind.t test is susceptible to false positives
when run on new systems and different distros due to the potential
for new false positives from system libraries which have not yet been
added to the suppressions file. This can confuse new users when the
test unnecessarily fails.

Disable the valgrind test by default to avoid these situations.
The test can be run with FLUX_ENABLE_VALGRIND_TEST (e.g. in CI) or
by passing the `-d, --debug` flag (since this is common when running
the test by hand).