### PR TITLE
report Fluxion version when broker modules are loaded

### DIFF
--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -618,6 +618,7 @@ int mod_start (flux_t *h, int argc, char **argv)
         flux_log_error (h, "%s: qmanager_new", __FUNCTION__);
         return rc;
     }
+
     // Because mod_main is always active, the following is safe.
     flux_aux_set (h, "sched-fluxion-qmanager", &ctx, nullptr);
 
@@ -664,6 +665,9 @@ int mod_start (flux_t *h, int argc, char **argv)
 extern "C" int mod_main (flux_t *h, int argc, char **argv)
 {
     eh_wrapper_t exception_safe_main;
+
+    flux_log (h, LOG_INFO, "version %s", PACKAGE_VERSION);
+
     int rc = exception_safe_main (mod_start, h, argc, argv);
     if (exception_safe_main.bad ())
         flux_log_error (h, "%s: %s", __FUNCTION__,

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -2617,6 +2617,9 @@ error:
 extern "C" int mod_main (flux_t *h, int argc, char **argv)
 {
     int rc = -1;
+
+    flux_log (h, LOG_INFO, "version %s", PACKAGE_VERSION);
+
     try {
         std::shared_ptr<resource_ctx_t> ctx = nullptr;
         uint32_t rank = 1;


### PR DESCRIPTION
This PR simply logs the flux-sched version when the qmanager and resource modules are loaded. This can aid users in determining if they've loaded the expected version of Fluxion, and can also be helpful to developers when users report issues.

e.g.
```console
$ flux dmesg | grep version
2023-01-26T18:39:18.234157Z sched-fluxion-resource.info[0]: version 0.25.0-12-gecf20b37
2023-01-26T18:39:18.311059Z sched-fluxion-qmanager.info[0]: version 0.25.0-12-gecf20b37
f(s=1,d=0) grondo@corona82:~/git/flux-core.git$ 
```