### PR TITLE
qmanager: support RFC33 TOML queue config

### DIFF
--- a/t/conf.d/16-multiqueue/sched-fluxion-qmanager.toml
+++ b/t/conf.d/16-multiqueue/sched-fluxion-qmanager.toml
@@ -2,10 +2,10 @@
 # Configuration for the qmanager module
 #
 
-[sched-fluxion-qmanager]
+[queues.debug]
+[queues.batch]
 
-# multiple queues
-queues = "debug batch"
+[sched-fluxion-qmanager]
 
 # queueing policy type
 queue-policy = "fcfs"

--- a/t/conf.d/17-mq-hetero/sched-fluxion-qmanager.toml
+++ b/t/conf.d/17-mq-hetero/sched-fluxion-qmanager.toml
@@ -2,10 +2,10 @@
 # Configuration for the qmanager module
 #
 
-[sched-fluxion-qmanager]
+[queues.debug]
+[queues.batch]
 
-# multiple queues
-queues = "debug batch"
+[sched-fluxion-qmanager]
 
 # queueing policy type
 queue-policy-per-queue = "debug:fcfs batch:hybrid"

--- a/t/conf.d/18-mq-override/sched-fluxion-qmanager.toml
+++ b/t/conf.d/18-mq-override/sched-fluxion-qmanager.toml
@@ -2,12 +2,12 @@
 # Configuration for the qmanager module
 #
 
+[queues.debug]
+[queues.batch]
+
 [sched-fluxion-qmanager]
 
 queue-policy = "easy"
-
-# multiple queues
-queues = "debug batch"
 
 # queueing policy type for one or more named queue
 #     batch should inherit the base policy (easy)

--- a/t/t1005-qmanager-conf.t
+++ b/t/t1005-qmanager-conf.t
@@ -255,4 +255,10 @@ test_expect_success 'qmanager: per-queue parameter overriding works' '
     check_policy_params2 ${outfile}.qbatch "\"\""
 '
 
+test_expect_success 'qmanager: load must fail when pre-rfc33 queues are provided' '
+    conf_name="19-pre-rfc33-queues" &&
+    outfile=${conf_name}.out &&
+    test_must_fail start_qmanager ${conf_base}/${conf_name} ${outfile}
+'
+
 test_done

--- a/t/t1006-qmanager-multiqueue.t
+++ b/t/t1006-qmanager-multiqueue.t
@@ -28,10 +28,6 @@ test_expect_success 'qmanager: loading qmanager with multiple queues' '
 
 	[policy.jobspec.defaults.system]
 	queue = "all"
-
-	# remove qmanager config once flux-framework/flux-sched#950 is fixed
-	[sched-fluxion-qmanager]
-	queues = "all batch debug"
 	EOT
 	flux config reload &&
 	load_qmanager
@@ -86,9 +82,7 @@ test_expect_success 'reconfigure qmanager with queues with different policies' '
 	[policy.jobspec.defaults.system]
 	queue = "queue3"
 
-	# remove qmanager config once flux-framework/flux-sched#950 is fixed
 	[sched-fluxion-qmanager]
-	queues = "queue1 queue2 queue3"
 	queue-policy-per-queue = "queue1:easy queue2:hybrid queue3:fcfs"
 	EOT
 	flux config reload &&
@@ -147,9 +141,7 @@ test_expect_success 'qmanager: incorrect queue policy can be caught' '
 	[queues.queue2]
 	[queues.queue3]
 
-	# remove qmanager config once flux-framework/flux-sched#950 is fixed
 	[sched-fluxion-qmanager]
-	queues = "queue1 queue2 queue3"
 	queue-policy-per-queue = "queue1:easy queue2:foo queue3:fcfs"
 	EOT
 	flux config reload &&
@@ -168,8 +160,6 @@ test_expect_success 'submit job with no queue' '
 test_expect_success 'reconfigure with one queue and load qmanager' '
 	cat >config/queues.toml <<-EOT &&
 	[queues.foo]
-	[sched-fluxion-qmanager]
-	queues = "foo"
 	EOT
 	flux config reload &&
 	load_qmanager

--- a/t/t1009-recovery-multiqueue.t
+++ b/t/t1009-recovery-multiqueue.t
@@ -49,10 +49,6 @@ test_expect_success 'qmanager: configure qmanager with two queues' '
 
 	[policy.jobspec.defaults.system]
 	queue = "batch"
-
-	# remove qmanager config once flux-framework/flux-sched#950 is fixed
-	[sched-fluxion-qmanager]
-	queues = "batch debug"
 	EOT
 	flux config reload &&
 	load_qmanager

--- a/t/t1011-dynstate-change.t
+++ b/t/t1011-dynstate-change.t
@@ -154,9 +154,7 @@ test_expect_success 'configure queues' '
 	[policy.jobspec.defaults.system]
 	queue = "batch"
 
-	# remove qmanager config once flux-framework/flux-sched#950 is fixed
 	[sched-fluxion-qmanager]
-	queues = "batch debug"
 	queue-policy-per-queue = "batch:easy debug:fcfs"
 	EOT
 	flux config reload

--- a/t/t1023-multiqueue-constraints.t
+++ b/t/t1023-multiqueue-constraints.t
@@ -18,10 +18,6 @@ requires = ["debug"]
 [queues.batch]
 requires = ["batch"]
 
-# remove qmanager config once flux-framework/flux-sched#950 is fixed
-[sched-fluxion-qmanager]
-queues = "debug batch"
-
 [sched-fluxion-resource]
 match-policy = "lonodex"
 match-format = "rv1_nosched"


### PR DESCRIPTION
Problem: fluxion queues are currently configured in the qmanager in the sched-fluxion-qmanager table, but a framework-wide TOML configuration was proposed in RFC 33.

Implement RFC33 queues in the qmanager by transforming the RFC 33 configuration into the old sched-fluxion-qmanager syntax.

Raise an error if queues are configured in the sched-fluxion table instead of in the RFC33-compliant way.