### PR TITLE
HLAPI: add CLI initialization and implement match_allocate, cancel, and info

### DIFF
--- a/qmanager/modules/Makefile.am
+++ b/qmanager/modules/Makefile.am
@@ -25,8 +25,6 @@ sched_fluxion_qmanager_la_SOURCES = \
     $(top_srcdir)/src/common/liboptmgr/optmgr_impl.hpp \
     $(top_srcdir)/resource/libjobspec/jobspec.hpp \
     $(top_srcdir)/resource/hlapi/bindings/c++/reapi.hpp \
-    $(top_srcdir)/resource/hlapi/bindings/c++/reapi_cli.hpp \
-    $(top_srcdir)/resource/hlapi/bindings/c++/reapi_cli_impl.hpp \
     $(top_srcdir)/resource/hlapi/bindings/c++/reapi_module.hpp \
     $(top_srcdir)/resource/hlapi/bindings/c++/reapi_module_impl.hpp \
     $(top_srcdir)/qmanager/config/queue_system_defaults.hpp \

--- a/qmanager/policies/queue_policy_factory_impl.hpp
+++ b/qmanager/policies/queue_policy_factory_impl.hpp
@@ -14,8 +14,6 @@
 #include "resource/hlapi/bindings/c++/reapi.hpp"
 #include "resource/hlapi/bindings/c++/reapi_module.hpp"
 #include "resource/hlapi/bindings/c++/reapi_module_impl.hpp"
-#include "resource/hlapi/bindings/c++/reapi_cli.hpp"
-#include "resource/hlapi/bindings/c++/reapi_cli_impl.hpp"
 #include "qmanager/policies/base/queue_policy_base.hpp"
 #include "qmanager/policies/base/queue_policy_base_impl.hpp"
 #include "qmanager/policies/queue_policy_fcfs.hpp"
