### PR TITLE
testsuite: update flux-tree-helper.py for new OutputFormat constructor

### DIFF
--- a/t/scripts/flux-tree-helper.py
+++ b/t/scripts/flux-tree-helper.py
@@ -104,7 +104,11 @@ class PerfOutputFormat(flux.util.OutputFormat):
         Throws an exception if any format fields do not match the allowed
         list of headings above.
         """
-        super().__init__(PerfOutputFormat.headings, fmt)
+        # Support both new and old style OutputFormat constructor:
+        try:
+            super().__init__(fmt, headings=self.headings, prepend="")
+        except TypeError:
+            super().__init__(PerfOutputFormat.headings, fmt)
 
 
 def write_data_to_file(output_filename, output_format, data):


### PR DESCRIPTION
Problem: The flux.util.OutputFormat class in flux-core will get an improved constructor where `headings` becomes an optional keyword argument, but this will break the PerfOutputFormat class in t/scripts/flux-tree-helper.py

Try the new-style constructor arguments in PerfOutputFormat. If that fails, fall back to the old style so that either works for the flux-tree-helper.py test script.

This PR will need to be merged to avoid a future PR in flux-core from breaking the `flux-tree` tests in flux-sched.