### PR TITLE
github: change ubuntu version for python ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
   python-format:
     name: python format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/setup-python@v1
       with:
@@ -31,7 +31,7 @@ jobs:
 
   python-lint:
     name: python lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/setup-python@v1
       with:


### PR DESCRIPTION
Problem: Using ubuntu-latest in the python-lint and python-format builders causes the check to fail with an error message saying that Python 3.6 cannot be found.

This PR just switches the version of Ubuntu to match flux-core's Ubuntu
version in their python-lint check: 20.04.

----

Just copying what was done in

https://github.com/flux-framework/flux-core/pull/4794
and
https://github.com/flux-framework/flux-accounting/pull/300

hopefully i did it right :P