### PR TITLE
Fix an integer overflow bug etc.

### DIFF
--- a/resource/readers/resource_reader_base.cpp
+++ b/resource/readers/resource_reader_base.cpp
@@ -93,7 +93,7 @@ void resource_reader_base_t::clear_err_message ()
 
 int resource_reader_base_t::split_hostname (const std::string &hn,
                                             std::string &basename,
-                                            int &id) const
+                                            int64_t &id) const
 {
     std::string suffix;
     std::size_t first;
@@ -121,7 +121,7 @@ int resource_reader_base_t::split_hostname (const std::string &hn,
 
     suffix = suffix.substr (first);
     try {
-        id = std::stoi (suffix);
+        id = std::stoll (suffix);
     } catch (std::invalid_argument &e) {
         errno = EINVAL;
         goto error;
@@ -136,7 +136,7 @@ error:
 }
 
 int resource_reader_base_t::get_hostname_suffix (const std::string &hn,
-                                                 int &id) const
+                                                 int64_t &id) const
 {
     if (hn == "") {
         errno = EINVAL;
@@ -153,7 +153,7 @@ int resource_reader_base_t::get_host_basename (const std::string &hn,
         errno = EINVAL;
         return -1;
     }
-    int id;
+    int64_t id;
     return split_hostname (hn, basename, id);
 }
 

--- a/resource/readers/resource_reader_base.hpp
+++ b/resource/readers/resource_reader_base.hpp
@@ -102,7 +102,7 @@ public:
      *
      * \return          0 if succeeds or -1 with errno if an error encountered
      */
-    int get_hostname_suffix (const std::string &hn, int &id) const;
+    int get_hostname_suffix (const std::string &hn, int64_t &id) const;
 
     /*! Query the host basename from hostname.
      *
@@ -124,7 +124,7 @@ public:
 protected:
     bool in_allowlist (const std::string &resource);
     int split_hostname (const std::string &hn,
-                        std::string &basename, int &id) const;
+                        std::string &basename, int64_t &id) const;
     std::set<std::string> allowlist;
     std::string m_err_msg = "";
 };

--- a/resource/readers/resource_reader_hwloc.cpp
+++ b/resource/readers/resource_reader_hwloc.cpp
@@ -63,7 +63,7 @@ vtx_t resource_reader_hwloc_t::create_cluster_vertex (
 
 vtx_t resource_reader_hwloc_t::add_new_vertex (resource_graph_t &g,
                                                resource_graph_metadata_t &m,
-                                               const vtx_t &parent, int id,
+                                               const vtx_t &parent, int64_t id,
                                                const std::string &subsys,
                                                const std::string &type,
                                                const std::string &basename,
@@ -147,7 +147,7 @@ int resource_reader_hwloc_t::walk_hwloc (resource_graph_t &g,
     bool supported_resource = true;
     std::string type, basename;
     std::string name = "";
-    int id = obj->logical_index;
+    int64_t id = obj->logical_index;
     int rc = 0;
     unsigned int size = 1;
     std::map<std::string, std::string> properties;

--- a/resource/readers/resource_reader_hwloc.hpp
+++ b/resource/readers/resource_reader_hwloc.hpp
@@ -84,7 +84,7 @@ private:
     vtx_t create_cluster_vertex (resource_graph_t &g,
                                  resource_graph_metadata_t &m);
     vtx_t add_new_vertex (resource_graph_t &g, resource_graph_metadata_t &m,
-                          const vtx_t &parent, int id,
+                          const vtx_t &parent, int64_t id,
                           const std::string &subsys, const std::string &type,
                           const std::string &basename, const std::string &name,
                           const std::map<std::string, std::string> &properties,

--- a/resource/readers/resource_reader_rv1exec.cpp
+++ b/resource/readers/resource_reader_rv1exec.cpp
@@ -31,7 +31,7 @@ using namespace Flux::resource_model;
 
 vtx_t resource_reader_rv1exec_t::add_vertex (resource_graph_t &g,
                                              resource_graph_metadata_t &m,
-                                             vtx_t parent, int id,
+                                             vtx_t parent, int64_t id,
                                              const std::string &subsys,
                                              const std::string &type,
                                              const std::string &basename,
@@ -319,7 +319,7 @@ int resource_reader_rv1exec_t::unpack_rank (resource_graph_t &g,
 {
     edg_t e;
     vtx_t v;
-    int iden;
+    int64_t iden;
     const char *hostname = nullptr;
     std::string basename;
     std::map<std::string, std::string> properties;
@@ -335,10 +335,13 @@ int resource_reader_rv1exec_t::unpack_rank (resource_graph_t &g,
 
     if ( !(hostname = hostlist_nth (hlist, static_cast<int> (rmap[rank]))))
         goto error;
-    if (get_hostname_suffix (hostname, iden) < 0)
+    if (get_hostname_suffix (hostname, iden) < 0
+        || get_host_basename (hostname, basename) < 0) {
+        m_err_msg += __FUNCTION__;
+        m_err_msg += ": error splitting hostname=";
+        m_err_msg += hostname + std::string ("; ");
         goto error;
-    if (get_host_basename (hostname, basename) < 0)
-        goto error;
+    }
 
     // Create and add a node vertex and link with cluster vertex
     v = add_vertex (g, m, parent, iden, "containment",

--- a/resource/readers/resource_reader_rv1exec.hpp
+++ b/resource/readers/resource_reader_rv1exec.hpp
@@ -83,7 +83,7 @@ public:
 private:
     vtx_t add_vertex (resource_graph_t &g,
                       resource_graph_metadata_t &m,
-                      vtx_t parent, int id,
+                      vtx_t parent, int64_t id,
                       const std::string &subsys,
                       const std::string &type,
                       const std::string &basename,

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -622,7 +622,7 @@ int dfu_impl_t::dom_slot (const jobmeta_t &meta, vtx_t u,
     qual_num_slots = cnt_slot (slot_shape, dfu_slot);
     for (unsigned int i = 0; i < qual_num_slots; ++i) {
         eval_egroup_t edg_group;
-        int score = MATCH_MET;
+        int64_t score = MATCH_MET;
         for (auto &slot_elem : slot_shape) {
             unsigned int j = 0;
             unsigned int qc = dfu_slot.qualified_count (dom, slot_elem.type);

--- a/t/t3027-resource-RV.t
+++ b/t/t3027-resource-RV.t
@@ -16,162 +16,162 @@ query="../../resource/utilities/resource-query"
 
 # print_ranks_nodes <RV1 JSON filename>
 print_ranks_nodes() {
-    jq -r ".execution.R_lite[].rank, .execution.nodelist[0]" $1 | sort
+	jq -r ".execution.R_lite[].rank, .execution.nodelist[0]" $1 | sort
 }
 
 test_expect_success 'RV1 is correct on rank and node ID order match' '
-    cat > cmds001 <<-EOF &&
+	cat > cmds001 <<-EOF &&
 	match allocate ${full_job}
 	quit
-EOF
-    ${query} -L ${jgf_orig} -f jgf -F rv1_nosched -t R1.out -P high < cmds001 &&
-    test_cmp R1.out ${exp_dir}/R1.out
+	EOF
+	${query} -L ${jgf_orig} -f jgf -F rv1_nosched -t R1.out -P high < cmds001 &&
+	test_cmp R1.out ${exp_dir}/R1.out
 '
 
 test_expect_success 'RV1 is correct on core ID modified' '
-    cat > cmds002 <<-EOF &&
+	cat > cmds002 <<-EOF &&
 	match allocate ${full_job}
 	quit
-EOF
-    ${query} -L ${jgf_mod1} -f jgf -F rv1_nosched -t R2.out -P high < cmds002 &&
-    test_cmp R2.out ${exp_dir}/R2.out
+	EOF
+	${query} -L ${jgf_mod1} -f jgf -F rv1_nosched -t R2.out -P high < cmds002 &&
+	test_cmp R2.out ${exp_dir}/R2.out
 '
 
 test_expect_success 'RV1 correct on rank/node ID mismatch + core ID modified' '
-    cat > cmds003 <<-EOF &&
+	cat > cmds003 <<-EOF &&
 	match allocate ${full_job}
 	quit
-EOF
-    ${query} -L ${jgf_mod2} -f jgf -F rv1_nosched -t R3.out -P high < cmds003 &&
-    test_cmp R3.out ${exp_dir}/R3.out
+	EOF
+	${query} -L ${jgf_mod2} -f jgf -F rv1_nosched -t R3.out -P high < cmds003 &&
+	test_cmp R3.out ${exp_dir}/R3.out
 '
 
 test_expect_success 'RV1 correct on heterogeneous configuration' '
-    flux mini submit -n 28 --dry-run hostname > n28.json &&
-    cat > cmds004 <<-EOF &&
-        match allocate n28.json
-        quit
-EOF
-    flux R encode -r 79-83 -c 0-3 -H fluke[82-86] > out4 &&
-    flux R encode -r 91-92 -c 0-2 -H fluke[94-95] >> out4 &&
-    flux R encode -r 97,99 -c 3 -H fluke[100,102] >> out4 &&
-    cat out4 | flux R append > c4.json &&
-    print_ranks_nodes c4.json > exp4 &&
-    cat c4.json | flux ion-R encode > a4.json &&
-    jq .scheduling a4.json > jgf4.json &&
-    ${query} -L jgf4.json -f jgf -F rv1_nosched -t R4.out -P lonode < cmds004 &&
-    grep -v INFO R4.out > R4.json &&
-    print_ranks_nodes R4.json > res4 &&
-    test_cmp exp4 res4
+	flux mini submit -n 28 --dry-run hostname > n28.json &&
+	cat > cmds004 <<-EOF &&
+	match allocate n28.json
+	quit
+	EOF
+	flux R encode -r 79-83 -c 0-3 -H fluke[82-86] > out4 &&
+	flux R encode -r 91-92 -c 0-2 -H fluke[94-95] >> out4 &&
+	flux R encode -r 97,99 -c 3 -H fluke[100,102] >> out4 &&
+	cat out4 | flux R append > c4.json &&
+	print_ranks_nodes c4.json > exp4 &&
+	cat c4.json | flux ion-R encode > a4.json &&
+	jq .scheduling a4.json > jgf4.json &&
+	${query} -L jgf4.json -f jgf -F rv1_nosched -t R4.out -P lonode < cmds004 &&
+	grep -v INFO R4.out > R4.json &&
+	print_ranks_nodes R4.json > res4 &&
+	test_cmp exp4 res4
 '
 
 test_expect_success 'RV1 correct on heterogeneous configuration 2' '
-    flux mini submit -n 14 --dry-run hostname > n14.json &&
-    cat > cmds005 <<-EOF &&
-        match allocate n14.json
-        quit
-EOF
-    cat > exp5 <<-EOF &&
+	flux mini submit -n 14 --dry-run hostname > n14.json &&
+	cat > cmds005 <<-EOF &&
+	match allocate n14.json
+	quit
+	EOF
+	cat > exp5 <<-EOF &&
 	79-81
 	82
 	fluke[82-85]
-EOF
-    ${query} -L jgf4.json -f jgf -F rv1_nosched -t R5.out -P lonode < cmds005 &&
-    grep -v INFO R5.out > R5.json &&
-    print_ranks_nodes R5.json > res5 &&
-    test_cmp exp5 res5
+	EOF
+	${query} -L jgf4.json -f jgf -F rv1_nosched -t R5.out -P lonode < cmds005 &&
+	grep -v INFO R5.out > R5.json &&
+	print_ranks_nodes R5.json > res5 &&
+	test_cmp exp5 res5
 '
 
 test_expect_success 'RV1 correct on heterogeneous configuration 3' '
-    cat > exp6 <<-EOF &&
+	cat > exp6 <<-EOF &&
 	82
 	83
 	91-92
 	97,99
 	fluke[85-86,94-95,100,102]
-EOF
-    ${query} -L jgf4.json -f jgf -F rv1_nosched -t R6.out -P hinode < cmds005 &&
-    grep -v INFO R6.out > R6.json &&
-    print_ranks_nodes R6.json > res6 &&
-    test_cmp exp6 res6
+	EOF
+	${query} -L jgf4.json -f jgf -F rv1_nosched -t R6.out -P hinode < cmds005 &&
+	grep -v INFO R6.out > R6.json &&
+	print_ranks_nodes R6.json > res6 &&
+	test_cmp exp6 res6
 '
 
 test_expect_success 'RV1 with nosched correct on heterogeneous configuration' '
-    flux mini submit -n 28 --dry-run hostname > n28.json &&
-    cat > cmds007 <<-EOF &&
-        match allocate n28.json
-        quit
-EOF
-    flux R encode -r 79-83 -c 0-3 -H fluke[82-86] > out7 &&
-    flux R encode -r 91-92 -c 0-2 -H fluke[94-95] >> out7 &&
-    flux R encode -r 97,99 -c 3 -H fluke[100,102] >> out7 &&
-    cat out7 | flux R append > c7.json &&
-    print_ranks_nodes c7.json > exp7 &&
-    ${query} -L c7.json -f rv1exec -F rv1_nosched -t R7.out -P lonode < cmds007 &&
-    grep -v INFO R7.out > R7.json &&
-    print_ranks_nodes R7.json > res7 &&
-    test_cmp exp7 res7
+	flux mini submit -n 28 --dry-run hostname > n28.json &&
+	cat > cmds007 <<-EOF &&
+	match allocate n28.json
+	quit
+	EOF
+	flux R encode -r 79-83 -c 0-3 -H fluke[82-86] > out7 &&
+	flux R encode -r 91-92 -c 0-2 -H fluke[94-95] >> out7 &&
+	flux R encode -r 97,99 -c 3 -H fluke[100,102] >> out7 &&
+	cat out7 | flux R append > c7.json &&
+	print_ranks_nodes c7.json > exp7 &&
+	${query} -L c7.json -f rv1exec -F rv1_nosched -t R7.out -P lonode < cmds007 &&
+	grep -v INFO R7.out > R7.json &&
+	print_ranks_nodes R7.json > res7 &&
+	test_cmp exp7 res7
 '
 
 test_expect_success 'RV1 with nosched correct on heterogeneous config 2' '
-    flux mini submit -n 14 --dry-run hostname > n14.json &&
-    cat > cmds008 <<-EOF &&
-        match allocate n14.json
-        quit
-EOF
-    cat > exp8 <<-EOF &&
+	flux mini submit -n 14 --dry-run hostname > n14.json &&
+	cat > cmds008 <<-EOF &&
+	match allocate n14.json
+	quit
+	EOF
+	cat > exp8 <<-EOF &&
 	79-81
 	82
 	fluke[82-85]
-EOF
-    ${query} -L c7.json -f rv1exec -F rv1_nosched -t R8.out -P lonode < cmds008 &&
-    grep -v INFO R8.out > R8.json &&
-    print_ranks_nodes R8.json > res8 &&
-    test_cmp exp8 res8
+	EOF
+	${query} -L c7.json -f rv1exec -F rv1_nosched -t R8.out -P lonode < cmds008 &&
+	grep -v INFO R8.out > R8.json &&
+	print_ranks_nodes R8.json > res8 &&
+	test_cmp exp8 res8
 '
 
 test_expect_success 'RV1 with nosched correct on heterogeneous config 3' '
-    cat > exp9 <<-EOF &&
+	cat > exp9 <<-EOF &&
 	82
 	83
 	91-92
 	97,99
 	fluke[85-86,94-95,100,102]
-EOF
-    ${query} -L c7.json -f rv1exec -F rv1_nosched -t R9.out -P hinode < cmds008 &&
-    grep -v INFO R9.out > R9.json &&
-    print_ranks_nodes R9.json > res9 &&
-    test_cmp exp9 res9
+	EOF
+	${query} -L c7.json -f rv1exec -F rv1_nosched -t R9.out -P hinode < cmds008 &&
+	grep -v INFO R9.out > R9.json &&
+	print_ranks_nodes R9.json > res9 &&
+	test_cmp exp9 res9
 '
 
 test_expect_success 'RV1 with nosched correct on nonconforming hostnames' '
-    flux mini submit -n 8 --dry-run hostname > n8.json &&
-    cat > cmds010 <<-EOF &&
-        match allocate n8.json
-        quit
-EOF
-    flux R encode -r 0-1 -c 0-3 -H foo,bar > c10.json &&
-    print_ranks_nodes c10.json > exp10 &&
-    ${query} -L c10.json -f rv1exec -F rv1_nosched -t R10.out -P lonode < cmds010 &&
-    grep -v INFO R10.out > R10.json &&
-    print_ranks_nodes R10.json > res10 &&
-    test_cmp exp10 res10
+	flux mini submit -n 8 --dry-run hostname > n8.json &&
+	cat > cmds010 <<-EOF &&
+	match allocate n8.json
+	quit
+	EOF
+	flux R encode -r 0-1 -c 0-3 -H foo,bar > c10.json &&
+	print_ranks_nodes c10.json > exp10 &&
+	${query} -L c10.json -f rv1exec -F rv1_nosched -t R10.out -P lonode < cmds010 &&
+	grep -v INFO R10.out > R10.json &&
+	print_ranks_nodes R10.json > res10 &&
+	test_cmp exp10 res10
 '
 
 test_expect_success 'RV1 with same hostnames work' '
-    flux mini submit -n 8 --dry-run hostname > n8.json &&
-    cat > cmds011 <<-EOF &&
+	flux mini submit -n 8 --dry-run hostname > n8.json &&
+	cat > cmds011 <<-EOF &&
 	match allocate n8.json
 	quit
-EOF
-    flux R encode -r 0-1 -c 0-3 -H fluke,fluke | flux ion-R encode > out11 &&
-    print_ranks_nodes out11 > exp11 &&
-    jq ".scheduling" out11 > c11.json &&
-    ${query} -L c11.json -f jgf -F rv1_nosched -t R11.out -P lonode \
-	< cmds011 &&
-    grep -v INFO R11.out > R11.json &&
-    print_ranks_nodes R11.json > res11 &&
-    test_cmp exp11 res11
+	EOF
+	flux R encode -r 0-1 -c 0-3 -H fluke,fluke | flux ion-R encode > out11 &&
+	print_ranks_nodes out11 > exp11 &&
+	jq ".scheduling" out11 > c11.json &&
+	${query} -L c11.json -f jgf -F rv1_nosched -t R11.out -P lonode \
+	    < cmds011 &&
+	grep -v INFO R11.out > R11.json &&
+	print_ranks_nodes R11.json > res11 &&
+	test_cmp exp11 res11
 '
 
 test_expect_success 'Scheduling RV1 with high node num works (pol=lonode)' '


### PR DESCRIPTION
This PR adds fixes for the following problems.

With the recently added lonode[x]/hinode[x] match policies, each node's
numeric ID (e.g., node1231 where ID=1231) is used in our score calculation
of all of its containing resource vertices (e.g., cores, gpus...). When its ID
becomes high, however, a type coercion bug can result in an integer
overflow of the score, leading to a undefined behavior. In addition, when
a node's ID becomes even larger such that it can't fit into a signed
32-bit integer, our graph loading fails. While it is less likely we will have
such a huge node ID, it would be ideal to prevent that from happening at all.

-  Use `int64_t` to capure a score within our traverser to match the type
with the rest of the code that is involved in scoring;
- Change `std::atoi` to `std::atoll` to convert a large number string into a number
without raising an overflow exception within a hostname querying method
and adjust the callers within our readers accordingly; 
- Align the column of `t3027-resource-RV.t` test cases where HERE doc is
used such a way that a consistent tab-leading indentation helps with readability. 

Fixes #932.

