### PR TITLE
fix invalid yaml in resource utilities README

### DIFF
--- a/resource/utilities/README.md
+++ b/resource/utilities/README.md
@@ -637,6 +637,7 @@ resources:
                   - type: slot
                     count: 2
                     label: bicore
+                    with:
                       - type: socket
                         count: 1
                         with:


### PR DESCRIPTION
Problem: one of the yaml examples in resource/utilities/README is invalid - it is missing a with: header for a section (and does not load). This fixes it.