### PR TITLE
testsuite: use explicit duration units

### DIFF
--- a/t/t1001-qmanager-basic.t
+++ b/t/t1001-qmanager-basic.t
@@ -22,7 +22,7 @@ exec_testattr() {
 }
 
 test_expect_success 'qmanager: generate jobspec for a simple test job' '
-    flux mini submit -n1 -t 100 --dry-run hostname > basic.json
+    flux mini submit -n1 -t 100s --dry-run hostname > basic.json
 '
 
 test_expect_success 'load test resources' '

--- a/t/t1002-qmanager-reload.t
+++ b/t/t1002-qmanager-reload.t
@@ -23,7 +23,7 @@ submit_jobs()   {
 }
 
 test_expect_success 'qmanager: generate jobspec for a simple test job' '
-    flux mini submit -n 1 -t 100 --dry-run sleep 10 > basic.json
+    flux mini submit -n 1 -t 100s --dry-run sleep 10 > basic.json
 '
 
 test_expect_success 'load test resources' '

--- a/t/t1014-annotation.t
+++ b/t/t1014-annotation.t
@@ -54,11 +54,11 @@ subsystems=containment policy=low &&
 '
 
 test_expect_success 'annotation: works with EASY policy' '
-    jobid1=$(flux mini submit -n 8 -t 360 sleep 300) &&
-    jobid2=$(flux mini submit -n 16 -t 360 sleep 300) && # reserved
-    jobid3=$(flux mini submit -n 16 -t 360 sleep 300) && # skipped
-    jobid4=$(flux mini submit -n 16 -t 360 sleep 300) && # skipped
-    jobid5=$(flux mini submit -n 2 -t 180 sleep 100) &&
+    jobid1=$(flux mini submit -n 8 -t 360s sleep 300) &&
+    jobid2=$(flux mini submit -n 16 -t 360s sleep 300) && # reserved
+    jobid3=$(flux mini submit -n 16 -t 360s sleep 300) && # skipped
+    jobid4=$(flux mini submit -n 16 -t 360s sleep 300) && # skipped
+    jobid5=$(flux mini submit -n 2 -t 180s sleep 100) &&
 
     flux job wait-event -t 10 ${jobid5} start &&
     validate_sched_annotation ${jobid1} default TRUE &&
@@ -84,11 +84,11 @@ subsystems=containment policy=low load-allowlist=cluster,node,core &&
 '
 
 test_expect_success 'annotation: works with HYBRID policy' '
-    jobid1=$(flux mini submit -n 8 -t 360 sleep 300) &&
-    jobid2=$(flux mini submit -n 16 -t 360 sleep 300) && # reserved
-    jobid3=$(flux mini submit -n 16 -t 360 sleep 300) && # reserved
-    jobid4=$(flux mini submit -n 16 -t 360 sleep 300) && # skipped
-    jobid5=$(flux mini submit -n 2 -t 180 sleep 100) &&
+    jobid1=$(flux mini submit -n 8 -t 360s sleep 300) &&
+    jobid2=$(flux mini submit -n 16 -t 360s sleep 300) && # reserved
+    jobid3=$(flux mini submit -n 16 -t 360s sleep 300) && # reserved
+    jobid4=$(flux mini submit -n 16 -t 360s sleep 300) && # skipped
+    jobid5=$(flux mini submit -n 2 -t 180s sleep 100) &&
 
     flux job wait-event -t 10 ${jobid5} start &&
     validate_sched_annotation ${jobid1} default TRUE &&
@@ -112,11 +112,11 @@ subsystems=containment policy=low load-allowlist=cluster,node,core &&
 '
 
 test_expect_success 'annotation: works with CONSERVATIVE policy' '
-    jobid1=$(flux mini submit -n 8 -t 360 sleep 300) &&
-    jobid2=$(flux mini submit -n 16 -t 360 sleep 300) && # reserved
-    jobid3=$(flux mini submit -n 16 -t 360 sleep 300) && # reserved
-    jobid4=$(flux mini submit -n 16 -t 360 sleep 300) && # reserved
-    jobid5=$(flux mini submit -n 2 -t 180 sleep 100) &&
+    jobid1=$(flux mini submit -n 8 -t 360s sleep 300) &&
+    jobid2=$(flux mini submit -n 16 -t 360s sleep 300) && # reserved
+    jobid3=$(flux mini submit -n 16 -t 360s sleep 300) && # reserved
+    jobid4=$(flux mini submit -n 16 -t 360s sleep 300) && # reserved
+    jobid5=$(flux mini submit -n 2 -t 180s sleep 100) &&
 
     flux job wait-event -t 10 ${jobid5} start &&
     validate_sched_annotation ${jobid1} default TRUE &&
@@ -140,11 +140,11 @@ subsystems=containment policy=low load-allowlist=cluster,node,core &&
 '
 
 test_expect_success 'annotation: works with FCFS policy' '
-    jobid1=$(flux mini submit -n 8 -t 360 sleep 300) &&
-    jobid2=$(flux mini submit -n 16 -t 360 sleep 300) && # block
-    jobid3=$(flux mini submit -n 16 -t 360 sleep 300) &&
-    jobid4=$(flux mini submit -n 16 -t 360 sleep 300) &&
-    jobid5=$(flux mini submit -n 2 -t 180 sleep 100) &&
+    jobid1=$(flux mini submit -n 8 -t 360s sleep 300) &&
+    jobid2=$(flux mini submit -n 16 -t 360s sleep 300) && # block
+    jobid3=$(flux mini submit -n 16 -t 360s sleep 300) &&
+    jobid4=$(flux mini submit -n 16 -t 360s sleep 300) &&
+    jobid5=$(flux mini submit -n 2 -t 180s sleep 100) &&
 
     flux job wait-event -t 10 ${jobid1} start &&
     flux job wait-event -t 10 ${jobid5} submit &&

--- a/t/t1019-qmanager-async.t
+++ b/t/t1019-qmanager-async.t
@@ -19,7 +19,7 @@ submit_jobs() {
 }
 
 test_expect_success 'qmanager: generate jobspec for a simple test job' '
-    flux mini submit -n16 -t 100 --dry-run sleep 100 > basic.json
+    flux mini submit -n16 -t 100s --dry-run sleep 100 > basic.json
 '
 
 test_expect_success 'load test resources' '


### PR DESCRIPTION
Problem: flux mini will fail when small durations are specified without units after flux-framework/flux-core#4565.

Add explicit units to flux mini CMD -t where necessary.