### PR TITLE
add workflow dispatch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-on: [ pull_request, push ]
+on: [ pull_request, push, workflow_dispatch ]
 name: ci
 jobs:
   check-pr:


### PR DESCRIPTION
Problem: we should be able to build the container on request without needing to commit.
Solution: add a workflow_dispatch event to the main workflow.