### PR TITLE
add an exception note to fatal queue exceptions

### DIFF
--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -252,9 +252,13 @@ void qmanager_cb_t::jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
     job->msg = flux_msg_copy (msg, true);
     auto &queue = ctx->queues.at (queue_name);
     if (queue->insert (job) < 0) {
+        snprintf (errbuf,
+                  sizeof (errbuf),
+                  "fluxion could not insert job into queue %s",
+                  queue_name.c_str());
         flux_log_error (h, "%s: queue insert (id=%jd)", __FUNCTION__,
                        static_cast<intmax_t> (job->id));
-        if (schedutil_alloc_respond_deny (ctx->schedutil, msg, NULL) < 0)
+        if (schedutil_alloc_respond_deny (ctx->schedutil, msg, errbuf) < 0)
             flux_log_error (h, "%s: schedutil_alloc_respond_deny",
                             __FUNCTION__);
         return;

--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -203,6 +203,7 @@ void qmanager_cb_t::jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
     double t_submit;
     json_t *jobspec;
     char *jobspec_str = NULL;
+    char errbuf[80];
 
     if (flux_msg_unpack (msg,
                          "{s:I s:i s:i s:f s:o}",
@@ -237,12 +238,14 @@ void qmanager_cb_t::jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
     job->jobspec = jobspec_str;
     free (jobspec_str);
     if (ctx->queues.find (queue_name) == ctx->queues.end ()) {
-        if (schedutil_alloc_respond_deny (ctx->schedutil, msg, NULL) < 0)
+        snprintf (errbuf,
+                  sizeof (errbuf),
+                  "queue (%s) doesn't exist",
+                  queue_name.c_str());
+        if (schedutil_alloc_respond_deny (ctx->schedutil, msg, errbuf) < 0)
             flux_log_error (h, "%s: schedutil_alloc_respond_deny",
                             __FUNCTION__);
         errno = ENOENT;
-        flux_log (h, LOG_DEBUG, "%s: queue (%s) doesn't exist",
-                  __FUNCTION__, queue_name.c_str ());
         return;
     }
 

--- a/t/t1006-qmanager-multiqueue.t
+++ b/t/t1006-qmanager-multiqueue.t
@@ -117,8 +117,9 @@ test_expect_success 'qmanager: job enqueued into explicitly default queue' '
 '
 
 test_expect_success 'qmanager: job is denied when submitted to unknown queue' '
-    test_must_fail flux mini run -n 1 --setattr system.queue=foo hostname &&
-    flux dmesg -C
+    test_must_fail flux mini run -n 1 --setattr system.queue=foo \
+	hostname 2>unknown.err &&
+    grep "queue (foo) doesn" unknown.err
 '
 
 test_expect_success 'qmanager: incorrect default-queue name can be caught' '


### PR DESCRIPTION
Problem: submitting a job to an unknown queue or failure to insert a job into a queue (an unlikely internal error) cause a fatal job exception with no "note", so the user doesn't get any reason why their job failed.

Add a note to the exception.