### PR TITLE
testsuite: make module list awk less fragile

### DIFF
--- a/t/t3300-system-dontblock.t
+++ b/t/t3300-system-dontblock.t
@@ -17,7 +17,7 @@ export FLUXION_RESOURCE_OPTIONS="load-allowlist=node,core,gpu load-format=hwloc"
 
 test_under_flux 2 system
 
-SCHED_MODULE=$(flux module list | awk '$6 == "sched" {print $1}')
+SCHED_MODULE=$(flux module list | awk '$NF == "sched" {print $1}')
 
 test_expect_success 'fluxion immediately fails to be loaded with hwloc reader' '
     test_debug "echo sched service provided by ${SCHED_MODULE}" &&

--- a/t/t3301-system-latestart.t
+++ b/t/t3301-system-latestart.t
@@ -21,7 +21,7 @@ test_under_flux 2 system
 
 startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
 
-SCHED_MODULE=$(flux module list | awk '$6 == "sched" {print $1}')
+SCHED_MODULE=$(flux module list | awk '$NF == "sched" {print $1}')
 
 test_expect_success 'sched service provided by fluxion' '
 	test_debug "echo sched service provided by ${SCHED_MODULE}" &&


### PR DESCRIPTION
Problem: if the number if fields output by 'flux module list' changes, some checks will fail.

Use $NF when grabbing the last field of output with awk instead of hard coding the column number of the last field.

flux-framework/flux-core#5085 proposes to change the output and would break this test.