### PR TITLE
complete support for RFC 31 Job Constraints 

### DIFF
--- a/resource/Makefile.am
+++ b/resource/Makefile.am
@@ -56,6 +56,7 @@ libresource_la_SOURCES = \
     schema/data_std.hpp \
     schema/infra_data.hpp \
     schema/sched_data.hpp \
+    schema/resource_base.hpp \
     schema/resource_data.hpp \
     schema/color.hpp \
     schema/ephemeral.hpp \

--- a/resource/libjobspec/Makefile.am
+++ b/resource/libjobspec/Makefile.am
@@ -13,12 +13,14 @@ libjobspec_conv_la_CXXFLAGS = \
 	$(WARNING_CXXFLAGS) \
 	$(CODE_COVERAGE_CXXFLAGS) \
 	$(YAMLCPP_CFLAGS) \
-	$(FLUX_HOSTLIST_CFLAGS)
+	$(FLUX_HOSTLIST_CFLAGS) \
+	$(FLUX_IDSET_CFLAGS)
 
 libjobspec_conv_la_LIBADD = \
 	$(CODE_COVERAGE_LIBS) \
 	$(YAMLCPP_LIBS) \
-	$(FLUX_HOSTLIST_LIBS)
+	$(FLUX_HOSTLIST_LIBS) \
+	$(FLUX_IDSET_LIBS)
 
 libjobspec_conv_la_SOURCES = \
 	jobspec.cpp \
@@ -27,7 +29,9 @@ libjobspec_conv_la_SOURCES = \
 	constraint.hpp \
 	constraint.cpp \
 	hostlist_constraint.hpp \
-	hostlist_constraint.cpp
+	hostlist_constraint.cpp \
+	rank_constraint.hpp \
+	rank_constraint.cpp
 
 TESTS = \
 	test_constraint.t

--- a/resource/libjobspec/Makefile.am
+++ b/resource/libjobspec/Makefile.am
@@ -1,3 +1,6 @@
+AM_CPPFLAGS = \
+	-I$(top_srcdir)
+
 noinst_PROGRAMS = flux-jobspec-validate
 noinst_LTLIBRARIES = libjobspec_conv.la
 
@@ -7,7 +10,6 @@ flux_jobspec_validate_LDADD = \
     $(YAMLCPP_LIBS)
 
 libjobspec_conv_la_CXXFLAGS = \
-	-I$(top_srcdir) \
 	$(WARNING_CXXFLAGS) \
 	$(CODE_COVERAGE_CXXFLAGS) \
 	$(YAMLCPP_CFLAGS)
@@ -16,5 +18,26 @@ libjobspec_conv_la_LIBADD = $(CODE_COVERAGE_LIBS) $(YAMLCPP_LIBS)
 libjobspec_conv_la_SOURCES = \
 	jobspec.cpp \
 	jobspec.hpp \
-	parse_error.hpp
+	parse_error.hpp \
+	constraint.hpp \
+	constraint.cpp
 
+TESTS = \
+	test_constraint.t
+
+check_PROGRAMS = \
+	$(TESTS)
+
+test_constraint_t_SOURCES = \
+	test/constraint.cpp
+test_constraint_t_CXXFLAGS = \
+	$(WARNING_CXXFLAGS) \
+	$(CODE_COVERAGE_CXXFLAGS) \
+	$(YAMLCPP_CFLAGS)
+test_constraint_t_LDADD = \
+	$(CODE_COVERAGE_LIBS) \
+	$(YAMLCPP_LIBS) \
+	libjobspec_conv.la \
+	$(top_builddir)/src/common/libtap/libtap.la
+test_constraint_t_LDFLAGS = \
+	-no-install

--- a/resource/libjobspec/Makefile.am
+++ b/resource/libjobspec/Makefile.am
@@ -12,15 +12,22 @@ flux_jobspec_validate_LDADD = \
 libjobspec_conv_la_CXXFLAGS = \
 	$(WARNING_CXXFLAGS) \
 	$(CODE_COVERAGE_CXXFLAGS) \
-	$(YAMLCPP_CFLAGS)
+	$(YAMLCPP_CFLAGS) \
+	$(FLUX_HOSTLIST_CFLAGS)
 
-libjobspec_conv_la_LIBADD = $(CODE_COVERAGE_LIBS) $(YAMLCPP_LIBS)
+libjobspec_conv_la_LIBADD = \
+	$(CODE_COVERAGE_LIBS) \
+	$(YAMLCPP_LIBS) \
+	$(FLUX_HOSTLIST_LIBS)
+
 libjobspec_conv_la_SOURCES = \
 	jobspec.cpp \
 	jobspec.hpp \
 	parse_error.hpp \
 	constraint.hpp \
-	constraint.cpp
+	constraint.cpp \
+	hostlist_constraint.hpp \
+	hostlist_constraint.cpp
 
 TESTS = \
 	test_constraint.t

--- a/resource/libjobspec/Makefile.am
+++ b/resource/libjobspec/Makefile.am
@@ -10,6 +10,10 @@ libjobspec_conv_la_CXXFLAGS = \
 	$(WARNING_CXXFLAGS) \
 	$(CODE_COVERAGE_CXXFLAGS) \
 	$(YAMLCPP_CFLAGS)
