### PR TITLE
testsuite: add test for double-booking

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -45,6 +45,7 @@ TESTS = \
     t1021-qmanager-nodex.t \
     t1022-property-constraints.t \
     t1023-multiqueue-constraints.t \
+    t1024-alloc-check.t \
     t2000-tree-basic.t \
     t2001-tree-real.t \
     t3000-jobspec.t \

--- a/t/t1024-alloc-check.t
+++ b/t/t1024-alloc-check.t
@@ -1,0 +1,71 @@
+test_description='Check that fluxion never double books resources'
+
+. `dirname $0`/sharness.sh
+
+hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+# 1 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
+excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers"
+
+export FLUX_SCHED_MODULE=none
+test_under_flux 1
+
+if ! flux jobtap load alloc-check.so; then
+    skip_all='this test requires the alloc-check.so plugin from flux core'
+    test_done
+fi
+
+test_expect_success 'load test resources' '
+    load_test_resources ${excl_1N1B}
+'
+
+test_expect_success 'load fluxion modules' '
+	load_resource &&
+	load_qmanager_sync
+'
+
+# Test for flux-framework/flux-sched#1043
+#
+test_expect_success 'configure epilog with delay' '
+	flux config load <<-EOT &&
+	[job-manager]
+	epilog.command = [ "flux", "perilog-run", "epilog", "-e", "sleep,2" ]
+	EOT
+	flux jobtap load perilog.so
+'
+# Jobs seem to need to be submitted separately to trigger the issue.
+test_expect_success 'submit node-exclusive jobs that exceed their time limit' '
+	(for i in $(seq 5); do \
+	    flux run -N1 -x -t1s sleep 30 || true; \
+	done) 2>joberr
+'
+test_expect_success 'some jobs received timeout exception' '
+	grep "job.exception type=timeout" joberr
+'
+test_expect_failure 'no jobs received alloc-check exception' '
+	test_must_fail grep "job.exception type=alloc-check" joberr
+'
+test_expect_success 'clean up' '
+	flux job cancelall -f &&
+	flux queue idle &&
+	flux resource undrain 0
+'
+test_expect_success 'submit non-exclusive jobs that exceed their time limit' '
+	(for i in $(seq 10); do \
+	    flux run --ntasks=1 --cores-per-task=8 -t1s sleep 30 || true; \
+	done) 2>joberr2
+'
+test_expect_success 'some jobs received timeout exception' '
+	grep "job.exception type=timeout" joberr2
+'
+test_expect_failure 'no jobs received alloc-check exception' '
+	test_must_fail grep "job.exception type=alloc-check" joberr2
+'
+test_expect_success 'clean up' '
+	cleanup_active_jobs
+'
+test_expect_success 'remove fluxion modules' '
+	remove_qmanager &&
+	remove_resource
+'
+
+test_done


### PR DESCRIPTION
Problem: there is no test script for ensuring fluxion never allocates the same resources to multiple jobs.

Add a sharness script that utilizes the alloc-check plugin to account for allocated resources and catch errors.  At this point, it just includes an "expected failure" test for #1043.

Note that this PR requires a version of flux-core with flux-framework/flux-core#5304 (just merged). I wanted to get this posted as I saw that @milroy was looking into #1043.