### PR TITLE
 Add false positives typos config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: Check Spelling
       uses: crate-ci/typos@7ad296c72fa8265059cc03d1eda562fbdfcd6df2 # v1.9.0
-      with:
-        files: ./NEWS.md ./README.md
 
   python-format:
     name: python format

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,6 +3,7 @@ queue_rules:
     conditions:
       - base=master
       - status-success="validate commits"
+      - status-success="spelling"
       - status-success="python format"
       - status-success="python lint"
       - status-success="bionic - gcc-8,distcheck"

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,20 @@
+# do not check code copied into the project
+# do not check testing data
+[files]
+extend-exclude = [
+  "config/*",
+  "m4/*",
+  "src/common/libutil/json.hpp",
+  "src/common/yggdrasil/*",
+  "resource/doxygen/*",
+  "t/sharness.sh",
+  "t/t0000-sharness.t",
+  "t/data/*",
+]
+
+[default.extend-words]
+# commonly used names/variables that aren't typos
+BA = "BA"
+inout = "inout"
+ststr = "ststr"
+alloced = "alloced"

--- a/resource/traversers/dfu.hpp
+++ b/resource/traversers/dfu.hpp
@@ -146,7 +146,7 @@ public:
      *                   which is also interpreted as "and" logical
      *                   operator of two expressions. Parentheses
      *                   are supported to group expressions with a higher
-     *                   operator precedence. For example, in "staus=up and
+     *                   operator precedence. For example, in "status=up and
      *                   (sched-now=allocated or sched-future=reserved)"
      *                   The parenthesized expression is evaluated
      *                   before taking the "and" operator with the


### PR DESCRIPTION
Problem: The current typos workflow check only checks a select number of files because there are so many false positives in flux-sched.

Solution: Add a .typos.toml configuration file to eliminate false positives so we can run the typo check on all of flux-sched.  The config file either skips files with lots of false positives or lists common false positives we wish to ignore.