### PR TITLE
testsuite: disable more failing test that need resource.get-xml

### DIFF
--- a/t/t4004-match-hwloc.t
+++ b/t/t4004-match-hwloc.t
@@ -122,43 +122,43 @@ test_expect_success 'removing resource works' '
     remove_resource
 '
 
-test_expect_success 'load test resources (4N4B)' '
+test_expect_success HAVE_GETXML 'load test resources (4N4B)' '
     load_test_resources ${excl_4N4B}
 '
 
-test_expect_success 'loading resource module with default resource info source' '
+test_expect_success HAVE_GETXML 'loading resource module with default resource info source' '
     load_resource subsystems=containment policy=high \
 	load-format=hwloc load-allowlist=node,socket,core
 '
 
-test_expect_success 'match-allocate works with four two-socket jobspecs' '
+test_expect_success HAVE_GETXML 'match-allocate works with four two-socket jobspecs' '
     flux ion-resource match allocate ${jobspec_2socket} &&
     flux ion-resource match allocate ${jobspec_2socket} &&
     flux ion-resource match allocate ${jobspec_2socket} &&
     flux ion-resource match allocate ${jobspec_2socket}
 '
 
-test_expect_success 'match-allocate fails when all resources are allocated' '
+test_expect_success HAVE_GETXML 'match-allocate fails when all resources are allocated' '
     test_expect_code 16 flux ion-resource match allocate ${jobspec_2socket} &&
     test_expect_code 16 flux ion-resource match allocate ${jobspec_2socket} &&
     test_expect_code 16 flux ion-resource match allocate ${jobspec_2socket} &&
     test_expect_code 16 flux ion-resource match allocate ${jobspec_2socket}
 '
 
-test_expect_success 'unload fluxion resource' '
+test_expect_success HAVE_GETXML 'unload fluxion resource' '
     remove_resource
 '
 
-test_expect_success 'load test resources (4N4B_sierra2)' '
+test_expect_success HAVE_GETXML 'load test resources (4N4B_sierra2)' '
     load_test_resources ${excl_4N4B_sierra2}
 '
 
-test_expect_success 'load fluxion resource' '
+test_expect_success HAVE_GETXML 'load fluxion resource' '
     load_resource subsystems=containment policy=high \
 	load-format=hwloc load-allowlist=node,socket,core,gpu
 '
 
-test_expect_success 'match allocate' '
+test_expect_success HAVE_GETXML 'match allocate' '
     flux ion-resource match allocate ${jobspec_1socket_2gpu} &&
     flux ion-resource match allocate ${jobspec_1socket_2gpu} &&
     flux ion-resource match allocate ${jobspec_1socket_2gpu} &&
@@ -170,7 +170,7 @@ test_expect_success 'match allocate' '
     test_expect_code 16 flux ion-resource match allocate ${jobspec_1socket_2gpu}
 '
 
-test_expect_success 'removing resource works' '
+test_expect_success HAVE_GETXML 'removing resource works' '
     remove_resource
 '
 


### PR DESCRIPTION
Apparently the list of tests that I proposed to disable in #926 was not complete.  This catches a couple more.

It was my bad for not checking my "fix" before proposing it...I was just going off of ci error logs.  This time I did verify that everything now passes against flux-core with flux-framework/flux-core#4263 applied.