### PR TITLE
qmanager: drop default-queue configuration

### DIFF
--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -64,9 +64,8 @@ int qmanager_cb_t::post_sched_loop (flux_t *h, schedutil_t *schedutil,
         while ( (job = queue->alloced_pop ()) != nullptr) {
             if (schedutil_alloc_respond_success_pack (schedutil, job->msg,
                                                       job->schedule.R.c_str (),
-                                                      "{ s:{s:s s:n} }",
+                                                      "{ s:{s:n} }",
                                                       "sched",
-                                                          "queue", queue_name.c_str (),
                                                           "t_estimate") < 0) {
                 flux_log_error (h, "%s: schedutil_alloc_respond_pack (queue=%s)",
                                 __FUNCTION__, queue_name.c_str ());
@@ -105,9 +104,8 @@ int qmanager_cb_t::post_sched_loop (flux_t *h, schedutil_t *schedutil,
                 continue;
             if (schedutil_alloc_respond_annotate_pack (
                     schedutil, job->msg,
-                    "{ s:{s:s s:f} }",
+                    "{ s:{s:f} }",
                     "sched",
-                        "queue", queue_name.c_str (),
                         "t_estimate", static_cast<double> (job->schedule.at))) {
                 flux_log_error (h, "%s: schedutil_alloc_respond_annotate_pack",
                                 __FUNCTION__);

--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -169,7 +169,7 @@ int qmanager_cb_t::jobmanager_hello_cb (flux_t *h, const flux_msg_t *msg,
         goto out;
     }
 
-    queue_name = qn_attr? qn_attr : ctx->opts.get_opt ().get_default_queue ();
+    queue_name = qn_attr? qn_attr : ctx->opts.get_opt ().get_default_queue_name ();
     json_decref (o);
     queue = ctx->queues.at (queue_name);
     running_job = std::make_shared<job_t> (job_state_kind_t::RUNNING,
@@ -195,7 +195,7 @@ void qmanager_cb_t::jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg,
     qmanager_cb_ctx_t *ctx = nullptr;
     ctx = static_cast<qmanager_cb_ctx_t *> (arg);
     Flux::Jobspec::Jobspec jobspec_obj;
-    std::string queue_name = ctx->opts.get_opt ().get_default_queue ();
+    std::string queue_name = ctx->opts.get_opt ().get_default_queue_name ();
     std::shared_ptr<job_t> job = std::make_shared<job_t> ();
     flux_jobid_t id;
     unsigned int priority;

--- a/qmanager/modules/qmanager_opts.hpp
+++ b/qmanager/modules/qmanager_opts.hpp
@@ -74,20 +74,17 @@ public:
     qmanager_opts_t (qmanager_opts_t &&o) = default;
     qmanager_opts_t &operator= (qmanager_opts_t &&o) = default;
 
-    void set_default_queue (const std::string &o);
     bool set_queue_policy (const std::string &o);
     void set_queue_params (const std::string &o);
     void set_policy_params (const std::string &o);
 
     const std::string &get_default_queue_name () const;
-    const std::string &get_default_queue () const;
     const queue_prop_t &get_queue_prop () const;
     const std::string &get_queue_policy () const;
     const std::string &get_queue_params () const;
     const std::string &get_policy_params () const;
     const std::map<std::string, queue_prop_t> &get_per_queue_prop () const;
 
-    bool is_default_queue_set () const;
     bool is_queue_policy_set () const;
     bool is_queue_params_set () const;
     bool is_policy_params_set () const;
@@ -138,7 +135,6 @@ private:
     int parse_queues (const std::string &queues);
 
     std::string m_default_queue_name = "default";
-    std::string m_default_queue = QMANAGER_OPTS_UNSET_STR;
 
     // default queue properties
     queue_prop_t m_queue_prop;

--- a/t/t1006-qmanager-multiqueue.t
+++ b/t/t1006-qmanager-multiqueue.t
@@ -8,129 +8,134 @@ export FLUX_SCHED_MODULE=none
 test_under_flux 1
 
 get_queue() {
-    queue=$1 &&
-    jobid=$(flux job id $2) &&
-    flux dmesg | grep ${queue} | grep ${jobid} | awk '{print $5}' \
-        | awk -F= '{print $2}'
+	queue=$1 &&
+	jobid=$(flux job id $2) &&
+	flux dmesg | grep ${queue} | grep ${jobid} | awk '{print $5}' \
+	    | awk -F= '{print $2}'
 }
 
 test_expect_success 'qmanager: loading qmanager with multiple queues' '
-    load_resource prune-filters=ALL:core subsystems=containment policy=low &&
-    load_qmanager "queues=all batch debug"
+	load_resource prune-filters=ALL:core subsystems=containment \
+	    policy=low &&
+	load_qmanager "queues=all batch debug"
 '
 
 test_expect_success 'qmanager: job can be submitted to queue=all' '
-    jobid=$(flux mini submit -n 1 --setattr system.queue=all hostname) &&
-    flux job wait-event -t 10 ${jobid} finish &&
-    queue=$(get_queue alloc ${jobid}) &&
-    test ${queue} = all &&
-    queue=$(get_queue free ${jobid}) &&
-    test ${queue} = all &&
-    flux dmesg -C
+	jobid=$(flux mini submit -n 1 --setattr system.queue=all hostname) &&
+	flux job wait-event -t 10 ${jobid} finish &&
+	queue=$(get_queue alloc ${jobid}) &&
+	test ${queue} = all &&
+	queue=$(get_queue free ${jobid}) &&
+	test ${queue} = all &&
+	flux dmesg -C
 '
 
 test_expect_success 'qmanager: job can be submitted to queue=batch' '
-    jobid=$(flux mini submit -n 1 --setattr system.queue=batch hostname) &&
-    flux job wait-event -t 10 ${jobid} finish &&
-    queue=$(get_queue alloc ${jobid}) &&
-    test ${queue} = batch &&
-    queue=$(get_queue free ${jobid}) &&
-    test ${queue} = batch &&
-    flux dmesg -C
+	jobid=$(flux mini submit -n 1 --setattr system.queue=batch hostname) &&
+	flux job wait-event -t 10 ${jobid} finish &&
+	queue=$(get_queue alloc ${jobid}) &&
+	test ${queue} = batch &&
+	queue=$(get_queue free ${jobid}) &&
+	test ${queue} = batch &&
+	flux dmesg -C
 '
 
 test_expect_success 'qmanager: job can be submitted to queue=debug' '
-    jobid=$(flux mini submit -n 1 --setattr system.queue=debug hostname) &&
-    flux job wait-event -t 10 ${jobid} finish &&
-    queue=$(get_queue alloc ${jobid}) &&
-    test ${queue} = debug &&
-    queue=$(get_queue free ${jobid}) &&
-    test ${queue} = debug &&
-    flux dmesg -C
+	jobid=$(flux mini submit -n 1 --setattr system.queue=debug hostname) &&
+	flux job wait-event -t 10 ${jobid} finish &&
+	queue=$(get_queue alloc ${jobid}) &&
+	test ${queue} = debug &&
+	queue=$(get_queue free ${jobid}) &&
+	test ${queue} = debug &&
+	flux dmesg -C
 '
 
 # when default-queue=queue-name is not given the lexicographically
 # earliest queue name becomes default
 test_expect_success 'qmanager: job enqueued into implicitly default queue' '
-    jobid=$(flux mini submit -n 1 hostname) &&
-    flux job wait-event -t 10 ${jobid} finish &&
-    queue=$(get_queue alloc ${jobid}) &&
-    test ${queue} = all &&
-    queue=$(get_queue free ${jobid}) &&
-    test ${queue} = all &&
-    flux dmesg -C
+	jobid=$(flux mini submit -n 1 hostname) &&
+	flux job wait-event -t 10 ${jobid} finish &&
+	queue=$(get_queue alloc ${jobid}) &&
+	test ${queue} = all &&
+	queue=$(get_queue free ${jobid}) &&
+	test ${queue} = all &&
+	flux dmesg -C
 '
 
 test_expect_success 'qmanager: qmanager with queues with different policies' '
-    flux module reload -f sched-fluxion-qmanager queues="queue1 queue2 queue3" \
-queue-policy-per-queue="queue1:easy queue2:hybrid queue3:fcfs" default-queue=queue3
+	flux module reload -f sched-fluxion-qmanager \
+	    queues="queue1 queue2 queue3" \
+	    queue-policy-per-queue="queue1:easy queue2:hybrid queue3:fcfs" \
+	    default-queue=queue3
 '
 
 test_expect_success 'qmanager: job can be submitted to queue=queue3 (fcfs)' '
-    jobid=$(flux mini submit -n 1 --setattr system.queue=queue3 hostname) &&
-    flux job wait-event -t 10 ${jobid} finish &&
-    queue=$(get_queue alloc ${jobid}) &&
-    test ${queue} = queue3 &&
-    queue=$(get_queue free ${jobid}) &&
-    test ${queue} = queue3 &&
-    flux dmesg -C
+	jobid=$(flux mini submit -n 1 --setattr system.queue=queue3 hostname) &&
+	flux job wait-event -t 10 ${jobid} finish &&
+	queue=$(get_queue alloc ${jobid}) &&
+	test ${queue} = queue3 &&
+	queue=$(get_queue free ${jobid}) &&
+	test ${queue} = queue3 &&
+	flux dmesg -C
 '
 
 test_expect_success 'qmanager: job can be submitted to queue=queue2 (hybrid)' '
-    jobid=$(flux mini submit -n 1 --setattr system.queue=queue2 hostname) &&
-    flux job wait-event -t 10 ${jobid} finish &&
-    queue=$(get_queue alloc ${jobid}) &&
-    test ${queue} = queue2 &&
-    queue=$(get_queue free ${jobid}) &&
-    test ${queue} = queue2 &&
-    flux dmesg -C
+	jobid=$(flux mini submit -n 1 --setattr system.queue=queue2 hostname) &&
+	flux job wait-event -t 10 ${jobid} finish &&
+	queue=$(get_queue alloc ${jobid}) &&
+	test ${queue} = queue2 &&
+	queue=$(get_queue free ${jobid}) &&
+	test ${queue} = queue2 &&
+	flux dmesg -C
 '
 
 test_expect_success 'qmanager: job submitted to queue=queue1 (conservative)' '
-    jobid=$(flux mini submit -n 1 --setattr system.queue=queue1 hostname) &&
-    flux job wait-event -t 10 ${jobid} finish &&
-    queue=$(get_queue alloc ${jobid}) &&
-    test ${queue} = queue1 &&
-    queue=$(get_queue free ${jobid}) &&
-    test ${queue} = queue1 &&
-    flux dmesg -C
+	jobid=$(flux mini submit -n 1 --setattr system.queue=queue1 hostname) &&
+	flux job wait-event -t 10 ${jobid} finish &&
+	queue=$(get_queue alloc ${jobid}) &&
+	test ${queue} = queue1 &&
+	queue=$(get_queue free ${jobid}) &&
+	test ${queue} = queue1 &&
+	flux dmesg -C
 '
 
 test_expect_success 'qmanager: job enqueued into explicitly default queue' '
-    jobid=$(flux mini submit -n 1 hostname) &&
-    flux job wait-event -t 10 ${jobid} finish &&
-    queue=$(get_queue alloc ${jobid}) &&
-    test ${queue} = queue3 &&
-    queue=$(get_queue free ${jobid}) &&
-    test ${queue} = queue3 &&
-    flux dmesg -C
+	jobid=$(flux mini submit -n 1 hostname) &&
+	flux job wait-event -t 10 ${jobid} finish &&
+	queue=$(get_queue alloc ${jobid}) &&
+	test ${queue} = queue3 &&
+	queue=$(get_queue free ${jobid}) &&
+	test ${queue} = queue3 &&
+	flux dmesg -C
 '
 
 test_expect_success 'qmanager: job is denied when submitted to unknown queue' '
-    test_must_fail flux mini run -n 1 --setattr system.queue=foo \
-	hostname 2>unknown.err &&
-    grep "queue (foo) doesn" unknown.err
+	test_must_fail flux mini run -n 1 --setattr system.queue=foo \
+	    hostname 2>unknown.err &&
+	grep "queue (foo) doesn" unknown.err
 '
 
 test_expect_success 'qmanager: incorrect default-queue name can be caught' '
-    flux module reload -f sched-fluxion-qmanager queues="queue1 queue2 queue3" \
-default-queue=foo &&
-    flux dmesg | grep "Unknown default queue (foo)"
+	flux module reload -f sched-fluxion-qmanager \
+	    queues="queue1 queue2 queue3" \
+	    default-queue=foo &&
+	flux dmesg | grep "Unknown default queue (foo)"
 '
 
 test_expect_success 'qmanager: incorrect queue-policy-per-queue can be caught' '
-    flux module reload -f sched-fluxion-qmanager queues="queue1 queue2 queue3" \
-queue-policy-per-queue="queue1:easy queue2:foo queue3:fcfs" &&
-    flux dmesg | grep "Unknown queuing policy"
+	flux module reload -f sched-fluxion-qmanager \
+	    queues="queue1 queue2 queue3" \
+	    queue-policy-per-queue="queue1:easy queue2:foo queue3:fcfs" &&
+	flux dmesg | grep "Unknown queuing policy"
 '
 
 test_expect_success 'cleanup active jobs' '
-    cleanup_active_jobs
+	cleanup_active_jobs
 '
 
 test_expect_success 'removing resource and qmanager modules' '
-    remove_qmanager &&
-    remove_resource
+	remove_qmanager &&
+	remove_resource
 '
 
 test_done

--- a/t/t1006-qmanager-multiqueue.t
+++ b/t/t1006-qmanager-multiqueue.t
@@ -7,8 +7,6 @@ test_description='Test multiple queue support within qmanager'
 export FLUX_SCHED_MODULE=none
 test_under_flux 1
 
-conf_base=${SHARNESS_TEST_SRCDIR}/conf.d
-
 get_queue() {
     queue=$1 &&
     jobid=$(flux job id $2) &&

--- a/t/t1009-recovery-multiqueue.t
+++ b/t/t1009-recovery-multiqueue.t
@@ -12,74 +12,74 @@ export FLUX_SCHED_MODULE=none
 test_under_flux 1
 
 check_requeue() {
-    local jobid=$(flux job id ${1})
-    local correct_queue=${2}
+	local jobid=$(flux job id ${1})
+	local correct_queue=${2}
 
-    flux ion-resource info ${jobid} | grep "ALLOCATED"
-    if [ $? -ne 0 ]
-    then
-        return $?
-    fi
-    local queue=$(flux dmesg | grep requeue | grep ${jobid} |\
-awk "{print \$5}" | awk -F= "{print \$2}")
-    test ${queue} = ${correct_queue}
+	flux ion-resource info ${jobid} | grep "ALLOCATED"
+	if [ $? -ne 0 ]
+	then
+	    return $?
+	fi
+	local queue=$(flux dmesg | grep requeue | grep ${jobid} |\
+	    awk "{print \$5}" | awk -F= "{print \$2}")
+	test ${queue} = ${correct_queue}
 }
 
 test_expect_success 'recovery: generate test jobspecs' '
-    flux mini run --dry-run -N 1 -n 8 -t 1h \
---setattr system.queue=batch sleep 3600 > basic.batch.json &&
-    flux mini run --dry-run -N 1 -n 8 -t 1h \
---setattr system.queue=debug sleep 3600 > basic.debug.json
+	flux mini run --dry-run -N 1 -n 8 -t 1h \
+	    --setattr system.queue=batch sleep 3600 > basic.batch.json &&
+	flux mini run --dry-run -N 1 -n 8 -t 1h \
+	    --setattr system.queue=debug sleep 3600 > basic.debug.json
 '
 
 test_expect_success 'load test resources' '
-    load_test_resources ${excl_1N1B}
+	load_test_resources ${excl_1N1B}
 '
 
 test_expect_success 'recovery: loading flux-sched modules with two queues' '
-    load_resource match-format=rv1 policy=high &&
-    load_qmanager "queues=batch debug"
+	load_resource match-format=rv1 policy=high &&
+	load_qmanager "queues=batch debug"
 '
 
 # jobid1 - 2 will be scheduled; jobid 3 - 4 pending
 test_expect_success 'recovery: submit to occupy resources fully (rv1)' '
-    jobid1=$(flux job submit basic.batch.json) &&
-    jobid2=$(flux job submit basic.debug.json) &&
-    jobid3=$(flux job submit basic.batch.json) &&
-    jobid4=$(flux job submit basic.debug.json) &&
-    flux job wait-event -t 10 ${jobid2} start &&
-    flux job wait-event -t 10 ${jobid4} submit
+	jobid1=$(flux job submit basic.batch.json) &&
+	jobid2=$(flux job submit basic.debug.json) &&
+	jobid3=$(flux job submit basic.batch.json) &&
+	jobid4=$(flux job submit basic.debug.json) &&
+	flux job wait-event -t 10 ${jobid2} start &&
+	flux job wait-event -t 10 ${jobid4} submit
 '
 
 test_expect_success 'recovery: works when both modules restart (rv1)' '
-    flux dmesg -C &&
-    reload_resource match-format=rv1 policy=high &&
-    reload_qmanager_sync "queues=batch debug" &&
-    check_requeue ${jobid1} batch &&
-    check_requeue ${jobid2} debug &&
-    test_must_fail flux job wait-event -t 0.5 ${jobid3} start &&
-    test_expect_code 3 flux ion-resource info ${jobid3}
+	flux dmesg -C &&
+	reload_resource match-format=rv1 policy=high &&
+	reload_qmanager_sync "queues=batch debug" &&
+	check_requeue ${jobid1} batch &&
+	check_requeue ${jobid2} debug &&
+	test_must_fail flux job wait-event -t 0.5 ${jobid3} start &&
+	test_expect_code 3 flux ion-resource info ${jobid3}
 '
 
 test_expect_success 'recovery: a cancel leads to a job schedule (rv1)' '
-    flux job cancel ${jobid2} &&
-    flux job wait-event -t 10 ${jobid4} start
+	flux job cancel ${jobid2} &&
+	flux job wait-event -t 10 ${jobid4} start
 '
 
 test_expect_success 'recovery: cancel all jobs (rv1_nosched)' '
-    flux job cancel ${jobid1} &&
-    flux job cancel ${jobid3} &&
-    flux job cancel ${jobid4} &&
-    flux job wait-event -t 10 ${jobid4} release
+	flux job cancel ${jobid1} &&
+	flux job cancel ${jobid3} &&
+	flux job cancel ${jobid4} &&
+	flux job wait-event -t 10 ${jobid4} release
 '
 
 test_expect_success 'cleanup active jobs' '
-    cleanup_active_jobs
+	cleanup_active_jobs
 '
 
 test_expect_success 'removing resource and qmanager modules' '
-    remove_qmanager &&
-    remove_resource
+	remove_qmanager &&
+	remove_resource
 '
 
 test_done

--- a/t/t1009-recovery-multiqueue.t
+++ b/t/t1009-recovery-multiqueue.t
@@ -53,8 +53,9 @@ test_expect_success 'recovery: submit to occupy resources fully (rv1)' '
 
 test_expect_success 'recovery: works when both modules restart (rv1)' '
 	flux dmesg -C &&
+	remove_qmanager &&
 	reload_resource match-format=rv1 policy=high &&
-	reload_qmanager_sync "queues=batch debug" &&
+	load_qmanager_sync "queues=batch debug" &&
 	check_requeue ${jobid1} batch &&
 	check_requeue ${jobid2} debug &&
 	test_must_fail flux job wait-event -t 0.5 ${jobid3} start &&

--- a/t/t1011-dynstate-change.t
+++ b/t/t1011-dynstate-change.t
@@ -15,178 +15,186 @@ export FLUX_SCHED_MODULE=none
 test_under_flux 4
 
 test_expect_success 'dyn-state: generate jobspecs' '
-    flux mini run --dry-run -N 4 -n 4 -c 44 -g 4 -t 1h sleep 3600 > basic.json &&
-    flux mini run --dry-run -N 1 -n 1 -c 44 -g 4 -t 1h sleep 3600 > 1N.json &&
-    flux mini run --dry-run -N 4 -n 4 -c 45 -g 4 -t 1h sleep 3600 > unsat.json &&
-    flux mini run --dry-run --setattr system.queue=debug \
-        -N 4 -n 4 -c 44 -g 4 -t 1h sleep 3600 > basic.debug.json &&
-    flux mini run --dry-run --setattr system.queue=debug \
-        -N 1 -n 1 -c 44 -g 4 -t 1h sleep 3600 > 1N.debug.json &&
-    flux mini run --dry-run --setattr system.queue=batch \
-        -N 4 -n 4 -c 44 -g 4 -t 1h sleep 3600 > basic.batch.json &&
-    flux mini run --dry-run --setattr system.queue=batch \
-        -N 1 -n 1 -c 44 -g 4 -t 1h sleep 3600 > 1N.batch.json
+	flux mini run --dry-run -N 4 -n 4 -c 44 -g 4 -t 1h \
+	    sleep 3600 > basic.json &&
+	flux mini run --dry-run -N 1 -n 1 -c 44 -g 4 -t 1h \
+	    sleep 3600 > 1N.json &&
+	flux mini run --dry-run -N 4 -n 4 -c 45 -g 4 -t 1h \
+	    sleep 3600 > unsat.json &&
+	flux mini run --dry-run -N 4 -n 4 -c 44 -g 4 -t 1h \
+	    --setattr system.queue=debug \
+	    sleep 3600 > basic.debug.json &&
+	flux mini run --dry-run -N 1 -n 1 -c 44 -g 4 -t 1h \
+	    --setattr system.queue=debug \
+	    sleep 3600 > 1N.debug.json &&
+	flux mini run --dry-run -N 4 -n 4 -c 44 -g 4 -t 1h \
+	    --setattr system.queue=batch \
+	    sleep 3600 > basic.batch.json &&
+	flux mini run --dry-run -N 1 -n 1 -c 44 -g 4 -t 1h \
+	    --setattr system.queue=batch \
+	    sleep 3600 > 1N.batch.json
 '
 
 test_expect_success 'load test resources' '
-    load_test_resources ${excl_4N4B}
+	load_test_resources ${excl_4N4B}
 '
 
 test_expect_success 'dyn-state: loading fluxion modules works' '
-    load_resource match-format=rv1 &&
-    load_qmanager
+	load_resource match-format=rv1 &&
+	load_qmanager
 '
 
 test_expect_success 'dyn-state: a full-size job can be scheduled and run' '
-    jobid1=$(flux job submit basic.json) &&
-    flux job wait-event -t 2 ${jobid1} start
+	jobid1=$(flux job submit basic.json) &&
+	flux job wait-event -t 2 ${jobid1} start
 '
 
 test_expect_success 'dyn-state: node drain does not kill the job' '
-    flux resource drain 1 &&
-    test_must_fail flux job wait-event -t 1 ${jobid1} finish
+	flux resource drain 1 &&
+	test_must_fail flux job wait-event -t 1 ${jobid1} finish
 '
 
 test_expect_success 'dyn-state: killing the job on the drained node works' '
-    flux job cancel ${jobid1} &&
-    flux job wait-event -t 10 ${jobid1} clean
+	flux job cancel ${jobid1} &&
+	flux job wait-event -t 10 ${jobid1} clean
 '
 
 test_expect_success 'dyn-state: undrain' '
-    flux resource undrain 1
+	flux resource undrain 1
 '
 
 test_expect_success 'dyn-state: the drained node with a job not used' '
-    jobid1=$(flux job submit 1N.json) &&
-    flux job wait-event -t 10 ${jobid1} start &&
-    rank=$(flux job info ${jobid1} R | jq " .execution.R_lite[0].rank ") &&
-    rank=${rank%\"} && rank=${rank#\"} &&
-    jobid2=$(flux job submit 1N.json) &&
-    jobid3=$(flux job submit 1N.json) &&
-    jobid4=$(flux job submit 1N.json) &&
-    flux job wait-event -t 10 ${jobid4} start &&
-    flux resource drain ${rank} &&
-    flux job cancel ${jobid1} &&
-    flux job wait-event -t 10 ${jobid1} clean &&
-    jobid5=$(flux job submit 1N.json) &&
-    test_must_fail flux job wait-event -t 1 ${jobid5} start
+	jobid1=$(flux job submit 1N.json) &&
+	flux job wait-event -t 10 ${jobid1} start &&
+	rank=$(flux job info ${jobid1} R \
+	    | jq " .execution.R_lite[0].rank ") &&
+	rank=${rank%\"} && rank=${rank#\"} &&
+	jobid2=$(flux job submit 1N.json) &&
+	jobid3=$(flux job submit 1N.json) &&
+	jobid4=$(flux job submit 1N.json) &&
+	flux job wait-event -t 10 ${jobid4} start &&
+	flux resource drain ${rank} &&
+	flux job cancel ${jobid1} &&
+	flux job wait-event -t 10 ${jobid1} clean &&
+	jobid5=$(flux job submit 1N.json) &&
+	test_must_fail flux job wait-event -t 1 ${jobid5} start
 '
 
 test_expect_success 'dyn-state: cancel all jobs' '
-    flux job cancel ${jobid2} &&
-    flux job cancel ${jobid3} &&
-    flux job cancel ${jobid4} &&
-    flux job cancel ${jobid5} &&
-    flux job wait-event -t 10 ${jobid2} clean &&
-    flux job wait-event -t 10 ${jobid3} clean &&
-    flux job wait-event -t 10 ${jobid4} clean &&
-    flux job wait-event -t 10 ${jobid5} clean &&
-    flux resource undrain ${rank}
+	flux job cancel ${jobid2} &&
+	flux job cancel ${jobid3} &&
+	flux job cancel ${jobid4} &&
+	flux job cancel ${jobid5} &&
+	flux job wait-event -t 10 ${jobid2} clean &&
+	flux job wait-event -t 10 ${jobid3} clean &&
+	flux job wait-event -t 10 ${jobid4} clean &&
+	flux job wait-event -t 10 ${jobid5} clean &&
+	flux resource undrain ${rank}
 '
 
 test_expect_success 'dyn-state: unsatifiability check works' '
-    jobid1=$(flux job submit unsat.json) &&
-    flux job wait-event -t 2 ${jobid1} clean &&
-    flux job eventlog ${jobid1} | grep unsatisfiable
+	jobid1=$(flux job submit unsat.json) &&
+	flux job wait-event -t 2 ${jobid1} clean &&
+	flux job eventlog ${jobid1} | grep unsatisfiable
 '
 
 test_expect_success 'dyn-state: drain prevents a full job from running' '
-    flux resource drain 0 &&
-    jobid1=$(flux job submit basic.json) &&
-    test_must_fail flux job wait-event -t 1 ${jobid1} start &&
-    flux job cancel ${jobid1}
+	flux resource drain 0 &&
+	jobid1=$(flux job submit basic.json) &&
+	test_must_fail flux job wait-event -t 1 ${jobid1} start &&
+	flux job cancel ${jobid1}
 '
 
 test_expect_success 'dyn-state: a full job blocks a later job under fcfs' '
-    jobid1=$(flux job submit basic.json) &&
-    jobid2=$(flux job submit 1N.json) &&
-    test_must_fail flux job wait-event -t 1 ${jobid2} start &&
-    flux job cancel ${jobid1} &&
-    flux job cancel ${jobid2}
+	jobid1=$(flux job submit basic.json) &&
+	jobid2=$(flux job submit 1N.json) &&
+	test_must_fail flux job wait-event -t 1 ${jobid2} start &&
+	flux job cancel ${jobid1} &&
+	flux job cancel ${jobid2}
 '
 
 test_expect_success 'dyn-state: correct unsatifiability after drain' '
-    jobid1=$(flux job submit unsat.json) &&
-    flux job wait-event -t 2 ${jobid1} clean &&
-    flux job eventlog ${jobid1} | grep unsatisfiable &&
-    flux resource undrain 0
+	jobid1=$(flux job submit unsat.json) &&
+	flux job wait-event -t 2 ${jobid1} clean &&
+	flux job eventlog ${jobid1} | grep unsatisfiable &&
+	flux resource undrain 0
 '
 
 test_expect_success 'dyn-state: removing fluxion modules' '
-    remove_qmanager &&
-    remove_resource
+	remove_qmanager &&
+	remove_resource
 '
 
 test_expect_success 'dyn-state: loading fluxion modules works' '
-    load_resource match-format=rv1 &&
-    load_qmanager queue-policy=easy
+	load_resource match-format=rv1 &&
+	load_qmanager queue-policy=easy
 '
 
 test_expect_success 'dyn-state: a full job skipped for a later job under easy' '
-    flux resource drain 3 &&
-    jobid1=$(flux job submit basic.json) &&
-    jobid2=$(flux job submit 1N.json) &&
-    flux job wait-event -t 10 ${jobid2} start &&
-    flux job cancel ${jobid2} &&
-    flux job wait-event -t 10 ${jobid2} clean &&
-    flux resource undrain 3 &&
-    flux job wait-event -t 10 ${jobid1} start &&
-    flux job cancel ${jobid1} &&
-    flux job wait-event -t 10 ${jobid1} clean
+	flux resource drain 3 &&
+	jobid1=$(flux job submit basic.json) &&
+	jobid2=$(flux job submit 1N.json) &&
+	flux job wait-event -t 10 ${jobid2} start &&
+	flux job cancel ${jobid2} &&
+	flux job wait-event -t 10 ${jobid2} clean &&
+	flux resource undrain 3 &&
+	flux job wait-event -t 10 ${jobid1} start &&
+	flux job cancel ${jobid1} &&
+	flux job wait-event -t 10 ${jobid1} clean
 '
 
 test_expect_success 'dyn-state: removing fluxion modules' '
-    remove_qmanager &&
-    remove_resource
+	remove_qmanager &&
+	remove_resource
 '
 
 test_expect_success 'dyn-state: loading fluxion modules works' '
-    load_resource match-format=rv1 &&
-    load_qmanager queues="batch debug" \
-queue-policy-per-queue="batch:easy debug:fcfs"
+	load_resource match-format=rv1 &&
+	load_qmanager queues="batch debug" \
+	    queue-policy-per-queue="batch:easy debug:fcfs"
 '
 
 test_expect_success 'dyn-state: a full job blocks a later job for fcfs queue' '
-    flux resource drain 2 &&
-    jobid1=$(flux job submit basic.debug.json) &&
-    jobid2=$(flux job submit 1N.debug.json) &&
-    test_must_fail flux job wait-event -t 1 ${jobid1} start &&
-    flux job cancel ${jobid1} &&
-    flux job cancel ${jobid2} &&
-    flux job wait-event -t 1 ${jobid2} clean
+	flux resource drain 2 &&
+	jobid1=$(flux job submit basic.debug.json) &&
+	jobid2=$(flux job submit 1N.debug.json) &&
+	test_must_fail flux job wait-event -t 1 ${jobid1} start &&
+	flux job cancel ${jobid1} &&
+	flux job cancel ${jobid2} &&
+	flux job wait-event -t 1 ${jobid2} clean
 '
 
 test_expect_success 'dyn-state: a job skipped for a later job for easy queue' '
-    jobid1=$(flux job submit basic.batch.json) &&
-    jobid2=$(flux job submit 1N.batch.json) &&
-    flux job wait-event -t 1 ${jobid2} start &&
-    flux job cancel ${jobid1} &&
-    flux job cancel ${jobid2} &&
-    flux job wait-event -t 1 ${jobid2} clean
+	jobid1=$(flux job submit basic.batch.json) &&
+	jobid2=$(flux job submit 1N.batch.json) &&
+	flux job wait-event -t 1 ${jobid2} start &&
+	flux job cancel ${jobid1} &&
+	flux job cancel ${jobid2} &&
+	flux job wait-event -t 1 ${jobid2} clean
 '
 
 test_expect_success 'dyn-state: removing fluxion modules' '
-    remove_qmanager &&
-    remove_resource
+	remove_qmanager &&
+	remove_resource
 '
 
 test_expect_success 'dyn-state: loading fluxion modules works' '
-    load_resource match-format=rv1 &&
-    load_qmanager
+	load_resource match-format=rv1 &&
+	load_qmanager
 '
 
 test_expect_success 'dyn-state: a job skipped for a later job for easy queue' '
-    jobid1=$(flux job submit basic.json) &&
-    test_must_fail flux job wait-event -t 1 ${jobid1} start
+	jobid1=$(flux job submit basic.json) &&
+	test_must_fail flux job wait-event -t 1 ${jobid1} start
 '
 
 test_expect_success 'cleanup active jobs' '
-    cleanup_active_jobs
+	cleanup_active_jobs
 '
 
 test_expect_success 'dyn-state: removing fluxion modules' '
-    remove_qmanager &&
-    remove_resource
+	remove_qmanager &&
+	remove_resource
 '
 
 test_done

--- a/t/t1014-annotation.t
+++ b/t/t1014-annotation.t
@@ -21,22 +21,15 @@ nonexistent_annotation(){
 
 validate_sched_annotation(){
     jobid=$(flux job id ${1}) &&
-    queue_name=${2} &&
-    start_time_is_zero=${3} &&
+    start_time_is_zero=${2} &&
     ann=$(flux job list -A | grep ${jobid} | jq -c '.annotations') &&
-    queue=$(echo ${ann} | jq '.sched.queue') &&
     t_est=$(echo ${ann} | jq '.sched.t_estimate') &&
-    test "\"${queue_name}\"" = "${queue}" &&
     if test x"${start_time_is_zero}" = x"TRUE";
     then
         test "${t_est}" = "null"
     else
         test "${t_est}" != "0"
     fi
-}
-
-print_queue() {
-    flux jobs -o '{sched.queue:>10h}'
 }
 
 print_t_estimate() {
@@ -61,12 +54,11 @@ test_expect_success 'annotation: works with EASY policy' '
     jobid5=$(flux mini submit -n 2 -t 180s sleep 100) &&
 
     flux job wait-event -t 10 ${jobid5} start &&
-    validate_sched_annotation ${jobid1} default TRUE &&
-    validate_sched_annotation ${jobid2} default FALSE &&
+    validate_sched_annotation ${jobid1} TRUE &&
+    validate_sched_annotation ${jobid2} FALSE &&
     nonexistent_annotation ${jobid3} &&
     nonexistent_annotation ${jobid4} &&
-    validate_sched_annotation ${jobid5} default TRUE &&
-    print_queue &&
+    validate_sched_annotation ${jobid5} TRUE &&
     print_t_estimate
 '
 
@@ -91,11 +83,11 @@ test_expect_success 'annotation: works with HYBRID policy' '
     jobid5=$(flux mini submit -n 2 -t 180s sleep 100) &&
 
     flux job wait-event -t 10 ${jobid5} start &&
-    validate_sched_annotation ${jobid1} default TRUE &&
-    validate_sched_annotation ${jobid2} default FALSE &&
-    validate_sched_annotation ${jobid3} default FALSE &&
+    validate_sched_annotation ${jobid1} TRUE &&
+    validate_sched_annotation ${jobid2} FALSE &&
+    validate_sched_annotation ${jobid3} FALSE &&
     nonexistent_annotation ${jobid4} &&
-    validate_sched_annotation ${jobid5} default TRUE
+    validate_sched_annotation ${jobid5} TRUE
 '
 
 test_expect_success 'annotation: cancel all active jobs 2' '
@@ -119,11 +111,11 @@ test_expect_success 'annotation: works with CONSERVATIVE policy' '
     jobid5=$(flux mini submit -n 2 -t 180s sleep 100) &&
 
     flux job wait-event -t 10 ${jobid5} start &&
-    validate_sched_annotation ${jobid1} default TRUE &&
-    validate_sched_annotation ${jobid2} default FALSE &&
-    validate_sched_annotation ${jobid3} default FALSE &&
-    validate_sched_annotation ${jobid4} default FALSE &&
-    validate_sched_annotation ${jobid5} default TRUE
+    validate_sched_annotation ${jobid1} TRUE &&
+    validate_sched_annotation ${jobid2} FALSE &&
+    validate_sched_annotation ${jobid3} FALSE &&
+    validate_sched_annotation ${jobid4} FALSE &&
+    validate_sched_annotation ${jobid5} TRUE
 '
 
 test_expect_success 'annotation: cancel all active jobs 3' '
@@ -148,7 +140,7 @@ test_expect_success 'annotation: works with FCFS policy' '
 
     flux job wait-event -t 10 ${jobid1} start &&
     flux job wait-event -t 10 ${jobid5} submit &&
-    validate_sched_annotation ${jobid1} default TRUE &&
+    validate_sched_annotation ${jobid1} TRUE &&
     nonexistent_annotation ${jobid2} &&
     nonexistent_annotation ${jobid3} &&
     nonexistent_annotation ${jobid4} &&


### PR DESCRIPTION
This drops the `default-queue` key from the qmanager configuration since it is now the ingest module's job to assign a default queue if one is configured per RFC 33.  

In addition, update the sharness tests that use queues to include RFC 33 style config in addition to the qmanager config, which should help ease the transition to the new style.