### PR TITLE
testsuite: drop meaningless check

### DIFF
--- a/t/t1010-sync-modules.t
+++ b/t/t1010-sync-modules.t
@@ -41,10 +41,6 @@ test_expect_success 'sync: unloading fluxion-resource removes qmanager' '
     test_must_fail remove_qmanager
 '
 
-test_expect_success 'sync: resource is still intact' '
-    flux module info resource
-'
-
 test_expect_success 'sync: load sched-simple' '
     flux module load sched-simple
 '


### PR DESCRIPTION
Problem: t1010-sync-modules.t calls 'flux module info' to "check if the module is still intact", but this command is for static queries of the module DSO so will always succeed.

flux-framework/flux-core#5085 proposes to remove the info subcommand.

This test seems like it wasn't needed anyway, so just drop it.