@@ -45,30 +43,19 @@ std::shared_ptr<queue_policy_base_t> create_queue_policy (
         if (policy == "fcfs") {
             if (reapi == "module")
                 p = std::make_shared<queue_policy_fcfs_t<reapi_module_t>> ();
-            else if (reapi == "cli")
-                p = std::make_shared<queue_policy_fcfs_t<reapi_cli_t>> ();
         }
         else if (policy == "easy") {
             if (reapi == "module")
                 p = std::make_shared<queue_policy_easy_t<reapi_module_t>> ();
-            else if (reapi == "cli")
-                p = std::make_shared<queue_policy_easy_t<reapi_cli_t>> ();
         }
         else if (policy == "hybrid") {
             if (reapi == "module")
                 p = std::make_shared<queue_policy_hybrid_t<reapi_module_t>> ();
-            else if (reapi == "cli")
-                p = std::make_shared<queue_policy_hybrid_t<reapi_cli_t>> ();
         }
         else if (policy == "conservative") {
-            if (reapi == "module") {
+            if (reapi == "module")
                 p = std::make_shared<queue_policy_conservative_t<
                                          reapi_module_t>> ();
-            }
-            else if (reapi == "cli") {
-                p = std::make_shared<queue_policy_conservative_t<
-                                         reapi_cli_t>> ();
-            }
         }
     } catch (std::bad_alloc &e) {
         errno = ENOMEM;

--- a/resource/hlapi/bindings/c++/reapi.hpp
+++ b/resource/hlapi/bindings/c++/reapi.hpp
@@ -116,8 +116,8 @@ public:
      *  \return          0 on success; -1 on error.
      */
     static int match_allocate (void *h, bool orelse_reserve,
-                               const std::string &jobspec, const uint64_t jobid,
-                               bool &reserved,
+                               const std::string &jobspec,
+                               const uint64_t jobid, bool &reserved,
                                std::string &R, int64_t &at, double &ov)
     {
         return -1;

--- a/resource/hlapi/bindings/c++/reapi.hpp
+++ b/resource/hlapi/bindings/c++/reapi.hpp
@@ -191,6 +191,7 @@ public:
      *                   service module, it is expected to be a pointer
      *                   to a flux_t object.
      *  \param jobid     const jobid of the uint64_t type.
+     *  \param mode      return string containing the job state.
      *  \param reserved  Boolean into which to return true if this job has been
      *                   reserved instead of allocated.
      *  \param at        If allocated, 0 is returned; if reserved, actual time
@@ -201,7 +202,8 @@ public:
      *  \return          0 on success; -1 on error.
      */
     static int info (void *h, const uint64_t jobid,
-                     bool &reserved, int64_t &at, double &ov)
+                     std::string &mode, bool &reserved, int64_t &at, 
+                     double &ov)
     {
         return -1;
     }

--- a/resource/hlapi/bindings/c++/reapi_cli.hpp
+++ b/resource/hlapi/bindings/c++/reapi_cli.hpp
@@ -27,7 +27,10 @@ namespace resource_model {
 namespace detail {
 
 class reapi_cli_t : public reapi_t {
-public:
+private:
+    static std::string m_err_msg;
+
+public:  
     static int match_allocate (void *h, bool orelse_reserve,
                                const std::string &jobspec,
                                const uint64_t jobid, bool &reserved,
@@ -43,6 +46,8 @@ public:
                      bool &reserved, int64_t &at, double &ov);
     static int stat (void *h, int64_t &V, int64_t &E,int64_t &J,
                      double &load, double &min, double &max, double &avg);
+    static const std::string &get_err_message ();
+    static void clear_err_message ();
 };
 
 

--- a/resource/hlapi/bindings/c++/reapi_cli.hpp
+++ b/resource/hlapi/bindings/c++/reapi_cli.hpp
@@ -137,7 +137,7 @@ public:
                                 const std::string &R, int64_t &at, double &ov,
                                 std::string &R_out);
     static int cancel (void *h, const uint64_t jobid, bool noent_ok);
-    static int info (void *h, const int64_t jobid,
+    static int info (void *h, const uint64_t jobid, std::string &mode,
                      bool &reserved, int64_t &at, double &ov);
     static int stat (void *h, int64_t &V, int64_t &E,int64_t &J,
                      double &load, double &min, double &max, double &avg);

--- a/resource/hlapi/bindings/c++/reapi_cli.hpp
+++ b/resource/hlapi/bindings/c++/reapi_cli.hpp
@@ -20,16 +20,111 @@ extern "C" {
 #include <cerrno>
 }
 
+#include <fstream>
+#include <memory>
 #include "resource/hlapi/bindings/c++/reapi.hpp"
+#include "resource/jobinfo/jobinfo.hpp"
+#include "resource/policies/dfu_match_policy_factory.hpp"
+#include "resource/traversers/dfu.hpp"
 
 namespace Flux {
 namespace resource_model {
 namespace detail {
 
-class reapi_cli_t : public reapi_t {
-private:
-    static std::string m_err_msg;
+enum class emit_format_t { GRAPHVIZ_DOT, GRAPH_ML, };
 
+struct match_perf_t {
+    double min;                 /* Min match time */
+    double max;                 /* Max match time */
+    double accum;               /* Total match time accumulated */
+};
+
+struct resource_params_t {
+    std::string load_file;      /* load file name */
+    std::string load_format;    /* load reader format */
+    std::string load_allowlist; /* load resource allowlist */
+    std::string matcher_name;   /* Matcher name */
+    std::string matcher_policy; /* Matcher policy name */
+    std::string o_fname;        /* Output file to dump the filtered graph */
+    std::ofstream r_out;        /* Output file stream for emitted R */
+    std::string r_fname;        /* Output file to dump the emitted R */
+    std::string o_fext;         /* File extension */
+    std::string prune_filters;  /* Raw prune-filter specification */
+    std::string match_format;   /* Format to emit a matched resources */
+    emit_format_t o_format;
+    bool elapse_time;           /* Print elapse time */
+    bool disable_prompt;        /* Disable resource-query> prompt */
+    bool flux_hwloc;            /* get hwloc info from flux instance */
+    size_t reserve_vtx_vec;     /* Allow for reserving vertex vector size */
+};
+
+class resource_query_t {
+public:
+    resource_query_t ();
+    resource_query_t (const std::string &rgraph, const std::string &options);
+    ~resource_query_t ();
+
+    /* Accessors */
+    const std::string &get_resource_query_err_msg () const;
+    const std::string &get_traverser_err_msg () const;
+    const bool job_exists (const uint64_t jobid);
+    const uint64_t get_job_counter () const;
+    const std::shared_ptr<job_info_t> &get_job (const uint64_t jobid);
+    const bool reservation_exists (const uint64_t jobid);
+    const bool allocation_exists (const uint64_t jobid);
+
+    /* Mutators */
+    void clear_resource_query_err_msg ();
+    void clear_traverser_err_msg ();
+    void set_reservation (const uint64_t jobid);
+    void erase_reservation (const uint64_t jobid);
+    void set_allocation (const uint64_t jobid);
+    void erase_allocation (const uint64_t jobid);
+    void set_job (const uint64_t jobid, 
+                  const std::shared_ptr<job_info_t> &job);
+    int remove_job (const uint64_t jobid);
+    void incr_job_counter ();
+
+    /* Run the traverser to match the jobspec */
+    int traverser_run (Flux::Jobspec::Jobspec &job, match_op_t op,
+                       int64_t jobid, int64_t &at);
+
+    // must be public; results in a deleted stringstream if converted to 
+    // a private member function
+    std::shared_ptr<match_writers_t> writers;  /* Vertex/Edge writers */
+
+private:
+    /************************************************************************
+     *                                                                      *
+     *                     Private Member Data                              *
+     *                                                                      *
+     ************************************************************************/
+
+    std::string m_err_msg;       /* class error message */
+    resource_params_t params;        /* Parameters for resource graph context */
+    uint64_t jobid_counter;      /* Hold the current jobid value */
+    std::shared_ptr<dfu_match_cb_t> matcher; /* Match callback object */
+    std::shared_ptr<dfu_traverser_t> traverser; /* Graph traverser object */
+    std::shared_ptr<resource_graph_db_t> db;    /* Resource graph data store */
+    std::shared_ptr<f_resource_graph_t> fgraph; /* Filtered graph */
+    match_perf_t perf;           /* Match performance stats */
+    std::map<uint64_t, std::shared_ptr<job_info_t>> jobs; /* Jobs table */
+    std::map<uint64_t, uint64_t> allocations;  /* Allocation table */
+    std::map<uint64_t, uint64_t> reservations; /* Reservation table */
+    std::shared_ptr<f_resource_graph_t> create_filtered_graph ();
+
+    /************************************************************************
+     *                                                                      *
+     *                        Private Util API                              *
+     *                                                                      *
+     ************************************************************************/
+
+    int subsystem_exist (const std::string &n);
+    int set_subsystems_use (const std::string &n);
+    int set_resource_ctx_params (const std::string &options);
+};
+
+class reapi_cli_t : public reapi_t {
 public:  
     static int match_allocate (void *h, bool orelse_reserve,
                                const std::string &jobspec,
@@ -48,6 +143,9 @@ public:
                      double &load, double &min, double &max, double &avg);
     static const std::string &get_err_message ();
     static void clear_err_message ();
+
+private:
+    static std::string m_err_msg;
 };
 
 

--- a/resource/hlapi/bindings/c++/reapi_cli.hpp
+++ b/resource/hlapi/bindings/c++/reapi_cli.hpp
@@ -136,7 +136,7 @@ public:
     static int update_allocate (void *h, const uint64_t jobid,
                                 const std::string &R, int64_t &at, double &ov,
                                 std::string &R_out);
-    static int cancel (void *h, const int64_t jobid, bool noent_ok);
+    static int cancel (void *h, const uint64_t jobid, bool noent_ok);
     static int info (void *h, const int64_t jobid,
                      bool &reserved, int64_t &at, double &ov);
     static int stat (void *h, int64_t &V, int64_t &E,int64_t &J,

--- a/resource/hlapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/hlapi/bindings/c++/reapi_cli_impl.hpp
@@ -18,7 +18,11 @@ extern "C" {
 #include <flux/core.h>
 }
 
+#include <stdexcept>
+#include <jansson.h>
+#include <boost/algorithm/string.hpp>
 #include "resource/hlapi/bindings/c++/reapi_cli.hpp"
+#include "resource/readers/resource_reader_factory.hpp"
 
 namespace Flux {
 namespace resource_model {
@@ -87,6 +91,430 @@ const std::string &reapi_cli_t::get_err_message ()
 void reapi_cli_t::clear_err_message ()
 {
     m_err_msg = "";
+}
+
+/****************************************************************************
+ *                                                                          *
+ *            Resource Query Class Private API Definitions                  *
+ *                                                                          *
+ ****************************************************************************/
+
+std::shared_ptr<f_resource_graph_t> resource_query_t::create_filtered_graph ()
+{
+    std::shared_ptr<f_resource_graph_t> fg = nullptr;
+
+    resource_graph_t &g = db->resource_graph;
+    vtx_infra_map_t vmap = get (&resource_pool_t::idata, g);
+    edg_infra_map_t emap = get (&resource_relation_t::idata, g);
+    const multi_subsystemsS &filter = 
+                        matcher->subsystemsS ();
+    subsystem_selector_t<vtx_t, f_vtx_infra_map_t> vtxsel (vmap, filter);
+    subsystem_selector_t<edg_t, f_edg_infra_map_t> edgsel (emap, filter);
+
+    try {
+        fg = std::make_shared<f_resource_graph_t> (g, edgsel, vtxsel);
+    } catch (std::bad_alloc &e) {
+        errno = ENOMEM;
+        m_err_msg += __FUNCTION__;
+        m_err_msg += ": Error allocating memory: " + std::string (e.what ())
+                    + "\n";
+        fg = nullptr;
+    }
+
+    return fg;
+}
+
+int resource_query_t::subsystem_exist (const std::string &n)
+{
+    int rc = 0;
+    if (db->metadata.roots.find (n) == db->metadata.roots.end ())
+        rc = -1;
+    return rc;
+}
+
+int resource_query_t::set_subsystems_use (const std::string &n)
+{
+    int rc = 0;
+    matcher->set_matcher_name (n);
+    const std::string &matcher_type = matcher->matcher_name ();
+
+    if (boost::iequals (matcher_type, std::string ("CA"))) {
+        if ( (rc = subsystem_exist ("containment")) == 0)
+            matcher->add_subsystem ("containment", "*");
+    } else if (boost::iequals (matcher_type, std::string ("IBA"))) {
+        if ( (rc = subsystem_exist ("ibnet")) == 0)
+            matcher->add_subsystem ("ibnet", "*");
+    } else if (boost::iequals (matcher_type, std::string ("IBBA"))) {
+        if ( (rc = subsystem_exist ("ibnetbw")) == 0)
+            matcher->add_subsystem ("ibnetbw", "*");
+    } else if (boost::iequals (matcher_type, std::string ("PFS1BA"))) {
+        if ( (rc = subsystem_exist ("pfs1bw")) == 0)
+            matcher->add_subsystem ("pfs1bw", "*");
+    } else if (boost::iequals (matcher_type, std::string ("PA"))) {
+        if ( (rc = subsystem_exist ("power")) == 0)
+            matcher->add_subsystem ("power", "*");
+    } else if (boost::iequals (matcher_type, std::string ("C+PFS1BA"))) {
+        if ( (rc = subsystem_exist ("containment")) == 0)
+            matcher->add_subsystem ("containment", "contains");
+        if ( !rc && (rc = subsystem_exist ("pfs1bw")) == 0)
+            matcher->add_subsystem ("pfs1bw", "*");
+    } else if (boost::iequals (matcher_type, std::string ("C+IBA"))) {
+        if ( (rc = subsystem_exist ("containment")) == 0)
+            matcher->add_subsystem ("containment", "contains");
+        if ( !rc && (rc = subsystem_exist ("ibnet")) == 0)
+            matcher->add_subsystem ("ibnet", "connected_up");
+    } else if (boost::iequals (matcher_type, std::string ("C+PA"))) {
+        if ( (rc = subsystem_exist ("containment")) == 0)
+            matcher->add_subsystem ("containment", "*");
+        if ( !rc && (rc = subsystem_exist ("power")) == 0)
+            matcher->add_subsystem ("power", "draws_from");
+    } else if (boost::iequals (matcher_type, std::string ("IB+IBBA"))) {
+        if ( (rc = subsystem_exist ("ibnet")) == 0)
+            matcher->add_subsystem ("ibnet", "connected_down");
+        if ( !rc && (rc = subsystem_exist ("ibnetbw")) == 0)
+            matcher->add_subsystem ("ibnetbw", "*");
+    } else if (boost::iequals (matcher_type, std::string ("C+P+IBA"))) {
+        if ( (rc = subsystem_exist ("containment")) == 0)
+            matcher->add_subsystem ("containment", "contains");
+        if ( (rc = subsystem_exist ("power")) == 0)
+            matcher->add_subsystem ("power", "draws_from");
+        if ( !rc && (rc = subsystem_exist ("ibnet")) == 0)
+            matcher->add_subsystem ("ibnet", "connected_up");
+    } else if (boost::iequals (matcher_type, std::string ("V+PFS1BA"))) {
+        if ( (rc = subsystem_exist ("virtual1")) == 0)
+            matcher->add_subsystem ("virtual1", "*");
+        if ( !rc && (rc = subsystem_exist ("pfs1bw")) == 0)
+            matcher->add_subsystem ("pfs1bw", "*");
+    } else if (boost::iequals (matcher_type, std::string ("VA"))) {
+        if ( (rc = subsystem_exist ("virtual1")) == 0)
+            matcher->add_subsystem ("virtual1", "*");
+    } else if (boost::iequals (matcher_type, std::string ("ALL"))) {
+        if ( (rc = subsystem_exist ("containment")) == 0)
+            matcher->add_subsystem ("containment", "*");
+        if ( !rc && (rc = subsystem_exist ("ibnet")) == 0)
+            matcher->add_subsystem ("ibnet", "*");
+        if ( !rc && (rc = subsystem_exist ("ibnetbw")) == 0)
+            matcher->add_subsystem ("ibnetbw", "*");
+        if ( !rc && (rc = subsystem_exist ("pfs1bw")) == 0)
+            matcher->add_subsystem ("pfs1bw", "*");
+        if ( (rc = subsystem_exist ("power")) == 0)
+            matcher->add_subsystem ("power", "*");
+    } else {
+        rc = -1;
+    }
+
+    return rc;
+}
+
+int resource_query_t::set_resource_ctx_params (const std::string &options)
+{
+    int rc = -1;
+    json_t *tmp_json = NULL, *opt_json = NULL;
+
+    // Set default values
+    perf.min = DBL_MAX;
+    perf.max = 0.0f;
+    perf.accum = 0.0f;
+    params.load_file = "conf/default";
+    params.load_format = "jgf";
+    params.load_allowlist = "";
+    params.matcher_name = "CA";
+    params.matcher_policy = "first";
+    params.o_fname = "";
+    params.r_fname = "";
+    params.o_fext = "dot";
+    params.match_format = "jgf";
+    params.o_format = emit_format_t::GRAPHVIZ_DOT;
+    params.prune_filters = "ALL:core";
+    params.reserve_vtx_vec = 0;
+    params.elapse_time = false;
+    params.disable_prompt = false;
+
+    if ( !(opt_json = json_loads (options.c_str (), JSON_DECODE_ANY, NULL))) {
+        errno = ENOMEM;
+        m_err_msg += __FUNCTION__;
+        m_err_msg += ": Error loading options\n";
+        goto out;
+    }
+
+    // Override defaults if present in options argument
+    if ( (tmp_json = json_object_get (opt_json, "load_format"))) {
+        params.load_format = json_string_value (tmp_json);
+        if (!params.load_format.c_str ()) { 
+            errno = EINVAL;
+            m_err_msg += __FUNCTION__;
+            m_err_msg += ": Error loading load_format\n";
+            json_decref (opt_json);
+            goto out;
+        }
+    }
+    if ( (tmp_json = json_object_get (opt_json, "load_allowlist"))) {
+        params.load_allowlist = json_string_value (tmp_json);
+        if (!params.load_allowlist.c_str ()) { 
+            errno = EINVAL;
+            m_err_msg += __FUNCTION__;
+            m_err_msg += ": Error loading load_allowlist\n";
+            json_decref (opt_json);
+            goto out;
+        }
+    }
+    if ( (tmp_json = json_object_get (opt_json, "matcher_name"))) {
+        params.matcher_name = json_string_value (tmp_json);
+        if (!params.matcher_name.c_str ()) { 
+            errno = EINVAL;
+            m_err_msg += __FUNCTION__;
+            m_err_msg += ": Error loading matcher_name\n";
+            json_decref (opt_json);
+            goto out;
+        }
+    }
+    if ( (tmp_json = json_object_get (opt_json, "matcher_policy"))) {
+        params.matcher_policy = json_string_value (tmp_json);
+        if (!params.matcher_policy.c_str ()) { 
+            errno = EINVAL;
+            m_err_msg += __FUNCTION__;
+            m_err_msg += ": Error loading matcher_policy\n";
+            json_decref (opt_json);
+            goto out;
+        }
+    }
+    if ( (tmp_json = json_object_get (opt_json, "match_format"))) {
+        params.match_format = json_string_value (tmp_json);
+        if (!params.match_format.c_str ()) { 
+            errno = EINVAL;
+            m_err_msg += __FUNCTION__;
+            m_err_msg += ": Error loading match_format\n";
+            json_decref (opt_json);
+            goto out;
+        }
+    }
+    if ( (tmp_json = json_object_get (opt_json, "prune_filters"))) {
+        params.prune_filters = json_string_value (tmp_json);
+        if (!params.prune_filters.c_str ()) { 
+            errno = EINVAL;
+            m_err_msg += __FUNCTION__;
+            m_err_msg += ": Error loading prune_filters\n";
+            json_decref (opt_json);
+            goto out;
+        }
+    }
+    if ( (tmp_json = json_object_get (opt_json, "reserve_vtx_vec")))
+        // No need for check here; returns 0 on failure
+        params.reserve_vtx_vec = json_integer_value (tmp_json);
+
+    rc = 0;
+
+out:
+    return rc;
+}
+
+/****************************************************************************
+ *                                                                          *
+ *            Resource Query Class Public API Definitions                   *
+ *                                                                          *
+ ****************************************************************************/
+
+resource_query_t::resource_query_t () 
+{
+
+}
+
+resource_query_t::~resource_query_t () 
+{
+
+}
+
+resource_query_t::resource_query_t (const std::string &rgraph,
+                                    const std::string &options)
+{
+    m_err_msg = "";
+    std::string tmp_err = "";
+    std::stringstream buffer{};
+    std::shared_ptr<resource_reader_base_t> rd;
+    match_format_t format;
+
+    // Both calls can throw bad_alloc. Client must handle the errors.
+    db = std::make_shared<resource_graph_db_t> ();
+    traverser = std::make_shared<dfu_traverser_t> ();
+
+    if (set_resource_ctx_params (options) < 0) {
+        tmp_err = __FUNCTION__;
+        tmp_err += ": ERROR: can't set resource graph parameters\n";
+        throw std::runtime_error (tmp_err);
+    }
+
+    if ( !(matcher = create_match_cb (params.matcher_policy))) {
+        tmp_err = __FUNCTION__;
+        tmp_err += ": ERROR: can't create matcher\n";
+        throw std::runtime_error (tmp_err);
+    }
+
+    if (params.reserve_vtx_vec != 0)
+        db->resource_graph.m_vertices.reserve (params.reserve_vtx_vec);
+
+    if ( (rd = create_resource_reader (params.load_format)) == nullptr) {
+        tmp_err = __FUNCTION__;
+        tmp_err +=  ": ERROR: can't create reader\n";
+        throw std::runtime_error (tmp_err);
+    }
+
+    if (params.load_allowlist != "") {
+        if (rd->set_allowlist (params.load_allowlist) < 0) {
+            m_err_msg += __FUNCTION__;
+            m_err_msg += ": ERROR: can't set allowlist\n";
+        }
+        if (!rd->is_allowlist_supported ())
+            m_err_msg += "WARN: allowlist unsupported\n";
+    }
+
+    if (db->load (rgraph, rd) != 0) {
+        tmp_err = __FUNCTION__;
+        tmp_err +=  ": ERROR: " + rd->err_message () + "\n";
+        tmp_err += "ERROR: error generating resources\n";
+        throw std::runtime_error (tmp_err);
+    }
+
+    if (set_subsystems_use (params.matcher_name) != 0) {
+        tmp_err = __FUNCTION__;
+        tmp_err +=  ": ERROR: can't set subsystem\n";
+        throw std::runtime_error (tmp_err);
+    }
+
+    if ( !(fgraph = create_filtered_graph ())) {
+        tmp_err = __FUNCTION__;
+        tmp_err +=  ": ERROR: can't create filtered graph\n";
+        throw std::runtime_error (tmp_err);
+    }
+
+    jobid_counter = 1;
+    if (params.prune_filters != ""
+        && matcher->set_pruning_types_w_spec (
+                                matcher->dom_subsystem (),
+                                params.prune_filters)
+                                < 0) {
+        tmp_err = __FUNCTION__;
+        tmp_err +=  ": ERROR: can't initialize pruning filters\n";
+        throw std::runtime_error (tmp_err);
+    }
+
+    if (traverser->initialize (fgraph, db, matcher) != 0) {
+        tmp_err = __FUNCTION__;
+        tmp_err +=  ": ERROR: can't initialize traverser\n";
+        throw std::runtime_error (tmp_err);
+    }
+
+    format = match_writers_factory_t::get_writers_type (params.match_format);
+    if ( !(writers = match_writers_factory_t::create (format))) {
+        tmp_err = __FUNCTION__;
+        tmp_err +=  ": ERROR: can't create match writer\n";
+        throw std::runtime_error (tmp_err);
+    }
+
+    return;
+}
+
+const std::string &resource_query_t::get_resource_query_err_msg () const
+{
+    return m_err_msg;
+}
+
+const std::string &resource_query_t::get_traverser_err_msg () const
+{
+    return traverser->err_message ();
+}
+
+const bool resource_query_t::job_exists (const uint64_t jobid)
+{
+    return jobs.find (jobid) != jobs.end ();
+}
+
+const uint64_t resource_query_t::get_job_counter () const
+{
+    return jobid_counter;
+}
+
+const std::shared_ptr<job_info_t> &resource_query_t::get_job (const uint64_t jobid)
+{
+    return jobs.at (jobid);
+}
+
+const bool resource_query_t::allocation_exists (const uint64_t jobid)
+{
+    return allocations.find (jobid) != allocations.end ();
+}
+
+const bool resource_query_t::reservation_exists (const uint64_t jobid)
+{
+    return reservations.find (jobid) != reservations.end ();
+}
+
+void resource_query_t::clear_resource_query_err_msg ()
+{
+    m_err_msg = "";
+}
+
+void resource_query_t::clear_traverser_err_msg ()
+{
+    traverser->clear_err_message ();
+}
+
+void resource_query_t::set_reservation (const uint64_t jobid)
+{
+    reservations[jobid] = jobid;
+}
+
+void resource_query_t::erase_reservation (const uint64_t jobid)
+{
+    reservations.erase (jobid);
+}
+
+void resource_query_t::set_allocation (const uint64_t jobid)
+{
+    allocations[jobid] = jobid;
+}
+
+void resource_query_t::erase_allocation (const uint64_t jobid)
+{
+    allocations.erase (jobid);
+}
+
+void resource_query_t::set_job (const uint64_t jobid,
+                                const std::shared_ptr<job_info_t> &job)
+{
+    jobs[jobid] = job;
+}
+
+int resource_query_t::remove_job (const uint64_t jobid)
+{
+    int rc = -1;
+
+    if (jobid > std::numeric_limits<int64_t>::max ()) {
+        errno = EOVERFLOW;
+        return rc;
+    }
+
+    rc = traverser->remove (static_cast<int64_t> (jobid));
+    if (rc == 0) {
+        if (jobs.find (jobid) != jobs.end ()) {
+            std::shared_ptr<job_info_t> info = jobs[jobid];
+            info->state = job_lifecycle_t::CANCELED;
+        }
+    } else {
+        m_err_msg += traverser->err_message ();
+        traverser->clear_err_message ();
+    }
+    return rc;
+}
+
+void resource_query_t::incr_job_counter ()
+{
+    jobid_counter++;
+}
+
+int resource_query_t::traverser_run (Flux::Jobspec::Jobspec &job, match_op_t op,
+                                     int64_t jobid, int64_t &at)
+{
+    return traverser->run (job, writers, op, jobid, &at);
 }
 
 

--- a/resource/hlapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/hlapi/bindings/c++/reapi_cli_impl.hpp
@@ -133,9 +133,32 @@ int reapi_cli_t::match_allocate_multi (void *h, bool orelse_reserve,
     return NOT_YET_IMPLEMENTED;
 }
 
-int reapi_cli_t::cancel (void *h, const int64_t jobid, bool noent_ok)
+int reapi_cli_t::cancel (void *h, const uint64_t jobid, bool noent_ok)
 {
-    return NOT_YET_IMPLEMENTED;
+    resource_query_t *rq = static_cast<resource_query_t *> (h);
+    int rc = -1;
+
+    if (rq->allocation_exists (jobid)) {
+        if ( (rc = rq->remove_job (jobid)) == 0)
+            rq->erase_allocation (jobid);
+    } else if (rq->reservation_exists (jobid)) {
+        if ( (rc = rq->remove_job (jobid)) == 0)
+            rq->erase_reservation (jobid);
+    } else {
+        m_err_msg += __FUNCTION__;
+        m_err_msg += ": ERROR: nonexistent job "
+                      + std::to_string (jobid) + "\n";
+        goto out;
+    }
+
+    if (rc != 0) {
+        m_err_msg += __FUNCTION__;
+        m_err_msg += ": ERROR: error encountered while removing job "
+                      + std::to_string (jobid) + "\n";
+    }
+
+out:
+    return rc;
 }
 
 int reapi_cli_t::info (void *h, const int64_t jobid,

--- a/resource/hlapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/hlapi/bindings/c++/reapi_cli_impl.hpp
@@ -26,6 +26,20 @@ namespace detail {
 
 const int NOT_YET_IMPLEMENTED = -1;
 
+/****************************************************************************
+ *                                                                          *
+ *               REAPI CLI Class Private Definitions                        *
+ *                                                                          *
+ ****************************************************************************/
+
+std::string reapi_cli_t::m_err_msg = "";
+
+/****************************************************************************
+ *                                                                          *
+ *            REAPI CLI Class Public API Definitions                        *
+ *                                                                          *
+ ****************************************************************************/
+
 int reapi_cli_t::match_allocate (void *h, bool orelse_reserve,
                                  const std::string &jobspec,
                                  const uint64_t jobid, bool &reserved,
@@ -63,6 +77,16 @@ int reapi_cli_t::stat (void *h, int64_t &V, int64_t &E,int64_t &J,
                        double &load, double &min, double &max, double &avg)
 {
     return NOT_YET_IMPLEMENTED;
+}
+
+const std::string &reapi_cli_t::get_err_message ()
+{
+    return m_err_msg;
+}
+
+void reapi_cli_t::clear_err_message ()
+{
+    m_err_msg = "";
 }
 
 

--- a/resource/hlapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/hlapi/bindings/c++/reapi_cli_impl.hpp
@@ -161,10 +161,26 @@ out:
     return rc;
 }
 
-int reapi_cli_t::info (void *h, const int64_t jobid,
+int reapi_cli_t::info (void *h, const uint64_t jobid, std::string &mode,
                        bool &reserved, int64_t &at, double &ov)
 {
-    return NOT_YET_IMPLEMENTED;
+    resource_query_t *rq = static_cast<resource_query_t *> (h);
+    std::shared_ptr<job_info_t> info = nullptr;
+
+    if ( !(rq->job_exists (jobid))) {
+       m_err_msg += __FUNCTION__;
+       m_err_msg += ": ERROR: nonexistent job "
+                     + std::to_string (jobid) + "\n";
+       return -1;
+    }
+
+    info = rq->get_job (jobid);
+    get_jobstate_str (info->state, mode);
+    reserved = (info->state == job_lifecycle_t::RESERVED)? true : false;
+    at = info->scheduled_at;
+    ov = info->overhead;
+
+    return 0;
 }
 
 int reapi_cli_t::stat (void *h, int64_t &V, int64_t &E,int64_t &J,

--- a/resource/hlapi/bindings/c/reapi_cli.cpp
+++ b/resource/hlapi/bindings/c/reapi_cli.cpp
@@ -173,11 +173,11 @@ out:
 extern "C" int reapi_cli_cancel (reapi_cli_ctx_t *ctx,
                                  const uint64_t jobid, bool noent_ok)
 {
-    if (!ctx || !ctx->h) {
+    if (!ctx || !ctx->rqt) {
         errno = EINVAL;
         return -1;
     }
-    return reapi_cli_t::cancel (ctx->h, jobid, noent_ok);
+    return reapi_cli_t::cancel (ctx->rqt, jobid, noent_ok);
 }
 
 extern "C" int reapi_cli_info (reapi_cli_ctx_t *ctx, const uint64_t jobid,

--- a/resource/hlapi/bindings/c/reapi_cli.cpp
+++ b/resource/hlapi/bindings/c/reapi_cli.cpp
@@ -97,11 +97,11 @@ extern "C" int reapi_cli_update_allocate (reapi_cli_ctx_t *ctx,
     int rc = -1;
     std::string R_buf = "";
     const char *R_buf_c = NULL;
-    if (!ctx || !ctx->h || !R) {
+    if (!ctx || !ctx->rqt || !R) {
         errno = EINVAL;
         goto out;
     }
-    if ( (rc = reapi_cli_t::update_allocate (ctx->h,
+    if ( (rc = reapi_cli_t::update_allocate (ctx->rqt,
                                              jobid, R, *at, *ov, R_buf)) < 0) {
         goto out;
     }
@@ -138,11 +138,11 @@ extern "C" int reapi_cli_stat (reapi_cli_ctx_t *ctx, int64_t *V,
                                int64_t *E, int64_t *J, double *load,
                                double *min, double *max, double *avg)
 {
-    if (!ctx || !ctx->h) {
+    if (!ctx || !ctx->rqt) {
         errno = EINVAL;
         return -1;
     }
-    return reapi_cli_t::stat (ctx->h, *V, *E, *J, *load, *min, *max, *avg);
+    return reapi_cli_t::stat (ctx->rqt, *V, *E, *J, *load, *min, *max, *avg);
 }
 
 extern "C" const char *reapi_cli_get_err_msg (reapi_cli_ctx_t *ctx)

--- a/resource/hlapi/bindings/c/reapi_cli.cpp
+++ b/resource/hlapi/bindings/c/reapi_cli.cpp
@@ -149,6 +149,27 @@ extern "C" void *reapi_cli_get_handle (reapi_cli_ctx_t *ctx)
     return ctx->h;
 }
 
+extern "C" const char *reapi_cli_get_err_msg (reapi_cli_ctx_t *ctx)
+{
+    std::string err_buf = "";
+
+    if (ctx->rqt)
+        err_buf = ctx->rqt->get_resource_query_err_msg () 
+                    + reapi_cli_t::get_err_message () + ctx->err_msg;
+    else
+        err_buf = reapi_cli_t::get_err_message () + ctx->err_msg;
+
+    return strdup (err_buf.c_str ());
+}
+
+extern "C" void reapi_cli_clear_err_msg (reapi_cli_ctx_t *ctx)
+{
+    if (ctx->rqt)
+        ctx->rqt->clear_resource_query_err_msg ();
+    reapi_cli_t::clear_err_message ();
+    ctx->err_msg = "";
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/resource/hlapi/bindings/c/reapi_cli.cpp
+++ b/resource/hlapi/bindings/c/reapi_cli.cpp
@@ -62,6 +62,34 @@ extern "C" void reapi_cli_destroy (reapi_cli_ctx_t *ctx)
     errno = saved_errno;
 }
 
+extern "C" int reapi_cli_initialize (reapi_cli_ctx_t *ctx, const char *rgraph,
+                                     const char *options)
+{
+    int rc = -1;
+    ctx->rqt = nullptr;
+
+    try {
+        ctx->rqt = new resource_query_t (rgraph, options);
+    } catch (std::bad_alloc &e) {
+        ctx->err_msg += __FUNCTION__;
+        ctx->err_msg += ": ERROR: can't allocate memory: "
+                         + std::string (e.what ()) + "\n";
+        errno = ENOMEM;
+        goto out;
+    } catch (std::runtime_error &e) {
+        ctx->err_msg += __FUNCTION__;
+        ctx->err_msg += ": Runtime error: "
+                         + std::string (e.what ()) + "\n";
+        errno = EPROTO;
+        goto out;
+    }
+
+    rc = 0;
+
+out:
+    return rc;    
+}
+
 extern "C" int reapi_cli_match_allocate (reapi_cli_ctx_t *ctx,
                    bool orelse_reserve, const char *jobspec,
                    const uint64_t jobid, bool *reserved,

--- a/resource/hlapi/bindings/c/reapi_cli.h
+++ b/resource/hlapi/bindings/c/reapi_cli.h
@@ -63,7 +63,7 @@ int reapi_cli_initialize (reapi_cli_ctx_t *ctx, const char *rgraph,
  *  \return          0 on success; -1 on error.
  */
 int reapi_cli_match_allocate (reapi_cli_ctx_t *ctx, bool orelse_reserve,
-                              const char *jobspec, const uint64_t jobid,
+                              const char *jobspec, uint64_t *jobid,
                               bool *reserved,
                               char **R, int64_t *at, double *ov);
 

--- a/resource/hlapi/bindings/c/reapi_cli.h
+++ b/resource/hlapi/bindings/c/reapi_cli.h
@@ -32,6 +32,15 @@ reapi_cli_ctx_t *reapi_cli_new ();
  */
 void reapi_cli_destroy (reapi_cli_ctx_t *ctx);
 
+/*! Initialize Fluxion with resource graph
+ *
+ * \param ctx           reapi_cli_ctx_t context object
+ * \param rgraph        string encoding the resource graph
+ * \param options       json string initialization options
+ */
+int reapi_cli_initialize (reapi_cli_ctx_t *ctx, const char *rgraph,
+                          const char *options);
+
 /*! Match a jobspec to the "best" resources and either allocate
  *  orelse reserve them. The best resources are determined by
  *  the selected match policy.

--- a/resource/hlapi/bindings/c/reapi_cli.h
+++ b/resource/hlapi/bindings/c/reapi_cli.h
@@ -135,6 +135,19 @@ int reapi_cli_set_handle (reapi_cli_ctx_t *ctx, void *handle);
  */
 void *reapi_cli_get_handle (reapi_cli_ctx_t *ctx);
 
+/*! Get the reapi cli error message.
+ *
+ *  \param ctx       reapi_cli_ctx_t context object
+ *  \return          string containing the error message
+ */
+const char *reapi_cli_get_err_msg (reapi_cli_ctx_t *ctx);
+
+/*! Clear the reapi cli error message.
+ *
+ *  \param ctx       reapi_cli_ctx_t context object
+ */
+void reapi_cli_clear_err_msg (reapi_cli_ctx_t *ctx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/resource/hlapi/bindings/c/reapi_cli.h
+++ b/resource/hlapi/bindings/c/reapi_cli.h
@@ -117,24 +117,6 @@ int reapi_cli_stat (reapi_cli_ctx_t *ctx, int64_t *V, int64_t *E,
                     int64_t *J, double *load,
                     double *min, double *max, double *avg);
 
-/*! Set the opaque handle to the reapi cli context.
- *
- *  \param ctx       reapi_cli_ctx_t context object
- *  \param h         Opaque handle. How it is used is an implementation
- *                   detail. However, when it is used within a Flux's
- *                   service cli, it is expected to be a pointer
- *                   to a flux_t object.
- *  \return          0 on success; -1 on error.
- */
-int reapi_cli_set_handle (reapi_cli_ctx_t *ctx, void *handle);
-
-/*! Set the opaque handle to the reapi cli context.
- *
- *  \param ctx       reapi_cli_ctx_t context object
- *  \return          handle
- */
-void *reapi_cli_get_handle (reapi_cli_ctx_t *ctx);
-
 /*! Get the reapi cli error message.
  *
  *  \param ctx       reapi_cli_ctx_t context object

--- a/resource/hlapi/bindings/c/reapi_cli.h
+++ b/resource/hlapi/bindings/c/reapi_cli.h
@@ -98,6 +98,7 @@ int reapi_cli_cancel (reapi_cli_ctx_t *ctx,
  *
  *  \param ctx       reapi_cli_ctx_t context object
  *  \param jobid     const jobid of the uint64_t type.
+ *  \param mode      return string containing the job state.
  *  \param reserved  Boolean into which to return true if this job has been
  *                   reserved instead of allocated.
  *  \param at        If allocated, 0 is returned; if reserved, actual time
@@ -108,7 +109,8 @@ int reapi_cli_cancel (reapi_cli_ctx_t *ctx,
  *  \return          0 on success; -1 on error.
  */
 int reapi_cli_info (reapi_cli_ctx_t *ctx, const uint64_t jobid,
-                    bool *reserved, int64_t *at, double *ov);
+                    char **mode, bool *reserved, int64_t *at, 
+                    double *ov);
 
 /*! Get the performance information about the resource infrastructure.
  *


### PR DESCRIPTION
This PR adds new capability to the Fluxion C/C++ CLI resource HLAPI so that clients such as KubeFlux can initialize a Fluxion context (and maintain it in an external binding).  This PR implements the `match_allocate`, `cancel`, and `info` functions which KubeFlux needs first.  Other HLAPI functions can be implemented in straightforward analogy to the changes in this PR.

Data structures such as `resource_context_t` and `resource_params_t` are defined as in `resource-query` and provide a foundation for the `reapi_cli`.  Note that the implementation of `reapi_cli_info` changes the public API to add a mode argument that returns the job status.

Since the `resource_ctx_t` is created as a raw pointer (as distinct from `resource_query` where it's a `std::shared_ptr`) , a threaded client must be careful how it consumes the API.  

~~This PR is WIP since the most appropriate pointer type and how to perform CI testing is still to be determined.~~