### PR TITLE
Fix build for GCC 13

### DIFF
--- a/resource/jobinfo/jobinfo.hpp
+++ b/resource/jobinfo/jobinfo.hpp
@@ -12,6 +12,7 @@
 #define JOBINFO_HPP
 
 #include <string>
+#include <stdint.h>
 
 namespace Flux {
 namespace resource_model {

--- a/resource/readers/resource_reader_jgf.cpp
+++ b/resource/readers/resource_reader_jgf.cpp
@@ -677,7 +677,7 @@ int resource_reader_jgf_t::update_vtx_plan (vtx_t v, resource_graph_t &g,
     if ( (avail = planner_avail_resources_during (plans, at, dur)) == -1) {
         m_err_msg += __FUNCTION__;
         m_err_msg += ": planner_avail_resource_during return -1 for ";
-        m_err_msg + g[v].name + ".\n";
+        m_err_msg += g[v].name + ".\n";
         goto done;
     }
 

--- a/resource/traversers/dfu_impl_update.cpp
+++ b/resource/traversers/dfu_impl_update.cpp
@@ -524,7 +524,7 @@ int dfu_impl_t::rem_exv (int64_t jobid)
             m_err_msg += __FUNCTION__;
             m_err_msg += ": planner_rem_span returned -1.\n";
             m_err_msg += "name=" + g[*vi].name + "uniq_id=";
-            m_err_msg + std::to_string (g[*vi].uniq_id) + ".\n";
+            m_err_msg += std::to_string (g[*vi].uniq_id) + ".\n";
             m_err_msg += strerror (errno);
             m_err_msg += ".\n";
         }


### PR DESCRIPTION
Fixes these build errors using GCC 13:

```
In file included from jobinfo/jobinfo.cpp:12:
../resource/jobinfo/jobinfo.hpp:22:25: error: expected ')' before 'j'
   22 |     job_info_t (uint64_t j, job_lifecycle_t s, int64_t at,
      |                ~        ^~
      |                         )
../resource/jobinfo/jobinfo.hpp:26:25: error: expected ')' before 'j'
   26 |     job_info_t (uint64_t j, job_lifecycle_t s, int64_t at,
      |                ~        ^~
      |                         )
../resource/jobinfo/jobinfo.hpp:29:5: error: 'uint64_t' does not name a type
   29 |     uint64_t jobid = UINT64_MAX;
      |     ^~~~~~~~
../resource/jobinfo/jobinfo.hpp:1:1: note: 'uint64_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
  +++ |+#include <cstdint>
    1 | /*****************************************************************************\
jobinfo/jobinfo.cpp:17:24: error: expected constructor, destructor, or type conversion before '(' token
   17 | job_info_t::job_info_t (uint64_t j, job_lifecycle_t s, int64_t at, const std::string &fn,
      |                        ^
jobinfo/jobinfo.cpp:25:24: error: expected constructor, destructor, or type conversion before '(' token
   25 | job_info_t::job_info_t (uint64_t j, job_lifecycle_t s, int64_t at, const std::string &fn,
      |                        ^
make[3]: *** [Makefile:881: jobinfo/libresource_la-jobinfo.lo] Error 1
```

and:

```
readers/resource_reader_jgf.cpp:680:38: error: ignoring return value of 'std::__cxx11::basic_string<_CharT, _Traits, _Allocator> std::operator+(__cxx11::basic_string<_CharT, _Traits, _Allocator>&&, const _CharT*) [with _CharT = char; _Traits = char_traits<char>; _Alloc = allocator<char>]', declared with attribute 'nodiscard' [-Werror=unused-result]
  680 |         m_err_msg + g[v].name + ".\n";
      |                                      ^
```