### PR TITLE
testsuite: t1024-alloc-check.t: do not fail if rank 0 not drained

### DIFF
--- a/t/t1024-alloc-check.t
+++ b/t/t1024-alloc-check.t
@@ -47,7 +47,7 @@ test_expect_failure 'no jobs received alloc-check exception' '
 test_expect_success 'clean up' '
 	flux job cancelall -f &&
 	flux queue idle &&
-	flux resource undrain 0
+	(flux resource undrain 0 || true)
 '
 test_expect_success 'submit non-exclusive jobs that exceed their time limit' '
 	(for i in $(seq 10); do \


### PR DESCRIPTION
Problem: Once flux-framework/flux-core#5319 is fixed, broker ranks will not be drained if the epilog is running when a job is canceled. However, this causes t1024-alloc-check.t to fail since `flux resource undrain 0` will fail.

Don't fail if the undrain of rank 0 fails, so that this test will pass even after fixing the flux-core bug.