### PR TITLE
testsuite: fix integer overflow

### DIFF
--- a/resource/policies/base/test/matcher_util_api_test01.cpp
+++ b/resource/policies/base/test/matcher_util_api_test01.cpp
@@ -121,8 +121,8 @@ json_t *test_jobspec_template::emit_count (unsigned int min, unsigned int max,
                                            const std::string &oper,
                                            unsigned int op)
 {
-    return json_pack ("{s:i s:i s:s s:i}",
-                        "min", min, "max", max,
+    return json_pack ("{s:i s:I s:s s:i}",
+                        "min", min, "max", (json_int_t)max,
                         "operator", oper.c_str (), "operand", op);
 }
 


### PR DESCRIPTION
Problem: matcher_util_api_test01 tries to encode a value of 2^32 with jansson "i" which overflows, then the Jobspec yaml parser refuses to parse a negative value.

Encode the value with jansson "I" instead.

Fixes #967