### PR TITLE
build: drop unnecessary preqreqs, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ easy-to-use environment.
 ### Fluxion Scheduler in Flux
 
 Fluxion introduces queuing and resource matching services to extend Flux
-to provide advanced batch scheduling. Jobs are submitted to Fluxion via
-`flux job submit` which are then added to our queues for scheduling.
+to provide advanced batch scheduling. Jobs are submitted to Flux as usual,
+and Fluxion makes a schedule to assign available resources to the job
+requests according to its configured algorithm.
 
 At the core of its functionality lie its two service modules:
 `sched-fluxion-qmanager` and `sched-fluxion-resource`.

--- a/README.md
+++ b/README.md
@@ -31,28 +31,12 @@ to provide advanced batch scheduling. Jobs are submitted to Flux as usual,
 and Fluxion makes a schedule to assign available resources to the job
 requests according to its configured algorithm.
 
-At the core of its functionality lie its two service modules:
-`sched-fluxion-qmanager` and `sched-fluxion-resource`.
-The first module is designed to manage our job queues and
-to enforce queueing policies that are configurable (e.g.,
-first-come-first-served, EASY, conservative backfilling policies etc).
-The second module uses a graph to represent
-resources of arbitrary types
-as well as their complex relationships and to match the highly sophisticated
-resource requirements of a Flux jobspec to the compute and other resources
-on this graph. Both of these modules are loaded into a Flux instance and
-work in tandem to provide highly effective scheduling.
+Fluxion installs two modules that are loaded by the Flux broker:
 
-Clearly, we recognize that a single scheduling policy will not sufficiently
-optimize the scheduling of different kinds of workflows. In fact, one of the
-main design points of flux-sched is its ability to customize the scheduling
-behaviors. Users can use environment variables or module-load time options
-to select and to tune the policies as to how resources are selected
-and when to run their jobs.
-
-Overall, the advanced job scheduling facility within Fluxion offers vastly
-many opportunities for modern HPC and other worfklows to meet their highly
-challenging scheduling objectives.
+* `sched-fluxion-qmanager`, which manages one or more prioritized job queues
+  with configurable queuing policies (fcfs, easy, conservative, or hybrid).
+* `sched-fluxion-resource`, which matches resource requests to available
+  resources using Fluxion's graph-based matching algorithm.
 
 
 #### Building Fluxion

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ boost-system              | libboost-system-dev     | == 1.53 or > 1.58 | *1*
 boost-filesystem          | libboost-filesystem-dev | == 1.53 or > 1.58 | *1*
 boost-regex               | libboost-regex-dev      | == 1.53 or > 1.58 | *1*
 libedit-devel             | libedit-dev             | >= 3.0            |
-libxml2-devel             | libxml2-dev             | >= 2.9.1          |
 python3-pyyaml            | python3-yaml            | >= 3.10           |
 yaml-cpp-devel            | libyaml-cpp-dev         | >= 0.5.1          |
 
@@ -92,14 +91,14 @@ jq                | jq                |
 
 ##### Installing RedHat/CentOS Packages
 ```
-sudo yum install hwloc-devel boost-devel boost-graph boost-system boost-filesystem boost-regex libedit-devel libxml2-devel python3-pyyaml yaml-cpp-devel
+sudo yum install hwloc-devel boost-devel boost-graph boost-system boost-filesystem boost-regex libedit-devel python3-pyyaml yaml-cpp-devel
 ```
 
 ##### Installing Ubuntu Packages
 
 ```
 sudo apt-get update
-sudo apt install libhwloc-dev libboost-dev libboost-system-dev libboost-filesystem-dev libboost-graph-dev libboost-regex-dev libedit-dev libxml2-dev libyaml-cpp-dev python3-yaml
+sudo apt install libhwloc-dev libboost-dev libboost-system-dev libboost-filesystem-dev libboost-graph-dev libboost-regex-dev libedit-dev libyaml-cpp-dev python3-yaml
 ```
 
 Clone flux-sched, the repo name for Fluxion, from an upstream repo and prepare for configure:

--- a/configure.ac
+++ b/configure.ac
@@ -78,7 +78,6 @@ AC_CHECK_LIB([dl], [dlerror],
              [AC_MSG_ERROR([Please install dl])])
 PKG_CHECK_MODULES([HWLOC], [hwloc >= 1.11.1], [], [])
 PKG_CHECK_MODULES([JANSSON], [jansson >= 2.10], [], [])
