### PR TITLE
Add property constraints-based matching support

### DIFF
--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -223,7 +223,14 @@ void qmanager_cb_t::jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
     job->userid = userid;
     job->t_submit = t_submit;
     job->priority = calc_priority (priority);
-    jobspec_obj = Flux::Jobspec::Jobspec (jobspec_str);
+    try {
+        jobspec_obj = Flux::Jobspec::Jobspec (jobspec_str);
+    } catch (const Flux::Jobspec::parse_error& e) {
+        if (schedutil_alloc_respond_deny (ctx->schedutil, msg, e.what ()) < 0)
+            flux_log_error (h, "%s: schedutil_alloc_respond_deny",
+                            __FUNCTION__);
+        return;
+    }
     if (jobspec_obj.attributes.system.queue != "")
         queue_name = jobspec_obj.attributes.system.queue;
     job->jobspec = jobspec_str;

--- a/resource/libjobspec/jobspec.hpp
+++ b/resource/libjobspec/jobspec.hpp
@@ -84,12 +84,17 @@ public:
     Task(const YAML::Node&);
 };
 
+struct Constraints {
+    std::vector<std::string> properties;
+};
+
 struct System {
     double duration = 0.0f;
     std::string queue = "";
     std::string cwd = "";
     std::unordered_map<std::string, std::string> environment;
     std::unordered_map<std::string, YAML::Node> optional;
+    Constraints constraints;
 
     System() = default;
     System(const System &s) = delete; // Force to use move ctor

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -1589,24 +1589,29 @@ static int run (std::shared_ptr<resource_ctx_t> &ctx, int64_t jobid,
                 const char *cmd, const std::string &jstr, int64_t *at)
 {
     int rc = -1;
-    Flux::Jobspec::Jobspec j {jstr};
-    dfu_traverser_t &tr = *(ctx->traverser);
+    try {
+        Flux::Jobspec::Jobspec j {jstr};
 
-    if (std::string ("allocate") == cmd)
-        rc = tr.run (j, ctx->writers, match_op_t::MATCH_ALLOCATE, jobid, at);
-    else if (std::string ("allocate_with_satisfiability") == cmd)
-        rc = tr.run (j, ctx->writers, match_op_t::
-                     MATCH_ALLOCATE_W_SATISFIABILITY, jobid, at);
-    else if (std::string ("allocate_orelse_reserve") == cmd)
-        rc = tr.run (j, ctx->writers, match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE,
-                     jobid, at);
-    else if (std::string ("satisfiability") == cmd)
-        rc = tr.run (j, ctx->writers, match_op_t::MATCH_SATISFIABILITY,
-                     jobid, at);
-    else
+        dfu_traverser_t &tr = *(ctx->traverser);
+
+        if (std::string ("allocate") == cmd)
+            rc = tr.run (j, ctx->writers, match_op_t::MATCH_ALLOCATE, jobid, at);
+        else if (std::string ("allocate_with_satisfiability") == cmd)
+            rc = tr.run (j, ctx->writers, match_op_t::
+                         MATCH_ALLOCATE_W_SATISFIABILITY, jobid, at);
+        else if (std::string ("allocate_orelse_reserve") == cmd)
+            rc = tr.run (j, ctx->writers, match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE,
+                         jobid, at);
+        else if (std::string ("satisfiability") == cmd)
+            rc = tr.run (j, ctx->writers, match_op_t::MATCH_SATISFIABILITY,
+                         jobid, at);
+        else
+            errno = EINVAL;
+    } catch (const Flux::Jobspec::parse_error& e) {
         errno = EINVAL;
+    }
 
-   return rc;
+    return rc;
 }
 
 static int run (std::shared_ptr<resource_ctx_t> &ctx, int64_t jobid,

--- a/resource/readers/resource_reader_rv1exec.hpp
+++ b/resource/readers/resource_reader_rv1exec.hpp
@@ -81,6 +81,18 @@ public:
     virtual bool is_allowlist_supported ();
 
 private:
+
+    class properties_t {
+    public:
+       int insert (const std::string &res_type, const std::string &property);
+       bool exist (const std::string &res_type);
+       int copy (const std::string &res_type,
+                 std::map<std::string, std::string> &properties);
+
+    private:
+        std::map<std::string, std::map<std::string, std::string>> m_properties;
+    };
+
     vtx_t add_vertex (resource_graph_t &g,
                       resource_graph_metadata_t &m,
                       vtx_t parent, int64_t id,
@@ -106,30 +118,39 @@ private:
 
     int build_rmap (json_t *rlite, std::map<unsigned, unsigned> &rmap);
 
+    int build_pmap (json_t *properties,
+                    std::map<unsigned, properties_t> &pmap);
+
     int unpack_child (resource_graph_t &g,
                       resource_graph_metadata_t &m, vtx_t parent,
                       const char *resource_type,
-                      const char *resource_ids, unsigned rank);
+                      const char *resource_ids, unsigned rank,
+                      std::map<unsigned, properties_t> &pmap);
 
     int unpack_children (resource_graph_t &g,
                          resource_graph_metadata_t &m,
-                         vtx_t parent, json_t *children, unsigned rank);
+                         vtx_t parent, json_t *children, unsigned rank,
+                         std::map<unsigned, properties_t> &pmap);
 
     int unpack_rank (resource_graph_t &g,
                      resource_graph_metadata_t &m,
                      vtx_t parent, unsigned rank, json_t *children,
-                     struct hostlist *hlist, std::map<unsigned,
-                                                      unsigned> &rmap);
+                     struct hostlist *hlist,
+                     std::map<unsigned, unsigned> &rmap,
+                     std::map<unsigned, properties_t> &pmap);
 
     int unpack_rlite_entry (resource_graph_t &g,
                             resource_graph_metadata_t &m,
                             vtx_t parent, json_t *entry,
-                            struct hostlist *hlist, std::map<unsigned,
-                                                             unsigned> &rmap);
+                            struct hostlist *hlist,
+                            std::map<unsigned, unsigned> &rmap,
+                            std::map<unsigned, properties_t> &pmap);
+
     int unpack_rlite (resource_graph_t &g,
                       resource_graph_metadata_t &m, json_t *rlite,
-                      struct hostlist *hlist, std::map<unsigned,
-                                                       unsigned> &rmap);
+                      struct hostlist *hlist,
+                      std::map<unsigned, unsigned> &rmap,
+                      std::map<unsigned, properties_t> &pmap);
 
     int unpack_internal (resource_graph_t &g,
                          resource_graph_metadata_t &m, json_t *rv1);

