### PR TITLE
testsuite: cover queues with non-overlapping resource constraints

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -45,6 +45,7 @@ TESTS = \
     t1020-qmanager-feasibility.t \
     t1021-qmanager-nodex.t \
     t1022-property-constraints.t \
+    t1023-multiqueue-constraints.t \
     t2000-tree-basic.t \
     t2001-tree-real.t \
     t3000-jobspec.t \

--- a/t/t1006-qmanager-multiqueue.t
+++ b/t/t1006-qmanager-multiqueue.t
@@ -154,8 +154,13 @@ test_expect_success 'qmanager: incorrect queue-policy-per-queue can be caught' '
 	flux dmesg | grep "Unknown queuing policy"
 '
 
-test_expect_success 'reconfigure queues so only fluxion config is active' '
+test_expect_success 'reconfigure queues with frobnicator disabled' '
 	cat >config/queues.toml <<-EOT &&
+	[ingest]
+	frobnicator.disable = true
+
+	[queues.foo]
+
 	[sched-fluxion-qmanager]
 	queues = "foo"
 	EOT

--- a/t/t1006-qmanager-multiqueue.t
+++ b/t/t1006-qmanager-multiqueue.t
@@ -141,10 +141,19 @@ test_expect_success 'qmanager: job is denied when submitted to unknown queue' '
 	grep "Invalid queue" unknown.err
 '
 
-test_expect_success 'qmanager: incorrect queue-policy-per-queue can be caught' '
-	flux module reload -f sched-fluxion-qmanager \
-	    queues="queue1 queue2 queue3" \
-	    queue-policy-per-queue="queue1:easy queue2:foo queue3:fcfs" &&
+test_expect_success 'qmanager: incorrect queue policy can be caught' '
+	cat >config/queues.toml <<-EOT &&
+	[queues.queue1]
+	[queues.queue2]
+	[queues.queue3]
+
+	# remove qmanager config once flux-framework/flux-sched#950 is fixed
+	[sched-fluxion-qmanager]
+	queues = "queue1 queue2 queue3"
+	queue-policy-per-queue = "queue1:easy queue2:foo queue3:fcfs"
+	EOT
+	flux config reload &&
+	reload_qmanager &&
 	flux dmesg | grep "Unknown queuing policy"
 '
 

--- a/t/t1006-qmanager-multiqueue.t
+++ b/t/t1006-qmanager-multiqueue.t
@@ -41,7 +41,7 @@ test_expect_success 'qmanager: loading qmanager with multiple queues' '
 '
 
 test_expect_success 'qmanager: job can be submitted to queue=all' '
-	jobid=$(flux mini submit -n 1 --setattr system.queue=all hostname) &&
+	jobid=$(flux mini submit -n 1 --queue=all hostname) &&
 	flux job wait-event -t 10 ${jobid} finish &&
 	queue=$(get_queue alloc ${jobid}) &&
 	test ${queue} = all &&
@@ -51,7 +51,7 @@ test_expect_success 'qmanager: job can be submitted to queue=all' '
 '
 
 test_expect_success 'qmanager: job can be submitted to queue=batch' '
-	jobid=$(flux mini submit -n 1 --setattr system.queue=batch hostname) &&
+	jobid=$(flux mini submit -n 1 --queue=batch hostname) &&
 	flux job wait-event -t 10 ${jobid} finish &&
 	queue=$(get_queue alloc ${jobid}) &&
 	test ${queue} = batch &&
@@ -61,7 +61,7 @@ test_expect_success 'qmanager: job can be submitted to queue=batch' '
 '
 
 test_expect_success 'qmanager: job can be submitted to queue=debug' '
-	jobid=$(flux mini submit -n 1 --setattr system.queue=debug hostname) &&
+	jobid=$(flux mini submit -n 1 --queue=debug hostname) &&
 	flux job wait-event -t 10 ${jobid} finish &&
 	queue=$(get_queue alloc ${jobid}) &&
 	test ${queue} = debug &&
@@ -102,7 +102,7 @@ test_expect_success 'reconfigure qmanager with queues with different policies' '
 '
 
 test_expect_success 'qmanager: job can be submitted to queue=queue3 (fcfs)' '
