### PR TITLE
testsuite: do not assume queues started by default

### DIFF
--- a/t/t1006-qmanager-multiqueue.t
+++ b/t/t1006-qmanager-multiqueue.t
@@ -30,6 +30,7 @@ test_expect_success 'qmanager: loading qmanager with multiple queues' '
 	queue = "all"
 	EOT
 	flux config reload &&
+	flux queue start --all &&
 	load_qmanager
 '
 
@@ -86,6 +87,7 @@ test_expect_success 'reconfigure qmanager with queues with different policies' '
 	queue-policy-per-queue = "queue1:easy queue2:hybrid queue3:fcfs"
 	EOT
 	flux config reload &&
+	flux queue start --all &&
 	reload_qmanager
 '
 
@@ -145,6 +147,7 @@ test_expect_success 'qmanager: incorrect queue policy can be caught' '
 	queue-policy-per-queue = "queue1:easy queue2:foo queue3:fcfs"
 	EOT
 	flux config reload &&
+	flux queue start --all &&
 	reload_qmanager &&
 	flux dmesg | grep "Unknown queuing policy"
 '
@@ -162,6 +165,7 @@ test_expect_success 'reconfigure with one queue and load qmanager' '
 	[queues.foo]
 	EOT
 	flux config reload &&
+	flux queue start --all &&
 	load_qmanager
 '
 test_expect_success 'job submitted with no queue gets fatal exception' '

--- a/t/t1009-recovery-multiqueue.t
+++ b/t/t1009-recovery-multiqueue.t
@@ -51,6 +51,7 @@ test_expect_success 'qmanager: configure qmanager with two queues' '
 	queue = "batch"
 	EOT
 	flux config reload &&
+	flux queue start --all &&
 	load_qmanager
 '
 

--- a/t/t1011-dynstate-change.t
+++ b/t/t1011-dynstate-change.t
@@ -157,7 +157,8 @@ test_expect_success 'configure queues' '
 	[sched-fluxion-qmanager]
 	queue-policy-per-queue = "batch:easy debug:fcfs"
 	EOT
-	flux config reload
+	flux config reload &&
+	flux queue start --all
 '
 
 test_expect_success 'dyn-state: loading fluxion modules works' '

--- a/t/t1023-multiqueue-constraints.t
+++ b/t/t1023-multiqueue-constraints.t
@@ -12,19 +12,22 @@ export FLUX_SCHED_MODULE=none
 
 mkdir -p conf.d
 
-cat >conf.d/conf.toml<<-EOF
-[queues.debug]
-requires = ["debug"]
-[queues.batch]
-requires = ["batch"]
-
-[sched-fluxion-resource]
-match-policy = "lonodex"
-match-format = "rv1_nosched"
-EOF
-
 test_under_flux 4 full -o,--config-path=$(pwd)/conf.d
 
+test_expect_success 'load queue configuration' '
+	cat >conf.d/conf.toml <<-EOT &&
+	[queues.debug]
+	requires = ["debug"]
+	[queues.batch]
+	requires = ["batch"]
+
+	[sched-fluxion-resource]
+	match-policy = "lonodex"
+	match-format = "rv1_nosched"
+	EOT
+	flux config reload &&
+	flux queue start --all
+'
 
 test_expect_success 'reload resource with properties set' '
 	flux kvs get resource.R >R.orig &&


### PR DESCRIPTION
Problem: In several tests, it is assumed that newly created named queues are "started" by default.  This is not a safe assumption going forward.

Solution: In tests that create named queues, start the queues immediately after they are configured.

This PR is needed to ensure `flux-sched` can pass once PR https://github.com/flux-framework/flux-core/pull/4857 is merged.  It is safe to merge before that PR (and necessary for that PR to pass `flux-sched` tests).