### PR TITLE
reader: fix index type

### DIFF
--- a/resource/readers/resource_reader_rv1exec.cpp
+++ b/resource/readers/resource_reader_rv1exec.cpp
@@ -176,7 +176,7 @@ int resource_reader_rv1exec_t::build_rmap (json_t *rlite,
                                            std::map<unsigned, unsigned> &rmap)
 {
     int i;
-    int index;
+    size_t index;
     unsigned rank;
     json_t *entry = nullptr;
     const char *ranks = nullptr;


### PR DESCRIPTION
Fix error reported by gcc 11.2.0: "comparison of integer expressions of different signedness: 'int' and 'size_t'"

I verified jansson expects `size_t` here:

https://jansson.readthedocs.io/en/latest/apiref.html?highlight=json_array_foreach#c.json_array_foreach
