### PR TITLE
Add rv1exec reader support

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
 sphinx==3.4.3
 sphinx-rtd-theme>=0.5.2
 docutils>=0.14,<0.18
+jinja2<3.1.0

--- a/resource/Makefile.am
+++ b/resource/Makefile.am
@@ -35,6 +35,7 @@ libresource_la_SOURCES = \
     readers/resource_reader_grug.cpp \
     readers/resource_reader_hwloc.cpp \
     readers/resource_reader_jgf.cpp \
+    readers/resource_reader_rv1exec.cpp \
     readers/resource_reader_factory.cpp \
     evaluators/scoring_api.cpp \
     evaluators/edge_eval_api.cpp \
@@ -68,6 +69,7 @@ libresource_la_SOURCES = \
     readers/resource_reader_grug.hpp \
     readers/resource_reader_hwloc.hpp \
     readers/resource_reader_jgf.hpp \
+    readers/resource_reader_rv1exec.hpp \
     readers/resource_reader_factory.hpp \
     evaluators/scoring_api.hpp \
     evaluators/edge_eval_api.hpp \
@@ -84,12 +86,14 @@ libresource_la_CXXFLAGS = \
     $(WARNING_CXXFLAGS) \
     $(CODE_COVERAGE_CFLAGS) \
     $(AM_CXXFLAGS) \
-    $(FLUX_HOSTLIST_CFLAGS)
+    $(FLUX_HOSTLIST_CFLAGS) \
+    $(FLUX_IDSET_CFLAGS)
 
 libresource_la_LIBADD = \
     $(top_builddir)/resource/planner/libplanner.la \
     $(top_builddir)/resource/libjobspec/libjobspec_conv.la \
     $(FLUX_HOSTLIST_LIBS) \
+    $(FLUX_IDSET_LIBS) \
     $(BOOST_LDFLAGS) \
     $(BOOST_SYSTEM_LIB) \
     $(BOOST_FILESYSTEM_LIB) \

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -307,7 +307,7 @@ static double get_elapse_time (timeval &st, timeval &et)
 static void set_default_args (std::shared_ptr<resource_ctx_t> &ctx)
 {
     resource_opts_t ct_opts;
-    ct_opts.set_load_format ("hwloc");
+    ct_opts.set_load_format ("rv1exec");
     ct_opts.set_match_subsystems ("containment");
     ct_opts.set_match_policy ("first");
     ct_opts.set_prune_filters ("ALL:core");
@@ -866,6 +866,34 @@ done:
     return rc;
 }
 
+static int grow_resource_db_rv1exec (std::shared_ptr<resource_ctx_t> &ctx,
+                                     struct idset *ids, json_t *resobj)
+{
+    int rc = -1;
+    int saved_errno;
+    resource_graph_db_t &db = *(ctx->db);
+    char *rv1_str = nullptr;
+
+    if (db.metadata.roots.find ("containment") == db.metadata.roots.end ()) {
+        if ( (rv1_str = json_dumps (resobj, JSON_INDENT (0))) == NULL) {
+            errno = ENOMEM;
+            goto done;
+        }
+        if ( (rc = db.load (rv1_str, ctx->reader, -1)) < 0) {
+            flux_log_error (ctx->h, "%s: db.load: %s",
+                            __FUNCTION__, ctx->reader->err_message ().c_str ());
+            goto done;
+        }
+        flux_log (ctx->h, LOG_DEBUG,
+                  "resource graph datastore loaded with rv1exec reader");
+    }
+done:
+    saved_errno = errno;
+    free (rv1_str);
+    errno = saved_errno;
+    return rc;
+}
+
 static int get_parent_job_resources (std::shared_ptr<resource_ctx_t> &ctx,
                                      json_t **resobj_p)
 {
@@ -1009,12 +1037,24 @@ static int grow_resource_db (std::shared_ptr<resource_ctx_t> &ctx,
         }
         rc = grow_resource_db_jgf (ctx, r_lite, jgf);
     } else {
-        if (ctx->reader == nullptr && (rc = create_reader (ctx, "hwloc")) < 0) {
-            flux_log (ctx->h, LOG_ERR, "%s: can't create hwloc reader",
-                      __FUNCTION__);
-            goto done;
+        if (ctx->opts.get_opt ().get_load_format () == "hwloc") {
+             if ( !ctx->reader && (rc = create_reader (ctx, "hwloc")) < 0) {
+                 flux_log (ctx->h, LOG_ERR, "%s: can't create hwloc reader",
+                           __FUNCTION__);
+                 goto done;
+             }
+             rc = grow_resource_db_hwloc (ctx, grow_set, r_lite);
+        } else if (ctx->opts.get_opt ().get_load_format () == "rv1exec") {
+             if ( !ctx->reader && (rc = create_reader (ctx, "rv1exec")) < 0) {
+                 flux_log (ctx->h, LOG_ERR, "%s: can't create rv1exec reader",
+                           __FUNCTION__);
+                 goto done;
+             }
+             rc = grow_resource_db_rv1exec (ctx, grow_set, resources);
+        } else {
+            errno = EINVAL;
+            rc = -1;
         }
-        rc = grow_resource_db_hwloc (ctx, grow_set, r_lite);
    }
 
 done:

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -861,6 +861,9 @@ static int grow_resource_db_hwloc (std::shared_ptr<resource_ctx_t> &ctx,
         rank = idset_next (ids, rank);
     }
 
+    flux_log (ctx->h, LOG_DEBUG,
+              "resource graph datastore loaded with hwloc reader");
+
 done:
     flux_future_destroy (f);
     return rc;
@@ -1008,6 +1011,10 @@ static int grow_resource_db_jgf (std::shared_ptr<resource_ctx_t> &ctx,
             goto done;
         }
     }
+
+    flux_log (ctx->h, LOG_DEBUG,
+              "resource graph datastore loaded with JGF reader");
+
 done:
     saved_errno = errno;
     json_decref (p_r_lite);

--- a/resource/readers/resource_reader_base.hpp
+++ b/resource/readers/resource_reader_base.hpp
@@ -94,6 +94,25 @@ public:
      */
     const std::string &err_message () const;
 
+    /*! Query the numeric ID suffix from hostname.
+     *
+     * \param hn        hostname string
+     * \param id        (Output) integer ID suffix of hostname
+     *                  -1 if hostname does not end with a numeric suffix.
+     *
+     * \return          0 if succeeds or -1 with errno if an error encountered
+     */
+    int get_hostname_suffix (const std::string &hn, int &id) const;
+
+    /*! Query the host basename from hostname.
+     *
+     * \param hn        hostname string
+     * \param basename  (Output) host basename
+     *
+     * \return          0 if succeeds or -1 with errno if an error encountered
+     */
+    int get_host_basename (const std::string &hn, std::string &basename) const;
+
     /*! Clear the error message string.
      */
     void clear_err_message ();
@@ -104,6 +123,8 @@ public:
 
 protected:
     bool in_allowlist (const std::string &resource);
+    int split_hostname (const std::string &hn,
+                        std::string &basename, int &id) const;
     std::set<std::string> allowlist;
     std::string m_err_msg = "";
 };

--- a/resource/readers/resource_reader_factory.cpp
+++ b/resource/readers/resource_reader_factory.cpp
@@ -12,6 +12,7 @@
 #include "resource/readers/resource_reader_grug.hpp"
 #include "resource/readers/resource_reader_hwloc.hpp"
 #include "resource/readers/resource_reader_jgf.hpp"
