### PR TITLE
Update sphinx version

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==3.4.3
+sphinx<6.0.0
 sphinx-rtd-theme>=0.5.2
 docutils>=0.14,<0.18
 jinja2<3.1.0


### PR DESCRIPTION
Readthedocs CI tests are fail due to an old version of Sphinx. This quick PR Updates the version in `requirements.txt`