### PR TITLE
mergify: update configuration to replace deprecated keys

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,14 +1,17 @@
-pull_request_rules:
-  - name: rebase and merge when passing all checks
+queue_rules:
+  - name: default
     conditions:
       - base=master
       - status-success="validate commits"
+      - status-success="python format"
+      - status-success="python lint"
       - status-success="bionic - gcc-8,distcheck"
       - status-success="bionic - clang-6.0"
       - status-success="bionic - test-install"
       - status-success="focal"
       - status-success="centos7"
       - status-success="centos8"
+      - status-success="fedora33"
       - status-success="coverage"
       - label="merge-when-passing"
       - label!="work-in-progress"
@@ -16,9 +19,29 @@ pull_request_rules:
       - "#approved-reviews-by>0"
       - "#changes-requested-reviews-by=0"
       - -title~=^\[*[Ww][Ii][Pp]
-    actions:
-      merge:
-        method: merge
-        strict: smart
-        strict_method: rebase
 
+pull_request_rules:
+  - name: rebase and merge when passing all checks
+    conditions:
+      - base=master
+      - label="merge-when-passing"
+      - label!="work-in-progress"
+      - -title~=^\[*[Ww][Ii][Pp]
+      - "approved-reviews-by=@flux-framework/core"
+      - "#approved-reviews-by>0"
+      - "#changes-requested-reviews-by=0"
+    actions:
+      queue:
+        name: default
+        method: merge
+        update_method: rebase
+  - name: remove outdated approved reviews
+    conditions:
+      - author!=@core
+    actions:
+      dismiss_reviews:
+        approved: true
+        changes_requested: false
+        message: |
+          Approving reviews have been dismissed because this pull request
+          was updated.


### PR DESCRIPTION
This PR description is adapted from the mergify update commits in flux-core authored by @grondo.

Problem 1: Mergify.io has deprecated the strict merge mode action:

https://blog.mergify.io/strict-mode-deprecation/

Replace the strict mode configuration with a default queue with a rebase action which should be equivalent.

Problem 2: The current mergify config specifies that PRs are merged using a rebase method and not merge. This would result in the PR branch being rebased onto the main branch instead of creating a merge commit, which we use to generate release notes. Luckily, flux-sched branch protection rules prevent the rebase from being completed by mergify.

Change the queue action for PRs to be merge, with an update_method of rebase, which should be similar to the previous 'strict' mode flux-sched was using earlier.

Note that the 
```YAML
+      - "approved-reviews-by=@flux-framework/core"
```
and
```YAML
+  - name: remove outdated approved reviews
+    conditions:
+      - author!=@core
+    actions:
+      dismiss_reviews:
+        approved: true
+        changes_requested: false
+        message: |
+          Approving reviews have been dismissed because this pull request
+          was updated.
```
changes may not apply to flux-sched.