### PR TITLE
resource: fix 'Internal match error' when hostlist constraint is provided

### DIFF
--- a/resource/libjobspec/hostlist_constraint.cpp
+++ b/resource/libjobspec/hostlist_constraint.cpp
@@ -34,9 +34,10 @@ HostlistConstraint::HostlistConstraint (const YAML::Node &values)
 
 bool HostlistConstraint::match (const Flux::resource_model::resource_t &r) const
 {
-    if (hostlist_find (hl, r.name.c_str()) < 0)
-        return false;
-    return true;
+    int saved_errno = errno;
+    int rc = hostlist_find (hl, r.name.c_str());
+    errno = saved_errno;
+    return rc < 0 ? false : true;
 }
 
 YAML::Node HostlistConstraint::as_yaml () const

--- a/resource/libjobspec/test/constraint.cpp
+++ b/resource/libjobspec/test/constraint.cpp
@@ -148,7 +148,9 @@ void test_match ()
     struct match_test *t = match_tests;
     while (t->desc) {
         auto c = constraint_parser (YAML::Load (t->json));
+        errno = 0;
         ok (c->match (resource) == t->result, "%s", t->desc);
+        ok (errno == 0, "errno is preserved");
         t++;
     }
 }

--- a/t/t1022-property-constraints.t
+++ b/t/t1022-property-constraints.t
@@ -115,6 +115,12 @@ test_expect_success RFC35_SYNTAX 'invalid rank constraint fails' '
 	test_must_fail flux mini run --requires=ranks:5-4 hostname
 '
 
+test_expect_success RFC35_SYNTAX 'unknown rank returns unsatisfiable' '
+	test_must_fail flux mini run --requires=ranks:999 hostname \
+	 >unknown-rank.out 2>&1 &&
+	grep -i unsatisfiable unknown-rank.out
+'
+
 test_expect_success RFC35_SYNTAX 'hostlist constraint works' '
 	flux mini run --requires=host:$(hostname) hostname
 '
@@ -123,6 +129,13 @@ test_expect_success RFC35_SYNTAX 'invalid hostlist constraint fails' '
 	test_must_fail flux mini run --requires=host:foo\[  hostname
 '
 
+test_expect_success RFC35_SYNTAX 'unknown host returns unsatisfiable' '
+	if test "$(hostname)" != "host:xyz123"; then
+		test_must_fail flux mini run --requires=host:xyz123 hostname \
+		 >host-unknown.out 2>&1 &&
+		grep -i unsatisfiable host-unknown.out
+	fi
+'
 test_expect_success 'removing resource and qmanager modules' '
 	remove_qmanager &&
 	remove_resource


### PR DESCRIPTION
This PR fixes cases of the resource module returning "Internal match error" when job requests should be "unsatisfiable" and a hostlist constraint is provided. The problem is that the hostlist constraint implementation overwrites `errno`, confusing the resource module which is looking specifically for `ENODATA`.

Fixes #1004