### PR TITLE
avoid use of deprecated flux mini commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ flux module list
 
 Submit jobs:
 ```
-flux mini submit -N3 -n3 hostname
-flux mini submit -N3 -n3 sleep 30
+flux submit -N3 -n3 hostname
+flux submit -N3 -n3 sleep 30
 ```
 
 Examine the status of these jobs:

--- a/t/scripts/flux-tree
+++ b/t/scripts/flux-tree
@@ -644,7 +644,7 @@ submit() {
             continue
         fi
         jobid=$(\
-flux mini submit --job-name=${FT_JOB_NAME} -N${N} -n${N} -c${c} ${G} \
+flux submit --job-name=${FT_JOB_NAME} -N${N} -n${N} -c${c} ${G} \
      flux start ${o} \
      flux tree -N${N} -c${c} ${G} ${T} ${Q} ${P} ${M} ${F} ${R} ${X} ${J} \
      -- "${FT_CL[@]}")

--- a/t/t1001-qmanager-basic.t
+++ b/t/t1001-qmanager-basic.t
@@ -22,7 +22,7 @@ exec_testattr() {
 }
 
 test_expect_success 'qmanager: generate jobspec for a simple test job' '
-    flux mini submit -n1 -t 100s --dry-run hostname > basic.json
+    flux submit -n1 -t 100s --dry-run hostname > basic.json
 '
 
 test_expect_success 'load test resources' '
@@ -44,7 +44,7 @@ test_expect_success 'qmanager: basic job runs in simulated mode' '
 '
 
 test_expect_success 'qmanager: canceling job during execution works' '
-    jobid=$(flux mini run --dry-run -t 100m hostname | \
+    jobid=$(flux run --dry-run -t 100m hostname | \
         exec_test | flux job submit) &&
     flux job wait-event -vt 10 ${jobid} start &&
     flux job cancel ${jobid} &&
@@ -56,7 +56,7 @@ test_expect_success 'qmanager: canceling job during execution works' '
 '
 
 test_expect_success 'qmanager: exception during initialization is supported' '
-    flux mini run --dry-run hostname | \
+    flux run --dry-run hostname | \
       exec_testattr mock_exception init > ex1.json &&
     jobid=$(flux job submit ex1.json) &&
     flux job wait-event -t 10 ${jobid} exception > exception.1.out &&
@@ -69,7 +69,7 @@ test_expect_success 'qmanager: exception during initialization is supported' '
 '
 
 test_expect_success 'qmanager: exception during run is supported' '
-	flux mini run --dry-run hostname | \
+	flux run --dry-run hostname | \
 	  exec_testattr mock_exception run > ex2.json &&
 	jobid=$(flux job submit ex2.json) &&
 	flux job wait-event -t 10 ${jobid} exception > exception.2.out &&
@@ -81,7 +81,7 @@ test_expect_success 'qmanager: exception during run is supported' '
 '
 
 test_expect_success 'qmanager: unsatisfiable jobspec rejected' '
-    jobid=$(flux mini run --dry-run -N 64 -n 64 hostname | \
+    jobid=$(flux run --dry-run -N 64 -n 64 hostname | \
         exec_test | flux job submit) &&
     flux job wait-event -t 10 ${jobid} clean &&
     flux job wait-event -t 10 ${jobid} exception | grep "unsatisfiable"

--- a/t/t1002-qmanager-reload.t
+++ b/t/t1002-qmanager-reload.t
@@ -23,7 +23,7 @@ submit_jobs()   {
 }
 
 test_expect_success 'qmanager: generate jobspec for a simple test job' '
-    flux mini submit -n 1 -t 100s --dry-run sleep 10 > basic.json
+    flux submit -n 1 -t 100s --dry-run sleep 10 > basic.json
 '
 
 test_expect_success 'load test resources' '

--- a/t/t1003-qmanager-policy.t
+++ b/t/t1003-qmanager-policy.t
@@ -16,17 +16,17 @@ test_under_flux 1
 exec_test()     { ${jq} '.attributes.system.exec.test = {}'; }
 
 test_expect_success 'qmanager: generate jobspecs of varying requirements' '
-    flux mini run --dry-run -n8 -t 60m hostname | exec_test > C08.T3600.json && #1
-    flux mini run --dry-run -n10 -t 60m hostname | exec_test > C10.T3600.json && #2
-    flux mini run --dry-run -n12 -t 60m hostname | exec_test > C12.T3600.json && #3
-    flux mini run --dry-run -n14 -t 60m hostname | exec_test > C14.T3600.json && #4
-    flux mini run --dry-run -n16 -t 60m hostname | exec_test > C16.T3600.json && #5
-    flux mini run --dry-run -n6 -t 121m hostname | exec_test > C06.T7260.json && #6
-    flux mini run --dry-run -n4 -t 179m hostname | exec_test > C04.T10800.json && #7
-    flux mini run --dry-run -n4 -t 239m hostname | exec_test > C04.T14400.json && #8
-    flux mini run --dry-run -n2 -t 239m hostname | exec_test > C02.T14400.json && #9
-    flux mini run --dry-run -n2 -t 299m hostname | exec_test > C02.T18000.json && #10
-    flux mini run --dry-run -n2 -t 59m hostname | exec_test > C02.T3600.json #11
+    flux run --dry-run -n8 -t 60m hostname | exec_test > C08.T3600.json && #1
+    flux run --dry-run -n10 -t 60m hostname | exec_test > C10.T3600.json && #2
+    flux run --dry-run -n12 -t 60m hostname | exec_test > C12.T3600.json && #3
+    flux run --dry-run -n14 -t 60m hostname | exec_test > C14.T3600.json && #4
+    flux run --dry-run -n16 -t 60m hostname | exec_test > C16.T3600.json && #5
+    flux run --dry-run -n6 -t 121m hostname | exec_test > C06.T7260.json && #6
+    flux run --dry-run -n4 -t 179m hostname | exec_test > C04.T10800.json && #7
+    flux run --dry-run -n4 -t 239m hostname | exec_test > C04.T14400.json && #8
+    flux run --dry-run -n2 -t 239m hostname | exec_test > C02.T14400.json && #9
+    flux run --dry-run -n2 -t 299m hostname | exec_test > C02.T18000.json && #10
+    flux run --dry-run -n2 -t 59m hostname | exec_test > C02.T3600.json #11
 '
 
 test_expect_success 'load test resources' '

--- a/t/t1004-qmanager-optimize.t
+++ b/t/t1004-qmanager-optimize.t
@@ -16,17 +16,17 @@ test_under_flux 1
 exec_test()     { ${jq} '.attributes.system.exec.test = {}'; }
 
 test_expect_success 'qmanager: generate jobspecs of varying requirements' '
-    flux mini run --dry-run -n8 -t 60m hostname | exec_test > C08.T3600.json && #1
-    flux mini run --dry-run -n10 -t 60m hostname | exec_test > C10.T3600.json && #2
-    flux mini run --dry-run -n12 -t 60m hostname | exec_test > C12.T3600.json && #3
-    flux mini run --dry-run -n14 -t 60m hostname | exec_test > C14.T3600.json && #4
-    flux mini run --dry-run -n16 -t 60m hostname | exec_test > C16.T3600.json && #5
-    flux mini run --dry-run -n6 -t 121m hostname | exec_test > C06.T7260.json && #6
-    flux mini run --dry-run -n4 -t 179m hostname | exec_test > C04.T10800.json && #7
-    flux mini run --dry-run -n4 -t 239m hostname | exec_test > C04.T14400.json && #8
-    flux mini run --dry-run -n2 -t 239m hostname | exec_test > C02.T14400.json && #9
-    flux mini run --dry-run -n2 -t 299m hostname | exec_test > C02.T18000.json && #10
-    flux mini run --dry-run -n2 -t 59m hostname | exec_test > C02.T3600.json #11
+    flux run --dry-run -n8 -t 60m hostname | exec_test > C08.T3600.json && #1
+    flux run --dry-run -n10 -t 60m hostname | exec_test > C10.T3600.json && #2
+    flux run --dry-run -n12 -t 60m hostname | exec_test > C12.T3600.json && #3
+    flux run --dry-run -n14 -t 60m hostname | exec_test > C14.T3600.json && #4
+    flux run --dry-run -n16 -t 60m hostname | exec_test > C16.T3600.json && #5
+    flux run --dry-run -n6 -t 121m hostname | exec_test > C06.T7260.json && #6
+    flux run --dry-run -n4 -t 179m hostname | exec_test > C04.T10800.json && #7
+    flux run --dry-run -n4 -t 239m hostname | exec_test > C04.T14400.json && #8
+    flux run --dry-run -n2 -t 239m hostname | exec_test > C02.T14400.json && #9
+    flux run --dry-run -n2 -t 299m hostname | exec_test > C02.T18000.json && #10
+    flux run --dry-run -n2 -t 59m hostname | exec_test > C02.T3600.json #11
 '
 
 test_expect_success 'load test resources' '

--- a/t/t1006-qmanager-multiqueue.t
+++ b/t/t1006-qmanager-multiqueue.t
@@ -35,7 +35,7 @@ test_expect_success 'qmanager: loading qmanager with multiple queues' '
 '
 
 test_expect_success 'qmanager: job can be submitted to queue=all' '
-	jobid=$(flux mini submit -n 1 --queue=all hostname) &&
+	jobid=$(flux submit -n 1 --queue=all hostname) &&
 	flux job wait-event -t 10 ${jobid} finish &&
 	queue=$(get_queue alloc ${jobid}) &&
 	test ${queue} = all &&
@@ -45,7 +45,7 @@ test_expect_success 'qmanager: job can be submitted to queue=all' '
 '
 
 test_expect_success 'qmanager: job can be submitted to queue=batch' '
-	jobid=$(flux mini submit -n 1 --queue=batch hostname) &&
+	jobid=$(flux submit -n 1 --queue=batch hostname) &&
 	flux job wait-event -t 10 ${jobid} finish &&
 	queue=$(get_queue alloc ${jobid}) &&
 	test ${queue} = batch &&
@@ -55,7 +55,7 @@ test_expect_success 'qmanager: job can be submitted to queue=batch' '
 '
 
 test_expect_success 'qmanager: job can be submitted to queue=debug' '
-	jobid=$(flux mini submit -n 1 --queue=debug hostname) &&
+	jobid=$(flux submit -n 1 --queue=debug hostname) &&
 	flux job wait-event -t 10 ${jobid} finish &&
 	queue=$(get_queue alloc ${jobid}) &&
 	test ${queue} = debug &&
@@ -65,7 +65,7 @@ test_expect_success 'qmanager: job can be submitted to queue=debug' '
 '
 
 test_expect_success 'qmanager: job enqueued into implicitly default queue' '
-	jobid=$(flux mini submit -n 1 hostname) &&
+	jobid=$(flux submit -n 1 hostname) &&
 	flux job wait-event -t 10 ${jobid} finish &&
 	queue=$(get_queue alloc ${jobid}) &&
 	test ${queue} = all &&
@@ -92,7 +92,7 @@ test_expect_success 'reconfigure qmanager with queues with different policies' '
 '
 
 test_expect_success 'qmanager: job can be submitted to queue=queue3 (fcfs)' '
-	jobid=$(flux mini submit -n 1 --queue=queue3 hostname) &&
+	jobid=$(flux submit -n 1 --queue=queue3 hostname) &&
 	flux job wait-event -t 10 ${jobid} finish &&
 	queue=$(get_queue alloc ${jobid}) &&
 	test ${queue} = queue3 &&
@@ -102,7 +102,7 @@ test_expect_success 'qmanager: job can be submitted to queue=queue3 (fcfs)' '
 '
 
 test_expect_success 'qmanager: job can be submitted to queue=queue2 (hybrid)' '
-	jobid=$(flux mini submit -n 1 --queue=queue2 hostname) &&
+	jobid=$(flux submit -n 1 --queue=queue2 hostname) &&
 	flux job wait-event -t 10 ${jobid} finish &&
 	queue=$(get_queue alloc ${jobid}) &&
 	test ${queue} = queue2 &&
@@ -112,7 +112,7 @@ test_expect_success 'qmanager: job can be submitted to queue=queue2 (hybrid)' '
 '
 
 test_expect_success 'qmanager: job submitted to queue=queue1 (conservative)' '
-	jobid=$(flux mini submit -n 1 --queue=queue1 hostname) &&
+	jobid=$(flux submit -n 1 --queue=queue1 hostname) &&
 	flux job wait-event -t 10 ${jobid} finish &&
 	queue=$(get_queue alloc ${jobid}) &&
 	test ${queue} = queue1 &&
@@ -122,7 +122,7 @@ test_expect_success 'qmanager: job submitted to queue=queue1 (conservative)' '
 '
 
 test_expect_success 'qmanager: job enqueued into explicitly default queue' '
-	jobid=$(flux mini submit -n 1 hostname) &&
+	jobid=$(flux submit -n 1 hostname) &&
 	flux job wait-event -t 10 ${jobid} finish &&
 	queue=$(get_queue alloc ${jobid}) &&
 	test ${queue} = queue3 &&
@@ -132,7 +132,7 @@ test_expect_success 'qmanager: job enqueued into explicitly default queue' '
 '
 
 test_expect_success 'qmanager: job is denied when submitted to unknown queue' '
-	test_must_fail flux mini run -n 1 --queue=foo \
+	test_must_fail flux run -n 1 --queue=foo \
 	    hostname 2>unknown.err &&
 	grep "Invalid queue" unknown.err
 '
@@ -158,7 +158,7 @@ test_expect_success 'unload qmanager and deconfigure queues' '
 	flux config reload
 '
 test_expect_success 'submit job with no queue' '
-	flux mini submit /bin/true >noqueue.jobid
+	flux submit /bin/true >noqueue.jobid
 '
 test_expect_success 'reconfigure with one queue and load qmanager' '
 	cat >config/queues.toml <<-EOT &&
@@ -176,7 +176,7 @@ test_expect_success 'unload qmanager' '
 	remove_qmanager
 '
 test_expect_success 'submit job with queue' '
-	flux mini submit --queue=foo /bin/true >withqueue.jobid
+	flux submit --queue=foo /bin/true >withqueue.jobid
 '
 test_expect_success 'deconfigure queues and load qmanager' '
 	cp /dev/null config/queues.toml &&

--- a/t/t1007-recovery-full.t
+++ b/t/t1007-recovery-full.t
@@ -20,7 +20,7 @@ flux setattr log-stderr-level 6
 
 
 test_expect_success 'recovery: generate a test jobspec' '
-    flux mini run --dry-run -N 1 -n 4 -t 1h sleep 3600 > basic.json
+    flux run --dry-run -N 1 -n 4 -t 1h sleep 3600 > basic.json
 '
 
 test_expect_success 'load test resources' '

--- a/t/t1009-recovery-multiqueue.t
+++ b/t/t1009-recovery-multiqueue.t
@@ -28,9 +28,9 @@ check_requeue() {
 }
 
 test_expect_success 'recovery: generate test jobspecs' '
-	flux mini run --dry-run -N 1 -n 8 -t 1h \
+	flux run --dry-run -N 1 -n 8 -t 1h \
 	    --queue=batch sleep 3600 > basic.batch.json &&
-	flux mini run --dry-run -N 1 -n 8 -t 1h \
+	flux run --dry-run -N 1 -n 8 -t 1h \
 	    --queue=debug sleep 3600 > basic.debug.json
 '
 

--- a/t/t1011-dynstate-change.t
+++ b/t/t1011-dynstate-change.t
@@ -17,19 +17,19 @@ export FLUX_SCHED_MODULE=none
 test_under_flux 4 full -o,--config-path=$(pwd)/config
 
 test_expect_success 'dyn-state: generate jobspecs' '
-	flux mini run --dry-run -N 4 -n 4 -c 44 -g 4 -t 1h \
+	flux run --dry-run -N 4 -n 4 -c 44 -g 4 -t 1h \
 	    sleep 3600 > basic.json &&
-	flux mini run --dry-run -N 1 -n 1 -c 44 -g 4 -t 1h \
+	flux run --dry-run -N 1 -n 1 -c 44 -g 4 -t 1h \
 	    sleep 3600 > 1N.json &&
-	flux mini run --dry-run -N 4 -n 4 -c 45 -g 4 -t 1h \
+	flux run --dry-run -N 4 -n 4 -c 45 -g 4 -t 1h \
 	    sleep 3600 > unsat.json &&
-	flux mini run --dry-run -N 4 -n 4 -c 44 -g 4 -t 1h --queue=debug \
+	flux run --dry-run -N 4 -n 4 -c 44 -g 4 -t 1h --queue=debug \
 	    sleep 3600 > basic.debug.json &&
-	flux mini run --dry-run -N 1 -n 1 -c 44 -g 4 -t 1h --queue=debug \
+	flux run --dry-run -N 1 -n 1 -c 44 -g 4 -t 1h --queue=debug \
 	    sleep 3600 > 1N.debug.json &&
-	flux mini run --dry-run -N 4 -n 4 -c 44 -g 4 -t 1h --queue=batch \
+	flux run --dry-run -N 4 -n 4 -c 44 -g 4 -t 1h --queue=batch \
 	    sleep 3600 > basic.batch.json &&
-	flux mini run --dry-run -N 1 -n 1 -c 44 -g 4 -t 1h --queue=batch \
+	flux run --dry-run -N 1 -n 1 -c 44 -g 4 -t 1h --queue=batch \
 	    sleep 3600 > 1N.batch.json
 '
 

--- a/t/t1012-find-status.t
+++ b/t/t1012-find-status.t
@@ -19,8 +19,8 @@ export FLUX_SCHED_MODULE=none
 test_under_flux 4
 
 test_expect_success 'find/status: generate jobspecs' '
-    flux mini run --dry-run -N 4 -n 4 -c 44 -g 4 -t 1h sleep 3600 > full.json &&
-    flux mini run --dry-run -N 1 -n 1 -c 22 -g 2 -t 1h sleep 3600 > c22g2.json
+    flux run --dry-run -N 4 -n 4 -c 44 -g 4 -t 1h sleep 3600 > full.json &&
+    flux run --dry-run -N 1 -n 1 -c 22 -g 2 -t 1h sleep 3600 > c22g2.json
 '
 
 validate_list_row() {

--- a/t/t1013-exclusion.t
+++ b/t/t1013-exclusion.t
@@ -15,8 +15,8 @@ export FLUX_SCHED_MODULE=none
 test_under_flux 4
 
 test_expect_success 'exclusion: generate jobspecs' '
-    flux mini run --dry-run -N 4 -n 4 -c 44 -g 4 -t 1h sleep 3600 > basic.json &&
-    flux mini run --dry-run -N 1 -n 1 -c 44 -g 4 -t 1h sleep 3600 > 1N.json
+    flux run --dry-run -N 4 -n 4 -c 44 -g 4 -t 1h sleep 3600 > basic.json &&
+    flux run --dry-run -N 1 -n 1 -c 44 -g 4 -t 1h sleep 3600 > 1N.json
 '
 
 test_expect_success 'exclusion: load config with resource exclusions' '

--- a/t/t1013-qmanager-priority.t
+++ b/t/t1013-qmanager-priority.t
@@ -23,15 +23,15 @@ test_expect_success 'priority: loading fluxion modules works' '
 '
 
 test_expect_success 'priority: a full-size job can be scheduled and run' '
-    jobid1=$(flux mini submit -N 1 -n 1 -c 44 -g 4 -t 1h \
+    jobid1=$(flux submit -N 1 -n 1 -c 44 -g 4 -t 1h \
 --urgency 16 sleep 3600) &&
     flux job wait-event -t 10 ${jobid1} start
 '
 
 test_expect_success 'priority: 2 jobs with higher urgency will not run' '
-    jobid2=$(flux mini submit -N 1 -n 1 -c 44 -g 4 -t 1h \
+    jobid2=$(flux submit -N 1 -n 1 -c 44 -g 4 -t 1h \
 --urgency 17 sleep 3600) &&
-    jobid3=$(flux mini submit -N 1 -n 1 -c 44 -g 4 -t 1h \
+    jobid3=$(flux submit -N 1 -n 1 -c 44 -g 4 -t 1h \
 --urgency 18 sleep 3600) &&
     test_must_fail flux job wait-event -t 1 ${jobid2} start
 '
@@ -42,7 +42,7 @@ test_expect_success 'priority: canceling the first job starts the last job' '
 '
 
 test_expect_success 'priority: submit job with higher urgency' '
-    jobid4=$(flux mini submit -N 1 -n 1 -c 44 -g 4 -t 1h \
+    jobid4=$(flux submit -N 1 -n 1 -c 44 -g 4 -t 1h \
 --urgency 20 sleep 3600) &&
     test_must_fail flux job wait-event -t 1 ${jobid4} start
 '

--- a/t/t1014-annotation.t
+++ b/t/t1014-annotation.t
@@ -51,11 +51,11 @@ subsystems=containment policy=low &&
 '
 
 test_expect_success 'annotation: works with EASY policy' '
-    jobid1=$(flux mini submit -n 8 -t 360s sleep 300) &&
-    jobid2=$(flux mini submit -n 16 -t 360s sleep 300) && # reserved
-    jobid3=$(flux mini submit -n 16 -t 360s sleep 300) && # skipped
-    jobid4=$(flux mini submit -n 16 -t 360s sleep 300) && # skipped
-    jobid5=$(flux mini submit -n 2 -t 180s sleep 100) &&
+    jobid1=$(flux submit -n 8 -t 360s sleep 300) &&
+    jobid2=$(flux submit -n 16 -t 360s sleep 300) && # reserved
+    jobid3=$(flux submit -n 16 -t 360s sleep 300) && # skipped
+    jobid4=$(flux submit -n 16 -t 360s sleep 300) && # skipped
+    jobid5=$(flux submit -n 2 -t 180s sleep 100) &&
 
     flux job wait-event -t 10 ${jobid5} start &&
     hasnt_annotation ${jobid1} &&
@@ -80,11 +80,11 @@ subsystems=containment policy=low load-allowlist=cluster,node,core &&
 '
 
 test_expect_success 'annotation: works with HYBRID policy' '
-    jobid1=$(flux mini submit -n 8 -t 360s sleep 300) &&
-    jobid2=$(flux mini submit -n 16 -t 360s sleep 300) && # reserved
-    jobid3=$(flux mini submit -n 16 -t 360s sleep 300) && # reserved
-    jobid4=$(flux mini submit -n 16 -t 360s sleep 300) && # skipped
-    jobid5=$(flux mini submit -n 2 -t 180s sleep 100) &&
+    jobid1=$(flux submit -n 8 -t 360s sleep 300) &&
+    jobid2=$(flux submit -n 16 -t 360s sleep 300) && # reserved
+    jobid3=$(flux submit -n 16 -t 360s sleep 300) && # reserved
+    jobid4=$(flux submit -n 16 -t 360s sleep 300) && # skipped
+    jobid5=$(flux submit -n 2 -t 180s sleep 100) &&
 
     flux job wait-event -t 10 ${jobid5} start &&
     hasnt_annotation ${jobid1} &&
@@ -108,11 +108,11 @@ subsystems=containment policy=low load-allowlist=cluster,node,core &&
 '
 
 test_expect_success 'annotation: works with CONSERVATIVE policy' '
-    jobid1=$(flux mini submit -n 8 -t 360s sleep 300) &&
-    jobid2=$(flux mini submit -n 16 -t 360s sleep 300) && # reserved
-    jobid3=$(flux mini submit -n 16 -t 360s sleep 300) && # reserved
-    jobid4=$(flux mini submit -n 16 -t 360s sleep 300) && # reserved
-    jobid5=$(flux mini submit -n 2 -t 180s sleep 100) &&
+    jobid1=$(flux submit -n 8 -t 360s sleep 300) &&
+    jobid2=$(flux submit -n 16 -t 360s sleep 300) && # reserved
+    jobid3=$(flux submit -n 16 -t 360s sleep 300) && # reserved
+    jobid4=$(flux submit -n 16 -t 360s sleep 300) && # reserved
+    jobid5=$(flux submit -n 2 -t 180s sleep 100) &&
 
     flux job wait-event -t 10 ${jobid5} start &&
     hasnt_annotation ${jobid1} &&
@@ -136,11 +136,11 @@ subsystems=containment policy=low load-allowlist=cluster,node,core &&
 '
 
 test_expect_success 'annotation: works with FCFS policy' '
-    jobid1=$(flux mini submit -n 8 -t 360s sleep 300) &&
-    jobid2=$(flux mini submit -n 16 -t 360s sleep 300) && # block
-    jobid3=$(flux mini submit -n 16 -t 360s sleep 300) &&
-    jobid4=$(flux mini submit -n 16 -t 360s sleep 300) &&
-    jobid5=$(flux mini submit -n 2 -t 180s sleep 100) &&
+    jobid1=$(flux submit -n 8 -t 360s sleep 300) &&
+    jobid2=$(flux submit -n 16 -t 360s sleep 300) && # block
+    jobid3=$(flux submit -n 16 -t 360s sleep 300) &&
+    jobid4=$(flux submit -n 16 -t 360s sleep 300) &&
+    jobid5=$(flux submit -n 2 -t 180s sleep 100) &&
 
     flux job wait-event -t 10 ${jobid1} start &&
     flux job wait-event -t 10 ${jobid5} submit &&

--- a/t/t1016-nest-namespace.t
+++ b/t/t1016-nest-namespace.t
@@ -37,7 +37,7 @@ EOF
 	2,3
 EOF
     chmod u+x nest.sh &&
-    jobid=$(flux mini batch --output=kvs -n1 -N1 -c22 -g2 ./nest.sh) &&
+    jobid=$(flux batch --output=kvs -n1 -N1 -c22 -g2 ./nest.sh) &&
     flux job wait-event -t10 ${jobid} release &&
     flux job attach ${jobid} > out1.a &&
     tail -3 out1.a > out1.a.fin &&
@@ -46,7 +46,7 @@ EOF
 
 test_expect_success HAVE_GETXML 'namespace: parent CUDA_VISIBLE_DEVICES has no effect' '
     export CUDA_VISIBLE_DEVICES="0,1,2,3" &&
-    jobid=$(flux mini batch --output=kvs -n1 -N1 -c22 -g2 ./nest.sh) &&
+    jobid=$(flux batch --output=kvs -n1 -N1 -c22 -g2 ./nest.sh) &&
     flux job wait-event -t10 ${jobid} release &&
     flux job attach ${jobid} > out1.b &&
     tail -3 out1.b > out1.b.fin &&
@@ -68,7 +68,7 @@ test_expect_success HAVE_GETXML 'namespace: gpu id remapping works with hwloc (p
 	1
 	0,1
 EOF
-    jobid=$(flux mini batch --output=kvs -n1 -N1 -c22 -g2 ./nest.sh) &&
+    jobid=$(flux batch --output=kvs -n1 -N1 -c22 -g2 ./nest.sh) &&
     flux job wait-event -t10 ${jobid} release &&
     flux job attach ${jobid} > out2.a &&
     tail -3 out2.a > out2.a.fin &&
@@ -77,7 +77,7 @@ EOF
 
 test_expect_success HAVE_GETXML 'namespace: parent CUDA_VISIBLE_DEVICES has no effect' '
     export CUDA_VISIBLE_DEVICES=-1 &&
-    jobid=$(flux mini batch --output=kvs -n1 -N1 -c22 -g2 ./nest.sh) &&
+    jobid=$(flux batch --output=kvs -n1 -N1 -c22 -g2 ./nest.sh) &&
     flux job wait-event -t10 ${jobid} release &&
     flux job attach ${jobid} > out2.b &&
     tail -3 out2.b > out2.b.fin &&
@@ -106,7 +106,7 @@ EOF
 	2,3
 EOF
     chmod u+x nest2.sh &&
-    jobid=$(flux mini batch --output=kvs -n1 -N1 -c22 -g2 ./nest2.sh) &&
+    jobid=$(flux batch --output=kvs -n1 -N1 -c22 -g2 ./nest2.sh) &&
     flux job wait-event -t10 ${jobid} release &&
     flux job attach ${jobid} > out3.a &&
     tail -1 out3.a > out3.a.fin &&
@@ -115,7 +115,7 @@ EOF
 
 test_expect_success 'namespace: parent CUDA_VISIBLE_DEVICES has no effect' '
     export CUDA_VISIBLE_DEVICES="0,1,2,3" &&
-    jobid=$(flux mini batch --output=kvs -n1 -N1 -c22 -g2 ./nest2.sh) &&
+    jobid=$(flux batch --output=kvs -n1 -N1 -c22 -g2 ./nest2.sh) &&
     flux job wait-event -t10 ${jobid} release &&
     flux job attach ${jobid} > out3.b &&
     tail -1 out3.b > out3.b.fin &&
@@ -135,7 +135,7 @@ test_expect_success 'namespace: gpu id remapping works with rv1exec (pol=hi)' '
     cat >exp4 <<-EOF &&
 	0,1
 EOF
-    jobid=$(flux mini batch --output=kvs -n1 -N1 -c22 -g2 ./nest2.sh) &&
+    jobid=$(flux batch --output=kvs -n1 -N1 -c22 -g2 ./nest2.sh) &&
     flux job wait-event -t10 ${jobid} release &&
     flux job attach ${jobid} > out4.a &&
     tail -1 out4.a > out4.a.fin &&
@@ -144,7 +144,7 @@ EOF
 
 test_expect_success 'namespace: parent CUDA_VISIBLE_DEVICES has no effect' '
     export CUDA_VISIBLE_DEVICES="0,1,2,3" &&
-    jobid=$(flux mini batch --output=kvs -n1 -N1 -c22 -g2 ./nest2.sh) &&
+    jobid=$(flux batch --output=kvs -n1 -N1 -c22 -g2 ./nest2.sh) &&
     flux job wait-event -t10 ${jobid} release &&
     flux job attach ${jobid} > out4.b &&
     tail -1 out4.b > out4.b.fin &&

--- a/t/t1017-rv1-bootstrap.t
+++ b/t/t1017-rv1-bootstrap.t
@@ -30,7 +30,7 @@ test_expect_success 'rv1-bootstrap: creating a nested batch script' '
 #!/bin/sh
 	flux module load sched-fluxion-resource match-format=rv1 policy=\$1
 	flux module load sched-fluxion-qmanager
-	nested_jobid=\$(flux mini submit -n\$2 -N\$3 -c\$4 -g\$5 sleep 0)
+	nested_jobid=\$(flux submit -n\$2 -N\$3 -c\$4 -g\$5 sleep 0)
 	flux job wait-event -t10 \${nested_jobid} start
 	flux job info \${nested_jobid} R > \$6
 	sleep inf
@@ -40,7 +40,7 @@ EOF
 
 # Idempotency check
 test_expect_success 'rv1-bootstrap: resource idempotency preserved' '
-    JOBID=$(flux mini batch -n4 -N4 -c44 -g4 \
+    JOBID=$(flux batch -n4 -N4 -c44 -g4 \
 	./nest.sh high 4 4 44 4 nest.json) &&
     $WAITFILE -t 600 -v -p \"R_lite\" nest.json &&
     jq " del(.execution.starttime, .execution.expiration) " \
@@ -59,7 +59,7 @@ test_expect_success 'rv1-bootstrap: killing a nested job works' '
 
 # 2 full nodes are scheduled for a nest flux instance
 test_expect_success 'rv1-bootstrap: 2N nesting works (policy=high)' '
-    JOBID1=$(flux mini batch -n2 -N2 -c44 -g4 \
+    JOBID1=$(flux batch -n2 -N2 -c44 -g4 \
 	./nest.sh high 2 2 44 4 nest1.json) &&
     $WAITFILE -t 600 -v -p \"R_lite\" nest1.json &&
     remap_rv1_resource_type nest1.json core > nest1.csv &&
@@ -73,7 +73,7 @@ test_expect_success 'rv1-bootstrap: 2N nesting works (policy=high)' '
 
 # 2 nodes each with partial resource set using match policy=high
 test_expect_success 'rv1-bootstrap: 2 partial node nesting works (high)' '
-    JOBID2=$(flux mini batch -n2 -N2 -c10 -g2 \
+    JOBID2=$(flux batch -n2 -N2 -c10 -g2 \
 	./nest.sh high 2 2 10 2 nest2.json) &&
     $WAITFILE -t 600 -v -p \"R_lite\" nest2.json &&
     flux job info ${JOBID2} R | jq . > job2.json &&
@@ -107,7 +107,7 @@ match-format=rv1 policy=low &&
 
 # 2 full nodes are scheduled for a nest flux instance
 test_expect_success 'rv1-bootstrap: 2N nesting works (policy=low)' '
-    JOBID3=$(flux mini batch -n2 -N2 -c44 -g4 \
+    JOBID3=$(flux batch -n2 -N2 -c44 -g4 \
 	./nest.sh low 2 2 44 4 nest3.json) &&
     $WAITFILE -t 600 -v -p \"R_lite\" nest3.json &&
     remap_rv1_resource_type nest3.json core > nest3.csv &&
@@ -120,7 +120,7 @@ test_expect_success 'rv1-bootstrap: 2N nesting works (policy=low)' '
 '
 
 test_expect_success 'rv1-bootstrap: 2 partial node nesting works (low)' '
-    JOBID4=$(flux mini batch -n2 -N2 -c10 -g2 \
+    JOBID4=$(flux batch -n2 -N2 -c10 -g2 \
 	./nest.sh low 2 2 10 2 nest4.json) &&
     $WAITFILE -t 600 -v -p \"R_lite\" nest4.json &&
     flux job info ${JOBID4} R | jq . > job4.json &&
@@ -147,9 +147,9 @@ test_expect_success 'rv1-bootstrap: creating doubly nested batch script' '
 	flux module load sched-fluxion-qmanager
 	hc=\$(expr \$4 / 2)
 	hg=\$(expr \$5 / 2)
-	job1=\$(flux mini batch -n\$2 -N\$3 -c\${hc} -g\${hg} \
+	job1=\$(flux batch -n\$2 -N\$3 -c\${hc} -g\${hg} \
 		./nest.sh \$1 \$2 \$3 \${hc} \${hg} \$8)
-	job2=\$(flux mini batch -n\$2 -N\$3 -c\${hc} -g\${hg} \
+	job2=\$(flux batch -n\$2 -N\$3 -c\${hc} -g\${hg} \
 		./nest.sh \$1 \$2 \$3 \${hc} \${hg} \$9)
 	\$WAITFILE -t 600 -v -p \"R_lite\" \$8
 	flux job info \${job1} R > \$6
@@ -161,7 +161,7 @@ EOF
 '
 
 test_expect_success 'rv1-bootstrap: double nesting works' '
-    JOBID5=$(flux mini batch -n2 -N2 -c10 -g2 ./dnest.sh low 2 2 10 2 \
+    JOBID5=$(flux batch -n2 -N2 -c10 -g2 ./dnest.sh low 2 2 10 2 \
 	job5.1.json job5.2.json nest5.1.json nest5.2.json) &&
     $WAITFILE -t 600 -v -p \"R_lite\" job5.1.json &&
     $WAITFILE -t 600 -v -p \"R_lite\" job5.2.json &&

--- a/t/t1018-rv1-bootstrap2.t
+++ b/t/t1018-rv1-bootstrap2.t
@@ -34,7 +34,7 @@ test_expect_success 'rv1-bootstrap2: creating a nested batch script' '
 	flux module load sched-fluxion-resource \
 load-allowlist=cluster,node,gpu,core match-format=rv1 policy=\$1
 	flux module load sched-fluxion-qmanager
-	nested_jobid=\$(flux mini submit -n\$2 -N\$3 -c\$4 -g\$5 sleep 0)
+	nested_jobid=\$(flux submit -n\$2 -N\$3 -c\$4 -g\$5 sleep 0)
 	flux job wait-event -t10 \${nested_jobid} start
 	flux job info \${nested_jobid} R > \$6
 	sleep inf
@@ -44,7 +44,7 @@ EOF
 
 # Idempotency check
 test_expect_success 'rv1-bootstrap: resource idempotency preserved' '
-    JOBID=$(flux mini batch -n4 -N4 -c44 -g4 \
+    JOBID=$(flux batch -n4 -N4 -c44 -g4 \
 	./nest.sh high 4 4 44 4 nest.json) &&
     $WAITFILE -t 600 -v -p \"R_lite\" nest.json &&
     jq " del(.execution.starttime, .execution.expiration) " \
@@ -63,7 +63,7 @@ test_expect_success 'rv1-bootstrap2: killing a nested job works' '
 
 # 2 full nodes are scheduled for a nest flux instnace -- requiring no remap
 test_expect_success 'rv1-bootstrap2: 2N nesting works (policy=high)' '
-    JOBID1=$(flux mini batch -n2 -N2 -c44 -g4 \
+    JOBID1=$(flux batch -n2 -N2 -c44 -g4 \
 	./nest.sh high 2 2 44 4 nest1.json) &&
     $WAITFILE -t 600 -v -p \"R_lite\" nest1.json &&
     remap_rv1_resource_type nest1.json core > nest1.csv &&
@@ -77,7 +77,7 @@ test_expect_success 'rv1-bootstrap2: 2N nesting works (policy=high)' '
 
 # 2 nodes each with partial resource set using match policy=high
 test_expect_success 'rv1-bootstrap2: 2 partial node nesting works (high)' '
-    JOBID2=$(flux mini batch -n2 -N2 -c10 -g2 \
+    JOBID2=$(flux batch -n2 -N2 -c10 -g2 \
 	./nest.sh high 2 2 10 2 nest2.json) &&
     $WAITFILE -t 600 -v -p \"R_lite\" nest2.json &&
     flux job info ${JOBID2} R | jq . > job2.json &&
@@ -110,7 +110,7 @@ match-format=rv1 policy=low &&
 
 # 2 full nodes are scheduled for a nest flux instnace -- requiring no remap
 test_expect_success 'rv1-bootstrap2: 2N nesting works (policy=low)' '
-    JOBID3=$(flux mini batch -n2 -N2 -c44 -g4 \
+    JOBID3=$(flux batch -n2 -N2 -c44 -g4 \
 	./nest.sh low 2 2 44 4 nest3.json) &&
     $WAITFILE -t 600 -v -p \"R_lite\" nest3.json &&
     remap_rv1_resource_type nest3.json core > nest3.csv &&
@@ -123,7 +123,7 @@ test_expect_success 'rv1-bootstrap2: 2N nesting works (policy=low)' '
 '
 
 test_expect_success 'rv1-bootstrap2: 2 partial node nesting works (low)' '
-    JOBID4=$(flux mini batch -n2 -N2 -c10 -g2 \
+    JOBID4=$(flux batch -n2 -N2 -c10 -g2 \
 	./nest.sh low 2 2 10 2 nest4.json) &&
     $WAITFILE -t 600 -v -p \"R_lite\" nest4.json &&
     flux job info ${JOBID4} R | jq . > job4.json &&
@@ -151,9 +151,9 @@ load-allowlist=cluster,node,gpu,core match-format=rv1 policy=\$1
 	flux module load sched-fluxion-qmanager
 	hc=\$(expr \$4 / 2)
 	hg=\$(expr \$5 / 2)
-	job1=\$(flux mini batch -n\$2 -N\$3 -c\${hc} -g\${hg} \
+	job1=\$(flux batch -n\$2 -N\$3 -c\${hc} -g\${hg} \
 		./nest.sh \$1 \$2 \$3 \${hc} \${hg} \$8)
-	job2=\$(flux mini batch -n\$2 -N\$3 -c\${hc} -g\${hg} \
+	job2=\$(flux batch -n\$2 -N\$3 -c\${hc} -g\${hg} \
 		./nest.sh \$1 \$2 \$3 \${hc} \${hg} \$9)
 	\$WAITFILE -t 600 -v -p \"R_lite\" \$8
 	flux job info \${job1} R > \$6
@@ -165,7 +165,7 @@ EOF
 '
 
 test_expect_success 'rv1-bootstrap2: double nesting works' '
-    JOBID5=$(flux mini batch -n2 -N2 -c10 -g2 ./dnest.sh low 2 2 10 2 \
+    JOBID5=$(flux batch -n2 -N2 -c10 -g2 ./dnest.sh low 2 2 10 2 \
 	job5.1.json job5.2.json nest5.1.json nest5.2.json) &&
     $WAITFILE -t 600 -v -p \"R_lite\" job5.1.json &&
     $WAITFILE -t 600 -v -p \"R_lite\" job5.2.json &&

--- a/t/t1019-qmanager-async.t
+++ b/t/t1019-qmanager-async.t
@@ -19,7 +19,7 @@ submit_jobs() {
 }
 
 test_expect_success 'qmanager: generate jobspec for a simple test job' '
-    flux mini submit -n16 -t 100s --dry-run sleep 100 > basic.json
+    flux submit -n16 -t 100s --dry-run sleep 100 > basic.json
 '
 
 test_expect_success 'load test resources' '

--- a/t/t1020-qmanager-feasibility.t
+++ b/t/t1020-qmanager-feasibility.t
@@ -22,10 +22,10 @@ subsystems=containment policy=low &&
 '
 
 test_expect_success HAVE_JQ 'feasibility: --plugins=feasibility works ' '
-    flux mini run -n 999 --dry-run hostname | \
+    flux run -n 999 --dry-run hostname | \
         flux job-validator --jobspec-only --plugins=feasibility \
         | jq -e ".errnum != 0" &&
-    flux mini run -n 999 --dry-run hostname | \
+    flux run -n 999 --dry-run hostname | \
         flux job-validator --jobspec-only \
         --plugins=feasibility \
         --feasibility-service=sched-fluxion-resource.satisfiability \
@@ -37,16 +37,16 @@ test_expect_success 'feasibility: loading job-ingest with feasibilty works' '
  '
 
  test_expect_success 'feasibility: unsatisfiable jobs are rejected' '
-    test_must_fail flux mini submit -n 170 hostname 2>err1 &&
+    test_must_fail flux submit -n 170 hostname 2>err1 &&
     grep "Unsatisfiable request" err1 &&
-    test_must_fail flux mini submit -N 2 -n2 hostname 2>err2 &&
+    test_must_fail flux submit -N 2 -n2 hostname 2>err2 &&
     grep "Unsatisfiable request" err2 &&
-    test_must_fail flux mini submit -g 1 hostname 2>err3 &&
+    test_must_fail flux submit -g 1 hostname 2>err3 &&
     grep -i "Unsatisfiable request" err3
  '
 
 test_expect_success 'feasibility: satisfiable jobs are accepted' '
-    jobid=$(flux mini submit -n 8 hostname) &&
+    jobid=$(flux submit -n 8 hostname) &&
     flux job wait-event -t 10 ${jobid} start &&
     flux job wait-event -t 10 ${jobid} finish &&
     flux job wait-event -t 10 ${jobid} release &&
@@ -58,16 +58,16 @@ test_expect_success 'feasibility: load job-ingest with two validators' '
  '
 
  test_expect_success 'feasibility: unsatisfiable jobs are rejected' '
-    test_must_fail flux mini submit -n 170 hostname 2>err4 &&
+    test_must_fail flux submit -n 170 hostname 2>err4 &&
     grep "Unsatisfiable request" err4 &&
-    test_must_fail flux mini submit -N 2 -n2 hostname 2>err5 &&
+    test_must_fail flux submit -N 2 -n2 hostname 2>err5 &&
     grep "Unsatisfiable request" err5 &&
-    test_must_fail flux mini submit -g 1 hostname 2>err6 &&
+    test_must_fail flux submit -g 1 hostname 2>err6 &&
     grep -i "Unsatisfiable request" err6
  '
 
 test_expect_success 'feasibility: satisfiable jobs are accepted' '
-    jobid=$(flux mini submit -n 8 hostname) &&
+    jobid=$(flux submit -n 8 hostname) &&
     flux job wait-event -t 10 ${jobid} start &&
     flux job wait-event -t 10 ${jobid} finish &&
     flux job wait-event -t 10 ${jobid} release &&

--- a/t/t1021-qmanager-nodex.t
+++ b/t/t1021-qmanager-nodex.t
@@ -38,12 +38,12 @@ test_expect_success 'qmanager-nodex: loading fluxion modules works (hinodex)' '
 '
 
 test_expect_success 'qmanager-nodex: submit a one-core jobs (hinodex)' '
-    JOBID1=$(flux mini submit sleep inf) &&
+    JOBID1=$(flux submit sleep inf) &&
     flux job wait-event -t 10 ${JOBID1} start
 '
 
 test_expect_success 'qmanager-nodex: submit a 8-core jobs (hinodex)' '
-    JOBID2=$(flux mini submit -n8 sleep inf) &&
+    JOBID2=$(flux submit -n8 sleep inf) &&
     flux job wait-event -t 10 ${JOBID2} start
 '
 
@@ -64,7 +64,7 @@ EOF
 '
 
 test_expect_success 'qmanager-nodex: submit a -N2 -n2 jobs (hinodex)' '
-    JOBID3=$(flux mini submit -N2 -n2 sleep inf) &&
+    JOBID3=$(flux submit -N2 -n2 sleep inf) &&
     flux job wait-event -t 10 ${JOBID3} start
 '
 
@@ -98,12 +98,12 @@ test_expect_success 'qmanager-nodex: loading fluxion modules works (lonodex)' '
 '
 
 test_expect_success 'qmanager-nodex: submit a one-core jobs (lonodex)' '
-    JOBID1=$(flux mini submit sleep inf) &&
+    JOBID1=$(flux submit sleep inf) &&
     flux job wait-event -t 10 ${JOBID1} start
 '
 
 test_expect_success 'qmanager-nodex: submit a 8-core jobs (lonodex)' '
-    JOBID2=$(flux mini submit -n8 sleep inf) &&
+    JOBID2=$(flux submit -n8 sleep inf) &&
     flux job wait-event -t 10 ${JOBID2} start
 '
 
@@ -124,7 +124,7 @@ EOF
 '
 
 test_expect_success 'qmanager-nodex: submit a -N2 -n2 jobs (lonodex)' '
-    JOBID3=$(flux mini submit -N2 -n2 sleep inf) &&
+    JOBID3=$(flux submit -N2 -n2 sleep inf) &&
     flux job wait-event -t 10 ${JOBID3} start
 '
 

--- a/t/t1022-property-constraints.t
+++ b/t/t1022-property-constraints.t
@@ -28,7 +28,7 @@ test_expect_success 'reload ingest without validator' '
 	flux module reload -f job-ingest disable-validator
 '
 test_expect_success 'simple property reqirement works' '
-	JOBID1=$(flux mini submit --requires="baz" hostname) &&
+	JOBID1=$(flux submit --requires="baz" hostname) &&
 	flux job wait-event -t 10 ${JOBID1} clean &&
 	flux job info ${JOBID1} R > JOBID1.R &&
 	RANK1=$(cat JOBID1.R | jq -r ".execution.R_lite[0].rank") &&
@@ -38,7 +38,7 @@ test_expect_success 'simple property reqirement works' '
 '
 
 test_expect_success 'multiple properties reqirement works' '
-	JOBID2=$(flux mini submit --requires="foo" --requires="bar" hostname) &&
+	JOBID2=$(flux submit --requires="foo" --requires="bar" hostname) &&
 	flux job wait-event -t 10 ${JOBID2} clean &&
 	flux job info ${JOBID2} R > JOBID2.R &&
 	RANK2=$(cat JOBID2.R | jq -r ".execution.R_lite[0].rank") &&
@@ -50,7 +50,7 @@ test_expect_success 'multiple properties reqirement works' '
 '
 
 test_expect_success '^property reqirement works' '
-	JOBID3=$(flux mini submit --requires="^foo" --requires="^bar" hostname) &&
+	JOBID3=$(flux submit --requires="^foo" --requires="^bar" hostname) &&
 	flux job wait-event -t 10 ${JOBID3} clean &&
 	flux job info ${JOBID3} R > JOBID3.R &&
 	RANK3=$(cat JOBID3.R | jq -r ".execution.R_lite[0].rank") &&
@@ -59,13 +59,13 @@ test_expect_success '^property reqirement works' '
 	test "${RANK3}" = "3" -a "${LENGTH3}" = "1" -a "${PROP_RANK3}" = "3"
 '
 test_expect_success 'nonexistient property works' '
-	JOBID4=$(flux mini submit --requires="yyy" hostname) &&
+	JOBID4=$(flux submit --requires="yyy" hostname) &&
 	flux job wait-event -t 10 ${JOBID4} clean &&
 	flux job eventlog ${JOBID4} > evlog4 2>&1 &&
 	grep -i "unsatisfiable" evlog4
 '
 test_expect_success 'invalid property works' '
-	JOBID5=$(flux mini submit --requires="f^oo" hostname) &&
+	JOBID5=$(flux submit --requires="f^oo" hostname) &&
 	flux job wait-event -t 10 ${JOBID5} clean &&
 	flux job eventlog ${JOBID5} > evlog5 &&
 	grep "f^oo is invalid" evlog5
@@ -74,10 +74,10 @@ test_expect_success 'reload ingest with feasibility' '
 	flux module reload -f job-ingest validator-plugins=feasibility
 '
 test_expect_success RFC35_SYNTAX 'complex constraints work' '
-	flux mini run --requires="foo&bar" flux getattr rank > c1.rank &&
+	flux run --requires="foo&bar" flux getattr rank > c1.rank &&
 	test_debug "cat c1.rank" &&
 	test $(cat c1.rank) -eq 1 &&
-	flux mini run -N3 --requires="foo|baz" flux getattr rank \
+	flux run -N3 --requires="foo|baz" flux getattr rank \
 		| sort > c2.ranks &&
 	cat <<-EOF >c2.expected &&
 	0
@@ -85,23 +85,23 @@ test_expect_success RFC35_SYNTAX 'complex constraints work' '
 	3
 	EOF
 	test_cmp c2.expected c2.ranks &&
-	flux mini run --requires="foo and not bar" flux getattr rank \
+	flux run --requires="foo and not bar" flux getattr rank \
 		> c3.rank &&
 	test_debug "cat c3.rank" &&
 	test $(cat c3.rank) -eq 0
 '
 
 test_expect_success RFC35_SYNTAX 'invalid complex constraint fails' '
-	test_must_fail flux mini run --requires="foo|bar badop:meep" hostname \
+	test_must_fail flux run --requires="foo|bar badop:meep" hostname \
 		> badop.out 2>&1 &&
 	grep -i "unknown constraint operator: badop" badop.out
 '
 
 test_expect_success RFC35_SYNTAX 'ranks constraint works' '
-	flux mini run --requires=rank:2 flux getattr rank > rank.out &&
+	flux run --requires=rank:2 flux getattr rank > rank.out &&
 	test_debug "cat rank.out" &&
 	test $(cat rank.out) -eq 2 &&
-	flux mini run -N2 --requires=rank:2-3 flux getattr rank \
+	flux run -N2 --requires=rank:2-3 flux getattr rank \
 		| sort > rank2-3.out &&
 	test_debug "cat rank2-3.out" &&
 	cat <<-EOF >rank2-3.expected &&
@@ -112,26 +112,26 @@ test_expect_success RFC35_SYNTAX 'ranks constraint works' '
 '
 
 test_expect_success RFC35_SYNTAX 'invalid rank constraint fails' '
-	test_must_fail flux mini run --requires=ranks:5-4 hostname
+	test_must_fail flux run --requires=ranks:5-4 hostname
 '
 
 test_expect_success RFC35_SYNTAX 'unknown rank returns unsatisfiable' '
-	test_must_fail flux mini run --requires=ranks:999 hostname \
+	test_must_fail flux run --requires=ranks:999 hostname \
 	 >unknown-rank.out 2>&1 &&
 	grep -i unsatisfiable unknown-rank.out
 '
 
 test_expect_success RFC35_SYNTAX 'hostlist constraint works' '
-	flux mini run --requires=host:$(hostname) hostname
+	flux run --requires=host:$(hostname) hostname
 '
 
 test_expect_success RFC35_SYNTAX 'invalid hostlist constraint fails' '
-	test_must_fail flux mini run --requires=host:foo\[  hostname
+	test_must_fail flux run --requires=host:foo\[  hostname
 '
 
 test_expect_success RFC35_SYNTAX 'unknown host returns unsatisfiable' '
 	if test "$(hostname)" != "host:xyz123"; then
-		test_must_fail flux mini run --requires=host:xyz123 hostname \
+		test_must_fail flux run --requires=host:xyz123 hostname \
 		 >host-unknown.out 2>&1 &&
 		grep -i unsatisfiable host-unknown.out
 	fi

--- a/t/t1023-multiqueue-constraints.t
+++ b/t/t1023-multiqueue-constraints.t
@@ -39,80 +39,80 @@ test_expect_success 'load fluxion modules' '
 	load_qmanager
 '
 test_expect_success 'run a job in each queue' '
-	flux mini run --queue=debug /bin/true &&
-	flux mini run --queue=batch /bin/true
+	flux run --queue=debug /bin/true &&
+	flux run --queue=batch /bin/true
 '
 test_expect_success 'occupy resources in first queue' '
-	flux mini submit --queue=debug sleep 300 >job1.out
+	flux submit --queue=debug sleep 300 >job1.out
 '
 test_expect_success 'run a job in second queue' '
-	flux mini run --queue=batch /bin/true
+	flux run --queue=batch /bin/true
 '
 test_expect_success 'create a backlog in first queue' '
-	flux mini submit --queue=debug /bin/true
+	flux submit --queue=debug /bin/true
 '
 test_expect_success 'run a job in second queue' '
-	flux mini run --queue=batch /bin/true
+	flux run --queue=batch /bin/true
 '
 test_expect_success 'occupy resources in second queue' '
-	flux mini submit --queue=batch -N3 sleep 300 >job2.out
+	flux submit --queue=batch -N3 sleep 300 >job2.out
 '
 test_expect_success 'cancel job occupying first queue' '
 	flux job cancel $(cat job1.out)
 '
 test_expect_success 'run a job in first queue' '
-	flux mini run --queue=debug /bin/true
+	flux run --queue=debug /bin/true
 '
 test_expect_success 'create a backlog in second queue' '
-	flux mini submit --queue=batch /bin/true
+	flux submit --queue=batch /bin/true
 '
 test_expect_success 'run a job in first queue' '
-	flux mini run --queue=debug /bin/true
+	flux run --queue=debug /bin/true
 '
 test_expect_success 'cancel job occupying second queue' '
 	flux job cancel $(cat job2.out)
 '
 test_expect_success 'run a job in each queue' '
-	flux mini run --queue=debug /bin/true &&
-	flux mini run --queue=batch /bin/true
+	flux run --queue=debug /bin/true &&
+	flux run --queue=batch /bin/true
 '
 test_expect_success 'a job with redundant constraint works' '
-	flux mini run --queue=debug --requires=debug /bin/true
+	flux run --queue=debug --requires=debug /bin/true
 '
 test_expect_success 'a job with unsatisfiable constraint fails' '
-	test_must_fail flux mini run --queue=debug --requires=tinymem /bin/true
+	test_must_fail flux run --queue=debug --requires=tinymem /bin/true
 '
 test_expect_success 'a job with unsatisfiable node count fails' '
-	test_must_fail flux mini run --queue=debug -N2 /bin/true
+	test_must_fail flux run --queue=debug -N2 /bin/true
 '
 test_expect_success 'a job with satisfiable constraint works' '
-	flux mini run --queue=batch --requires=tinymem /bin/true
+	flux run --queue=batch --requires=tinymem /bin/true
 '
 test_expect_success 'a job with multiple constraints works in both queues' '
-	flux mini run --queue=debug --requires=bigmem /bin/true &&
-	flux mini run --queue=batch --requires=bigmem /bin/true
+	flux run --queue=debug --requires=bigmem /bin/true &&
+	flux run --queue=batch --requires=bigmem /bin/true
 '
 test_expect_success 'stop queues' '
 	flux queue stop --all
 '
 test_expect_success 'submit a held job to the first queue' '
-	flux mini submit --flags=waitable \
+	flux submit --flags=waitable \
 	    --queue=debug --urgency=hold /bin/true >job3.out
 '
 test_expect_success 'submit a diverse set of jobs to both queues' '
-	flux mini submit --flags=waitable \
+	flux submit --flags=waitable \
 	    --queue=debug --requires=bigmem /bin/true &&
-	flux mini submit --flags=waitable --cc=1-10 -N2 \
+	flux submit --flags=waitable --cc=1-10 -N2 \
 	    --queue=batch /bin/true &&
-	flux mini submit --flags=waitable \
+	flux submit --flags=waitable \
 	    --queue=debug --requires=bigmem --urgency=31 /bin/true &&
-	flux mini submit --flags=waitable \
+	flux submit --flags=waitable \
 	    --queue=batch --requires=bigmem /bin/true &&
-	flux mini submit --flags=waitable --cc=1-10 \
+	flux submit --flags=waitable --cc=1-10 \
 	    --queue=debug /bin/true &&
-	flux mini submit --flags=waitable \
+	flux submit --flags=waitable \
 	    --queue=debug --requires=bigmem --urgency=1 /bin/true &&
-	flux mini submit --flags=waitable \
+	flux submit --flags=waitable \
 	    --queue=debug /bin/true
 '
 test_expect_success 'drain a node' '
@@ -122,9 +122,9 @@ test_expect_success 'start queues - bunch of alloc requests arrive at once' '
 	flux queue start --all
 '
 test_expect_success 'submit some additional work on top of that' '
-	flux mini submit --flags=waitable --cc=1-10 \
+	flux submit --flags=waitable --cc=1-10 \
 	    --queue=batch /bin/true &&
-	flux mini submit --flags=waitable --cc=1-10 \
+	flux submit --flags=waitable --cc=1-10 \
 	    --queue=debug /bin/true
 '
 test_expect_success 'undrain the node' '

--- a/t/t2001-tree-real.t
+++ b/t/t2001-tree-real.t
@@ -68,7 +68,7 @@ JOB_NAME="foobar"
 test_expect_success 'flux-tree: successfully runs alongside other jobs' '
     flux tree -T 1 -N 1 -c 1 -J 1 -o p.out5 --perf-format="$PERF_FORMAT" \
          --job-name="${JOB_NAME}" -- hostname &&
-    flux mini run -N1 -c1 hostname &&
+    flux run -N1 -c1 hostname &&
     echo "$PERF_BLOB" | run_timeout 5 flux tree-helper --perf-out=p.out6 \
          --perf-format="$PERF_FORMAT" 1 "tree-perf" "${JOB_NAME}" &&
     test_cmp p.out5 p.out6

--- a/t/t3027-resource-RV.t
+++ b/t/t3027-resource-RV.t
@@ -48,7 +48,7 @@ test_expect_success 'RV1 correct on rank/node ID mismatch + core ID modified' '
 '
 
 test_expect_success 'RV1 correct on heterogeneous configuration' '
-	flux mini submit -n 28 --dry-run hostname > n28.json &&
+	flux submit -n 28 --dry-run hostname > n28.json &&
 	cat > cmds004 <<-EOF &&
 	match allocate n28.json
 	quit
@@ -67,7 +67,7 @@ test_expect_success 'RV1 correct on heterogeneous configuration' '
 '
 
 test_expect_success 'RV1 correct on heterogeneous configuration 2' '
-	flux mini submit -n 14 --dry-run hostname > n14.json &&
+	flux submit -n 14 --dry-run hostname > n14.json &&
 	cat > cmds005 <<-EOF &&
 	match allocate n14.json
 	quit
@@ -98,7 +98,7 @@ test_expect_success 'RV1 correct on heterogeneous configuration 3' '
 '
 
 test_expect_success 'RV1 with nosched correct on heterogeneous configuration' '
-	flux mini submit -n 28 --dry-run hostname > n28.json &&
+	flux submit -n 28 --dry-run hostname > n28.json &&
 	cat > cmds007 <<-EOF &&
 	match allocate n28.json
 	quit
@@ -115,7 +115,7 @@ test_expect_success 'RV1 with nosched correct on heterogeneous configuration' '
 '
 
 test_expect_success 'RV1 with nosched correct on heterogeneous config 2' '
-	flux mini submit -n 14 --dry-run hostname > n14.json &&
+	flux submit -n 14 --dry-run hostname > n14.json &&
 	cat > cmds008 <<-EOF &&
 	match allocate n14.json
 	quit
@@ -146,7 +146,7 @@ test_expect_success 'RV1 with nosched correct on heterogeneous config 3' '
 '
 
 test_expect_success 'RV1 with nosched correct on nonconforming hostnames' '
-	flux mini submit -n 8 --dry-run hostname > n8.json &&
+	flux submit -n 8 --dry-run hostname > n8.json &&
 	cat > cmds010 <<-EOF &&
 	match allocate n8.json
 	quit
@@ -160,7 +160,7 @@ test_expect_success 'RV1 with nosched correct on nonconforming hostnames' '
 '
 
 test_expect_success 'RV1 with same hostnames work' '
-	flux mini submit -n 8 --dry-run hostname > n8.json &&
+	flux submit -n 8 --dry-run hostname > n8.json &&
 	cat > cmds011 <<-EOF &&
 	match allocate n8.json
 	quit
@@ -176,7 +176,7 @@ test_expect_success 'RV1 with same hostnames work' '
 '
 
 test_expect_success 'Scheduling RV1 with high node num works (pol=lonode)' '
-	flux mini submit -n 16 -c 94 --dry-run hostname > n94.json &&
+	flux submit -n 16 -c 94 --dry-run hostname > n94.json &&
 	cat > cmds012 <<-EOF &&
 	match allocate n94.json
 	quit

--- a/t/t3034-resource-pconstraints.t
+++ b/t/t3034-resource-pconstraints.t
@@ -17,19 +17,19 @@ test_expect_success 'pconstraints: configuring a heterogeneous machine works' '
 '
 
 test_expect_success 'pconstraints: generate property-based jobspecs' '
-	flux mini submit --requires="arm-v9@core" --dry-run hostname \
+	flux submit --requires="arm-v9@core" --dry-run hostname \
 		> job.arm-v9.json &&
-	flux mini submit --requires="arm-v8@core,amd-mi60@gpu" \
+	flux submit --requires="arm-v8@core,amd-mi60@gpu" \
 		 --dry-run hostname > job.arm-v9+amd-mi60.json &&
-	flux mini submit --requires="amd-m50@gpu" --dry-run hostname \
+	flux submit --requires="amd-m50@gpu" --dry-run hostname \
 		> job.amd-mi50.json &&
-	flux mini submit -n2 -c1 -g2 --requires="arm-v9@core" \
+	flux submit -n2 -c1 -g2 --requires="arm-v9@core" \
 		 --dry-run hostname > job.arm-v9+gpu.json &&
-	flux mini submit -n1 --requires="^arm-v9@core" \
+	flux submit -n1 --requires="^arm-v9@core" \
 		--dry-run hostname > job.not-arm-v9.json &&
-	flux mini submit -n1 --requires="ar^m-v9@core" \
+	flux submit -n1 --requires="ar^m-v9@core" \
 		--dry-run hostname > job.invalid.json &&
-	flux mini submit -n1 -c1 -g1 --dry-run hostname > job.gpu.json
+	flux submit -n1 -c1 -g1 --dry-run hostname > job.gpu.json
 '
 
 #

--- a/t/t3301-system-latestart.t
+++ b/t/t3301-system-latestart.t
@@ -59,11 +59,11 @@ test_expect_success 'flux exec -r 1 fails with EHOSTUNREACH' '
 '
 
 test_expect_success 'single node job can run with only rank 0 up' '
-	run_timeout 30 flux mini run -n1 /bin/true
+	run_timeout 30 flux run -n1 /bin/true
 '
 
 test_expect_success 'two node job is accepted although it cannot run yet' '
-	flux mini submit -N2 -n2 echo Hello >jobid
+	flux submit -N2 -n2 echo Hello >jobid
 '
 
 test_expect_success 'start rank 1' '

--- a/t/t4009-match-update.t
+++ b/t/t4009-match-update.t
@@ -19,7 +19,7 @@ export FLUX_SCHED_MODULE=none
 test_under_flux 1
 
 test_expect_success 'update: generate jobspec for a simple test job' '
-    flux mini run --dry-run -N 1 -n 1 -t 1h hostname > basic.json
+    flux run --dry-run -N 1 -n 1 -t 1h hostname > basic.json
 '
 
 test_expect_success 'update: load test resources' '

--- a/t/t4011-match-duration.t
+++ b/t/t4011-match-duration.t
@@ -16,9 +16,9 @@ test_expect_success HAVE_JQ 'parent duration is inherited when duration=0' '
 	flux job info \$FLUX_JOB_ID R
 	EOT
 	chmod +x get_R.sh &&
-	out=$(flux mini run -t20s -n1 flux start flux mini run -n1 ./get_R.sh) &&
+	out=$(flux run -t20s -n1 flux start flux run -n1 ./get_R.sh) &&
 	echo "$out" | jq -e ".execution.expiration - .execution.starttime <= 20" &&
-	out=$(flux mini run -t30s -n1 flux start flux mini run -n1 ./get_R.sh) &&
+	out=$(flux run -t30s -n1 flux start flux run -n1 ./get_R.sh) &&
 	echo "$out" | jq -e ".execution.expiration - .execution.starttime <= 30"
 '
 

--- a/t/t7000-shell-datastaging.t
+++ b/t/t7000-shell-datastaging.t
@@ -136,12 +136,12 @@ test_expect_success 'submitting combined storage jobspec succeeded' '
 '
 
 test_expect_success 'datastaging logging is not overly verbose by default' '
-    flux mini run hostname 2> non-verbose.err &&
+    flux run hostname 2> non-verbose.err &&
         test_must_be_empty non-verbose.err
 '
 
 test_expect_success 'datastaging logging can be access with verbose option' '
-    flux mini run -o verbose=2 hostname 2> verbose-run.err &&
+    flux run -o verbose=2 hostname 2> verbose-run.err &&
         grep -q " DEBUG:.* Jobspec does not contain data-staging attributes. "\
 "No staging necessary." verbose-run.err
 '

--- a/t/valgrind/workload.d/00-job
+++ b/t/valgrind/workload.d/00-job
@@ -7,7 +7,7 @@ NJOBS=${NJOBS:-10}
 
 echo Submitting $NJOBS jobs
 for i in `seq 1 $NJOBS`; do
-    flux mini submit /bin/true
+    flux submit /bin/true
 done
 echo Waiting jobs to complete
 flux queue drain


### PR DESCRIPTION
This PR replaces the use of `flux mini <cmd>` with `flux <cmd>` in flux-sched.

This will cause the testsuite to fail when run using versions of flux-core <= 0.47.0, but thought I'd go ahead and post the PR in case that is acceptable.