### PR TITLE
testsuite: drop flux overlay status from test

### DIFF
--- a/t/t3301-system-latestart.t
+++ b/t/t3301-system-latestart.t
@@ -41,10 +41,6 @@ test_expect_success HAVE_JQ 'startctl shows rank 1 pids as -1' '
 	test $($startctl status | jq -r ".procs[1].pid") = "-1"
 '
 
-test_expect_success 'overlay status is partial' '
-        test "$(flux overlay status)" = "partial"
-'
-
 test_expect_success 'resource list shows one down nodes' '
 	echo 1 >down.exp &&
 	flux resource list -n -s down -o {nnodes} >down.out &&
@@ -76,10 +72,6 @@ test_expect_success 'start rank 1' '
 
 test_expect_success HAVE_JQ 'startctl shows rank 1 pid not -1' '
 	test $($startctl status | jq -r ".procs[1].pid") != "-1"
-'
-
-test_expect_success 'wait for overlay status to be full' '
-        flux overlay status --wait full --timeout 10s
 '
 
 # Side effect: this test blocks until the rank 1 broker has a chance to


### PR DESCRIPTION
Problem: the flux overlay status interface is changing in
flux core but flux sched is still using the old one
in t3301-system-latestart.t.

Drop the calls to flux overlay status from this test so it
can work with flux-core both before and after the change
proposed in flux-framework/flux-core#3974.

The test is no worse for the wear.