### PR TITLE
ensure licenses appear in distribution tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,6 +4,7 @@ SUBDIRS = src resource qmanager doc etc t
 
 EXTRA_DIST= \
 	config/tap-driver.sh \
+	LICENSE \
 	NOTICE.LLNS \
 	README.md \
 	NEWS.md

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -1,3 +1,6 @@
 SUBDIRS = \
 	libtap \
 	c++wrappers
+
+EXTRA_DIST = \
+	yggdrasil/LICENSE.txt

--- a/src/python/fluxion/Makefile.am
+++ b/src/python/fluxion/Makefile.am
@@ -7,6 +7,9 @@ nobase_fluxionpy_PYTHON = \
 	resourcegraph/__init__.py \
 	resourcegraph/V1.py
 
+EXTRA_DIST = \
+	jsongraph/LICENSE
+
 clean-local:
 	-rm -f *.pyc */*.pyc *.pyo */*.pyo
 	-rm -rf __pycache__ */__pycache__


### PR DESCRIPTION
@jan-janssen noticed that the Fluxion `LICENSE` file is currently not included in the distribution tarball created by `make dist`.
Add this and other licenses to `EXTRA_DIST` so that they are included in the distribution.