### PR TITLE
reapi: implement find

### DIFF
--- a/resource/reapi/bindings/c++/reapi_cli.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli.hpp
@@ -88,6 +88,7 @@ public:
     /* Run the traverser to match the jobspec */
     int traverser_run (Flux::Jobspec::Jobspec &job, match_op_t op,
                        int64_t jobid, int64_t &at);
+    int traverser_find (std::string criteria);
 
     // must be public; results in a deleted stringstream if converted to 
     // a private member function
@@ -137,6 +138,7 @@ public:
                                 const std::string &R, int64_t &at, double &ov,
                                 std::string &R_out);
     static int cancel (void *h, const uint64_t jobid, bool noent_ok);
+    static int find (void *h, std::string criteria, json_t *&o );
     static int info (void *h, const uint64_t jobid, std::string &mode,
                      bool &reserved, int64_t &at, double &ov);
     static int stat (void *h, int64_t &V, int64_t &E,int64_t &J,

--- a/resource/reapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli_impl.hpp
@@ -186,6 +186,32 @@ out:
     return rc;
 }
 
+int reapi_cli_t::find (void *h, std::string criteria,
+                       json_t *&o )
+{
+    int rc = -1;
+    resource_query_t *rq = static_cast<resource_query_t *> (h);
+    
+    if ( (rc = rq->traverser_find (criteria)) < 0) {
+        if (rq->get_traverser_err_msg () != "") {
+             m_err_msg += __FUNCTION__;
+             m_err_msg += rq->get_traverser_err_msg ();
+            rq->clear_traverser_err_msg ();
+        }
+        return rc;
+    }
+    
+
+    if ( (rc = rq->writers->emit_json (&o)) < 0) {
+        m_err_msg += __FUNCTION__;
+        m_err_msg += ": ERROR: find writer emit: "
+                      + std::string (strerror (errno)) + "\n";
+       return rc;
+    }
+
+    return rc;
+}
+
 int reapi_cli_t::info (void *h, const uint64_t jobid, std::string &mode,
                        bool &reserved, int64_t &at, double &ov)
 {
@@ -646,6 +672,11 @@ int resource_query_t::traverser_run (Flux::Jobspec::Jobspec &job, match_op_t op,
                                      int64_t jobid, int64_t &at)
 {
     return traverser->run (job, writers, op, jobid, &at);
+}
+
+int resource_query_t::traverser_find (std::string criteria)
+{
+    return traverser->find (writers, criteria);
 }
 
 


### PR DESCRIPTION
This MR adds functionality to the reapi. 

The new function, `find` is implemented based off of the old find function from resources query and by using the structure many of the other functions from reapi_cli use. It uses a `traverser_find` helper function to performs the actual query then uses a writer to handle the out put. 

This functionality has had some simple tests done using the new resource query tool that uses the reapi, though those changes are not yet ready to be merged into the main repo. 