+#include "resource/readers/resource_reader_rv1exec.hpp"
 
 namespace Flux {
 namespace resource_model {
@@ -19,7 +20,7 @@ namespace resource_model {
 bool known_resource_reader (const std::string &name)
 {
     bool rc = false;
-    if (name == "grug" || name == "hwloc" || name == "jgf")
+    if (name == "grug" || name == "hwloc" || name == "jgf" || name == "rv1exec")
         rc = true;
     return rc;
 }
@@ -36,6 +37,8 @@ std::shared_ptr<resource_reader_base_t> create_resource_reader (
             reader = std::make_shared<resource_reader_hwloc_t> ();
         } else if (name == "jgf") {
             reader = std::make_shared<resource_reader_jgf_t> ();
+        } else if (name == "rv1exec") {
+            reader = std::make_shared<resource_reader_rv1exec_t> ();
         } else {
             errno = EINVAL;
         }

--- a/resource/readers/resource_reader_grug.hpp
+++ b/resource/readers/resource_reader_grug.hpp
@@ -34,7 +34,7 @@ public:
      * \param rank   assign rank to all of the newly created resource vertices
      * \return       0 on success; non-zero integer on an error
      *                   ENOMEM: out of memory
-     *                   EINVAL: input input or operation
+     *                   EINVAL: invalid input or operation
      */
     virtual int unpack (resource_graph_t &g, resource_graph_metadata_t &m,
                         const std::string &str, int rank = -1);

--- a/resource/readers/resource_reader_hwloc.cpp
+++ b/resource/readers/resource_reader_hwloc.cpp
@@ -162,41 +162,9 @@ int resource_reader_hwloc_t::walk_hwloc (resource_graph_t &g,
         }
         type = "node";
         name = hwloc_name;
-        basename = hwloc_name;
-        id = -1;
-
-        std::size_t last = basename.find_last_not_of ("0123456789");
-        if (last == (basename.size () - 1))
-            break; // no numeric suffix, done
-
-        std::string suffix;
-        if (last != std::string::npos) {
-            // has numeric suffix
-            suffix = basename.substr (last + 1);
-            basename = basename.substr (0, last + 1);
-        } else {
-            // all numbers
-            suffix = basename;
-        }
-        std::size_t first = suffix.find_first_not_of ("0");
-        if (first == std::string::npos) {
-            id = 0; // all 0s
-            break;
-        }
-
-        suffix = suffix.substr (first); // remove leading 0s
-        try {
-            id = std::stoi (suffix);
-        } catch (std::invalid_argument &e) {
-            errno = EINVAL;
-            m_err_msg += "Error converting node id=" + suffix + "; ";
+        if (split_hostname (name, basename, id) < 0) {
+            m_err_msg += "Error converting node id for " + name + "; ";
             rc = -1;
-            break;
-        } catch (std::out_of_range &e) {
-            errno = ERANGE;
-            m_err_msg += "Error converting node id=" + suffix + "; ";
-            rc = -1;
-            break;
         }
         break;
     }

--- a/resource/readers/resource_reader_hwloc.hpp
+++ b/resource/readers/resource_reader_hwloc.hpp
@@ -34,7 +34,7 @@ public:
      * \param rank   assign rank to all of the newly created resource vertices
      * \return       0 on success; non-zero integer on an error
      *                   ENOMEM: out of memory
-     *                   EINVAL: input input or operation (e.g. malformed str,
+     *                   EINVAL: invalid input or operation (e.g. malformed str,
      *                               hwloc version or operation error)
      */
     virtual int unpack (resource_graph_t &g, resource_graph_metadata_t &m,

--- a/resource/readers/resource_reader_jgf.hpp
+++ b/resource/readers/resource_reader_jgf.hpp
@@ -39,7 +39,7 @@ public:
      * \param rank   assign rank to all of the newly created resource vertices
      * \return       0 on success; non-zero integer on an error
      *                   ENOMEM: out of memory
-     *                   EINVAL: input input or operation
+     *                   EINVAL: invalid input or operation
      */
     virtual int unpack (resource_graph_t &g, resource_graph_metadata_t &m,
                         const std::string &str, int rank = -1);

--- a/resource/readers/resource_reader_rv1exec.cpp
+++ b/resource/readers/resource_reader_rv1exec.cpp
@@ -1,0 +1,556 @@
+/*****************************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+#include <map>
+#include <string>
+#include <jansson.h>
+
+#include "resource/readers/resource_reader_rv1exec.hpp"
+#include "resource/planner/planner.h"
+
+extern "C" {
+#include <flux/idset.h>
+}
+
+using namespace Flux;
+using namespace Flux::resource_model;
+
+
+/********************************************************************************
+ *                                                                              *
+ *                   Public RV1EXEC Resource Reader Interface                   *
+ *                                                                              *
+ ********************************************************************************/
+
+vtx_t resource_reader_rv1exec_t::add_vertex (resource_graph_t &g,
+                                             resource_graph_metadata_t &m,
+                                             vtx_t parent, int id,
+                                             const std::string &subsys,
+                                             const std::string &type,
+                                             const std::string &basename,
+                                             const std::string &name,
+                                             const std::map<std::string,
+                                                            std::string> &props,
+                                             int size, int rank)
+{
+    planner_t *plan = nullptr;
+    planner_t *x_checker = nullptr;
+
+    if ( !(plan = planner_new (0, INT64_MAX, size, type.c_str ())))
+        return boost::graph_traits<resource_graph_t>::null_vertex ();
+
+    if ( !(x_checker = planner_new (0, INT64_MAX,
+                                    X_CHECKER_NJOBS, X_CHECKER_JOBS_STR)))
+        return boost::graph_traits<resource_graph_t>::null_vertex ();
+
+    vtx_t v = boost::add_vertex (g);
+
+    // Set properties of the new vertex
+    bool is_root = false;
+    if (parent == boost::graph_traits<resource_graph_t>::null_vertex ())
+        is_root = true;
+
+    std::string istr = (id != -1)? std::to_string (id) : "";
+    std::string prefix =  is_root ? "" : g[parent].paths[subsys];
+
+    g[v].type = type;
+    g[v].basename = basename;
+    g[v].size = size;
+    g[v].uniq_id = v;
+    g[v].rank = rank;
+    g[v].schedule.plans = plan;
+    g[v].idata.x_checker = x_checker;
+    g[v].id = id;
+    g[v].name = (name != "")? name : basename + istr;
+    g[v].paths[subsys] = prefix + "/" + g[v].name;
+    g[v].idata.member_of[subsys] = "*";
+    g[v].status = resource_pool_t::status_t::UP;
+    g[v].properties = props;
+
+    // Indexing for fast look-up
+    m.by_path[g[v].paths[subsys]] = v;
+    m.by_type[g[v].type].push_back (v);
+    m.by_name[g[v].name].push_back (v);
+    m.by_rank[rank].push_back (v);
+
+    return v;
+}
+
+int resource_reader_rv1exec_t::add_metadata (resource_graph_t &g,
+                                             resource_graph_metadata_t &m,
+                                             edg_t e, vtx_t src, vtx_t dst)
+{
+    // add this edge to by_outedges metadata
+    auto iter = m.by_outedges.find (src);
+    if (iter == m.by_outedges.end ()) {
+        auto ret = m.by_outedges.insert (
+                         std::make_pair (
+                             src,
+                             std::map<std::pair<uint64_t, int64_t>, edg_t,
+                                      std::greater<
+                                               std::pair<uint64_t,
+                                                         int64_t>>> ()));
+        if (!ret.second) {
+            errno = ENOMEM;
+            m_err_msg += __FUNCTION__;
+            m_err_msg += "error creating out-edge metadata map: "
+                              + g[src].name + " -> " + g[dst].name + "; ";
+            return -1;
+        }
+        iter = m.by_outedges.find (src);
+    }
+    std::pair<uint64_t, int64_t> key = std::make_pair (
+                                                g[e].idata.get_weight (),
+                                                g[dst].uniq_id);
+    auto ret = iter->second.insert (std::make_pair (key, e));
+    if (!ret.second) {
+        errno = ENOMEM;
+        m_err_msg += __FUNCTION__;
+        m_err_msg += "error inserting an edge to out-edge metadata map: "
+                          + g[src].name + " -> " + g[dst].name + "; ";
+        return -1;
+    }
+    return 0;
+}
+
+int resource_reader_rv1exec_t::add_edges (resource_graph_t &g,
+                                          resource_graph_metadata_t &m,
+                                          vtx_t src, vtx_t dst,
+                                          const std::string &subsys,
+                                          const std::string &relation,
+                                          const std::string &rev_relation)
+{
+    edg_t e;
+    bool inserted;
+
+    tie (e, inserted) = add_edge (src, dst, g);
+    if (!inserted) {
+        errno = ENOMEM;
+        goto error;
+    }
+    g[e].idata.member_of[subsys] = relation;
+    g[e].name[subsys] = relation;
+    if (add_metadata (g, m, e, src, dst) < 0)
+       goto error;
+
+    tie (e, inserted) = add_edge (dst, src, g);
+    if (!inserted) {
+        errno = ENOMEM;
+        goto error;
+    }
+    g[e].idata.member_of[subsys] = rev_relation;
+    g[e].name[subsys] = rev_relation;
+    if (add_metadata (g, m, e, dst, src) < 0)
+       goto error;
+
+    return 0;
+
+error:
+    return -1;
+}
+
+int resource_reader_rv1exec_t::add_cluster_vertex (resource_graph_t &g,
+                                                   resource_graph_metadata_t &m)
+{
+    vtx_t v;
+    const std::map<std::string, std::string> p;
+    if ( (v = add_vertex (g, m,
+                          boost::graph_traits<resource_graph_t>::null_vertex (),
+                          0, "containment", "cluster", "cluster", "", p, 1, -1))
+         == boost::graph_traits<resource_graph_t>::null_vertex ())
+        return -1;
+
+    m.roots.emplace ("containment", v);
+    m.v_rt_edges.emplace ("containment", relation_infra_t ());
+    return 0;
+}
+
+int resource_reader_rv1exec_t::build_rmap (json_t *rlite,
+                                           std::map<unsigned, unsigned> &rmap)
+{
+    int i;
+    int index;
+    unsigned rank;
+    json_t *entry = nullptr;
+    const char *ranks = nullptr;
+    struct idset *ids = nullptr;
+    struct idset *r_ids = nullptr;
+
+    if (!rlite) {
+        errno = EINVAL;
+        goto error;
+    }
+    if ( !(ids = idset_create (0, IDSET_FLAG_AUTOGROW)))
+        goto error;
+
+    // Create a global rank set that combines all ranks from R_lite array
+    json_array_foreach (rlite, index, entry) {
+        if (json_unpack (entry, "{s:s}", "rank", &ranks) < 0) {
+            errno = EINVAL;
+            goto error;
+        }
+        if ( !(r_ids = idset_decode (ranks)))
+            goto error;
+
+        rank = idset_first (r_ids);
+        while (rank != IDSET_INVALID_ID) {
+            if (idset_set (ids, rank) < 0)
+                goto error;
+
+            rank = idset_next (r_ids, rank);
+        }
+        idset_destroy (r_ids);
+    }
+
+    // A rank map mapping mononically increasing ranks to consecutive IDs from 0
+    i = 0;
+    rank = idset_first (ids);
+    while (rank != IDSET_INVALID_ID) {
+        if (rmap.find (rank) != rmap.end ()) {
+            errno = EEXIST;
+            m_err_msg += __FUNCTION__;
+            m_err_msg += "rmap has no rank=" + std::to_string (rank) + "; ";
+            goto error;
+        }
+
+        auto res = rmap.insert (std::pair<unsigned, unsigned> (rank, i));
+        if (!res.second) {
+            errno = ENOMEM;
+            goto error;
+        }
+
+        rank = idset_next (ids, rank);
+        i++;
+    }
+    idset_destroy (ids);
+    return 0;
+
+error:
+    idset_destroy (r_ids);
+    idset_destroy (ids);
+    return -1;
+}
+
+int resource_reader_rv1exec_t::unpack_child (resource_graph_t &g,
+                                             resource_graph_metadata_t &m,
+                                             vtx_t parent,
+                                             const char *resource_type,
+                                             const char *resource_ids,
+                                             unsigned rank)
+{
+    int rc = -1;
+    unsigned id;
+    struct idset *ids = nullptr;
+
+    if (!resource_type || !resource_ids) {
+        errno = EINVAL;
+        goto ret;
+    }
+    if ( !(ids = idset_decode (resource_ids)))
+        goto ret;
+
+    id = idset_first (ids);
+    while (id != IDSET_INVALID_ID) {
+        edg_t e;
+        vtx_t v;
+        std::string name = resource_type + std::to_string (id);
+        std::map<std::string, std::string> p;
+        v = add_vertex (g, m, parent, id,
+                        "containment", resource_type,
+                        resource_type, name, p, 1, rank);
+        if (v == boost::graph_traits<resource_graph_t>::null_vertex ())
+            goto ret;
+        if (add_edges (g, m, parent, v, "containment", "contains", "in") < 0)
+            goto ret;
+
+        id = idset_next (ids, id);
+    }
+
+    rc = 0;
+ret:
+    idset_destroy (ids);
+    return rc;
+}
+
+
+int resource_reader_rv1exec_t::unpack_children (resource_graph_t &g,
+                                                resource_graph_metadata_t &m,
+                                                vtx_t parent,
+                                                json_t *children,
+                                                unsigned rank)
+{
+    json_t *res_ids = nullptr;
+    const char *res_type = nullptr;
+
+    if (!children) {
+        errno = EINVAL;
+        goto error;
+    }
+
+    json_object_foreach (children, res_type, res_ids) {
+        if (!json_is_string (res_ids)) {
+            errno = EINVAL;
+            goto error;
+        }
+        const char *ids_str = json_string_value (res_ids);
+        if (unpack_child (g, m, parent, res_type, ids_str, rank) < 0)
+            goto error;
+    } 
+    return 0;
+
+error:
+    return -1;
+}
+
+int resource_reader_rv1exec_t::unpack_rank (resource_graph_t &g,
+                                            resource_graph_metadata_t &m,
+                                            vtx_t parent,
+                                            unsigned rank,
+                                            json_t *children,
+                                            struct hostlist *hlist,
+                                            std::map<unsigned, unsigned> &rmap)
+{
+    edg_t e;
+    vtx_t v;
+    int iden;
+    const char *hostname = nullptr;
+    std::string basename;
+    std::map<std::string, std::string> properties;
+
+    if (!children || !hlist) {
+        errno = EINVAL;
+        goto error;
+    }
+    if (rmap.find (rank) == rmap.end ()) {
+        errno = EINVAL;
+        goto error;
+    }
+
+    if ( !(hostname = hostlist_nth (hlist, static_cast<int> (rmap[rank]))))
+        goto error;
+    if (get_hostname_suffix (hostname, iden) < 0)
+        goto error;
+    if (get_host_basename (hostname, basename) < 0)
+        goto error;
+
+    // Create and add a node vertex and link with cluster vertex
+    v = add_vertex (g, m, parent, iden, "containment",
+                    "node", basename, hostname, properties, 1, rank);
+    if (v == boost::graph_traits<resource_graph_t>::null_vertex ())
+        goto error;
+    if (add_edges (g, m, parent, v, "containment", "contains", "in") < 0)
+        goto error;
+    // Unpack children node-local resources
+    if (unpack_children (g, m, v, children, rank) < 0)
+        goto error;
+
+    return 0;
+
+error:
+    return -1;
+}
+
+int resource_reader_rv1exec_t::unpack_rlite_entry (resource_graph_t &g,
+                                                   resource_graph_metadata_t &m,
+                                                   vtx_t parent,
+                                                   json_t *entry,
+                                                   struct hostlist *hlist,
+                                                   std::map<unsigned,
+                                                            unsigned> &rmap)
+{
+    int rc = -1;
+    unsigned rank;
+    json_t *children = nullptr;
+    const char *ranks = nullptr;
+    struct idset *r_ids = nullptr;
+
+    if (!entry || !hlist) {
+        errno = EINVAL;
+        goto ret;
+    }
+
+    if (json_unpack (entry, "{s:s s:o}",
+                                "rank", &ranks,
+                                "children", &children) < 0) {
+        errno = EINVAL;
+        goto ret;
+    }
+
+    if ( !(r_ids = idset_decode (ranks)))
+        goto ret;
+
+    rank = idset_first (r_ids);
+    while (rank != IDSET_INVALID_ID) {
+        if (unpack_rank (g, m, parent, rank, children, hlist, rmap) < 0)
+            goto ret;
+
+        rank = idset_next (r_ids, rank);
+    }
+
+    rc = 0;
+ret:
+    idset_destroy (r_ids);
+    return rc;
+}
+
+int resource_reader_rv1exec_t::unpack_rlite (resource_graph_t &g,
+                                             resource_graph_metadata_t &m,
+                                             json_t *rlite,
+                                             struct hostlist *hlist,
+                                             std::map<unsigned, unsigned> &rmap)
+{
+    size_t index;
+    vtx_t cluster_vtx;
+    json_t *entry = nullptr;
+
+    if (!rlite || !hlist) {
+        errno = EINVAL;
+        goto error;
+    }
+
+    if (m.roots.find ("containment") == m.roots.end ()) {
+        errno = ENOENT;
+        goto error;
+    }
+
+    cluster_vtx = m.roots["containment"];
+    json_array_foreach (rlite, index, entry) {
+        if (unpack_rlite_entry (g, m, cluster_vtx, entry, hlist, rmap) < 0)
+            goto error;
+    }
+    return 0;
+
+error:
+    return -1;
+}
+
+int resource_reader_rv1exec_t::unpack_internal (resource_graph_t &g,
+                                                resource_graph_metadata_t &m,
+                                                json_t *rv1)
+{
+    int rc = -1;
+    int version;
+    size_t index;
+    json_t *val = nullptr;
+    json_t *rlite = nullptr;
+    json_t *nodelist = nullptr;
+    struct hostlist *hlist = nullptr;
+    std::map<unsigned, unsigned> rmap; 
+
+    if (json_unpack (rv1, "{s:i s:{s:o s:o}}",
+                              "version", &version,
+                              "execution",
+                                  "R_lite", &rlite,
+                                  "nodelist", &nodelist) < 0) {
+        errno = EINVAL;
+        goto ret;
+    }
+    if (version != 1) {
+        errno = EINVAL;
+        goto ret;
+    }
+    // Create rank-to-0-based-index mapping.
+    if (build_rmap (rlite, rmap) < 0)
+        goto ret;
+    if ( !(hlist = hostlist_create ()))
+        goto ret;
+
+    // Encode all nodes in nodelist array into a hostlist object.
+    json_array_foreach (nodelist, index, val) {
+        const char *hlist_str = nullptr;
+        if (!json_is_string (val)) {
+            errno = EINVAL;
+            goto ret;
+        }
+        if ( !(hlist_str = json_string_value (val))) {
+            errno = EINVAL;
+            goto ret;
+        }
+        if (hostlist_append (hlist, hlist_str) < 0)
+            goto ret;
+    }
+    if (unpack_rlite (g, m, rlite, hlist, rmap) < 0)
+        goto ret;
+
+    rc = 0;
+
+ret:
+    hostlist_destroy (hlist);
+    return rc;
+}
+
+
+/********************************************************************************
+ *                                                                              *
+ *                   Public RV1EXEC Resource Reader Interface                   *
+ *                                                                              *
+ ********************************************************************************/
+
+resource_reader_rv1exec_t::~resource_reader_rv1exec_t ()
+{
+
+}
+
+int resource_reader_rv1exec_t::unpack (resource_graph_t &g,
+                                       resource_graph_metadata_t &m,
+                                       const std::string &str, int rank)
+{
+    int rc = -1;
+    json_error_t error;
+    json_t *rv1 = nullptr;
+    int saved_errno;
+
+    if (str == "") {
+        errno = EINVAL;
+        goto ret;
+    }
+    if (add_cluster_vertex (g, m) < 0)
+        goto ret;
+
+    if ( !(rv1 = json_loads (str.c_str (), 0, &error))) {
+        errno = ENOMEM;
+        goto ret;
+    }
+    rc = unpack_internal (g, m, rv1);
+
+ret:
+    saved_errno = errno;
+    json_decref (rv1);
+    errno = saved_errno;
+    return rc;
+}
+
+int resource_reader_rv1exec_t::unpack_at (resource_graph_t &g,
+                                          resource_graph_metadata_t &m,
+                                          vtx_t &vtx,
+                                          const std::string &str, int rank)
+{
+    errno = ENOTSUP;
+    return -1;
+}
+
+int resource_reader_rv1exec_t::update (resource_graph_t &g,
+                                       resource_graph_metadata_t &m,
+                                       const std::string &str, int64_t jobid,
+                                       int64_t at, uint64_t dur, bool rsv,
+                                       uint64_t token)
+{
+    errno = ENOTSUP; // RV1Exec reader currently does not support update
+    return -1;
+}
+
+bool resource_reader_rv1exec_t::is_allowlist_supported ()
+{
+    return false;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/readers/resource_reader_rv1exec.hpp
+++ b/resource/readers/resource_reader_rv1exec.hpp
@@ -1,0 +1,145 @@
+/*****************************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+#ifndef RESOURCE_READER_RV1EXEC_HPP
+#define RESOURCE_READER_RV1EXEC_HPP
+
+extern "C" {
+#include <flux/hostlist.h>
+}
+
+#include "resource/schema/resource_graph.hpp"
+#include "resource/readers/resource_reader_base.hpp"
+
+namespace Flux {
+namespace resource_model {
+
+
+/*! RV1EXEC resource reader class.
+ */
+class resource_reader_rv1exec_t : public resource_reader_base_t {
+public:
+
+    virtual ~resource_reader_rv1exec_t ();
+
+    /*! Unpack str into a resource graph.
+     *
+     * \param g      resource graph
+     * \param m      resource graph meta data
+     * \param str    string containing a RV1's .execution key value
+     * \param rank   assign rank to all of the newly created resource vertices
+     * \return       0 on success; non-zero integer on an error
+     *                   EOVERFLOW: hostname suffix too large
+     *                   EEXIST: mal-formed ranks
+     *                   ENOMEM: out of memory
+     *                   EINVAL: invalid input or operation
+     */
+    virtual int unpack (resource_graph_t &g, resource_graph_metadata_t &m,
+                        const std::string &str, int rank = -1);
+
+    /*! Unpack str into a resource graph and graft
+     *  the top-level vertices to vtx.
+     *
+     * \param g      resource graph
+     * \param m      resource graph meta data
+     * \param vtx    parent vtx at which to graft the deserialized graph
+     * \param str    string containing a RV1's .execution key value
+     * \param rank   assign this rank to all the newly created resource vertices
+     * \return       -1 with ENOTSUP (Not supported yet)
+     */
+    virtual int unpack_at (resource_graph_t &g, resource_graph_metadata_t &m,
+                           vtx_t &vtx, const std::string &str, int rank = -1);
+
+    /*! Update resource graph g with str.
+     *
+     * \param g      resource graph
+     * \param m      resource graph meta data
+     * \param str    resource set string
+     * \param jobid  jobid of str
+     * \param at     start time of this job
+     * \param dur    duration of this job
+     * \param rsv    true if this update is for a reservation.
+     * \param trav_token
+     *               token to be used by traverser
+     * \return       -1 with ENOTSUP (Not supported yet)
+     */
+    virtual int update (resource_graph_t &g, resource_graph_metadata_t &m,
+                        const std::string &str, int64_t jobid, int64_t at,
+                        uint64_t dur, bool rsv, uint64_t trav_token);
+
+    /*! Is the selected reader format support allowlist
+     *
+     * \return       false
+     */
+    virtual bool is_allowlist_supported ();
+
+private:
+    vtx_t add_vertex (resource_graph_t &g,
+                      resource_graph_metadata_t &m,
+                      vtx_t parent, int id,
+                      const std::string &subsys,
+                      const std::string &type,
+                      const std::string &basename,
+                      const std::string &name,
+                      const std::map<std::string,
+                                     std::string> &props, int size, int rank);
+
+    int add_metadata (resource_graph_t &g,
+                      resource_graph_metadata_t &m,
+                      edg_t e, vtx_t src, vtx_t dst);
+
+    int add_edges (resource_graph_t &g,
+                   resource_graph_metadata_t &m,
+                   vtx_t src, vtx_t dst,
+                   const std::string &subsys,
+                   const std::string &relation,
+                   const std::string &rev_relation);
+
+    int add_cluster_vertex (resource_graph_t &g, resource_graph_metadata_t &m);
+
+    int build_rmap (json_t *rlite, std::map<unsigned, unsigned> &rmap);
+
+    int unpack_child (resource_graph_t &g,
+                      resource_graph_metadata_t &m, vtx_t parent,
+                      const char *resource_type,
+                      const char *resource_ids, unsigned rank);
+
+    int unpack_children (resource_graph_t &g,
+                         resource_graph_metadata_t &m,
+                         vtx_t parent, json_t *children, unsigned rank);
+
+    int unpack_rank (resource_graph_t &g,
+                     resource_graph_metadata_t &m,
+                     vtx_t parent, unsigned rank, json_t *children,
+                     struct hostlist *hlist, std::map<unsigned,
+                                                      unsigned> &rmap);
+
+    int unpack_rlite_entry (resource_graph_t &g,
+                            resource_graph_metadata_t &m,
+                            vtx_t parent, json_t *entry,
+                            struct hostlist *hlist, std::map<unsigned,
+                                                             unsigned> &rmap);
+    int unpack_rlite (resource_graph_t &g,
+                      resource_graph_metadata_t &m, json_t *rlite,
+                      struct hostlist *hlist, std::map<unsigned,
+                                                       unsigned> &rmap);
+
+    int unpack_internal (resource_graph_t &g,
+                         resource_graph_metadata_t &m, json_t *rv1);
+};
+
+} // namespace resource_model
+} // namespace Flux
+
+#endif // RESOURCE_READER_RV1EXEC_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -97,7 +97,7 @@ static void usage (int code)
 "            Input file from which to load the resource graph data store\n"
 "            (default=conf/default)\n"
 "\n"
-"    -f, --load-format=<grug|hwloc|jgf>\n"
+"    -f, --load-format=<grug|hwloc|jgf|rv1exec>\n"
 "            Format of the load file (default=grug)\n"
 "\n"
 "    -W, --load-allowlist=<resource1[,resource2[,resource3...]]>\n"

--- a/t/t1001-qmanager-basic.t
+++ b/t/t1001-qmanager-basic.t
@@ -31,7 +31,7 @@ test_expect_success 'load test resources' '
 
 test_expect_success 'qmanager: loading resource and qmanager modules works' '
     flux module load sched-fluxion-resource prune-filters=ALL:core \
-subsystems=containment policy=low load-allowlist=node,core &&
+subsystems=containment policy=low &&
     load_qmanager
 '
 

--- a/t/t1002-qmanager-reload.t
+++ b/t/t1002-qmanager-reload.t
@@ -31,8 +31,7 @@ test_expect_success 'load test resources' '
 '
 
 test_expect_success 'qmanager: loading resource and qmanager modules works' '
-    load_resource prune-filters=ALL:core \
-subsystems=containment policy=low load-allowlist=node,socket,core,gpu &&
+    load_resource prune-filters=ALL:core subsystems=containment policy=low &&
     load_qmanager
 '
 

--- a/t/t1003-qmanager-policy.t
+++ b/t/t1003-qmanager-policy.t
@@ -34,8 +34,7 @@ test_expect_success 'load test resources' '
 '
 
 test_expect_success 'qmanager: loading qmanager (queue-policy=easy)' '
-    load_resource prune-filters=ALL:core \
-subsystems=containment policy=first load-allowlist=cluster,node,core &&
+    load_resource prune-filters=ALL:core subsystems=containment policy=first &&
     load_qmanager queue-policy=easy
 '
 
@@ -67,10 +66,8 @@ test_expect_success 'qmanager: EASY policy correctly schedules jobs' '
 
 test_expect_success 'qmanager: loading qmanager (queue-policy=hybrid)' '
     remove_resource &&
-    load_resource prune-filters=ALL:core \
-subsystems=containment policy=low load-allowlist=cluster,node,core &&
-    load_qmanager queue-policy=hybrid \
-policy-params=reservation-depth=3
+    load_resource prune-filters=ALL:core subsystems=containment policy=low &&
+    load_qmanager queue-policy=hybrid policy-params=reservation-depth=3
 '
 
 test_expect_success 'qmanager: HYBRID policy correctly schedules jobs' '
@@ -101,8 +98,7 @@ test_expect_success 'qmanager: HYBRID policy correctly schedules jobs' '
 
 test_expect_success 'qmanager: loading qmanager (queue-policy=conservative)' '
     remove_resource &&
-    load_resource prune-filters=ALL:core \
-subsystems=containment policy=high load-allowlist=cluster,node,core &&
+    load_resource prune-filters=ALL:core subsystems=containment policy=high &&
     load_qmanager queue-policy=conservative
 '
 

--- a/t/t1004-qmanager-optimize.t
+++ b/t/t1004-qmanager-optimize.t
@@ -34,10 +34,8 @@ test_expect_success 'load test resources' '
 '
 
 test_expect_success 'qmanager: loading with easy+queue-depth=5' '
-    load_resource prune-filters=ALL:core \
-subsystems=containment policy=low load-allowlist=cluster,node,core &&
-    load_qmanager queue-policy=easy \
-queue-params=queue-depth=5
+    load_resource prune-filters=ALL:core subsystems=containment policy=low &&
+    load_qmanager queue-policy=easy queue-params=queue-depth=5
 '
 
 test_expect_success 'qmanager: EASY policy conforms to queue-depth=5' '
@@ -68,8 +66,7 @@ test_expect_success 'qmanager: EASY policy conforms to queue-depth=5' '
 
 test_expect_success 'qmanager: loading with hybrid+queue-depth=5' '
     remove_resource &&
-    load_resource prune-filters=ALL:core \
-subsystems=containment policy=low load-allowlist=cluster,node,core &&
+    load_resource prune-filters=ALL:core subsystems=containment policy=low &&
     load_qmanager queue-policy=hybrid \
 queue-params=queue-depth=5 policy-params=reservation-depth=3
 '
@@ -97,10 +94,8 @@ test_expect_success 'qmanager: HYBRID policy conforms to queue-depth=5' '
 
 test_expect_success 'qmanager: loading with conservative+queue-depth=5' '
     remove_resource &&
-    load_resource prune-filters=ALL:core \
-subsystems=containment policy=low load-allowlist=cluster,node,core &&
-    load_qmanager queue-policy=conservative \
-queue-params=queue-depth=5
+    load_resource prune-filters=ALL:core subsystems=containment policy=low &&
+    load_qmanager queue-policy=conservative queue-params=queue-depth=5
 '
 
 test_expect_success 'qmanager: CONSERVATIVE policy conforms to queue-depth=5' '

--- a/t/t1005-qmanager-conf.t
+++ b/t/t1005-qmanager-conf.t
@@ -30,8 +30,7 @@ start_qmanager () {
     QMANAGER_OPTIONS=$*
     echo $QMANAGER_OPTIONS > options
     flux broker --config-path=${config} bash -c \
-"flux module reload -f sched-fluxion-resource load-allowlist=node,core,gpu "\
-"policy=high && "\
+"flux module reload -f sched-fluxion-resource policy=high && "\
 "flux module reload -f sched-fluxion-qmanager ${QMANAGER_OPTIONS} && "\
 "flux module stats sched-fluxion-qmanager && "\
 "flux module stats sched-fluxion-resource && "\
@@ -42,8 +41,7 @@ start_qmanager_noconfig () {
     local outfile=$1; shift
     QMANAGER_OPTIONS=$*
     flux broker bash -c \
-"flux module reload -f sched-fluxion-resource load-allowlist=node,core,gpu "\
-"policy=high && "\
+"flux module reload -f sched-fluxion-resource policy=high && "\
 "flux module reload -f sched-fluxion-qmanager ${QMANAGER_OPTIONS} && "\
 "flux module stats sched-fluxion-qmanager && "\
 "flux module stats sched-fluxion-resource && "\

--- a/t/t1006-qmanager-multiqueue.t
+++ b/t/t1006-qmanager-multiqueue.t
@@ -25,8 +25,7 @@ get_queue() {
 }
 
 test_expect_success 'qmanager: loading qmanager with multiple queues' '
-    load_resource prune-filters=ALL:core \
-	subsystems=containment policy=low load-allowlist=node,core,gpu &&
+    load_resource prune-filters=ALL:core subsystems=containment policy=low &&
     load_qmanager "queues=all batch debug"
 '
 

--- a/t/t1007-recovery-full.t
+++ b/t/t1007-recovery-full.t
@@ -25,7 +25,7 @@ test_expect_success 'load test resources' '
 '
 
 test_expect_success 'recovery: loading flux-sched modules works (rv1)' '
-    load_resource load-allowlist=node,core,gpu match-format=rv1 policy=high &&
+    load_resource match-format=rv1 policy=high &&
     load_qmanager
 '
 
@@ -55,7 +55,7 @@ test_expect_success 'recovery: cancel one running job without fluxion' '
 # flux module stats commands ensure a proper sync between
 # flux ion-resource info and the rest of fluxion module loads
 test_expect_success 'recovery: works when both modules restart (rv1)' '
-    reload_resource load-allowlist=node,core,gpu match-format=rv1 policy=high &&
+    reload_resource match-format=rv1 policy=high &&
     reload_qmanager &&
     flux module stats sched-fluxion-qmanager &&
     flux module stats sched-fluxion-resource &&
@@ -90,7 +90,7 @@ test_expect_success 'recovery: a cancel leads to a job schedule (rv1)' '
 '
 
 test_expect_success 'recovery: both modules restart (rv1->rv1_nosched)' '
-    reload_resource load-allowlist=node,core,gpu match-format=rv1_nosched \
+    reload_resource match-format=rv1_nosched \
     policy=high &&
     reload_qmanager &&
     flux module stats sched-fluxion-qmanager &&
@@ -122,7 +122,7 @@ test_expect_success 'recovery: cancel all jobs (rv1_nosched)' '
 '
 
 test_expect_success 'recovery: restart w/ no running jobs (rv1_nosched)' '
-    reload_resource load-allowlist=node,core,gpu match-format=rv1_nosched \
+    reload_resource match-format=rv1_nosched \
     policy=high &&
     reload_qmanager &&
     flux module stats sched-fluxion-qmanager &&

--- a/t/t1008-recovery-none.t
+++ b/t/t1008-recovery-none.t
@@ -25,7 +25,7 @@ test_expect_success 'load test resources' '
 '
 
 test_expect_success 'recovery: loading flux-sched modules works (rv1_nosched)' '
-    load_resource load-allowlist=node,core,gpu match-format=rv1_nosched &&
+    load_resource match-format=rv1_nosched &&
     load_qmanager
 '
 
@@ -35,7 +35,7 @@ test_expect_success 'recovery: submit a job (rv1_nosched)' '
 '
 
 test_expect_success 'recovery: qmanager w/o an option must fail (rv1_nosched)' '
-    reload_resource load-allowlist=node,core,gpu match-format=rv1_nosched &&
+    reload_resource match-format=rv1_nosched &&
     reload_qmanager &&
     test_must_fail flux module stats sched-fluxion-qmanager
 '

--- a/t/t1009-recovery-multiqueue.t
+++ b/t/t1009-recovery-multiqueue.t
@@ -37,7 +37,7 @@ test_expect_success 'load test resources' '
 '
 
 test_expect_success 'recovery: loading flux-sched modules with two queues' '
-    load_resource load-allowlist=node,core,gpu match-format=rv1 policy=high &&
+    load_resource match-format=rv1 policy=high &&
     load_qmanager "queues=batch debug"
 '
 
@@ -53,7 +53,7 @@ test_expect_success 'recovery: submit to occupy resources fully (rv1)' '
 
 test_expect_success 'recovery: works when both modules restart (rv1)' '
     flux dmesg -C &&
-    reload_resource load-allowlist=node,core,gpu match-format=rv1 policy=high &&
+    reload_resource match-format=rv1 policy=high &&
     reload_qmanager "queues=batch debug" &&
     flux module stats sched-fluxion-qmanager &&
     flux module stats sched-fluxion-resource &&

--- a/t/t1010-sync-modules.t
+++ b/t/t1010-sync-modules.t
@@ -15,7 +15,7 @@ test_expect_success 'load sched-simple and wait for resources to be acquired' '
 '
 
 test_expect_success 'sync: fluxion-resource cannot load w/ sched-simple' '
-    load_resource policy=low load-allowlist=node,socket,core,gpu &&
+    load_resource policy=low &&
     test_must_fail flux module stats sched-fluxion-resource
 '
 
@@ -29,7 +29,7 @@ test_expect_success 'remove sched-simple' '
 
 # sched-simple releases the exclusive access to resource.
 test_expect_success 'sync: fluxion-resource loads w/ sched-simple unloaded' '
-    load_resource load-allowlist=node,socket,core,gpu policy=high
+    load_resource policy=high
 '
 
 test_expect_success 'sync: qmanager loads w/ sched-fluxion-resource loaded' '
@@ -56,7 +56,7 @@ test_expect_success 'sync: remove sched-simple' '
 '
 
 test_expect_success 'sync: qmanager will not prematurely proceed' '
-    load_resource load-allowlist=node,socket,core,gpu policy=high &&
+    load_resource policy=high &&
     flux dmesg -C &&
     load_qmanager &&
     flux module stats sched-fluxion-qmanager &&

--- a/t/t1011-dynstate-change.t
+++ b/t/t1011-dynstate-change.t
@@ -33,7 +33,7 @@ test_expect_success 'load test resources' '
 '
 
 test_expect_success 'dyn-state: loading fluxion modules works' '
-    load_resource load-allowlist=cluster,node,core,gpu match-format=rv1 &&
+    load_resource match-format=rv1 &&
     load_qmanager
 '
 
@@ -118,7 +118,7 @@ test_expect_success 'dyn-state: removing fluxion modules' '
 '
 
 test_expect_success 'dyn-state: loading fluxion modules works' '
-    load_resource load-allowlist=cluster,node,core,gpu match-format=rv1 &&
+    load_resource match-format=rv1 &&
     load_qmanager queue-policy=easy
 '
 
@@ -141,7 +141,7 @@ test_expect_success 'dyn-state: removing fluxion modules' '
 '
 
 test_expect_success 'dyn-state: loading fluxion modules works' '
-    load_resource load-allowlist=cluster,node,core,gpu match-format=rv1 &&
+    load_resource match-format=rv1 &&
     load_qmanager queues="batch debug" \
 queue-policy-per-queue="batch:easy debug:fcfs"
 '
@@ -171,7 +171,7 @@ test_expect_success 'dyn-state: removing fluxion modules' '
 '
 
 test_expect_success 'dyn-state: loading fluxion modules works' '
-    load_resource load-allowlist=cluster,node,core,gpu match-format=rv1 &&
+    load_resource match-format=rv1 &&
     load_qmanager
 '
 

--- a/t/t1012-find-status.t
+++ b/t/t1012-find-status.t
@@ -40,7 +40,7 @@ test_expect_success 'load test resources' '
 '
 
 test_expect_success 'find/status: loading fluxion modules works' '
-    load_resource load-allowlist=cluster,node,core,gpu policy=high &&
+    load_resource policy=high &&
     load_qmanager queue-policy=easy
 '
 

--- a/t/t1013-exclusion.t
+++ b/t/t1013-exclusion.t
@@ -32,7 +32,7 @@ test_expect_success 'load test resources' '
 '
 
 test_expect_success 'exclusion: loading fluxion modules works' '
-    load_resource load-allowlist=cluster,node,core,gpu policy=high &&
+    load_resource policy=high &&
     load_qmanager
 '
 
@@ -58,7 +58,7 @@ EOF
 '
 
 test_expect_success 'exclusion: loading fluxion modules works' '
-    load_resource load-allowlist=cluster,node,core,gpu &&
+    load_resource &&
     load_qmanager
 '
 

--- a/t/t1013-qmanager-priority.t
+++ b/t/t1013-qmanager-priority.t
@@ -18,7 +18,7 @@ test_expect_success 'load test resources' '
 '
 
 test_expect_success 'priority: loading fluxion modules works' '
-    load_resource load-allowlist=cluster,node,core,gpu &&
+    load_resource &&
     load_qmanager
 '
 

--- a/t/t1014-annotation.t
+++ b/t/t1014-annotation.t
@@ -49,7 +49,7 @@ test_expect_success 'load test resources' '
 
 test_expect_success 'annotation: loading qmanager (queue-policy=easy)' '
     load_resource prune-filters=ALL:core \
-subsystems=containment policy=low load-allowlist=cluster,node,core &&
+subsystems=containment policy=low &&
     load_qmanager queue-policy=easy
 '
 

--- a/t/t1015-find-format.t
+++ b/t/t1015-find-format.t
@@ -61,7 +61,7 @@ test_expect_success 'find/status: reloading resources works' '
 '
 
 test_expect_success 'find/status: loading fluxion modules works' '
-    load_resource load-allowlist=cluster,node,core &&
+    load_resource &&
     load_qmanager queue-policy=easy
 '
 

--- a/t/t1016-nest-namespace.t
+++ b/t/t1016-nest-namespace.t
@@ -24,7 +24,7 @@ test_expect_success 'namespace: loading resource and qmanager modules works' '
 test_expect_success 'namespace: gpu id remapping works with hwloc (pol=hi)' '
     cat >nest.sh <<-EOF &&
 	#!/bin/sh
-	flux module load sched-fluxion-resource load-allowlist=cluster,node,gpu,core policy=high
+	flux module load sched-fluxion-resource load-format=hwloc load-allowlist=cluster,node,gpu,core policy=high
 	flux module load sched-fluxion-qmanager
 	flux resource list
 	flux ion-resource ns-info 0 gpu 0
@@ -58,7 +58,7 @@ test_expect_success 'namespace: removing resource and qmanager modules' '
 '
 
 test_expect_success 'namespace: loading resource and qmanager modules works' '
-    load_resource load-allowlist=cluster,node,gpu,core policy=low &&
+    load_resource load-format=hwloc load-allowlist=cluster,node,gpu,core policy=low &&
     load_qmanager
 '
 

--- a/t/t1017-rv1-bootstrap.t
+++ b/t/t1017-rv1-bootstrap.t
@@ -31,6 +31,7 @@ test_expect_success 'rv1-bootstrap: creating a nested batch script' '
 	flux module load sched-fluxion-resource match-format=rv1 policy=\$1
 	flux module load sched-fluxion-qmanager
 	nested_jobid=\$(flux mini submit -n\$2 -N\$3 -c\$4 -g\$5 sleep 0)
+	flux job wait-event -t10 \${nested_jobid} start
 	flux job info \${nested_jobid} R > \$6
 	sleep inf
 EOF

--- a/t/t1017-rv1-bootstrap.t
+++ b/t/t1017-rv1-bootstrap.t
@@ -28,8 +28,7 @@ match-format=rv1 policy=high &&
 test_expect_success 'rv1-bootstrap: creating a nested batch script' '
     cat >nest.sh <<-EOF &&
 #!/bin/sh
-	flux module load sched-fluxion-resource \
-load-allowlist=cluster,node,gpu,core match-format=rv1 policy=\$1
+	flux module load sched-fluxion-resource match-format=rv1 policy=\$1
 	flux module load sched-fluxion-qmanager
 	nested_jobid=\$(flux mini submit -n\$2 -N\$3 -c\$4 -g\$5 sleep 0)
 	flux job info \${nested_jobid} R > \$6
@@ -143,8 +142,7 @@ test_expect_success 'rv1-bootstrap: killing nested jobs works' '
 test_expect_success 'rv1-bootstrap: creating doubly nested batch script' '
     cat >dnest.sh <<-EOF &&
 #!/bin/sh
-	flux module load sched-fluxion-resource \
-load-allowlist=cluster,node,gpu,core match-format=rv1 policy=\$1
+	flux module load sched-fluxion-resource match-format=rv1 policy=\$1
 	flux module load sched-fluxion-qmanager
 	hc=\$(expr \$4 / 2)
 	hg=\$(expr \$5 / 2)

--- a/t/t1018-rv1-bootstrap2.t
+++ b/t/t1018-rv1-bootstrap2.t
@@ -35,6 +35,7 @@ test_expect_success 'rv1-bootstrap2: creating a nested batch script' '
 load-allowlist=cluster,node,gpu,core match-format=rv1 policy=\$1
 	flux module load sched-fluxion-qmanager
 	nested_jobid=\$(flux mini submit -n\$2 -N\$3 -c\$4 -g\$5 sleep 0)
+	flux job wait-event -t10 \${nested_jobid} start
 	flux job info \${nested_jobid} R > \$6
 	sleep inf
 EOF

--- a/t/t1019-qmanager-async.t
+++ b/t/t1019-qmanager-async.t
@@ -28,7 +28,7 @@ test_expect_success 'load test resources' '
 
 test_expect_success 'qmanager: loading resource and qmanager modules works' '
     flux module load sched-fluxion-resource prune-filters=ALL:core \
-subsystems=containment policy=low load-allowlist=node,core &&
+subsystems=containment policy=low &&
     load_qmanager
 '
 

--- a/t/t1020-qmanager-feasibility.t
+++ b/t/t1020-qmanager-feasibility.t
@@ -17,7 +17,7 @@ test_expect_success 'feasibility: loading test resources works' '
 
 test_expect_success 'feasibility: loading resource and qmanager modules works' '
     flux module load sched-fluxion-resource prune-filters=ALL:core \
-subsystems=containment policy=low load-allowlist=node,core &&
+subsystems=containment policy=low &&
     load_qmanager
 '
 

--- a/t/t1021-qmanager-nodex.t
+++ b/t/t1021-qmanager-nodex.t
@@ -33,7 +33,7 @@ test_expect_success 'qmanager-nodex: load test resources' '
 '
 
 test_expect_success 'qmanager-nodex: loading fluxion modules works (hinodex)' '
-    load_resource load-allowlist=cluster,node,gpu,core policy=hinodex &&
+    load_resource policy=hinodex &&
     load_qmanager
 '
 
@@ -93,7 +93,7 @@ test_expect_success 'qmanager-nodex: removing fluxion modules (hinodex)' '
 '
 
 test_expect_success 'qmanager-nodex: loading fluxion modules works (lonodex)' '
-    load_resource load-allowlist=cluster,node,gpu,core policy=lonodex &&
+    load_resource policy=lonodex &&
     load_qmanager
 '
 

--- a/t/t2001-tree-real.t
+++ b/t/t2001-tree-real.t
@@ -21,8 +21,7 @@ if test -z "${FLUX_SCHED_TEST_INSTALLED}" || test -z "${FLUX_SCHED_CO_INST}"
 fi
 
 test_expect_success 'flux-tree: prep for testing in real mode works' '
-    load_resource prune-filters=ALL:core \
-subsystems=containment policy=low load-allowlist=node,core,gpu &&
+    load_resource prune-filters=ALL:core subsystems=containment policy=low &&
     load_qmanager
 '
 

--- a/t/t3027-resource-RV.t
+++ b/t/t3027-resource-RV.t
@@ -96,4 +96,66 @@ EOF
     test_cmp exp6 res6
 '
 
+test_expect_success 'RV1 with nosched correct on heterogeneous configuration' '
+    flux mini submit -n 28 --dry-run hostname > n28.json &&
+    cat > cmds007 <<-EOF &&
+        match allocate n28.json
+        quit
+EOF
+    flux R encode -r 79-83 -c 0-3 -H fluke[82-86] > out7 &&
+    flux R encode -r 91-92 -c 0-2 -H fluke[94-95] >> out7 &&
+    flux R encode -r 97,99 -c 3 -H fluke[100,102] >> out7 &&
+    cat out7 | flux R append > c7.json &&
+    print_ranks_nodes c7.json > exp7 &&
+    ${query} -L c7.json -f rv1exec -F rv1_nosched -t R7.out -P lonode < cmds007 &&
+    grep -v INFO R7.out > R7.json &&
+    print_ranks_nodes R7.json > res7 &&
+    test_cmp exp7 res7
+'
+
+test_expect_success 'RV1 with nosched correct on heterogeneous config 2' '
+    flux mini submit -n 14 --dry-run hostname > n14.json &&
+    cat > cmds008 <<-EOF &&
+        match allocate n14.json
+        quit
+EOF
+    cat > exp8 <<-EOF &&
+	79-81
+	82
+	fluke[82-85]
+EOF
+    ${query} -L c7.json -f rv1exec -F rv1_nosched -t R8.out -P lonode < cmds008 &&
+    grep -v INFO R8.out > R8.json &&
+    print_ranks_nodes R8.json > res8 &&
+    test_cmp exp8 res8
+'
+
+test_expect_success 'RV1 with nosched correct on heterogeneous config 3' '
+    cat > exp9 <<-EOF &&
+	82
+	83
+	91-92
+	97,99
+	fluke[85-86,94-95,100,102]
+EOF
+    ${query} -L c7.json -f rv1exec -F rv1_nosched -t R9.out -P hinode < cmds008 &&
+    grep -v INFO R9.out > R9.json &&
+    print_ranks_nodes R9.json > res9 &&
+    test_cmp exp9 res9
+'
+
+test_expect_success 'RV1 with nosched correct on nonconforming hostnames' '
+    flux mini submit -n 8 --dry-run hostname > n8.json &&
+    cat > cmds010 <<-EOF &&
+        match allocate n8.json
+        quit
+EOF
+    flux R encode -r 0-1 -c 0-3 -H foo,bar > c10.json &&
+    print_ranks_nodes c10.json > exp10 &&
+    ${query} -L c10.json -f rv1exec -F rv1_nosched -t R10.out -P lonode < cmds010 &&
+    grep -v INFO R10.out > R10.json &&
+    print_ranks_nodes R10.json > res10 &&
+    test_cmp exp10 res10
+'
+
 test_done

--- a/t/t3300-system-dontblock.t
+++ b/t/t3300-system-dontblock.t
@@ -10,6 +10,7 @@ export TEST_UNDER_FLUX_START_MODE=leader
 export FLUX_RC_EXTRA=${SHARNESS_TEST_SRCDIR}/rc
 unset FLUXION_RESOURCE_RC_NOOP
 unset FLUXION_QMANAGER_RC_NOOP
+export FLUXION_RESOURCE_OPTIONS="load-allowlist=node,core,gpu load-format=hwloc"
 
 # Comment in the following to generated scheduling key to R
 # TEST_UNDER_FLUX_AUGMENT_R=t
@@ -18,7 +19,7 @@ test_under_flux 2 system
 
 SCHED_MODULE=$(flux module list | awk '$6 == "sched" {print $1}')
 
-test_expect_success 'fluxion immediately fails to be loaded' '
+test_expect_success 'fluxion immediately fails to be loaded with hwloc reader' '
     test_debug "echo sched service provided by ${SCHED_MODULE}" &&
     echo $SCHED_MODULE > out &&
     test "$SCHED_MODULE" != "sched-fluxion-qmanager"

--- a/t/t4004-match-hwloc.t
+++ b/t/t4004-match-hwloc.t
@@ -101,7 +101,7 @@ test_expect_success 'resource-query works with allowlist' '
 
 # Test using the full resource matching service
 test_expect_success 'loading resource module with a tiny hwloc xml file works' '
-    load_resource load-file=${hwloc_4core}
+    load_resource load-file=${hwloc_4core} load-format=hwloc
 '
 
 test_expect_success 'match-allocate works with four one-core jobspecs' '
@@ -128,7 +128,7 @@ test_expect_success 'load test resources (4N4B)' '
 
 test_expect_success 'loading resource module with default resource info source' '
     load_resource subsystems=containment policy=high \
-load-allowlist=node,socket,core
+	load-format=hwloc load-allowlist=node,socket,core
 '
 
 test_expect_success 'match-allocate works with four two-socket jobspecs' '
@@ -154,8 +154,8 @@ test_expect_success 'load test resources (4N4B_sierra2)' '
 '
 
 test_expect_success 'load fluxion resource' '
-    load_resource subsystems=containment \
-        policy=high load-allowlist=node,socket,core,gpu
+    load_resource subsystems=containment policy=high \
+	load-format=hwloc load-allowlist=node,socket,core,gpu
 '
 
 test_expect_success 'match allocate' '

--- a/t/t4009-match-update.t
+++ b/t/t4009-match-update.t
@@ -35,7 +35,7 @@ test_expect_success 'update: load test resources' '
 '
 
 test_expect_success 'update: loading sched-fluxion-resource works' '
-    load_resource load-allowlist=node,core,gpu match-format=rv1 policy=high
+    load_resource match-format=rv1 policy=high
 '
 
 test_expect_success 'update: resource.match-allocate works with a jobspec' '
@@ -51,7 +51,7 @@ awk "NR==5{ print; }" > R4
 
 test_expect_success 'update: reloading sched-fluxion-resource works' '
     remove_resource &&
-    load_resource load-allowlist=node,core,gpu match-format=rv1 policy=high
+    load_resource match-format=rv1 policy=high
 '
 
 test_expect_success 'update: sched-fluxion-resource.update works with R1' '

--- a/t/t4010-match-conf.t
+++ b/t/t4010-match-conf.t
@@ -77,7 +77,7 @@ test_expect_success 'resource: sched-fluxion-resource loads with no config' '
     outfile=noconfig.out &&
     start_resource_noconfig ${outfile} &&
     check_load_file ${outfile} null &&
-    check_load_format ${outfile} "\"hwloc\"" &&
+    check_load_format ${outfile} "\"rv1exec\"" &&
     check_load_allowlist ${outfile} null &&
     check_match_policy ${outfile} "\"first\"" &&
     check_match_format ${outfile} "\"rv1_nosched\"" &&
@@ -91,7 +91,7 @@ test_expect_success 'resource: sched-fluxion-resource loads with valid toml' '
     outfile=${conf_name}.out &&
     start_resource ${conf_base}/${conf_name} ${outfile} &&
     check_load_file ${outfile} null &&
-    check_load_format ${outfile} "\"hwloc\"" &&
+    check_load_format ${outfile} "\"rv1exec\"" &&
     check_load_allowlist ${outfile} "\"node,core,gpu\"" &&
     check_match_policy ${outfile} "\"lonodex\"" &&
     check_match_format ${outfile} "\"rv1_nosched\"" &&
@@ -106,7 +106,7 @@ test_expect_success 'resource: module load options take precedence' '
     start_resource ${conf_base}/${conf_name} ${outfile} \
 	policy=high match-format=rv1 &&
     check_load_file ${outfile} null &&
-    check_load_format ${outfile} "\"hwloc\"" &&
+    check_load_format ${outfile} "\"rv1exec\"" &&
     check_load_allowlist ${outfile} "\"node,core,gpu\"" &&
     check_match_policy ${outfile} "\"high\"" &&
     check_match_format ${outfile} "\"rv1\"" &&
@@ -120,7 +120,7 @@ test_expect_success 'resource: sched-fluxion-resource loads with no keys' '
     outfile=${conf_name}.out &&
     start_resource ${conf_base}/${conf_name} ${outfile} &&
     check_load_file ${outfile} null &&
-    check_load_format ${outfile} "\"hwloc\"" &&
+    check_load_format ${outfile} "\"rv1exec\"" &&
     check_load_allowlist ${outfile} null &&
     check_match_policy ${outfile} "\"first\"" &&
     check_match_format ${outfile} "\"rv1_nosched\"" &&
@@ -134,7 +134,7 @@ test_expect_success 'resource: sched-fluxion-resource loads with extra keys' '
     outfile=${conf_name}.out &&
     start_resource ${conf_base}/${conf_name} ${outfile} &&
     check_load_file ${outfile} null &&
-    check_load_format ${outfile} "\"hwloc\"" &&
+    check_load_format ${outfile} "\"rv1exec\"" &&
     check_load_allowlist ${outfile} "\"node,core,gpu,foo\"" &&
     check_match_policy ${outfile} "\"lonodex\"" &&
     check_match_format ${outfile} "\"rv1_nosched\"" &&

--- a/t/t6002-graph-hwloc.t
+++ b/t/t6002-graph-hwloc.t
@@ -10,7 +10,7 @@ excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers"
 
 verify() {
     local of=$1
-    echo "{\"[0-3]\": 37}" | jq ' ' > ref.out
+    echo "{\"[0-3]\": 17}" | jq ' ' > ref.out
     cat ${of} | grep Rank: | awk '{ print $6 $7}' | jq ' ' > cmp.out
     diff cmp.out ref.out
     return $?


### PR DESCRIPTION
This PR adds rv1exec reader support. 

Problem: `sched-fluxion-resource` currently uses to hwloc reader when
the rv1 object it receives from resource.acquire does not contain
the scheduling key (whose value is an JGF graph object). This
presents at least two challenges: 1) the initial R configured
at the system level must include a large JGF object which is hard to
verify and debug by admins and 2) the hwloc reader can be brittle
when the system-installed hwloc library isn't configured correctly:
e.g., not detecting GPUs correctly.

- Add an rv1exec reader implementation to overcome these challenges.
- Integrate this reader to both `resource-query` and
  `sched-fluxion-resource` and make `rv1exec` as the module's default.
- Adjust a few failing test cases and drop `load-allowlist` for some tests
  where this option is a NOOP with `rv1exec` reader.
-  Add new test coverage for the remapping of resource ID spaces
    where we don't need remapping as rv1 object should already have
    been remapped. 

A few other clean-ups and misc. changes.

Fixes Issue #868 and #898.