-	jobid=$(flux mini submit -n 1 --setattr system.queue=queue3 hostname) &&
+	jobid=$(flux mini submit -n 1 --queue=queue3 hostname) &&
 	flux job wait-event -t 10 ${jobid} finish &&
 	queue=$(get_queue alloc ${jobid}) &&
 	test ${queue} = queue3 &&
@@ -112,7 +112,7 @@ test_expect_success 'qmanager: job can be submitted to queue=queue3 (fcfs)' '
 '
 
 test_expect_success 'qmanager: job can be submitted to queue=queue2 (hybrid)' '
-	jobid=$(flux mini submit -n 1 --setattr system.queue=queue2 hostname) &&
+	jobid=$(flux mini submit -n 1 --queue=queue2 hostname) &&
 	flux job wait-event -t 10 ${jobid} finish &&
 	queue=$(get_queue alloc ${jobid}) &&
 	test ${queue} = queue2 &&
@@ -122,7 +122,7 @@ test_expect_success 'qmanager: job can be submitted to queue=queue2 (hybrid)' '
 '
 
 test_expect_success 'qmanager: job submitted to queue=queue1 (conservative)' '
-	jobid=$(flux mini submit -n 1 --setattr system.queue=queue1 hostname) &&
+	jobid=$(flux mini submit -n 1 --queue=queue1 hostname) &&
 	flux job wait-event -t 10 ${jobid} finish &&
 	queue=$(get_queue alloc ${jobid}) &&
 	test ${queue} = queue1 &&
@@ -142,7 +142,7 @@ test_expect_success 'qmanager: job enqueued into explicitly default queue' '
 '
 
 test_expect_success 'qmanager: job is denied when submitted to unknown queue' '
-	test_must_fail flux mini run -n 1 --setattr system.queue=foo \
+	test_must_fail flux mini run -n 1 --queue=foo \
 	    hostname 2>unknown.err &&
 	grep "Invalid queue" unknown.err
 '
@@ -179,7 +179,7 @@ test_expect_success 'job submitted with no queue runs' '
 '
 
 test_expect_success 'job submitted with queue gets fatal exception' '
-	test_must_fail flux mini run --setattr queue=foo /bin/true \
+	test_must_fail flux mini run --queue=foo /bin/true \
 	    2>foo.err &&
 	grep "job.exception type=alloc severity=0 queue" foo.err
 '

--- a/t/t1006-qmanager-multiqueue.t
+++ b/t/t1006-qmanager-multiqueue.t
@@ -22,9 +22,6 @@ test_expect_success 'qmanager: load resource' '
 
 test_expect_success 'qmanager: loading qmanager with multiple queues' '
 	cat >config/queues.toml <<-EOT &&
-	[ingest]
-	frobnicator.plugins = [ "defaults" ]
-
 	[queues.all]
 	[queues.batch]
 	[queues.debug]
@@ -82,9 +79,6 @@ test_expect_success 'qmanager: job enqueued into implicitly default queue' '
 
 test_expect_success 'reconfigure qmanager with queues with different policies' '
 	cat >config/queues.toml <<-EOT &&
-	[ingest]
-	frobnicator.plugins = [ "defaults" ]
-
 	[queues.queue1]
 	[queues.queue2]
 	[queues.queue3]

--- a/t/t1009-recovery-multiqueue.t
+++ b/t/t1009-recovery-multiqueue.t
@@ -44,9 +44,6 @@ test_expect_success 'recovery: loading fluxion resource module' '
 
 test_expect_success 'qmanager: configure qmanager with two queues' '
 	cat >config/queues.toml <<-EOT &&
-	[ingest]
-	frobnicator.plugins = [ "defaults" ]
-
 	[queues.batch]
 	[queues.debug]
 

--- a/t/t1009-recovery-multiqueue.t
+++ b/t/t1009-recovery-multiqueue.t
@@ -72,7 +72,7 @@ test_expect_success 'recovery: works when both modules restart (rv1)' '
 	flux dmesg -C &&
 	remove_qmanager &&
 	reload_resource match-format=rv1 policy=high &&
-	load_qmanager_sync "queues=batch debug" &&
+	load_qmanager_sync &&
 	check_requeue ${jobid1} batch &&
 	check_requeue ${jobid2} debug &&
 	test_must_fail flux job wait-event -t 0.5 ${jobid3} start &&