+
 libjobspec_conv_la_LIBADD = $(CODE_COVERAGE_LIBS) $(YAMLCPP_LIBS)
-libjobspec_conv_la_SOURCES = jobspec.cpp jobspec.hpp
+libjobspec_conv_la_SOURCES = \
+	jobspec.cpp \
+	jobspec.hpp \
+	parse_error.hpp
 

--- a/resource/libjobspec/Makefile.am
+++ b/resource/libjobspec/Makefile.am
@@ -7,6 +7,7 @@ flux_jobspec_validate_LDADD = \
     $(YAMLCPP_LIBS)
 
 libjobspec_conv_la_CXXFLAGS = \
+	-I$(top_srcdir) \
 	$(WARNING_CXXFLAGS) \
 	$(CODE_COVERAGE_CXXFLAGS) \
 	$(YAMLCPP_CFLAGS)

--- a/resource/libjobspec/constraint.cpp
+++ b/resource/libjobspec/constraint.cpp
@@ -19,6 +19,7 @@ extern "C" {
 
 #include "jobspec.hpp"
 #include "constraint.hpp"
+#include "hostlist_constraint.hpp"
 
 using namespace Flux::Jobspec;
 
@@ -82,6 +83,9 @@ Flux::Jobspec::constraint_parser (const YAML::Node &constraint)
     if (operation == "properties")
         return std::unique_ptr<PropertyConstraint>
             (new PropertyConstraint (operands));
+    else if (operation == "hostlist")
+        return std::unique_ptr<HostlistConstraint>
+            (new HostlistConstraint (operands));
     else if (operation == "and" || operation == "or" || operation == "not")
         return std::unique_ptr<ConditionalConstraint>
             (new ConditionalConstraint (operation, operands));

--- a/resource/libjobspec/constraint.cpp
+++ b/resource/libjobspec/constraint.cpp
@@ -20,6 +20,7 @@ extern "C" {
 #include "jobspec.hpp"
 #include "constraint.hpp"
 #include "hostlist_constraint.hpp"
+#include "rank_constraint.hpp"
 
 using namespace Flux::Jobspec;
 
@@ -86,6 +87,9 @@ Flux::Jobspec::constraint_parser (const YAML::Node &constraint)
     else if (operation == "hostlist")
         return std::unique_ptr<HostlistConstraint>
             (new HostlistConstraint (operands));
+    else if (operation == "ranks")
+        return std::unique_ptr<RankConstraint>
+            (new RankConstraint (operands));
     else if (operation == "and" || operation == "or" || operation == "not")
         return std::unique_ptr<ConditionalConstraint>
             (new ConditionalConstraint (operation, operands));

--- a/resource/libjobspec/constraint.cpp
+++ b/resource/libjobspec/constraint.cpp
@@ -1,0 +1,210 @@
+/*****************************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+}
+
+#include <iostream>
+#include <string>
+
+#include "jobspec.hpp"
+#include "constraint.hpp"
+
+using namespace Flux::Jobspec;
+
+// Derived Constraint classes:
+//
+class PropertyConstraint : public Constraint {
+public:
+    PropertyConstraint (const YAML::Node&);
+    PropertyConstraint ();
+    ~PropertyConstraint () = default;
+
+private:
+    std::vector<std::string> values;
+
+public:
+    virtual bool match (const Flux::resource_model::resource_t &resource) const;
+    virtual YAML::Node as_yaml () const;
+};
+
+class ConditionalConstraint : public Constraint {
+public:
+    ConditionalConstraint (std::string&, const YAML::Node&);
+    ConditionalConstraint () = default;
+    ~ConditionalConstraint () {};
+
+private:
+    std::string op;
+    std::vector<std::unique_ptr<Constraint>> values;
+
+public:
+    virtual bool match (const Flux::resource_model::resource_t &resource) const;
+    bool match_and (const Flux::resource_model::resource_t &resource) const;
+    bool match_or (const Flux::resource_model::resource_t &resource) const;
+
+    virtual YAML::Node as_yaml () const;
+};
+
+std::unique_ptr<Constraint>
+Flux::Jobspec::constraint_parser (const YAML::Node &constraint)
+{
+    YAML::const_iterator it;
+    YAML::Node operands;
+
+    if (!constraint.IsMap ())
+        throw parse_error (constraint, "constraint is not a mapping");
+    if (constraint.size () > 1)
+        throw parse_error (constraint,
+                           "constraint map may not contain > 1 operation");
+    if (constraint.size () == 0)
+        return std::unique_ptr<Constraint>(new Constraint());
+
+    it = constraint.begin();
+    std::string operation = it->first.as<std::string>();
+    operands = it->second;
+
+    if (!operands.IsSequence ()) {
+        std::string msg = operation + " operator value must be an array";
+        throw parse_error (operands, msg.c_str());
+    }
+
+    if (operation == "properties")
+        return std::unique_ptr<PropertyConstraint>
+            (new PropertyConstraint (operands));
+    else if (operation == "and" || operation == "or" || operation == "not")
+        return std::unique_ptr<ConditionalConstraint>
+            (new ConditionalConstraint (operation, operands));
+
+    std::string msg = "unknown constraint operator: " + operation;
+    throw parse_error (constraint, msg.c_str());
+}
+
+// base Constraint implementation
+//
+
+// Base Constraint returns an empty map
+YAML::Node Constraint::as_yaml () const
+{
+    return YAML::Node(YAML::NodeType::Map);
+}
+
+// Base Constraint always matches
+bool Constraint::match (const Flux::resource_model::resource_t &r) const
+{
+    return true;
+}
+
+// PropertyConstraint implementation
+//
+
+PropertyConstraint::PropertyConstraint (const YAML::Node &properties)
+{
+    for (auto&& property: properties) {
+        // YAML::Node::as<std:string> will work on a non-string YAML node.
+        //  use Tag() instead to determine if the scalar is a quoted string,
+        //   in which case "!" is returned.
+        //
+        //  Ref: https://yaml.org/spec/1.2-old/spec.html#id2804923
+        if (!property.IsScalar() || property.Tag() != "!")
+            throw parse_error (properties, "non-string property specified");
+
+        std::string prop = property.as<std::string>();
+        if (prop[0] == '^')
+            prop = prop.substr (1);
+        if (prop.find_first_of ("!&\'\"^`|()") != std::string::npos) {
+            std::string errmsg = property.as<std::string>() + " is invalid";
+            throw parse_error (properties, errmsg.c_str ());
+        }
+        values.push_back(property.as<std::string>());
+    }
+}
+
+bool PropertyConstraint::match (const Flux::resource_model::resource_t &r) const
+{
+    for (auto&& value: values) {
+        std::string property = value;
+        bool negate = false;
+
+        if (property[0] == '^') {
+            negate = true;
+            property = property.substr (1);
+        }
+        bool found = r.properties.find (property) != r.properties.end ();
+        if (negate)
+            found = !found;
+        if (!found)
+            return false;
+    }
+    return true;
+}
+
+YAML::Node PropertyConstraint::as_yaml () const
+{
+    YAML::Node node;
+    for (auto && property: values)
+        node["properties"].push_back (property);
+    return node;
+}
+
+
+// ConditionalConstraint implementation
+
+ConditionalConstraint::ConditionalConstraint (std::string &operation,
+                                              const YAML::Node &vals)
+{
+    op = operation;
+    for (auto&& constraint: vals)
+        values.emplace_back (constraint_parser (constraint));
+}
+
+bool
+ConditionalConstraint::match_and (const Flux::resource_model::resource_t &r) const
+{
+    for (auto&& constraint: values) {
+        if (!constraint->match (r))
+            return false;
+    }
+    return true;
+}
+
+bool
+ConditionalConstraint::match_or (const Flux::resource_model::resource_t &r) const
+{
+    for (auto&& constraint: values) {
+        if (constraint->match (r))
+            return true;
+    }
+    return false;
+}
+
+bool
+ConditionalConstraint::match (const Flux::resource_model::resource_t &r) const
+{
+    if (op == "and")
+        return match_and (r);
+    if (op == "or")
+        return match_or (r);
+    if (op == "not")
+        return !match_and (r);
+    return false;
+}
+
+YAML::Node ConditionalConstraint::as_yaml () const
+{
+    YAML::Node node;
+    for (auto&& constraint: values)
+        node[op].push_back(constraint->as_yaml ());
+    return node;
+}
+

--- a/resource/libjobspec/constraint.hpp
+++ b/resource/libjobspec/constraint.hpp
@@ -1,0 +1,41 @@
+/*****************************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+/*
+ * Parse RFC 31 Constraint from Jobspec into a Constraint object
+ */
+
+#ifndef JOBSPEC_CONSTRAINT_HPP
+#define JOBSPEC_CONSTRAINT_HPP
+
+#include <iostream>
+#include <string>
+#include <yaml-cpp/yaml.h>
+
+#include "resource/schema/resource_base.hpp"
+#include "parse_error.hpp"
+
+namespace Flux {
+namespace Jobspec {
+
+class Constraint {
+public:
+    Constraint () = default;
+    virtual ~Constraint () = default;
+    virtual bool match (const Flux::resource_model::resource_t &resource) const;
+    virtual YAML::Node as_yaml () const;
+};
+
+std::unique_ptr<Constraint> constraint_parser (const YAML::Node &constraint);
+
+} // namespace Jobspec
+} // namespace Flux
+
+#endif // JOBSPEC_CONSTRAINT_HPP

--- a/resource/libjobspec/hostlist_constraint.cpp
+++ b/resource/libjobspec/hostlist_constraint.cpp
@@ -1,0 +1,49 @@
+/*****************************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+}
+
+#include "hostlist_constraint.hpp"
+
+using namespace Flux::Jobspec;
+
+HostlistConstraint::HostlistConstraint (const YAML::Node &values)
+{
+    if (!(hl = hostlist_create ()))
+        throw parse_error (values, "Out of memory");
+    for (auto&& val: values) {
+        std::string hosts = val.as<std::string>();
+        if (hostlist_append (hl, hosts.c_str()) < 0) {
+            hostlist_destroy (hl);
+            std::string msg = "Invalid hostlist `" + hosts + "'";
+            throw parse_error (val, msg.c_str());
+        }
+    }
+}
+
+bool HostlistConstraint::match (const Flux::resource_model::resource_t &r) const
+{
+    if (hostlist_find (hl, r.name.c_str()) < 0)
+        return false;
+    return true;
+}
+
+YAML::Node HostlistConstraint::as_yaml () const
+{
+    YAML::Node node;
+    char *hosts = hostlist_encode (hl);
+    node["hostlist"].push_back (hosts);
+    free (hosts);
+    return node;
+}

--- a/resource/libjobspec/hostlist_constraint.hpp
+++ b/resource/libjobspec/hostlist_constraint.hpp
@@ -1,0 +1,39 @@
+/*****************************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+#ifndef HOSTLIST_CONSTRAINT_HPP
+#define HOSTLIST_CONSTRAINT_HPP
+
+#include <flux/hostlist.h>
+
+#include "jobspec.hpp"
+#include "constraint.hpp"
+
+namespace Flux {
+namespace Jobspec {
+
+class HostlistConstraint : public Constraint {
+public:
+    HostlistConstraint (const YAML::Node&);
+    HostlistConstraint () = default;
+    ~HostlistConstraint () { hostlist_destroy (hl); };
+
+private:
+    struct hostlist *hl = nullptr;
+
+public:
+    virtual bool match (const Flux::resource_model::resource_t &resource) const;
+    virtual YAML::Node as_yaml () const;
+};
+
+} // namespace Jobspec
+} // namespace Flux
+
+#endif // HOSTLIST_CONSTRAINT_HPP

--- a/resource/libjobspec/jobspec.cpp
+++ b/resource/libjobspec/jobspec.cpp
@@ -330,35 +330,7 @@ Attributes parse_yaml_attributes (const YAML::Node &attrs)
                     }
                 }
                 else if (s.first.as<std::string>() == "constraints") {
-                    for (auto&& kv2 : s.second) {
-                        if (kv2.first.as<std::string>() == "properties") {
-                            if (!kv2.second.IsSequence()) {
-                                throw parse_error (
-                                          kv2.second,
-                                          "\"properties\" is not a sequence");
-                            }
-                            for (auto&& p : kv2.second) {
-                                std::string p_validate = p.as<std::string> ();
-                                if (p_validate.find_first_of ("^") == 0) {
-                                    // '^' is valid only when appears before
-                                    // the property string per RFC31.
-                                    p_validate = p_validate.substr (1);
-                                }
-
-                                if (p_validate.find_first_of (
-                                        "!&\'\"^`|()") != std::string::npos) {
-                                    std::string errmsg = p.as<std::string> ()
-                                                             + " is invalid";
-                                    throw parse_error (p, errmsg.c_str ());
-                                }
-                                a.system
-                                      .constraints
-                                           .properties
-                                                .push_back (
-                                                     p.as<std::string>());
-                            }
-                        }
-                    }
+                    a.system.constraint = constraint_parser (s.second);
                 } else {
                     a.system.optional[s.first.as<std::string>()] = s.second;
                 }
@@ -511,11 +483,13 @@ std::ostream& Flux::Jobspec::operator<<(std::ostream& s, Jobspec const& jobspec)
         s << "      " << e.first << ": " << e.second << std::endl;
     }
     s << "    " << "constraints:" << std::endl;
-    s << "      " << "properties:" << std::endl;
-    for (auto&& p : jobspec.attributes.system.constraints.properties) {
-        s << "        " << p << std::endl;
+    if (jobspec.attributes.system.constraint != nullptr) {
+        std::stringstream ss;
+        std::string line;
+        ss << jobspec.attributes.system.constraint->as_yaml ();
+        while (std::getline (ss, line))
+            s << "      " << line << std::endl;
     }
-
     return s;
 }
 

--- a/resource/libjobspec/jobspec.hpp
+++ b/resource/libjobspec/jobspec.hpp
@@ -38,6 +38,7 @@
 #include <yaml-cpp/yaml.h>
 
 #include "parse_error.hpp"
+#include "constraint.hpp"
 
 namespace Flux {
 namespace Jobspec {
@@ -77,17 +78,13 @@ public:
     Task(const YAML::Node&);
 };
 
-struct Constraints {
-    std::vector<std::string> properties;
-};
-
 struct System {
     double duration = 0.0f;
     std::string queue = "";
     std::string cwd = "";
     std::unordered_map<std::string, std::string> environment;
     std::unordered_map<std::string, YAML::Node> optional;
-    Constraints constraints;
+    std::shared_ptr<Constraint> constraint = nullptr;
 
     System() = default;
     System(const System &s) = delete; // Force to use move ctor

--- a/resource/libjobspec/jobspec.hpp
+++ b/resource/libjobspec/jobspec.hpp
@@ -37,17 +37,10 @@
 #include <limits>
 #include <yaml-cpp/yaml.h>
 
+#include "parse_error.hpp"
+
 namespace Flux {
 namespace Jobspec {
-
-class parse_error : public std::runtime_error {
-public:
-    int position;
-    int line;
-    int column;
-    parse_error(const char *msg);
-    parse_error(const YAML::Node& node, const char *msg);
-};
 
 enum class tristate_t { FALSE, TRUE, UNSPECIFIED };
 

--- a/resource/libjobspec/parse_error.hpp
+++ b/resource/libjobspec/parse_error.hpp
@@ -1,0 +1,36 @@
+/*****************************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+/*
+ * separate Flux::Jobspec::parse_error header for circular dependency
+ * resolution
+ */
+
+#ifndef JOBSPEC_PARSE_ERROR_HPP
+#define JOBSPEC_PARSE_ERROR_HPP
+
+#include <stdexcept>
+
+namespace Flux {
+namespace Jobspec {
+
+class parse_error : public std::runtime_error {
+public:
+    int position;
+    int line;
+    int column;
+    parse_error(const char *msg);
+    parse_error(const YAML::Node& node, const char *msg);
+};
+
+} // namespace Jobspec
+} // namespace Flux
+
+#endif // JOBSPEC_PARSE_ERROR_HPP

--- a/resource/libjobspec/rank_constraint.cpp
+++ b/resource/libjobspec/rank_constraint.cpp
@@ -1,0 +1,59 @@
+/*****************************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+}
+
+#include "rank_constraint.hpp"
+
+using namespace Flux::Jobspec;
+
+static int add_idset_string (struct idset *idset, const char *s)
+{
+    int rc;
+    struct idset *ids;
+
+    if (!(ids = idset_decode (s)))
+        return -1;
+    rc = idset_add (idset, ids);
+    idset_destroy (ids);
+    return rc;
+}
+
+RankConstraint::RankConstraint (const YAML::Node &values)
+{
+    if (!(ranks = idset_create (0, IDSET_FLAG_AUTOGROW)))
+        throw parse_error (values, "Out of memory");
+    for (auto&& val: values) {
+        std::string ids = val.as<std::string>();
+        if (add_idset_string (ranks, ids.c_str()) < 0) {
+            idset_destroy (ranks);
+            std::string msg = "Invalid idset `" + ids + "'";
+            throw parse_error (val, msg.c_str());
+        }
+    }
+}
+
+bool RankConstraint::match (const Flux::resource_model::resource_t &r) const
+{
+    return idset_test (ranks, r.rank);
+}
+
+YAML::Node RankConstraint::as_yaml () const
+{
+    YAML::Node node;
+    char *s = idset_encode (ranks, IDSET_FLAG_RANGE);
+    node["ranks"].push_back (s);
+    free (s);
+    return node;
+}

--- a/resource/libjobspec/rank_constraint.hpp
+++ b/resource/libjobspec/rank_constraint.hpp
@@ -1,0 +1,39 @@
+/*****************************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+#ifndef RANK_CONSTRAINT_HPP
+#define RANK_CONSTRAINT_HPP
+
+#include <flux/idset.h>
+
+#include "jobspec.hpp"
+#include "constraint.hpp"
+
+namespace Flux {
+namespace Jobspec {
+
+class RankConstraint : public Constraint {
+public:
+    RankConstraint (const YAML::Node&);
+    RankConstraint () = default;
+    ~RankConstraint () { idset_destroy (ranks); };
+
+private:
+    struct idset *ranks = nullptr;
+
+public:
+    virtual bool match (const Flux::resource_model::resource_t &resource) const;
+    virtual YAML::Node as_yaml () const;
+};
+
+} // namespace Jobspec
+} // namespace Flux
+
+#endif // RANK_CONSTRAINT_HPP

--- a/resource/libjobspec/test/constraint.cpp
+++ b/resource/libjobspec/test/constraint.cpp
@@ -124,6 +124,14 @@ struct match_test match_tests[] = {
       "{\"hostlist\": [\"foo[1-3]\"]}",
       false,
     },
+    { "ranks operator works",
+      "{\"ranks\": [\"0-2\"]}",
+      true,
+    },
+    { "ranks operator works with non-intersecting ranks",
+      "{\"ranks\": [\"1-3\"]}",
+      false,
+    },
     { NULL, NULL, false },
 };
 
@@ -232,6 +240,16 @@ struct validate_test validate_tests[] = {
       "{\"hostlist\": [\"foo0-10]\"]}",
       -1,
       "Invalid hostlist `foo0-10]'",
+    },
+    { "ranks can be included",
+      "{\"ranks\": [\"0-10\"]}",
+      0,
+      NULL
+    },
+    { "invalid ranks entry fails",
+      "{\"ranks\": [\"5,1-3\"]}",
+      -1,
+      "Invalid idset `5,1-3'",
     },
     { NULL, NULL, 0, NULL }
 };

--- a/resource/libjobspec/test/constraint.cpp
+++ b/resource/libjobspec/test/constraint.cpp
@@ -116,6 +116,14 @@ struct match_test match_tests[] = {
        }",
        false,
     },
+    { "hostlist operator works",
+      "{\"hostlist\": [\"foo[0-2]\"]}",
+      true,
+    },
+    { "hostlist operator works with non-matching hostlist",
+      "{\"hostlist\": [\"foo[1-3]\"]}",
+      false,
+    },
     { NULL, NULL, false },
 };
 
@@ -214,6 +222,16 @@ struct validate_test validate_tests[] = {
       }",
       0,
       NULL
+    },
+    { "hostlist can be included",
+      "{\"hostlist\": [\"foo[0-10]\"]}",
+      0,
+      NULL
+    },
+    { "invalid hostlist fails",
+      "{\"hostlist\": [\"foo0-10]\"]}",
+      -1,
+      "Invalid hostlist `foo0-10]'",
     },
     { NULL, NULL, 0, NULL }
 };

--- a/resource/libjobspec/test/constraint.cpp
+++ b/resource/libjobspec/test/constraint.cpp
@@ -1,0 +1,255 @@
+/*****************************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <iostream>
+#include <string>
+#include <map>
+#include <yaml-cpp/yaml.h>
+
+#include "resource/schema/resource_base.hpp"
+#include "resource/libjobspec/constraint.hpp"
+#include "src/common/libtap/tap.h"
+
+// fake resource type for testing
+struct resource : Flux::resource_model::resource_t {
+    resource () {};
+    void add_property (std::string name) {
+        properties.insert(std::pair<std::string, std::string>(name, "t"));
+    }
+};
+
+using namespace Flux;
+using namespace Flux::Jobspec;
+
+struct match_test {
+    const char *desc;
+    const char *json;
+    bool result;
+};
+
+struct validate_test {
+    const char *desc;
+    const char *json;
+    int rc;
+    const char *err;
+};
+
+/*  These tests all assume a node object foo0 with properties xx and yy.
+ */
+struct match_test match_tests[] = {
+    { "empty json object matches everything", "{}", true },
+    {  "empty properties dict matches everything",
+       "{\"properties\": [] }",
+       true
+    },
+    {  "property matches",
+       "{\"properties\": [\"xx\"]}",
+        true,
+    },
+    {  "logical not on property",
+       "{\"properties\": [\"^xx\"]}",
+        false,
+    },
+    {  "logical not on unset property",
+       "{\"properties\": [\"^zz\"]}",
+        true,
+    },
+    {  "property list matches like 'and'",
+       "{\"properties\": [\"xx\", \"yy\"]}",
+        true,
+    },
+    {  "property list match fails unless node has all",
+       "{\"properties\": [\"xx\", \"zz\"]}",
+        false,
+    },
+    { "property list match fails if property missing",
+       "{\"properties\": [\"zz\"]}",
+        false,
+    },
+    { "and with two true statements",
+      "{\"and\": [ {\"properties\": [\"xx\"]}, \
+                   {\"properties\": [\"yy\"]}  \
+                 ]}",
+        true,
+    },
+    { "and with one false statement",
+      "{\"and\": [ {\"properties\": [\"xx\"]}, \
+                   {\"properties\": [\"zz\"]}  \
+                 ]}",
+        false,
+    },
+    { "or with two true statements",
+      "{\"or\": [ {\"properties\": [\"xx\"]}, \
+                  {\"properties\": [\"yy\"]}  \
+                 ]}",
+        true,
+    },
+    { "or with one true statements",
+      "{\"or\": [ {\"properties\": [\"zz\"]}, \
+                  {\"properties\": [\"yy\"]}  \
+                 ]}",
+        true,
+    },
+    { "or with two false statements",
+      "{\"or\": [ {\"properties\": [\"zz\"]}, \
+                  {\"properties\": [\"aa\"]}  \
+                 ]}",
+        false,
+    },
+    { "not with or with one true statement",
+      "{\"not\": [ \
+        {\"or\": [ {\"properties\": [\"zz\"]}, \
+                   {\"properties\": [\"yy\"]}  \
+                 ]} \
+        ] \
+       }",
+       false,
+    },
+    { NULL, NULL, false },
+};
+
+void test_match ()
+{
+    resource resource;
+    resource.add_property ("xx");
+    resource.add_property ("yy");
+    resource.type = "node";
+    resource.name = "foo0";
+    resource.basename = "foo";
+    resource.rank = 0;
+
+    struct match_test *t = match_tests;
+    while (t->desc) {
+        auto c = constraint_parser (YAML::Load (t->json));
+        ok (c->match (resource) == t->result, "%s", t->desc);
+        t++;
+    }
+}
+
+struct validate_test validate_tests[] = {
+    { "non-object fails",
+      "[]",
+      -1,
+      "constraint is not a mapping",
+    },
+    { "Unknown operation fails",
+      "{ \"foo\": [] }",
+      -1,
+      "unknown constraint operator: foo",
+    },
+    { "multiple operations in one object fails",
+      "{\"properties\": [\"xx\"], \"hostlist\": [\"foo\"]}",
+      -1,
+      "constraint map may not contain > 1 operation",
+    },
+    { "non-array argument to 'and' fails",
+      "{ \"and\": \"foo\" }",
+      -1,
+      "and operator value must be an array",
+    },
+    { "non-array argument to 'or' fails",
+      "{ \"or\": \"foo\" }",
+      -1,
+      "or operator value must be an array",
+    },
+    { "non-array argument to 'properties' fails",
+      "{ \"properties\": \"foo\" }",
+      -1,
+      "properties operator value must be an array",
+    },
+    { "non-string property fails",
+      "{ \"properties\": [ \"foo\", 42 ] }",
+      -1,
+      "non-string property specified",
+    },
+    { "invalid property string fails",
+      "{ \"properties\": [ \"foo\", \"bar&\" ] }",
+      -1,
+      "bar& is invalid",
+    },
+    { "empty object is valid constraint",
+      "{}",
+      0,
+      NULL
+    },
+    { "empty and object is valid constraint",
+      "{ \"and\": [] }",
+      0,
+      NULL
+    },
+    { "empty or object is valid constraint",
+      "{ \"or\": [] }",
+      0,
+      NULL
+    },
+    { "empty properties object is valid constraint",
+      "{ \"properties\": [] }",
+      0,
+      NULL
+    },
+    { "complex conditional works",
+      "{ \"and\": \
+         [ { \"or\": \
+             [ {\"properties\": [\"foo\"]}, \
+               {\"properties\": [\"bar\"]}  \
+             ] \
+           }, \
+           { \"and\": \
+             [ {\"properties\": [\"xx\"]}, \
+               {\"properties\": [\"yy\"]}  \
+             ] \
+           } \
+         ] \
+      }",
+      0,
+      NULL
+    },
+    { NULL, NULL, 0, NULL }
+};
+
+
+void test_validate ()
+{
+    struct validate_test *t = validate_tests;
+    while (t->desc) {
+        bool exception = false;
+        std::string errmsg;
+
+        try {
+            constraint_parser (YAML::Load (t->json));
+        }
+        catch (Flux::Jobspec::parse_error& e) {
+            exception = true;
+            errmsg = e.what ();
+        }
+        if (t->rc != 0) {
+            ok (exception, "%s", t->desc);
+            is (errmsg.c_str(), t->err, "%s: got expected error", t->desc);
+        }
+        else {
+            ok (!exception, "%s", t->desc);
+        }
+        t++;
+    }
+}
+
+int main (int ac, char *argv[])
+{
+    plan (NO_PLAN);
+    test_match ();
+    test_validate ();
+    done_testing ();
+    return 0;
+}
+

--- a/resource/schema/resource_base.hpp
+++ b/resource/schema/resource_base.hpp
@@ -1,0 +1,38 @@
+/*****************************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+#ifndef RESOURCE_BASE_HPP
+#define RESOURCE_BASE_HPP
+
+#include <string>
+#include <map>
+
+namespace Flux {
+namespace resource_model {
+
+//! Base resource type.
+//  Allows derived resource types for testing
+struct resource_t {
+    std::string type;
+    std::string basename;
+    std::string name;
+    std::map<std::string, std::string> properties;
+    int64_t id = -1;
+    int rank = -1;
+};
+
+} // namespace resource_model
+} // namespace Flux
+
+#endif // RESOURCE_BASE_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/schema/resource_data.hpp
+++ b/resource/schema/resource_data.hpp
@@ -18,6 +18,7 @@
 #include <unordered_map>
 #include <set>
 #include "resource/schema/color.hpp"
+#include "resource/schema/resource_base.hpp"
 #include "resource/schema/data_std.hpp"
 #include "resource/schema/sched_data.hpp"
 #include "resource/schema/infra_data.hpp"
@@ -27,7 +28,7 @@ namespace Flux {
 namespace resource_model {
 
 //! Resource pool data type
-struct resource_pool_t {
+struct resource_pool_t : public resource_t {
     resource_pool_t ();
     resource_pool_t (const resource_pool_t &o);
     resource_pool_t &operator= (const resource_pool_t &o);
@@ -43,15 +44,9 @@ struct resource_pool_t {
     static const std::string status_to_str (status_t s);
 
     // Resource pool data
-    std::string type;
     std::map<std::string, std::string> paths;
-    std::string basename;
-    std::string name;
-    std::map<std::string, std::string> properties;
-    int64_t id = -1;
     int64_t uniq_id;
     unsigned int size = 0;
-    int rank = -1;
     std::string unit;
 
     schedule_t schedule;    //!< schedule data

--- a/resource/schema/resource_graph.hpp
+++ b/resource/schema/resource_graph.hpp
@@ -24,7 +24,7 @@ namespace resource_model {
 enum class emit_format_t { GRAPHVIZ_DOT, GRAPH_ML, };
 
 using pinfra_t = pool_infra_t resource_pool_t::*;
-using pname_t  = std::string resource_pool_t::*;
+using pname_t  = std::string resource_t::*;
 using rname_t  = std::string resource_relation_t::*;
 using rinfra_t = relation_infra_t resource_relation_t::*;
 using resource_graph_t = boost::adjacency_list<boost::vecS,

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -327,24 +327,6 @@ done:
     return *ret;
 }
 
-bool dfu_impl_t::is_pconstraint_matched (vtx_t u, const std::string &property)
-{
-    bool neg = false;
-    bool found = false;
-    std::string p_operand = property;
-
-    if (property.find_first_of ("^") == 0) {
-        neg = true;
-        p_operand = property.substr (1);
-    }
-    found = (*m_graph)[u].properties.find (p_operand)
-                != (*m_graph)[u].properties.end ();
-
-    // W/ no operator, matched == found
-    // W/ negation operator, matched == unfound
-    return neg? !found : found;
-}
-
 /* Accumulate counts into accum[type] if the type is one of the pruning
  * filter type.
  */
@@ -707,16 +689,13 @@ int dfu_impl_t::dom_dfv (const jobmeta_t &meta, vtx_t u,
     *excl = x_in;
     (*m_graph)[u].idata.colors[dom] = m_color.black ();
 
-    if (!meta.properties.empty ()) {
-        if (meta.properties.find ((*m_graph)[u].type)
-            != meta.properties.end ()) {
-            auto iter = meta.properties.find ((*m_graph)[u].type);
-            for (auto &k : iter->second) {
-                if (!is_pconstraint_matched (u, k))
-                    goto done;
-            }
-        }
-    }
+    //  RFC 31 constraints only match against type == "node"
+    //  unspecified constraint matches everything
+    if (meta.constraint != nullptr
+        && (*m_graph)[u].type == "node"
+        && !meta.constraint->match ((*m_graph)[u]))
+        goto done;
+
     p = (*m_graph)[u].schedule.plans;
     if ( (avail = planner_avail_resources_during (p, at, duration)) == 0) {
         goto done;

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -53,7 +53,7 @@ struct jobmeta_t {
     int64_t at = -1;
     int64_t now = -1;
     uint64_t duration = SYSTEM_DEFAULT_DURATION; // will need config ultimately
-    std::map<std::string, std::set<std::string>> properties;
+    std::shared_ptr <Jobspec::Constraint> constraint;
 
     bool is_queue_set () const {
         return m_queue_set;
@@ -94,28 +94,7 @@ struct jobmeta_t {
             m_queue = jobspec.attributes.system.queue;
             m_queue_set = true;
         }
-        if (jobspec.attributes.system
-                                  .constraints.properties.size () != 0) {
-            for (auto &p : jobspec.attributes.system.constraints.properties) {
-                std::string prop = p;
-                if (properties.find ("node") == properties.end ()) {
-                    auto res = properties.insert (
-                                   std::pair<
-                                       std::string,
-                                       std::set<std::string>> ("node",
-                                                               std::set<std::string> ()));
-                    if (!res.second) {
-                        errno = ENOMEM;
-                        return -1;
-                    }
-                }
-                auto res2 = properties["node"].insert (prop);
-                if (!res2.second) {
-                    errno = ENOMEM;
-                    return -1;
-                }
-            }
-        }
+        constraint = jobspec.attributes.system.constraint;
         return 0;
     }
 

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -316,7 +316,7 @@ static int set_subsystems_use (std::shared_ptr<resource_context_t> &ctx,
 static void write_to_graphviz (f_resource_graph_t &fg, subsystem_t ss,
                                std::fstream &o)
 {
-    f_res_name_map_t vmap = get (&resource_pool_t::name, fg);
+    f_res_name_map_t vmap = get (&resource_t::name, fg);
     f_edg_infra_map_t emap = get (&resource_relation_t::idata, fg);
     label_writer_t<f_res_name_map_t, vtx_t> vwr (vmap);
     edg_label_writer_t ewr (emap, ss);

--- a/resource/utilities/test/benchmark.yaml
+++ b/resource/utilities/test/benchmark.yaml
@@ -17,7 +17,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: app
+  - command: ["app"]
     slot: default
     count:
       per_slot: 1

--- a/t/data/resource/jobspecs/validation/valid/constraints.yaml
+++ b/t/data/resource/jobspecs/validation/valid/constraints.yaml
@@ -1,0 +1,24 @@
+version: 9999
+resources:
+  - type: slot
+    count: 4
+    label: default
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: [ "flux", "start" ]
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 3600.0
+    constraints:
+      and:
+      - or:
+        - hostlist: [ "foo" ]
+        - ranks: [ 0 ]
+        - properties: [ "bar", "baz" ]
+      - not:
+        - properties: [ "foo", "bar" ]


### PR DESCRIPTION
This PR is a WIP. The current solution almost works, but there is a compilation error discussed on slack in `resource/utilities/resource-query.cpp` due to the addition of a `Flux::resource_model::resource_t` base class.

```
  CXX      resource_query-resource-query.o
resource-query.cpp: In function ‘void write_to_graphviz(Flux::resource_model::f_resource_graph_t&, Flux::resource_model::subsystem_t, std::fstream&)’:
resource-query.cpp:319:33: error: conversion from ‘vec_adj_list_vertex_property_map<[...],[...],[...],[...],std::__cxx11::basic_string<char> Flux::resource_model::resource_t::*>’ to non-scalar type ‘vec_adj_list_vertex_property_map<[...],[...],[...],[...],std::__cxx11::basic_string<char> Flux::resource_model::resource_pool_t::*>’ requested
  319 |     f_res_name_map_t vmap = get (&resource_pool_t::name, fg);
      |                             ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I'm posting the PR early to not only get help fixing or working around this error, but to get any feedback on the implementation so far.

Summary:

This PR adds more complete support for RFC 31 Job Constraints specified in jobspec. Currently, Fluxion only supports constraints of the exact form `{ "properties": [ "xx", "yy" ] }`, however to support constraints on hosts, ranks, etc we will need to support the more full RFC 31 (currently optional) set of "operators" including the boolean operators `and` `or` and `not`.

This PR adds a new `Jobspec::Constraint` base class and constraint "parser" which parses the constraints section of jobspec and, if valid, returns a `Constraint *` which can then be used to determine if the constraint matches a resource vertex.

Each operator is implemented as a derived class of `Constraint`, e.g. a `PropertyConstraint` contains a vector of properties and its `match()` method handles checking that all specified properties are set in the resource, and the `ConditionalConstraint` contains a vector of other `Constraint` objects and returns the appropriate result if all/none/one match (`and`/`not`/`or`).

Later, we can add a `HostlistConstraint` and `RankConstraint` to support constraining jobs to hosts/ranks and/or excluding hosts/ranks.

The `constraint_parser()` function returns a `shared_ptr` because the Constraint has to be shared between the jobspec class and the `jobmeta` class used in the traverser.

Fixes #942
Fixes #965
 