### PR TITLE
testsuite: fix a couple brittle tests

### DIFF
--- a/t/t1006-qmanager-multiqueue.t
+++ b/t/t1006-qmanager-multiqueue.t
@@ -26,7 +26,7 @@ get_queue() {
 
 test_expect_success 'qmanager: loading qmanager with multiple queues' '
     load_resource prune-filters=ALL:core \
-subsystems=containment policy=low &&
+	subsystems=containment policy=low load-allowlist=node,core,gpu &&
     load_qmanager "queues=all batch debug"
 '
 

--- a/t/t1011-dynstate-change.t
+++ b/t/t1011-dynstate-change.t
@@ -33,7 +33,7 @@ test_expect_success 'load test resources' '
 '
 
 test_expect_success 'dyn-state: loading fluxion modules works' '
-    load_resource load-allowlist=cluster,node,core,gpu &&
+    load_resource load-allowlist=cluster,node,core,gpu match-format=rv1 &&
     load_qmanager
 '
 
@@ -118,7 +118,7 @@ test_expect_success 'dyn-state: removing fluxion modules' '
 '
 
 test_expect_success 'dyn-state: loading fluxion modules works' '
-    load_resource load-allowlist=cluster,node,core,gpu &&
+    load_resource load-allowlist=cluster,node,core,gpu match-format=rv1 &&
     load_qmanager queue-policy=easy
 '
 
@@ -141,7 +141,7 @@ test_expect_success 'dyn-state: removing fluxion modules' '
 '
 
 test_expect_success 'dyn-state: loading fluxion modules works' '
-    load_resource load-allowlist=cluster,node,core,gpu &&
+    load_resource load-allowlist=cluster,node,core,gpu match-format=rv1 &&
     load_qmanager queues="batch debug" \
 queue-policy-per-queue="batch:easy debug:fcfs"
 '
@@ -171,7 +171,7 @@ test_expect_success 'dyn-state: removing fluxion modules' '
 '
 
 test_expect_success 'dyn-state: loading fluxion modules works' '
-    load_resource load-allowlist=cluster,node,core,gpu &&
+    load_resource load-allowlist=cluster,node,core,gpu match-format=rv1 &&
     load_qmanager
 '
 


### PR DESCRIPTION
This PR fixes issues seen recently in `t1006-qmanager-multiqueue.t` and `t1011-dynstate-change.t` as discussed in issues #907 and #908.