### PR TITLE
Don't assume each hierarchical path is unique

### DIFF
--- a/resource/readers/resource_reader_grug.cpp
+++ b/resource/readers/resource_reader_grug.cpp
@@ -239,7 +239,7 @@ vtx_t dfs_emitter_t::emit_vertex (ggv_t u, gge_t e, const gg_t &recipe,
     //
     // Indexing for fast look-up...
     //
-    m.by_path[g[v].paths[ssys]] = v;
+    m.by_path[g[v].paths[ssys]].push_back (v);
     m.by_type[g[v].type].push_back (v);
     m.by_name[g[v].name].push_back (v);
     m.by_rank[m_rank].push_back (v);
@@ -347,7 +347,8 @@ void dfs_emitter_t::tree_edge (gge_t e, const gg_t &recipe)
                 g[tgt_vtx].paths[recipe[e].e_subsystem]
                     = g[src_vtx].paths[recipe[e].e_subsystem]
                           + "/" + g[tgt_vtx].name;
-                m.by_path[g[tgt_vtx].paths[recipe[e].e_subsystem]] = tgt_vtx;
+                const std::string &tp = g[tgt_vtx].paths[recipe[e].e_subsystem];
+                m.by_path[tp].push_back (tgt_vtx);
                 g[tgt_vtx].idata.member_of[recipe[e].e_subsystem]
                     = "*";
                 emit_edges (e, recipe, src_vtx, tgt_vtx);
@@ -377,7 +378,8 @@ void dfs_emitter_t::tree_edge (gge_t e, const gg_t &recipe)
                 g[tgt_vtx].paths[recipe[e].e_subsystem]
                     = g[src_vtx].paths[recipe[e].e_subsystem]
                           + "/" + g[tgt_vtx].name;
-                m.by_path[g[tgt_vtx].paths[recipe[e].e_subsystem]] = tgt_vtx;
+                const std::string &tp = g[tgt_vtx].paths[recipe[e].e_subsystem];
+                m.by_path[tp].push_back (tgt_vtx);
                 g[tgt_vtx].idata.member_of[recipe[e].e_subsystem]
                     = "*";
                 emit_edges (e, recipe, src_vtx, tgt_vtx);

--- a/resource/readers/resource_reader_hwloc.cpp
+++ b/resource/readers/resource_reader_hwloc.cpp
@@ -96,7 +96,7 @@ vtx_t resource_reader_hwloc_t::add_new_vertex (resource_graph_t &g,
     g[v].properties = properties;
 
     // Indexing for fast look-up
-    m.by_path[g[v].paths[subsys]] = v;
+    m.by_path[g[v].paths[subsys]].push_back (v);
     m.by_type[g[v].type].push_back (v);
     m.by_name[g[v].name].push_back (v);
     m.by_rank[rank].push_back (v);

--- a/resource/readers/resource_reader_jgf.hpp
+++ b/resource/readers/resource_reader_jgf.hpp
@@ -91,8 +91,10 @@ private:
                       json_t **path, json_t **properties);
     int unpack_vtx (json_t *element, fetch_helper_t &f);
     vtx_t create_vtx (resource_graph_t &g, const fetch_helper_t &fetcher);
-    vtx_t vtx_in_graph (const resource_graph_metadata_t &m, 
-                        const std::map<std::string, std::string> &paths);
+    vtx_t vtx_in_graph (const resource_graph_t &g,
+                        const resource_graph_metadata_t &m,
+                        const std::map<std::string,
+                                       std::string> &paths, int rank);
     bool is_root (const std::string &path);
     int check_root (vtx_t v, resource_graph_t &g,
                     std::map<std::string, bool> &is_roots);
@@ -104,6 +106,10 @@ private:
     int add_vtx (resource_graph_t &g, resource_graph_metadata_t &m,
                  std::map<std::string, vmap_val_t> &vmap,
                  const fetch_helper_t &fetcher);
+    int exist (resource_graph_t &g,
+               resource_graph_metadata_t &m,
+               const std::string &path, int rank,
+               const std::string &vid, vtx_t &v);
     int find_vtx (resource_graph_t &g, resource_graph_metadata_t &m,
                   std::map<std::string, vmap_val_t> &vmap,
                   const fetch_helper_t &fetcher, vtx_t &ret_v);

--- a/resource/readers/resource_reader_rv1exec.cpp
+++ b/resource/readers/resource_reader_rv1exec.cpp
@@ -75,7 +75,7 @@ vtx_t resource_reader_rv1exec_t::add_vertex (resource_graph_t &g,
     g[v].properties = props;
 
     // Indexing for fast look-up
-    m.by_path[g[v].paths[subsys]] = v;
+    m.by_path[g[v].paths[subsys]].push_back (v);
     m.by_type[g[v].type].push_back (v);
     m.by_name[g[v].name].push_back (v);
     m.by_rank[rank].push_back (v);

--- a/resource/store/resource_graph_store.hpp
+++ b/resource/store/resource_graph_store.hpp
@@ -29,7 +29,7 @@ struct resource_graph_metadata_t {
     std::map<std::string, std::vector <vtx_t>> by_type;
     std::map<std::string, std::vector <vtx_t>> by_name;
     std::map<int64_t, std::vector <vtx_t>> by_rank;
-    std::map<std::string, vtx_t> by_path;
+    std::map<std::string, std::vector<vtx_t>> by_path;
     // by_outedges enables graph traversing order to edge "weight"
     // E.g., the more available resources an edge point to, the heavier
     std::map<vtx_t,

--- a/resource/traversers/dfu_impl_update.cpp
+++ b/resource/traversers/dfu_impl_update.cpp
@@ -654,7 +654,7 @@ int dfu_impl_t::remove (vtx_t root, int64_t jobid)
 int dfu_impl_t::mark (const std::string &root_path, 
                       resource_pool_t::status_t status)
 {
-    std::map<std::string, vtx_t>::const_iterator vit_root =
+    std::map<std::string, std::vector<vtx_t>>::const_iterator vit_root =
         m_graph_db->metadata.by_path.find (root_path);
 
     if (vit_root == m_graph_db->metadata.by_path.end ()) {
@@ -664,7 +664,8 @@ int dfu_impl_t::mark (const std::string &root_path,
                   + root_path + ") in resource graph.\n";
         return -1;
     }
-    (*m_graph)[vit_root->second].status = status;
+    for (auto &v : vit_root->second)
+        (*m_graph)[v].status = status;
     
     return 0;
 }

--- a/t/data/resource/expected/resource_property/003.R.out
+++ b/t/data/resource/expected/resource_property/003.R.out
@@ -1,1 +1,1 @@
-No properties were found for /tiny0/rack0/node0. 
+No properties were found for /tiny0/rack0/node0.

--- a/t/data/resource/expected/resource_property/006.R.out
+++ b/t/data/resource/expected/resource_property/006.R.out
@@ -1,16 +1,16 @@
 Couldn't find path /dont/exist in resource graph.
 Incorrect input format. 
 Please use `set-property <resource> PROPERTY=VALUE`.
-No properties were found for /tiny0/rack0/node0. 
+No properties were found for /tiny0/rack0/node0.
 Incorrect input format. 
 Please use `set-property <resource> PROPERTY=VALUE`.
-No properties were found for /tiny0/rack0/node0. 
+No properties were found for /tiny0/rack0/node0.
 Incorrect input format. 
 Please use `set-property <resource> PROPERTY=VALUE`.
-No properties were found for /tiny0/rack0/node0. 
+No properties were found for /tiny0/rack0/node0.
 Incorrect input format. 
 Please use `set-property <resource> PROPERTY=VALUE`.
-No properties were found for /tiny0/rack0/node0. 
+No properties were found for /tiny0/rack0/node0.
 class==1
 class=1=class=random
 class=1

--- a/t/scripts/flux-ion-resource.py
+++ b/t/scripts/flux-ion-resource.py
@@ -253,7 +253,7 @@ def get_property_action(args):
     gp_resource_path = args.gp_resource_path
     gp_key = args.gp_key
     resp = r.rpc_get_property(gp_resource_path, gp_key)
-    print(args.gp_key, "=", resp["value"])
+    print(args.gp_key, "=", resp["values"])
 
 
 """

--- a/t/t3012-resource-properties.t
+++ b/t/t3012-resource-properties.t
@@ -10,6 +10,10 @@ exp_dir="${SHARNESS_TEST_SRCDIR}/data/resource/expected/resource_property"
 grugs="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/tiny.graphml"
 query="../../resource/utilities/resource-query"
 
+filter_run_variations(){
+   sed "s/ (vtx's uniq_id=[[:digit:]])//g" ${1}
+}
+
 #
 # Selection Policy -- High ID first (-P high)
 #     The resource vertex with higher ID is preferred among its kind
@@ -37,7 +41,8 @@ test003_desc="test get-property without setting any properties"
 test_expect_success "${test003_desc}" '
    sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds003} > cmds003 &&
    ${query} -L ${grugs} -S CA -P high -t 003.R.out < cmds003 &&
-   test_cmp 003.R.out ${exp_dir}/003.R.out
+   filter_run_variations 003.R.out > 003.R.out.filt &&
+   test_cmp 003.R.out.filt ${exp_dir}/003.R.out
 '
 
 cmds004="${cmd_dir}/cmds04.in"
@@ -61,7 +66,8 @@ test006_desc="test incorrect inputs to set-property"
 test_expect_success "${test006_desc}" '
    sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds006} > cmds006 &&
    ${query} -L ${grugs} -S CA -P high -t 006.R.out < cmds006 &&
-   test_cmp 006.R.out ${exp_dir}/006.R.out
+   filter_run_variations 006.R.out > 006.R.out.filt &&
+   test_cmp 006.R.out.filt ${exp_dir}/006.R.out
 '
 
 test_done

--- a/t/t3012-resource-properties.t
+++ b/t/t3012-resource-properties.t
@@ -70,4 +70,20 @@ test_expect_success "${test006_desc}" '
    test_cmp 006.R.out.filt ${exp_dir}/006.R.out
 '
 
+test_expect_success 'get|set property works on multiple same hostnames' '
+	cat > cmds007 <<-EOF &&
+	set-property /cluster0/fluke class=1
+	get-property /cluster0/fluke
+	quit
+	EOF
+	cat > expected7 <<-EOF &&
+	class=1
+	class=1
+	EOF
+	flux R encode -r 0-1 -c 0-3 -H fluke,fluke > out7.json &&
+	${query} -L out7.json -f rv1exec -F rv1_nosched -t 007.R.out -P lonode \
+		< cmds007 &&
+	test_cmp 007.R.out expected7
+'
+
 test_done

--- a/t/t3027-resource-RV.t
+++ b/t/t3027-resource-RV.t
@@ -158,4 +158,20 @@ EOF
     test_cmp exp10 res10
 '
 
+test_expect_success 'RV1 with same hostnames work' '
+    flux mini submit -n 8 --dry-run hostname > n8.json &&
+    cat > cmds011 <<-EOF &&
+	match allocate n8.json
+	quit
+EOF
+    flux R encode -r 0-1 -c 0-3 -H fluke,fluke | flux ion-R encode > out11 &&
+    print_ranks_nodes out11 > exp11 &&
+    jq ".scheduling" out11 > c11.json &&
+    ${query} -L c11.json -f jgf -F rv1_nosched -t R11.out -P lonode \
+	< cmds011 &&
+    grep -v INFO R11.out > R11.json &&
+    print_ranks_nodes R11.json > res11 &&
+    test_cmp exp11 res11
+'
+
 test_done

--- a/t/t4006-properties.t
+++ b/t/t4006-properties.t
@@ -37,14 +37,14 @@ load-file=${grug} load-format=grug \
 prune-filters=ALL:core subsystems=containment policy=high
 '
 
-test_expect_success 'set/get property basic test works' '
+test_expect_success 'set/get property basic test works' "
 	flux ion-resource set-property /tiny0/rack0/node0 class=one &&
 	flux ion-resource get-property /tiny0/rack0/node0 class > sp.0 &&
-	echo "class = one" > expected &&
+	echo \"class = ['one']\" > expected &&
 	test_cmp expected sp.0
-'
+"
 
-test_expect_success 'set/get property multiple resources works' '
+test_expect_success 'set/get property multiple resources works' "
 	flux ion-resource set-property /tiny0/rack0/node0 nodeprop=1 &&
 	flux ion-resource set-property /tiny0/rack0/node0/socket1 sockprop=abc &&
 	flux ion-resource set-property /tiny0/rack0/node1/socket0/core17 coreprop=z &&
@@ -52,14 +52,14 @@ test_expect_success 'set/get property multiple resources works' '
 	flux ion-resource get-property /tiny0/rack0/node0/socket1 sockprop >> sp.1 &&
 	flux ion-resource get-property /tiny0/rack0/node1/socket0/core17 coreprop >> sp.1 &&
 	cat <<-EOF >expected &&
-	nodeprop = 1
-	sockprop = abc
-	coreprop = z
+	nodeprop = ['1']
+	sockprop = ['abc']
+	coreprop = ['z']
 	EOF
 	test_cmp expected sp.1
-'
+"
 
-test_expect_success 'set/get property multiple properties works' '
+test_expect_success 'set/get property multiple properties works' "
 	flux ion-resource set-property /tiny0/rack0/node0 prop1=a &&
 	flux ion-resource set-property /tiny0/rack0/node0 prop2=foo &&
 	flux ion-resource set-property /tiny0/rack0/node0 prop3=123 &&
@@ -71,14 +71,14 @@ test_expect_success 'set/get property multiple properties works' '
 	flux ion-resource get-property /tiny0/rack0/node0 prop4 >> sp.2 &&
 	flux ion-resource get-property /tiny0/rack0/node0 prop5 >> sp.2 &&
 	cat <<-EOF >expected &&
-	prop1 = a
-	prop2 = foo
-	prop3 = 123
-	prop4 = bar
-	prop5 = baz
+	prop1 = ['a']
+	prop2 = ['foo']
+	prop3 = ['123']
+	prop4 = ['bar']
+	prop5 = ['baz']
 	EOF
 	test_cmp expected sp.2
-'
+"
 
 test_expect_success 'test with no path works' '
 	test_expect_code 3 flux ion-resource set-property /dont/exist random=1
@@ -99,7 +99,7 @@ test_expect_success 'test with malformed inputs works' '
 	test_expect_code 3 flux ion-resource get-property /tiny0/rack0/node0 badprop
 '
 
-test_expect_success 'test with complex inputs works' '
+test_expect_success 'test with complex inputs works' "
 	flux ion-resource set-property /tiny0/rack0/node0 badprop==1 &&
 	flux ion-resource get-property /tiny0/rack0/node0 badprop > sp.5 &&
 	flux ion-resource set-property /tiny0/rack0/node0 badprop=1=class=random &&
@@ -107,12 +107,12 @@ test_expect_success 'test with complex inputs works' '
 	flux ion-resource set-property /tiny0/rack0/node0 badprop=1 &&
 	flux ion-resource get-property /tiny0/rack0/node0 badprop >> sp.5 &&
 	cat <<-EOF >expected &&
-	badprop = =1
-	badprop = 1=class=random
-	badprop = 1
+	badprop = ['=1']
+	badprop = ['1=class=random']
+	badprop = ['1']
 	EOF
 	test_cmp expected sp.5
-'
+"
 
 test_expect_success 'removing resource works' '
 	remove_resource


### PR DESCRIPTION
Problem: We currently assume that there exits one and only one unique
graph vertex that corresponds to a path. But in various emulation
modes where we run multiple brokers on a single node, this unique path
assumption does not hold: having more than one node vertex with
an identical hostname breaks this assumption. As a result, our reader
code balks at loading our resource graph data store under certain
conditions. The JGF reader will fail to initialize with:
"grow_resource_db_jgf: db.load: error inserting an edge to outedge
metadata map"

Add support so that we can drop the unique path assumption.

- Modify `by_path` graph metadata index to be a map of vector of vertices
  instead of a map of vertices. Since this map is keyed by paths, one 
  path can have multiple vertices corresponding to it. 
- Adjust various readers to use the modified data structure to break
  their unique path assumption.
- Modify both `sched-fluxion-resource` module and `resource-query` to use 
  the new structure to break the assumption.
- Change the format of returned data for both `sched-fluxion-resource`
  and `resource-query` on path-based queries such as get-property.
- Adjust the affected test cases.

Fixes Issue #828 