### PR TITLE
Improve Fluxion match performance

### DIFF
--- a/resource/evaluators/fold.hpp
+++ b/resource/evaluators/fold.hpp
@@ -20,21 +20,21 @@ namespace resource_model {
 
 namespace fold {
 struct greater {
-    bool operator() (const eval_egroup_t &a, const eval_egroup_t &b) const
+    inline bool operator() (const eval_egroup_t &a, const eval_egroup_t &b) const
     {
         return a.score > b.score;
     }
 };
 
 struct less {
-    bool operator() (const eval_egroup_t &a, const eval_egroup_t &b) const
+    inline bool operator() (const eval_egroup_t &a, const eval_egroup_t &b) const
     {
         return a.score < b.score;
     }
 };
 
 struct interval_greater {
-    bool operator() (const eval_egroup_t &a, const eval_egroup_t &b) const
+    inline bool operator() (const eval_egroup_t &a, const eval_egroup_t &b) const
     {
         return *(ivset.find (a.score)) > *(ivset.find (b.score));
     }
@@ -42,7 +42,7 @@ struct interval_greater {
 };
 
 struct interval_less {
-    bool operator() (const eval_egroup_t &a, const eval_egroup_t &b) const
+    inline bool operator() (const eval_egroup_t &a, const eval_egroup_t &b) const
     {
         return *(ivset.find (a.score)) < *(ivset.find (b.score));
     }
@@ -50,8 +50,8 @@ struct interval_less {
 };
 
 struct plus {
-    const int64_t operator() (const int64_t result,
-                              const eval_egroup_t &a) const
+    inline const int64_t operator() (const int64_t &result,
+                                     const eval_egroup_t &a) const
     {
         return result + a.score;
     }

--- a/resource/policies/dfu_match_multilevel_id.hpp
+++ b/resource/policies/dfu_match_multilevel_id.hpp
@@ -107,7 +107,8 @@ private:
                         unsigned int add_by,
                         unsigned int multiply_by);
         score_factor_t (const score_factor_t &o) = default;
-        int64_t calc_factor (int64_t base_factor, int64_t break_tie) const;
+        int64_t calc_factor (int64_t base_factor, int64_t break_tie);
+        int64_t m_factor = 0;
 
     private:
         std::string m_type;
@@ -116,11 +117,10 @@ private:
     };
 
     void set_base_factor (const std::string &type, unsigned int id);
-    int64_t calc_multilevel_scores () const;
 
     FOLD m_comp;
     unsigned m_stop_on_k_matches = 0;
-    std::vector<int64_t> m_multilevel_scores;
+    int64_t m_multilevel_scores = 0;
     std::unordered_map<std::string, score_factor_t> m_multilevel_factors;
 };
 


### PR DESCRIPTION
As reported in issue #1001 `flux mini submit` experiences pronounced slowdown for most of the Fluxion match policies except `first`. With the debugging help of @grondo and @trws we traced one source to an un-inlined accumulate operation. 
Adding the `inline` hint to the function allows the compiler to properly inline it and performance improves by a factor of >100 for all policies except `lonodex` and `hinodex` (or, e.g., `lonode` with `--exclusive -N1`.
Another hotspot we encountered in debugging is the `accumulate` operation in `calc_multilevel_scores`: https://github.com/flux-framework/flux-sched/blob/f7bdcb508d4e93ac880845a40d670c03bebf0306/resource/policies/dfu_match_multilevel_id_impl.hpp#L71
This O(_n_) `accumulate` operation is called for each `finish_vtx`, and even worse, currently scales linearly with the number of matches. This is because the accumulated vector isn't cleared after each traversal. We can replace the `accumulate` operation by a single `int64_t` which stores the prefix value.

While these changes improve performance for all policies, `lonodex` and `hinodex` are still slow. Future PRs will further improve performance by optimizing graph filtration and lookups on edge iteration.