### PR TITLE
WIP:  raise fatal exception on running jobs during reload

### DIFF
--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -306,15 +306,19 @@ void qmanager_cb_t::jobmanager_free_cb (flux_t *h, const flux_msg_t *msg,
         flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
         return;
     }
+    /* See flux-framework/flux-sched#991
+     * Treat free of unknown job as non-fatal so job can go inactive.
+     */
     if (ctx->find_queue (id, queue_name, queue) < 0) {
         flux_log_error (h, "%s: can't find queue for job (id=%jd)",
                         __FUNCTION__, static_cast<intmax_t> (id));
-        return;
     }
-    if ((queue->remove (id)) < 0) {
-        flux_log_error (h, "%s: remove (queue=%s id=%jd)", __FUNCTION__,
-                       queue_name.c_str (), static_cast<intmax_t> (id));
-        return;
+    else {
+        if ((queue->remove (id)) < 0) {
+            flux_log_error (h, "%s: remove (queue=%s id=%jd)", __FUNCTION__,
+                           queue_name.c_str (), static_cast<intmax_t> (id));
+            return;
+        }
     }
     if (schedutil_free_respond (ctx->schedutil, msg) < 0) {
         flux_log_error (h, "%s: schedutil_free_respond", __FUNCTION__);


### PR DESCRIPTION
Problem: in `rv1_nosched` mode (where R doesn't contain the JGF scheduling key), qmanager fails to load if any running jobs are presented during the initial handshake with the job manager, as described in #991.

This is a proposed workaround, where
- jobs that lack the scheduling key get a fatal exception during "hello" processing
- we allow a "Free" to succeed even when a job is not found, so that it can clean up properly

With this in place, I can start a sleep job on my test system, reload qmanager, and the job is cleaned up, and left with a reasonable eventlog:
```
$ flux mini submit -q batch -t 30m  sleep 300
ƒJhxb25A7J7
$ flux jobs
       JOBID QUEUE    USER     NAME       ST NTASKS NNODES     TIME INFO
 ƒJhxb25A7J7 batch    garlick  sleep       R      1      1   2.606s picl3

$ sudo flux module reload sched-fluxion-qmanager
$ sudo flux dmesg
[snip]
2023-01-27T00:41:58.711754Z sched-fluxion-qmanager.info[0]: raising fatal exception on running job id=131515456010846208
2023-01-27T00:41:58.714113Z sched-fluxion-qmanager.debug[0]: handshaking with job-manager completed
2023-01-27T00:41:59.260293Z sched-fluxion-qmanager.err[0]: jobmanager_free_cb: can't find queue for job (id=131515456010846208): No such file or directory
2023-01-27T00:41:59.260358Z sched-fluxion-qmanager.debug[0]: free succeeded (queue= id=131515456010846208)

$ flux job eventlog -T offset ƒJhxb25A7J7
0.000000 submit userid=5588 urgency=16 flags=0 version=1
0.015252 validate
0.028913 depend
0.028999 priority priority=16
0.052865 alloc
0.053501 prolog-start description="job-manager.prolog"
0.494725 prolog-finish description="job-manager.prolog" status=0
0.508227 start
53.056224 exception type="scheduler" severity=0 userid=500 note="scheduler could not process running job on reload"
53.110109 finish status=36608
53.110640 epilog-start description="job-manager.epilog"
53.140245 release ranks="all" final=true
53.603844 epilog-finish description="job-manager.epilog" status=0
53.604728 free
53.604833 clean
```

Although... this example is kind of contrived because the exec system is still aware of the job and can generate the other cleanup events like "release" and "finish".  We might still get stuck in CLEANUP in the node restart scenario waiting for those.

I'll get a better test set up (and add one tor ci).  Meanwhile posting as a WIP in case people have feedback on this approach.