### PR TITLE
fix subsystems

### DIFF
--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -530,8 +530,9 @@ int dfu_impl_t::aux_upv (const jobmeta_t &meta, vtx_t u, const subsystem_t &aux,
     if ((prune (meta, x_in, aux, u, resources) == -1)
         || (m_match->aux_discover_vtx (u, aux, resources, *m_graph)) != 0)
         goto done;
+    (*m_graph)[u].idata.colors[aux] = m_color.gray ();
 
-    if (u != (*m_roots)[aux])
+    if (u != m_graph_db->metadata.roots[aux])
         explore (meta, u, aux, resources, pristine, excl, visit_t::UPV, upv);
 
     p = (*m_graph)[u].schedule.plans;
@@ -543,6 +544,7 @@ int dfu_impl_t::aux_upv (const jobmeta_t &meta, vtx_t u, const subsystem_t &aux,
         m_err_msg += ".\n";
         goto done;
     }
+    (*m_graph)[u].idata.colors[aux] = m_color.black ();
     if (m_match->aux_finish_vtx (u, aux, resources, *m_graph, upv) != 0)
         goto done;
     if ((rc = resolve (upv, to_parent)) != 0)


### PR DESCRIPTION
This is a first cut at fixing multi-subsystem traversals.  When I tried one earlier today, resource-query segfaulted trying to access an uninitialized `shared_ptr`.  I'm not sure how the aux traversals got to this point, but it looks like they're pretty thoroughly broken right now.  Fixing just the segfault puts it into infinite recursion and hits a stack overflow, so added vertex coloring also.

Any feedback on this, or thoughts on what we can do here would be appreciated.  Especially the coloring I'm not sure is actually appropriate since a node colored exploring from one point might need to be explored from another point in the containment tree to find a proper match, but without it the rest of the design fails pretty spectacularly.

Has anyone done recent work with non-containment subsystems?