### PR TITLE
build: fix missing doc file in distributed tarball

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -3,7 +3,7 @@
 SUBDIRS = . test
 
 MAN5_FILES = \
-	man5/flux-config-sched-fluxion-qmanager.5
+	man5/flux-config-sched-fluxion-qmanager.5 \
 	man5/flux-config-sched-fluxion-resource.5
 
 RST_FILES = \


### PR DESCRIPTION
Problem: A missing line continuation character in doc/Makefile.am
caused doc/man5/flux-config-sched-fluxion-resource.rst to be
missed from the `make dist` tarball.

Add the missing line continuation to fix the distribution build.

Fixes #914