### PR TITLE
Resource graph duration and job expiration to conform to RFC 14

### DIFF
--- a/resource/config/system_defaults.hpp
+++ b/resource/config/system_defaults.hpp
@@ -15,8 +15,8 @@
 namespace Flux {
 namespace resource_model {
 namespace detail {
-    const uint64_t SYSTEM_DEFAULT_DURATION = 43200; // 12 hours
-    const uint64_t SYSTEM_MAX_DURATION = 604800;    //  7 days
+    const int64_t SYSTEM_DEFAULT_DURATION = 43200; // 12 hours
+    const int64_t SYSTEM_MAX_DURATION = 3153600000; // 100 years
 } // namespace detail
 } // namespace resource_model
 } // namespace Flux

--- a/resource/store/resource_graph_store.cpp
+++ b/resource/store/resource_graph_store.cpp
@@ -14,6 +14,21 @@
 using namespace Flux;
 using namespace Flux::resource_model;
 
+void resource_graph_metadata_t::set_graph_duration (
+                            graph_duration_t &g_duration)
+{
+    if ( (g_duration.graph_start == std::chrono::system_clock::from_time_t (0))
+                                 && (g_duration.graph_end
+                              == std::chrono::system_clock::from_time_t (0))) {
+        graph_duration.graph_start = std::chrono::system_clock::now ();
+        graph_duration.graph_end = graph_duration.graph_start +
+                            std::chrono::seconds (detail::SYSTEM_MAX_DURATION);
+    } else {
+        graph_duration.graph_start = g_duration.graph_start;
+        graph_duration.graph_end = g_duration.graph_end;
+    }
+}
+
 bool resource_graph_db_t::known_subsystem (const std::string &s)
 {
     return (metadata.roots.find (s) != metadata.roots.end ())? true : false;

--- a/resource/store/resource_graph_store.hpp
+++ b/resource/store/resource_graph_store.hpp
@@ -13,12 +13,21 @@
 
 #include <string>
 #include <memory>
+#include <chrono>
 #include "resource/schema/resource_graph.hpp"
+#include "resource/config/system_defaults.hpp"
 
 namespace Flux {
 namespace resource_model {
 
 class resource_reader_base_t;
+
+struct graph_duration_t {
+    std::chrono::time_point<std::chrono::system_clock> graph_start =
+                                    std::chrono::system_clock::from_time_t (0);
+    std::chrono::time_point<std::chrono::system_clock> graph_end =
+        std::chrono::system_clock::from_time_t (detail::SYSTEM_MAX_DURATION);
+};
 
 /*! Resource graph data metadata.
  *  Adjacency_list graph, roots of this graph and various indexing.
@@ -35,6 +44,14 @@ struct resource_graph_metadata_t {
     std::map<vtx_t,
              std::map<std::pair<uint64_t, int64_t>, edg_t,
                       std::greater<std::pair<uint64_t, int64_t>>>> by_outedges;
+    graph_duration_t graph_duration;
+
+    /*! Set the resource graph duration.
+     *
+     * \param g_duration  graph_duration_t of time_points used to set
+     *                    the graph duration
+     */
+    void set_graph_duration (graph_duration_t &g_duration);
 };
 
 /*! Resource graph data store.

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -96,6 +96,7 @@ TESTS = \
     t4008-match-jgf.t \
     t4009-match-update.t \
     t4010-match-conf.t \
+    t4011-match-duration.t \
     t5000-valgrind.t \
     t6000-graph-size.t \
     t6001-match-formats.t \

--- a/t/data/resource/expected/RV/R21.out
+++ b/t/data/resource/expected/RV/R21.out
@@ -1,0 +1,4 @@
+INFO: =============================
+INFO: No matching resources found
+INFO: JOBID=1
+INFO: =============================

--- a/t/data/resource/jobspecs/RV/duration3600.yaml
+++ b/t/data/resource/jobspecs/RV/duration3600.yaml
@@ -1,0 +1,30 @@
+version: 9999
+resources:
+    - type: cluster
+      count: 1
+      with:
+        - type: rack
+          count: 1
+          with:
+            - type: node
+              count: 1
+              with:
+                  - type: slot
+                    count: 1
+                    label: default
+                    with:
+                      - type: socket
+                        count: 1
+                        with:
+                          - type: core
+                            count: 1
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: [ "app" ]
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/data/resource/jobspecs/duration/test001.yaml
+++ b/t/data/resource/jobspecs/duration/test001.yaml
@@ -1,0 +1,30 @@
+version: 9999
+resources:
+    - type: cluster
+      count: 1
+      with:
+        - type: rack
+          count: 1
+          with:
+            - type: node
+              count: 1
+              with:
+                  - type: slot
+                    count: 1
+                    label: default
+                    with:
+                      - type: socket
+                        count: 1
+                        with:
+                          - type: core
+                            count: 1
+# a comment
+attributes:
+  system:
+    duration: 1.0E+30
+tasks:
+  - command: [ "app" ]
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/data/resource/jobspecs/duration/test002.yaml
+++ b/t/data/resource/jobspecs/duration/test002.yaml
@@ -1,0 +1,30 @@
+version: 9999
+resources:
+    - type: cluster
+      count: 1
+      with:
+        - type: rack
+          count: 1
+          with:
+            - type: node
+              count: 1
+              with:
+                  - type: slot
+                    count: 1
+                    label: default
+                    with:
+                      - type: socket
+                        count: 1
+                        with:
+                          - type: core
+                            count: 1
+# a comment
+attributes:
+  system:
+    duration: -1
+tasks:
+  - command: [ "app" ]
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/t4001-match-allocate.t
+++ b/t/t4001-match-allocate.t
@@ -11,6 +11,8 @@ Ensure that the match (allocate) handler within the resource module works
 grug="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/tiny.graphml"
 jobspec="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/basics/test001.yaml"
 malform="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/basics/bad.yaml"
+duration_too_large="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/duration/test001.yaml"
+duration_negative="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/duration/test002.yaml"
 
 #
 # test_under_flux is under sharness.d/
@@ -53,6 +55,12 @@ test_expect_success 'detecting of a non-existent jobspec file works' '
 test_expect_success 'handling of a malformed jobspec works' '
     test_expect_code 2 flux ion-resource match allocate ${malform}
 '
+
+test_expect_success 'invalid duration is caught' '
+    test_must_fail flux ion-resource match allocate ${duration_too_large} &&
+    test_must_fail flux ion-resource match allocate ${duration_negative}
+'
+
 
 test_expect_success 'removing resource works' '
     remove_resource

--- a/t/t4011-match-duration.t
+++ b/t/t4011-match-duration.t
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+test_description='Test that parent duration is inherited according to RFC14'
+
+. `dirname $0`/sharness.sh
+
+#
+# test_under_flux is under sharness.d/
+#
+test_under_flux 1
+
+test_expect_success HAVE_JQ 'parent duration is inherited when duration=0' '
+	cat >get_R.sh <<-EOT &&
+	#!/bin/sh
+
+	flux job info \$FLUX_JOB_ID R
+	EOT
+	chmod +x get_R.sh &&
+	out=$(flux mini run -t20s -n1 flux start flux mini run -n1 ./get_R.sh) &&
+	echo "$out" | jq -e ".execution.expiration - .execution.starttime <= 20" &&
+	out=$(flux mini run -t30s -n1 flux start flux mini run -n1 ./get_R.sh) &&
+	echo "$out" | jq -e ".execution.expiration - .execution.starttime <= 30"
+'
+
+test_done


### PR DESCRIPTION
This PR fixes issue #913 by introducing a `graph_duration_t` struct to hold a `std::chrono::time_point` for start and end times into the resource graph metadata and then setting it based on a `resource.acquire` RPC. At schedule time, jobs that specify a `duration` greater than the resource graph duration are rejected. However, jobs with scheduled runtimes that extend beyond the resource graph duration are fit into the resource graph duration procrustean bed.

~~This PR is WIP.~~ First, we need to determine if the procrustean approach complies with updated RFC 14 (https://github.com/flux-framework/rfc/pull/315). Furthermore, we need to consider if the `reader` is the right place for setting the resource graph duration. Beyond that, several items need to be addressed before it can be merged:

- [x] Are the `starttime` and `expiration` received via `resource.acquire` always type `double`? Other segments of `resource_match` unpack them as `I`. More generally: Fluxion stores these times as `int64_t` and `uint64_t`. We need to determine if this mismatch causes undefined behavior.
- [x] Ensure the checks in `unpack_resources` handle corner cases for `starttime` and `expiration`
- [x] Refactor or use system defaults: https://github.com/flux-framework/flux-sched/blob/master/resource/config/system_defaults.hpp#L18
- [x] Create test cases via commits to `testsuite`

The PR also introduces `std::chrono` into Fluxion. We intend for it to replace the mixture of `double`, `uint64_t` and `int64_t` time representations in Fluxion in the future. For the present, careful checks for representability, validity, and overflow need to be introduced to interface with flux-core and the various components of Fluxion.

