### PR TITLE
testsuite: start/stop all queues with --all option

### DIFF
--- a/t/sharness.d/sched-sharness.sh
+++ b/t/sharness.d/sched-sharness.sh
@@ -91,7 +91,7 @@ load_test_resources () {
 
 # N.B. this assumes that a scheduler is loaded
 cleanup_active_jobs () {
-    flux queue stop &&
+    flux queue stop --all &&
         flux job cancelall -f &&
         flux queue idle
 }

--- a/t/t1023-multiqueue-constraints.t
+++ b/t/t1023-multiqueue-constraints.t
@@ -90,7 +90,7 @@ test_expect_success 'a job with multiple constraints works in both queues' '
 	flux mini run --queue=batch --requires=bigmem /bin/true
 '
 test_expect_success 'stop queues' '
-	flux queue stop
+	flux queue stop --all
 '
 test_expect_success 'submit a held job to the first queue' '
 	flux mini submit --flags=waitable \
@@ -116,7 +116,7 @@ test_expect_success 'drain a node' '
 	flux resource drain 1 testing...
 '
 test_expect_success 'start queues - bunch of alloc requests arrive at once' '
-	flux queue start
+	flux queue start --all
 '
 test_expect_success 'submit some additional work on top of that' '
 	flux mini submit --flags=waitable --cc=1-10 \


### PR DESCRIPTION
Problem: flux-core PR 4776 added the ability for queues to be individually started and stopped.  As an update, starting/stopping all queues with the `flux queue` command now requires the --all option to be specified.  This is not specified in several flux-sched tests, leading to test failures.

Update all callers to specify --all when multiple queues are started or stopped.

***This should not be merged until https://github.com/flux-framework/flux-core/pull/4776 is merged***