--- a/t/t1009-recovery-multiqueue.t
+++ b/t/t1009-recovery-multiqueue.t
@@ -29,9 +29,9 @@ check_requeue() {
 
 test_expect_success 'recovery: generate test jobspecs' '
 	flux mini run --dry-run -N 1 -n 8 -t 1h \
-	    --setattr system.queue=batch sleep 3600 > basic.batch.json &&
+	    --queue=batch sleep 3600 > basic.batch.json &&
 	flux mini run --dry-run -N 1 -n 8 -t 1h \
-	    --setattr system.queue=debug sleep 3600 > basic.debug.json
+	    --queue=debug sleep 3600 > basic.debug.json
 '
 
 test_expect_success 'load test resources' '

--- a/t/t1011-dynstate-change.t
+++ b/t/t1011-dynstate-change.t
@@ -148,9 +148,6 @@ test_expect_success 'dyn-state: removing fluxion modules' '
 
 test_expect_success 'configure queues' '
 	cat >config/queues.toml <<-EOT &&
-	[ingest]
-	frobnicator.plugins = [ "defaults" ]
-
 	[queues.batch]
 	[queues.debug]
 

--- a/t/t1011-dynstate-change.t
+++ b/t/t1011-dynstate-change.t
@@ -23,17 +23,13 @@ test_expect_success 'dyn-state: generate jobspecs' '
 	    sleep 3600 > 1N.json &&
 	flux mini run --dry-run -N 4 -n 4 -c 45 -g 4 -t 1h \
 	    sleep 3600 > unsat.json &&
-	flux mini run --dry-run -N 4 -n 4 -c 44 -g 4 -t 1h \
-	    --setattr system.queue=debug \
+	flux mini run --dry-run -N 4 -n 4 -c 44 -g 4 -t 1h --queue=debug \
 	    sleep 3600 > basic.debug.json &&
-	flux mini run --dry-run -N 1 -n 1 -c 44 -g 4 -t 1h \
-	    --setattr system.queue=debug \
+	flux mini run --dry-run -N 1 -n 1 -c 44 -g 4 -t 1h --queue=debug \
 	    sleep 3600 > 1N.debug.json &&
-	flux mini run --dry-run -N 4 -n 4 -c 44 -g 4 -t 1h \
-	    --setattr system.queue=batch \
+	flux mini run --dry-run -N 4 -n 4 -c 44 -g 4 -t 1h --queue=batch \
 	    sleep 3600 > basic.batch.json &&
-	flux mini run --dry-run -N 1 -n 1 -c 44 -g 4 -t 1h \
-	    --setattr system.queue=batch \
+	flux mini run --dry-run -N 1 -n 1 -c 44 -g 4 -t 1h --queue=batch \
 	    sleep 3600 > 1N.batch.json
 '
 

--- a/t/t1023-multiqueue-constraints.t
+++ b/t/t1023-multiqueue-constraints.t
@@ -1,0 +1,149 @@
+#!/bin/sh
+
+test_description='Test queues with non-overlapping constraints
+
+Partitioned node resources with batch and debug queues is expected
+to be a common configuration.
+'
+
+. `dirname $0`/sharness.sh
+
+export FLUX_SCHED_MODULE=none
+
+mkdir -p conf.d
+
+cat >conf.d/conf.toml<<-EOF
+[queues.debug]
+requires = ["debug"]
+[queues.batch]
+requires = ["batch"]
+
+# remove qmanager config once flux-framework/flux-sched#950 is fixed
+[sched-fluxion-qmanager]
+queues = "debug batch"
+
+[sched-fluxion-resource]
+match-policy = "lonodex"
+match-format = "rv1_nosched"
+EOF
+
+test_under_flux 4 full -o,--config-path=$(pwd)/conf.d
+
+
+test_expect_success 'reload resource with properties set' '
+	flux kvs get resource.R >R.orig &&
+	flux R set-property debug:0 batch:1-3 bigmem:0-1 tinymem:2 <R.orig >R &&
+	flux resource reload R
+'
+test_expect_success 'load fluxion modules' '
+	load_resource &&
+	load_qmanager
+'
+test_expect_success 'run a job in each queue' '
+	flux mini run --queue=debug /bin/true &&
+	flux mini run --queue=batch /bin/true
+'
+test_expect_success 'occupy resources in first queue' '
+	flux mini submit --queue=debug sleep 300 >job1.out
+'
+test_expect_success 'run a job in second queue' '
+	flux mini run --queue=batch /bin/true
+'
+test_expect_success 'create a backlog in first queue' '
+	flux mini submit --queue=debug /bin/true
+'
+test_expect_success 'run a job in second queue' '
+	flux mini run --queue=batch /bin/true
+'
+test_expect_success 'occupy resources in second queue' '
+	flux mini submit --queue=batch -N3 sleep 300 >job2.out
+'
+test_expect_success 'cancel job occupying first queue' '
+	flux job cancel $(cat job1.out)
+'
+test_expect_success 'run a job in first queue' '
+	flux mini run --queue=debug /bin/true
+'
+test_expect_success 'create a backlog in second queue' '
+	flux mini submit --queue=batch /bin/true
+'
+test_expect_success 'run a job in first queue' '
+	flux mini run --queue=debug /bin/true
+'
+test_expect_success 'cancel job occupying second queue' '
+	flux job cancel $(cat job2.out)
+'
+test_expect_success 'run a job in each queue' '
+	flux mini run --queue=debug /bin/true &&
+	flux mini run --queue=batch /bin/true
+'
+test_expect_success 'a job with redundant constraint works' '
+	flux mini run --queue=debug --requires=debug /bin/true
+'
+test_expect_success 'a job with unsatisfiable constraint fails' '
+	test_must_fail flux mini run --queue=debug --requires=tinymem /bin/true
+'
+test_expect_success 'a job with unsatisfiable node count fails' '
+	test_must_fail flux mini run --queue=debug -N2 /bin/true
+'
+test_expect_success 'a job with satisfiable constraint works' '
+	flux mini run --queue=batch --requires=tinymem /bin/true
+'
+test_expect_success 'a job with multiple constraints works in both queues' '
+	flux mini run --queue=debug --requires=bigmem /bin/true &&
+	flux mini run --queue=batch --requires=bigmem /bin/true
+'
+test_expect_success 'stop queues' '
+	flux queue stop
+'
+test_expect_success 'submit a held job to the first queue' '
+	flux mini submit --flags=waitable \
+	    --queue=debug --urgency=hold /bin/true >job3.out
+'
+test_expect_success 'submit a diverse set of jobs to both queues' '
+	flux mini submit --flags=waitable \
+	    --queue=debug --requires=bigmem /bin/true &&
+	flux mini submit --flags=waitable --cc=1-10 -N2 \
+	    --queue=batch /bin/true &&
+	flux mini submit --flags=waitable \
+	    --queue=debug --requires=bigmem --urgency=31 /bin/true &&
+	flux mini submit --flags=waitable \
+	    --queue=batch --requires=bigmem /bin/true &&
+	flux mini submit --flags=waitable --cc=1-10 \
+	    --queue=debug /bin/true &&
+	flux mini submit --flags=waitable \
+	    --queue=debug --requires=bigmem --urgency=1 /bin/true &&
+	flux mini submit --flags=waitable \
+	    --queue=debug /bin/true
+'
+test_expect_success 'drain a node' '
+	flux resource drain 1 testing...
+'
+test_expect_success 'start queues - bunch of alloc requests arrive at once' '
+	flux queue start
+'
+test_expect_success 'submit some additional work on top of that' '
+	flux mini submit --flags=waitable --cc=1-10 \
+	    --queue=batch /bin/true &&
+	flux mini submit --flags=waitable --cc=1-10 \
+	    --queue=debug /bin/true
+'
+test_expect_success 'undrain the node' '
+	flux resource undrain 1
+'
+test_expect_success 'unhold the job' '
+	flux job urgency $(cat job3.out) default
+'
+test_expect_success 'wait for all jobs to complete successfully' '
+	flux job wait --all
+'
+test_expect_success 'cleanup active jobs' '
+        cleanup_active_jobs
+'
+test_expect_success 'removing resource and qmanager modules' '
+	remove_qmanager &&
+	remove_resource
+'
+
+test_done
+


### PR DESCRIPTION
This adds a sharness test with  high level testing for queues with non-overlapping (partitioned) resources.  Nothing too fancy, just ensuring that the scheduler remains responsive when both queues are processing active jobs, a node gets drained, etc..

There's also some test cleanup, enabled by recent flux-core changes.