### PR TITLE
Fix compilation issues with clang-12 and gcc-11

### DIFF
--- a/qmanager/modules/qmanager_opts.hpp
+++ b/qmanager/modules/qmanager_opts.hpp
@@ -124,7 +124,7 @@ public:
 private:
     int parse_queues (const std::string &queues);
 
-    const std::string m_default_queue_name = "default";
+    std::string m_default_queue_name = "default";
     std::string m_default_queue = QMANAGER_OPTS_UNSET_STR;
 
     // default queue properties

--- a/resource/planner/planner.h
+++ b/resource/planner/planner.h
@@ -13,6 +13,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/resource/schema/sched_data.hpp
+++ b/resource/schema/sched_data.hpp
@@ -27,7 +27,7 @@ struct schedule_t {
 
     std::map<int64_t, int64_t> allocations;
     std::map<int64_t, int64_t> reservations;
-    planner_t *plans = NULL;
+    planner_t *plans = nullptr;
 };
 
 } // Flux::resource_model


### PR DESCRIPTION
This PR adds a few compilation issues that were reported against clang-12, clang-13 and gcc-11.

- Use `nullptr` instead of `NULL` within `resource/schema/sched_data.hpp` (Issue with gcc-11 and clang-13);
- Include `stddef.h` to pick up `size_t` for `resource/planner/planner.h` (Issue with gcc-11 and clang-13);
- Drop `const` from one of the class members to use defaulted constructors within `qmanager/modules/qmanager_opts.hpp` (Issue with clang-12 and clang-13).

Fixes Issue #877 