### PR TITLE
NEWS: add release notes for 0.25.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,31 @@
+flux-sched version 0.25.0 - 2022-10-04
+--------------------------------------
+
+Note: the flux-sched test suite requires flux-core 0.44.0 or newer.
+
+### New Features
+
+ * qmanager: support RFC33 TOML queue config (#980, #971)
+
+### Fixes
+ * Resource graph duration and job expiration to conform to RFC 14 (#969)
+ * Fix REAPI C++ bindings  (#974)
+ * add an exception note to fatal queue exceptions (#957)
+
+### Cleanup
+
+ * rc: combine fluxion rc scripts (#958)
+ * move flux-tree to the test suite (#956)
+ * build: drop unnecessary preqreqs, update README (#954)
+
+### Testsuite
+
+ * testsuite: fix coverage method for queue exception (#978)
+ * testsuite: cover queues with non-overlapping resource constraints (#976)
+ * testsuite: fix integer overflow (#968)
+ * testsuite: use explicit duration units (#966)
+ * minor cleanup (#973, #959)
+
 flux-sched version 0.24.0 - 2022-08-03
 --------------------------------------
 


### PR DESCRIPTION
Here are some tentative release notes for 0.25.0 that assume we merge #980.  Feel free to push updates directly to this branch.

I tried building the current master against flux-core 0.43.0 on fluke and  encountered test failures, hence the note about the test suite requiring 0.44.0 or newer.  I didn't investigate deeply, but did note that some tests now use `flux mini CMD --queue` which  was only recently added.  I suspect the scheduler will work fine on older releases but since that has not been tried, I figured the test suite failures were enough to justify that note.