### PR TITLE
qmanager: fix potential leak in alloc callback

### DIFF
--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -229,6 +229,7 @@ void qmanager_cb_t::jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
         if (schedutil_alloc_respond_deny (ctx->schedutil, msg, e.what ()) < 0)
             flux_log_error (h, "%s: schedutil_alloc_respond_deny",
                             __FUNCTION__);
+        free (jobspec_str);
         return;
     }
     if (jobspec_obj.attributes.system.queue != "")


### PR DESCRIPTION
Problem: If an alloc request results in a jobspec parse error, the
jobspec string is leaked.

Free the newly created jobspec string in the error path to avoid
the leak.