-PKG_CHECK_MODULES([XML2], [libxml-2.0])
 AX_VALGRIND_H
 
 PKG_CHECK_MODULES([UUID], [uuid], [], [])

--- a/configure.ac
+++ b/configure.ac
@@ -71,11 +71,6 @@ AC_CHECK_PROG(ASPELL,[aspell],[aspell])
 # Checks for libraries.
 PKG_PROG_PKG_CONFIG
 PKG_CHECK_MODULES([CZMQ], [libczmq >= 3.0.0])
-AC_CHECK_LIB([dl], [dlerror],
-             [AC_SUBST([DL_LIBS], ["-ldl"])
-              AC_DEFINE([HAVE_LIBDL], [1],
-                        [Define if you have libdl])],
-             [AC_MSG_ERROR([Please install dl])])
 PKG_CHECK_MODULES([HWLOC], [hwloc >= 1.11.1], [], [])
 PKG_CHECK_MODULES([JANSSON], [jansson >= 2.10], [], [])
 AX_VALGRIND_H

--- a/resource/modules/Makefile.am
+++ b/resource/modules/Makefile.am
@@ -30,7 +30,6 @@ sched_fluxion_resource_la_LIBADD = \
     $(FLUX_IDSET_LIBS) \
     $(FLUX_HOSTLIST_LIBS) \
     $(FLUX_CORE_LIBS) \
-    $(DL_LIBS) \
     $(HWLOC_LIBS) \
     $(UUID_LIBS) \
     $(JANSSON_LIBS) \

--- a/src/test/docker/bionic/Dockerfile
+++ b/src/test/docker/bionic/Dockerfile
@@ -10,7 +10,6 @@ RUN sudo apt-get -qq install -y --no-install-recommends \
 	libboost-system-dev \
 	libboost-filesystem-dev \
 	libboost-regex-dev \
-	libxml2-dev \
 	python-yaml \
 	libyaml-cpp-dev \
 	libedit-dev

--- a/src/test/docker/el7/Dockerfile
+++ b/src/test/docker/el7/Dockerfile
@@ -9,7 +9,6 @@ RUN sudo yum -y install \
 	libboost-system-devel \
 	libboost-filesystem-devel \
 	libboost-regex-devel \
-	libxml2-devel \
 	python-yaml \
 	yaml-cpp-devel \
 	libedit-devel

--- a/src/test/docker/el8/Dockerfile
+++ b/src/test/docker/el8/Dockerfile
@@ -10,7 +10,6 @@ RUN sudo yum -y install \
 	boost-system \
 	boost-filesystem \
 	boost-regex \
-	libxml2-devel \
 	readline-devel \
 	python3-pyyaml \
 	yaml-cpp-devel \

--- a/src/test/docker/fedora33/Dockerfile
+++ b/src/test/docker/fedora33/Dockerfile
@@ -13,7 +13,6 @@ RUN sudo yum -y update \
 	boost-system \
 	boost-filesystem \
 	boost-regex \
-	libxml2-devel \
 	readline-devel \
 	python3-pyyaml \
 	yaml-cpp-devel \

--- a/src/test/docker/fedora34/Dockerfile
+++ b/src/test/docker/fedora34/Dockerfile
@@ -13,7 +13,6 @@ RUN sudo yum -y update \
 	boost-system \
 	boost-filesystem \
 	boost-regex \
-	libxml2-devel \
 	readline-devel \
 	python3-pyyaml \
 	yaml-cpp-devel \

--- a/src/test/docker/focal/Dockerfile
+++ b/src/test/docker/focal/Dockerfile
@@ -10,7 +10,6 @@ RUN sudo apt-get -qq install -y --no-install-recommends \
 	libboost-system-dev \
 	libboost-filesystem-dev \
 	libboost-regex-dev \
-	libxml2-dev \
 	python-yaml \
 	libyaml-cpp-dev \
 	libedit-dev


### PR DESCRIPTION
Problem: The fluxion build system wants libxml and libdl, neither of which appear to actually be used.

Drop these from the build system and update the README.md.

Also, modernize and trim down the "Fluxion Scheduler in Flux" section of the README.md.