--- a/resource/traversers/dfu.cpp
+++ b/resource/traversers/dfu.cpp
@@ -293,7 +293,9 @@ int dfu_traverser_t::run (Jobspec::Jobspec &jobspec,
     bool x = detail::dfu_impl_t::exclusivity (jobspec.resources, root);
     std::unordered_map<std::string, int64_t> dfv;
     detail::dfu_impl_t::prime_jobspec (jobspec.resources, dfv);
-    meta.build (jobspec, detail::jobmeta_t::alloc_type_t::AT_ALLOC, jobid, *at);
+    if (meta.build (jobspec,
+                    detail::jobmeta_t::alloc_type_t::AT_ALLOC, jobid, *at) < 0)
+        return -1;
 
     if ( (op == match_op_t::MATCH_SATISFIABILITY)
         && (rc = is_satisfiable (jobspec, meta, x, root, dfv)) == 0) {

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -358,6 +358,8 @@ private:
     const std::vector<Jobspec::Resource> &test (vtx_t u,
              const std::vector<Jobspec::Resource> &resources,
              bool &prestine, unsigned int &nslots, match_kind_t &ko);
+    bool is_pconstraint_matched (vtx_t u, const std::string &property);
+
 
     /*! Accumulate count into accum if type matches with one of the resource
      *  types used in the scheduler-driven aggregate update (SDAU) scheme.

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -53,6 +53,7 @@ struct jobmeta_t {
     int64_t at = -1;
     int64_t now = -1;
     uint64_t duration = SYSTEM_DEFAULT_DURATION; // will need config ultimately
+    std::map<std::string, std::set<std::string>> properties;
 
     bool is_queue_set () const {
         return m_queue_set;
@@ -62,7 +63,7 @@ struct jobmeta_t {
         return m_queue;
     }
 
-    void build (Jobspec::Jobspec &jobspec,
+    int build (Jobspec::Jobspec &jobspec,
                 alloc_type_t alloc, int64_t id, int64_t t)
     {
         at = t;
@@ -78,6 +79,29 @@ struct jobmeta_t {
             m_queue = jobspec.attributes.system.queue;
             m_queue_set = true;
         }
+        if (jobspec.attributes.system
+                                  .constraints.properties.size () != 0) {
+            for (auto &p : jobspec.attributes.system.constraints.properties) {
+                std::string prop = p;
+                if (properties.find ("node") == properties.end ()) {
+                    auto res = properties.insert (
+                                   std::pair<
+                                       std::string,
+                                       std::set<std::string>> ("node",
+                                                               std::set<std::string> ()));
+                    if (!res.second) {
+                        errno = ENOMEM;
+                        return -1;
+                    }
+                }
+                auto res2 = properties["node"].insert (prop);
+                if (!res2.second) {
+                    errno = ENOMEM;
+                    return -1;
+                }
+            }
+        }
+        return 0;
     }
 
 private:

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -493,9 +493,9 @@ static int populate_resource_db (std::shared_ptr<resource_context_t> &ctx)
                      ctx->db->metadata.by_name.size () << std::endl;
         std::cout << "INFO: by_path Key-Value Pairs: " <<
                      ctx->db->metadata.by_path.size () << std::endl;
-        for (auto it = ctx->db->metadata.by_rank.begin (); 
+        for (auto it = ctx->db->metadata.by_rank.begin ();
                      it != ctx->db->metadata.by_rank.end (); ++it) {
-            std::cout << "INFO: number of vertices with rank " 
+            std::cout << "INFO: number of vertices with rank "
                         << it->first << ": " << it->second.size () << "\n";
         }
     }

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -334,19 +334,25 @@ static void flatten (f_resource_graph_t &fg,
     for (tie (vi, v_end) = vertices (fg); vi != v_end; ++vi) {
         paths[*vi] = "{";
         for (auto &kv : fg[*vi].paths) {
-            paths[*vi] += kv.first + ": \"" + kv.second + "\"";
+            if (paths[*vi].size () > 1)
+                paths[*vi] += ",";
+            paths[*vi] += kv.first + "=" + kv.second;
         }
         paths[*vi] += "}";
         subsystems[*vi] = "{";
         for (auto &kv : fg[*vi].idata.member_of) {
-            subsystems[*vi] += kv.first + ": \"" + kv.second + "\"";
+            if (subsystems[*vi].size () > 1)
+                subsystems[*vi] += ",";
+            subsystems[*vi] += kv.first + "=" + kv.second;
         }
         subsystems[*vi] += "}";
     }
     for (tie (ei, e_end) = edges (fg); ei != e_end; ++ei) {
         esubsystems[*ei] = "{";
         for (auto &kv : fg[*ei].idata.member_of) {
-            esubsystems[*ei] += kv.first + ": \"" + kv.second + "\"";
+            if (esubsystems[*ei].size () > 0)
+                esubsystems[*ei] += ",";
+            esubsystems[*ei] += kv.first + "=" + kv.second;
         }
         esubsystems[*ei] += "}";
     }

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -326,7 +326,8 @@ static void write_to_graphviz (f_resource_graph_t &fg, subsystem_t ss,
 static void flatten (f_resource_graph_t &fg,
                      std::map<vtx_t, std::string> &paths,
                      std::map<vtx_t, std::string> &subsystems,
-                     std::map<edg_t, std::string> &esubsystems)
+                     std::map<edg_t, std::string> &esubsystems,
+                     std::map<vtx_t, std::string> &properties)
 {
     f_vtx_iterator_t vi, v_end;
     f_edg_iterator_t ei, e_end;
@@ -346,6 +347,13 @@ static void flatten (f_resource_graph_t &fg,
             subsystems[*vi] += kv.first + "=" + kv.second;
         }
         subsystems[*vi] += "}";
+        properties[*vi] = "{";
+        for (auto &kv : fg[*vi].properties) {
+            if (properties[*vi].size () > 1)
+                properties[*vi] += ",";
+            properties[*vi] += kv.first + "=" + kv.second;
+        }
+        properties[*vi] += "}";
     }
     for (tie (ei, e_end) = edges (fg); ei != e_end; ++ei) {
         esubsystems[*ei] = "{";
@@ -372,7 +380,7 @@ static void write_to_graphml (f_resource_graph_t &fg, std::fstream &o)
     boost::associative_property_map<
         std::map<vtx_t, std::string>> paths_map (paths);
 
-    flatten (fg, paths, subsystems, esubsystems);
+    flatten (fg, paths, subsystems, esubsystems, properties);
 
     // Resource pool vertices
     dp.property ("paths", paths_map);

--- a/resource/writers/match_writers.cpp
+++ b/resource/writers/match_writers.cpp
@@ -760,12 +760,12 @@ int rlite_match_writers_t::fill (json_t *rlite_array, json_t *host_array)
         if ( !(ranks = json_string (s.str ().c_str ()))) {
             json_decref (robj);
             rc = -1;
-            errno = ENOMEM;
+            errno = EINVAL;
             goto ret;
         }
         if ( (rc = json_object_set_new (robj, "rank", ranks)) < 0) {
             json_decref (robj);
-            errno = ENOMEM;
+            errno = EINVAL;
             goto ret;
         }
         if ( !(cobj = json_loads (kv.first.c_str (), 0, &err))) {
@@ -804,7 +804,7 @@ int rlite_match_writers_t::fill (json_t *rlite_array, json_t *host_array)
             if ( (rc = json_array_append_new (host_array,
                                               json_string (hl_out))) < 0) {
                 json_decref (rlite_array);
-                errno = ENOMEM;
+                errno = EINVAL;
                 goto ret;
             }
         }
@@ -895,7 +895,7 @@ int rv1_match_writers_t::emit_json (json_t **j_o, json_t **aux)
         json_decref (ndlist_o);
         json_decref (jgf_o);
         rc = -1;
-        errno = ENOMEM;
+        errno = EINVAL;
         goto ret;
     }
     if (!m_attrs.empty ()) {
@@ -907,7 +907,7 @@ int rv1_match_writers_t::emit_json (json_t **j_o, json_t **aux)
         }
         if ( (rc = json_object_set_new (o, "attributes", attrs_o)) == -1) {
             json_decref (o);
-            errno = ENOMEM;
+            errno = EINVAL;
             goto ret;
         }
     }
@@ -1009,7 +1009,7 @@ int rv1_nosched_match_writers_t::emit_json (json_t **j_o, json_t **aux)
         json_decref (rlite_o);
         json_decref (ndlist_o);
         rc = -1;
-        errno = ENOMEM;
+        errno = EINVAL;
         goto ret;
     }
 

--- a/resource/writers/match_writers.hpp
+++ b/resource/writers/match_writers.hpp
@@ -137,12 +137,14 @@ private:
     bool m_reducer_set ();
     int emit_gatherer (const f_resource_graph_t &g, const vtx_t &u);
     int get_gatherer_children (std::string &children);
-    int fill (json_t *rlite_array, json_t *host_array);
+    int fill (json_t *rlite_array, json_t *host_array, json_t *props);
     int fill_hosts (std::vector<std::string> &hosts, json_t *host_array);
 
     std::map<std::string, std::vector<int64_t>> m_reducer;
     std::map<std::string, std::vector<rank_host_t>> m_gl_gatherer;
+    std::map<std::string, std::vector<int64_t>> m_gl_prop_gatherer;
     std::set<std::string> m_gatherer;
+
 };
 
 

--- a/src/python/fluxion/resourcegraph/V1.py
+++ b/src/python/fluxion/resourcegraph/V1.py
@@ -216,7 +216,7 @@ class FluxionResourceGraphV1(Graph):
             True,
             "",
             1,
-            "",
+            [],
             "/cluster0",
         )
         self._add_and_tick_uniq_id(vtx, None)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -80,6 +80,7 @@ TESTS = \
     t3030-resource-multi.t \
     t3031-resource-minmax2.t \
     t3033-resource-nodex.t \
+    t3034-resource-pconstraints.t \
     t3300-system-dontblock.t \
     t3301-system-latestart.t \
     t4000-match-params.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -44,6 +44,7 @@ TESTS = \
     t1019-qmanager-async.t \
     t1020-qmanager-feasibility.t \
     t1021-qmanager-nodex.t \
+    t1022-property-constraints.t \
     t2000-tree-basic.t \
     t2001-tree-real.t \
     t3000-jobspec.t \

--- a/t/data/resource/jobspecs/validation/invalid/attributes_bad_properties.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/attributes_bad_properties.yaml
@@ -1,0 +1,18 @@
+version: 9999
+resources:
+  - type: slot
+    count: 4
+    label: default
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: [ "flux", "start" ]
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 3600.0
+    constraints:
+      properties: [ "fo`o", "b!ar" ]

--- a/t/data/resource/jobspecs/validation/invalid/attributes_bad_properties2.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/attributes_bad_properties2.yaml
@@ -1,0 +1,18 @@
+version: 9999
+resources:
+  - type: slot
+    count: 4
+    label: default
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: [ "flux", "start" ]
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 3600.0
+    constraints:
+      properties: "foo"

--- a/t/data/resource/jobspecs/validation/invalid/attributes_bad_properties3.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/attributes_bad_properties3.yaml
@@ -1,0 +1,18 @@
+version: 9999
+resources:
+  - type: slot
+    count: 4
+    label: default
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: [ "flux", "start" ]
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 3600.0
+    constraints:
+      properties: [ "f^oo" ]

--- a/t/data/resource/jobspecs/validation/invalid/attributes_bad_properties4.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/attributes_bad_properties4.yaml
@@ -1,0 +1,18 @@
+version: 9999
+resources:
+  - type: slot
+    count: 4
+    label: default
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: [ "flux", "start" ]
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 3600.0
+    constraints:
+      properties: [ "^f^oo" ]

--- a/t/data/resource/jobspecs/validation/valid/attributes_properties.yaml
+++ b/t/data/resource/jobspecs/validation/valid/attributes_properties.yaml
@@ -1,0 +1,18 @@
+version: 9999
+resources:
+  - type: slot
+    count: 4
+    label: default
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: [ "flux", "start" ]
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 3600.0
+    constraints:
+      properties: [ "^foo" ]

--- a/t/data/resource/jobspecs/validation/valid/use_case_1.8.yaml
+++ b/t/data/resource/jobspecs/validation/valid/use_case_1.8.yaml
@@ -1,0 +1,18 @@
+version: 9999
+resources:
+  - type: slot
+    count: 4
+    label: default
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: [ "flux", "start" ]
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 3600.0
+    constraints:
+      properties: [ "foo$", "+bar" ]

--- a/t/t1022-property-constraints.t
+++ b/t/t1022-property-constraints.t
@@ -1,0 +1,76 @@
+#!/bin/sh
+
+test_description='Test pconstraints complementing t3034-resource-pconstraints.t'
+
+. `dirname $0`/sharness.sh
+
+skip_all_unless_have jq
+
+export FLUX_SCHED_MODULE=none
+
+test_under_flux 4
+
+test_expect_success 'reload resource with properties set' '
+	flux kvs put resource.R="$(flux kvs get resource.R | \
+		flux R set-property foo:0-1 bar:1-2 baz:3)" &&
+	flux module reload resource
+'
+
+test_expect_success 'load fluxion' '
+	load_resource policy=hinodex &&
+	load_qmanager
+'
+
+test_expect_success 'simple property reqirement works' '
+	JOBID1=$(flux mini submit --requires="baz" hostname) &&
+	flux job wait-event -t 10 ${JOBID1} clean &&
+	flux job info ${JOBID1} R > JOBID1.R &&
+	RANK1=$(cat JOBID1.R | jq -r ".execution.R_lite[0].rank") &&
+	LENGTH1=$(cat JOBID1.R | jq -r ".execution.properties" | jq length) &&
+	PROP_RANK1=$(cat JOBID1.R | jq -r ".execution.properties.baz") &&
+	test "${RANK1}" = "3" -a "${LENGTH1}" = "1" -a "${PROP_RANK1}" = "3"
+'
+
+test_expect_success 'multiple properties reqirement works' '
+	JOBID2=$(flux mini submit --requires="foo" --requires="bar" hostname) &&
+	flux job wait-event -t 10 ${JOBID2} clean &&
+	flux job info ${JOBID2} R > JOBID2.R &&
+	RANK2=$(cat JOBID2.R | jq -r ".execution.R_lite[0].rank") &&
+	LENGTH2=$(cat JOBID2.R | jq -r ".execution.properties" | jq length) &&
+	PROP_RANK2=$(cat JOBID2.R | jq -r ".execution.properties.foo") &&
+	PROP_RANK2B=$(cat JOBID2.R | jq -r ".execution.properties.bar") &&
+	test "${RANK2}" = "1" -a "${LENGTH2}" = "2" &&
+	test "${PROP_RANK2}" = "1" -a "${PROP_RANK2B}" = "1"
+'
+
+test_expect_success '^property reqirement works' '
+	JOBID3=$(flux mini submit --requires="^foo" --requires="^bar" hostname) &&
+	flux job wait-event -t 10 ${JOBID3} clean &&
+	flux job info ${JOBID3} R > JOBID3.R &&
+	RANK3=$(cat JOBID3.R | jq -r ".execution.R_lite[0].rank") &&
+	LENGTH3=$(cat JOBID3.R | jq -r ".execution.properties" | jq length) &&
+	PROP_RANK3=$(cat JOBID3.R | jq -r ".execution.properties.baz") &&
+	test "${RANK3}" = "3" -a "${LENGTH3}" = "1" -a "${PROP_RANK3}" = "3"
+'
+
+test_expect_success 'nonexistient property works' '
+	JOBID4=$(flux mini submit --requires="yyy" hostname) &&
+	flux job wait-event -t 10 ${JOBID4} clean &&
+	flux job eventlog ${JOBID4} > evlog4 &&
+	grep "unsatisfiable" evlog4
+'
+
+test_expect_success 'invalid property works' '
+	JOBID5=$(flux mini submit --requires="f^oo" hostname) &&
+	flux job wait-event -t 10 ${JOBID5} clean &&
+	flux job eventlog ${JOBID5} > evlog5 &&
+	grep "f^oo is invalid" evlog5
+'
+
+test_expect_success 'removing resource and qmanager modules' '
+	remove_qmanager &&
+	remove_resource
+'
+
+test_done
+

--- a/t/t3027-resource-RV.t
+++ b/t/t3027-resource-RV.t
@@ -282,4 +282,24 @@ test_expect_success 'node num > max(int64_t) must fail to load' '
 	test_must_fail ${query} -L out18.json -f rv1exec -F rv1_nosched < cmds018
 '
 
+test_expect_success 'Misconfigured RV1 is handled correctly' '
+        cat > cmds019 <<-EOF &&
+	quit
+	EOF
+	flux R encode -r 0 -c 0-1 -H fluke1 | \
+		jq " .execution.R_lite[0].rank |= 0 " > out19.json &&
+	test_must_fail ${query} -L out19.json -f rv1exec -F rv1_nosched \
+		-t R19.out -P first < cmds019
+'
+
+test_expect_success 'Misconfigured RV1 is handled correctly 2' '
+        cat > cmds020 <<-EOF &&
+	quit
+	EOF
+	flux R encode -r 0-1 -c 0-1 -H fluke[1-0] | \
+		jq " .execution.R_lite[0].rank |= \"0^2\" " > out20.json &&
+	test_must_fail ${query} -L out20.json -f rv1exec -F rv1_nosched \
+		-t R20.out -P first < cmds020
+'
+
 test_done

--- a/t/t3034-resource-pconstraints.t
+++ b/t/t3034-resource-pconstraints.t
@@ -122,6 +122,14 @@ test_expect_success 'allocate 1 job with invalid property (pol=hinodex)' '
 	grep "Jobspec error" 007.R.out2
 '
 
+test_expect_success 'graphml output can be generated with properties' '
+	cat <<-EOF > cmds008 &&
+	quit
+	EOF
+	${query} -L hetero.json -f rv1exec -S CA -P hinodex -t 008.R.out \
+		-o 008 -g graphml -F rv1_nosched < cmds008
+'
+
 test_expect_success 'allocate 1 job with arm-v9@core and rv1 (pol=hinodex)' '
 	cat <<-EOF > cmds011 &&
 	match allocate job.arm-v9.json

--- a/t/t3034-resource-pconstraints.t
+++ b/t/t3034-resource-pconstraints.t
@@ -1,0 +1,165 @@
+#!/bin/sh
+
+test_description='Test property constraints-based matching'
+
+. $(dirname $0)/sharness.sh
+
+query="../../resource/utilities/resource-query"
+
+skip_all_unless_have jq
+
+test_expect_success 'pconstraints: configuring a heterogeneous machine works' '
+	flux R encode -r 0 -c 0-1 -g 0-1 -p "arm-v9@core:0" -H foo2 > out &&
+	flux R encode -r 1 -c 0 -H foo3 -p "arm-v8@core:1" >> out &&
+	flux R encode -r 2-3 -c 0-1 -g 0-1 -p "arm-v9@core:2-3" \
+	    -p "amd-mi60@gpu:2-3" -H foo[1,4] >> out &&
+	cat out | flux R append > hetero.json
+'
+
+test_expect_success 'pconstraints: generate property-based jobspecs' '
+	flux mini submit --requires="arm-v9@core" --dry-run hostname \
+		> job.arm-v9.json &&
+	flux mini submit --requires="arm-v8@core,amd-mi60@gpu" \
+		 --dry-run hostname > job.arm-v9+amd-mi60.json &&
+	flux mini submit --requires="amd-m50@gpu" --dry-run hostname \
+		> job.amd-mi50.json &&
+	flux mini submit -n2 -c1 -g2 --requires="arm-v9@core" \
+		 --dry-run hostname > job.arm-v9+gpu.json &&
+	flux mini submit -n1 --requires="^arm-v9@core" \
+		--dry-run hostname > job.not-arm-v9.json &&
+	flux mini submit -n1 --requires="ar^m-v9@core" \
+		--dry-run hostname > job.invalid.json &&
+	flux mini submit -n1 -c1 -g1 --dry-run hostname > job.gpu.json
+'
+
+#
+# Selection Policy -- High node first with node exclusivity (-P hinodex)
+#     Selection behavior is identical to hinode except that
+#     it marks each selected node as exclusive even if the
+#     jobspec doen not require node exclusivity and
+#     that it selects and emits all of the node-local resources
+#     for each node where at least one node-local resource is selected.
+#
+#     For a jobspec with node[1]->slot[1]->core[1], it selects
+#     36 cores from the selected node if there is a total of
+#     36 cores in that node.
+#
+#     For a jobspec with slot[18]->core[1], it selects
+#     again all 36 cores from the current available highest node.
+#
+
+test_expect_success 'allocate 1 job with arm-v9@core (pol=hinodex)' '
+	cat <<-EOF > cmds001 &&
+	match allocate job.arm-v9.json
+	quit
+	EOF
+	${query} -L hetero.json -f rv1exec -S CA -P hinodex -t 001.R.out \
+		-F rv1_nosched < cmds001 &&
+	host=$(cat 001.R.out | grep -v INFO | jq -r ".execution.nodelist[]") &&
+	test "${host}" = "foo4"
+'
+
+test_expect_success 'allocate 1 job with unsat properties (pol=hinodex)' '
+	cat <<-EOF > cmds002 &&
+	match allocate job.arm-v9+amd-mi60.json
+	quit
+	EOF
+	${query} -L hetero.json -f rv1exec -S CA -P hinodex -t 002.R.out \
+		-F rv1_nosched < cmds002 &&
+	grep "No matching resources found" 002.R.out
+'
+
+test_expect_success 'allocate 1 job with nonexistent property (pol=hinodex)' '
+	cat <<-EOF > cmds003 &&
+	match allocate job.amd-mi50.json
+	quit
+	EOF
+	${query} -L hetero.json -f rv1exec -S CA -P hinodex -t 003.R.out \
+		-F rv1_nosched < cmds003 &&
+	grep "No matching resources found" 003.R.out
+'
+
+test_expect_success 'allocate 1 job with heterogeneous GPUs (pol=hinodex)' '
+	cat <<-EOF > cmds004 &&
+	match allocate job.arm-v9+gpu.json
+	quit
+	EOF
+	${query} -L hetero.json -f rv1exec -S CA -P hinodex -t 004.R.out \
+		-F rv1_nosched < cmds004 &&
+	host=$(cat 004.R.out | grep -v INFO | jq -r ".execution.nodelist[]") &&
+	test "${host}" = "foo[2,4]"
+'
+
+test_expect_success 'allocate 1 job with generic GPU (pol=hinodex)' '
+	cat <<-EOF > cmds005 &&
+	match allocate job.gpu.json
+	quit
+	EOF
+	${query} -L hetero.json -f rv1exec -S CA -P hinodex -t 005.R.out \
+		-F rv1_nosched < cmds005 &&
+	host=$(cat 005.R.out | grep -v INFO | jq -r ".execution.nodelist[]") &&
+	test "${host}" = "foo4"
+'
+
+test_expect_success 'allocate 1 job with ^arm-v9@core (pol=hinodex)' '
+	cat <<-EOF > cmds006 &&
+	match allocate job.not-arm-v9.json
+	quit
+	EOF
+	${query} -L hetero.json -f rv1exec -S CA -P hinodex -t 006.R.out \
+		-F rv1_nosched < cmds006 &&
+	host=$(cat 006.R.out | grep -v INFO | jq -r ".execution.nodelist[]") &&
+	test "${host}" = "foo3"
+'
+
+test_expect_success 'allocate 1 job with invalid property (pol=hinodex)' '
+	cat <<-EOF > cmds007 &&
+	match allocate job.invalid.json
+	quit
+	EOF
+	${query} -L hetero.json -f rv1exec -S CA -P hinodex -t 007.R.out \
+		-F rv1_nosched < cmds007 2> 007.R.out2 &&
+	grep "Jobspec error" 007.R.out2
+'
+
+test_expect_success 'allocate 1 job with arm-v9@core and rv1 (pol=hinodex)' '
+	cat <<-EOF > cmds011 &&
+	match allocate job.arm-v9.json
+	quit
+	EOF
+	cat <<-EOF > prop11.exp &&
+	amd-mi60@gpu
+	arm-v9@core
+	EOF
+	${query} -L hetero.json -f rv1exec -S CA -P hinodex -t 011.R.out \
+		-F rv1 < cmds011 &&
+	cat 011.R.out | grep -v INFO | jq -r ".scheduling.graph.nodes[] | \
+		select (.metadata.type == \"node\") | .metadata.properties \
+		| keys[]" > prop11.out &&
+	test_cmp prop11.exp prop11.out &&
+	host=$(cat 011.R.out | grep -v INFO | jq -r ".execution.nodelist[]") &&
+	jgfh=$(cat 011.R.out | grep -v INFO | \
+		jq -r ".scheduling.graph.nodes[] | \
+		select (.metadata.type == \"node\") | .metadata.name") &&
+	test "$host" = "${jgfh}"
+'
+
+test_expect_success 'allocate 1 job with arm-v9@core and JGF (pol=hinodex)' '
+	cat <<-EOF > cmds012 &&
+	match allocate job.arm-v9.json
+	quit
+	EOF
+	cat <<-EOF > prop12.exp &&
+	amd-mi60@gpu
+	arm-v9@core
+	EOF
+	${query} -L hetero.json -f rv1exec -S CA -P hinodex -t 012.R.out \
+		-F rv1 < cmds012 &&
+	cat 012.R.out | grep -v INFO | jq -r ".scheduling" > jgf.json &&
+	${query} -L jgf.json -f jgf -S CA -P hinodex -t 012.R2.out \
+		-F rv1_nosched < cmds012 &&
+        host=$(cat 012.R2.out | grep -v INFO | jq -r ".execution.nodelist[]") &&
+        test "${host}" = "foo4"
+'
+
+test_done


### PR DESCRIPTION
This is a WIP PR that adds  property constraints-based matching support.

This builds on a pending PR #921 so don't merge this before landing that  PR.

- Add property support into flux ion-R encode: e.g., `flux R encode -r 0 -c 0-1 -g 0-1 -p "arm-v9@core:0" -H foo2 | flux ion-R encode` is now supported.
- Add properties support into libjobspec in accordance with new property addition to RFC14.
- Add property support within our new rv1exec reader
- Extend our job meta class to capture the property information
- Extend our traverser to use the properties captured in our job meta object to do perform property-based matching
- A bunch of test cases

I want to see if we can land this as part of this month's release? I still need to add a one end-to-end test case using `sched-fluxion-resource`.