### PR TITLE
Add development environment

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,47 @@
+FROM fluxrm/flux-core:focal
+
+LABEL maintainer="Vanessasaurus <@vsoch>"
+
+# Match the default user id for a single system so we aren't root
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=1000
+ENV USERNAME=${USERNAME}
+ENV USER_UID=${USER_UID}
+ENV USER_GID=${USER_GID}
+USER root
+RUN apt-get update
+
+# Install extra buildrequires for flux-sched:
+RUN sudo apt-get update
+RUN sudo apt-get -qq install -y --no-install-recommends \
+        libboost-graph-dev \
+        libboost-system-dev \
+        libboost-filesystem-dev \
+        libboost-regex-dev \
+        python-yaml \
+        libyaml-cpp-dev \
+        libedit-dev
+
+# Assuming installing to /usr/local
+ENV LD_LIBRARY_PATH=/usr/local/lib
+
+# Install Go 19 for TBA bindings (if Go bindings desired)
+RUN wget https://go.dev/dl/go1.19.10.linux-amd64.tar.gz  && tar -xvf go1.19.10.linux-amd64.tar.gz && \
+         mv go /usr/local && rm go1.19.10.linux-amd64.tar.gz
+      
+ENV PATH=$PATH:/usr/local/go/bin:/home/vscode/go/bin
+
+# extra interactive utilities
+RUN apt-get update \
+ && apt-get -qq install -y --no-install-recommends \
+    fd-find \
+    less \
+    bats \
+    ripgrep
+
+# Add the group and user that match our ids
+RUN groupadd -g ${USER_GID} ${USERNAME} && \
+    adduser --disabled-password --uid ${USER_UID} --gid ${USER_GID} --gecos "" ${USERNAME} && \
+    echo "${USERNAME} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers
+USER $USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+    "name": "Flux Sched Developer Environment",
+    "dockerFile": "Dockerfile",
+    "context": "../",
+
+    "customizations": {
+      "vscode": {
+        "settings": {
+          "terminal.integrated.defaultProfile.linux": "bash"
+        }
+      }
+    }
+  },
+  "postStartCommand": "git config --global --add safe.directory /workspaces/flux-sched"
+}

--- a/vscode.md
+++ b/vscode.md
@@ -1,0 +1,54 @@
+
+# VSCode Dev Containers
+
+We have a [Dev Container](https://code.visualstudio.com/docs/remote/containers)
+provided via the assets in [.devcontainer](https://code.visualstudio.com/docs/remote/containers#_create-a-devcontainerjson-file).
+
+You can follow the [tutorial](https://code.visualstudio.com/docs/remote/containers-tutorial) where you'll basically
+need to:
+
+1. Install Docker, or compatible engine
+2. Install the [Development Containers](vscode:extension/ms-vscode-remote.remote-containers) extension
+
+Then you can go to the command palette (View -> Command Palette) and select `Dev Containers: Open Workspace in Container.`
+and select your cloned flux-sched repository root. This will build a development environment from [fluxrm/testenv](https://hub.docker.com/r/fluxrm/testenv/tags)
+that are built from [src/test/docker](src/test/docker) (the focal tag) with a few tweaks to add linting and dev tools.
+
+In addition to the usual flux testenv requirements, you get:
+
+* bear
+* fd
+* gdb
+* ripgrep
+
+You are free to change the base image and rebuild if you need to test on another operating system!
+When your container is built, when you open `Terminal -> New Terminal`, and you'll be in the container.
+The dependencies for building flux-sched are installed. Try building - it will work without a hitch!
+
+```bash
+./autogen.sh
+./configure --prefix=/usr/local
+make
+# This will install in the container to /usr/local
+sudo make install
+# This will test in the container
+make check
+```
+
+Note that the above assumes installing libraries to `/usr/local`. If you install elsewhere, you'll need to adjust your
+`LD_LIBRARY_PATH` or similar. IPython is provided in the container for Python development, along with other linting tools.
+If you ever need to rebuild, you can either restart VSCode and open in the same way (and it will give you the option)
+or you can do on demand in the command palette with `Dev Containers: Rebuild Container` (with or without cache).
+
+**Important** the development container assumes you are on a system with uid 1000 and gid 1000. If this isn't the case,
+edit the [.devcontainer/Dockerfile](.devcontainer/Dockerfile) to be your user and group id. This will ensure
+changes written inside the container are owned by your user. It's recommended that you commit on your system
+(not inside the container) because if you need to sign your commits, the container doesn't
+have access and won't be able to. If you find that you accidentally muck up permissions
+and need to fix, you can run this from your terminal outside of VSCode:
+
+```bash
+$ sudo chown -R $USER .git/
+# and then commit
+```
+


### PR DESCRIPTION
Problem: We do not yet have a developer environment for flux-sched. More specifically, to easily test the go bindings without needing to build a container, it would be nice to have this. I'm anticipating helping with #1008 and this would be super to have, so I've added an install of go 1.19 to the container.

Solution: Add a .devcontainer setup to flux-sched!
