### PR TITLE
mark all ranks known to graph when "all" is specified

### DIFF
--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -1114,14 +1114,10 @@ done:
 static int decode_all (std::shared_ptr<resource_ctx_t> &ctx,
                        std::set<int64_t> &ranks)
 {
-    unsigned int size = 0;
-    unsigned int rank = 0;
-    if (flux_get_size (ctx->h, &size) < -1) {
-        flux_log (ctx->h, LOG_ERR, "%s: flux_get_size", __FUNCTION__);
-        return -1;
-    }
-    for (rank = 0; rank < size; ++rank) {
-        auto ret = ranks.insert (static_cast<int64_t> (rank));
+    int64_t size = ctx->db->metadata.by_rank.size();
+    
+    for (int64_t rank = 0; rank < size; ++rank) {
+        auto ret = ranks.insert (rank);
         if (!ret.second) {
             errno = EEXIST;
             return -1;


### PR DESCRIPTION
This changes the behavior a bit, in that it marks *all* ranks known to the database.  The original tried to mark all ranks active in flux, but marked the first N.  The new behavior seems more intuitive, but we may want to change it if we grow or shrink in the future.


fixes #1040