### PR TITLE
Planner comparison and update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,8 @@ if(DEFINED ENV{WITH_GO})
   include(GolangSimple)
 endif()
 
+include(FindValgrind) # Search for Valgrind
+
 include_directories(.)
 add_subdirectory( etc )
 add_subdirectory( src )

--- a/cmake/FindValgrind.cmake
+++ b/cmake/FindValgrind.cmake
@@ -1,0 +1,19 @@
+# Look for Valgrind headers and binary.
+#
+# Variables defined by this module:
+# 	Valgrind_FOUND System has valgrind
+# 	Valgrind_INCLUDE_DIR where to find valgrind/memcheck.h, etc.
+# 	Valgrind_EXECUTABLE the valgrind executable.
+# This module appends to config.h so t5000-valgrind.t succeeds.
+# We may need to change this behavior once remaining autotools 
+# files are removed.
+
+find_path(Valgrind_INCLUDE_DIR valgrind HINTS ${Valgrind_INCLUDE_PATH})
+find_program(Valgrind_EXECUTABLE NAMES valgrind PATH ${Valgrind_BINARY_PATH})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Valgrind DEFAULT_MSG Valgrind_INCLUDE_DIR Valgrind_EXECUTABLE)
+
+if(Valgrind_FOUND)
+	file(APPEND config.h "#define HAVE_VALGRIND 1\n")
+endif()

--- a/resource/planner/c++/CMakeLists.txt
+++ b/resource/planner/c++/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(planner_cxx STATIC
 	./scheduled_point_tree.cpp
 	./mintime_resource_tree.cpp
 	./planner_multi.cpp
+	./planner_internal_tree.cpp
 	./mintime_resource_tree.hpp
 	./planner_internal_tree.hpp
 	./scheduled_point_tree.hpp

--- a/resource/planner/c++/Makefile.am
+++ b/resource/planner/c++/Makefile.am
@@ -33,7 +33,8 @@ libplanner_cxx_la_SOURCES = \
         planner.cpp \
         planner_multi.cpp \
         scheduled_point_tree.cpp \
-        mintime_resource_tree.cpp
+        mintime_resource_tree.cpp \
+        planner_internal_tree.cpp
 
 libplanner_cxx_la_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/resource/planner/c++
 

--- a/resource/planner/c++/mintime_resource_tree.cpp
+++ b/resource/planner/c++/mintime_resource_tree.cpp
@@ -207,6 +207,17 @@ bool mt_resource_rb_node_t::operator< (const mt_resource_rb_node_t &other) const
     return this->remaining < other.remaining;
 }
 
+bool mt_resource_rb_node_t::operator== (const mt_resource_rb_node_t &other) const
+{
+    return this->remaining == other.remaining;
+}
+
+bool mt_resource_rb_node_t::operator!= (const mt_resource_rb_node_t &other) const
+{
+    return !operator == (other);
+}
+
+
 
 /*******************************************************************************
  *                                                                             *

--- a/resource/planner/c++/mintime_resource_tree.hpp
+++ b/resource/planner/c++/mintime_resource_tree.hpp
@@ -24,6 +24,8 @@ struct mt_resource_rb_node_t
     int64_t subtree_min;
     int64_t remaining;
     bool operator< (const mt_resource_rb_node_t &other) const;
+    bool operator== (const mt_resource_rb_node_t &other) const;
+    bool operator!= (const mt_resource_rb_node_t &other) const;
 };
 
 template <class mt_resource_rb_node_t, class NodeTraits>

--- a/resource/planner/c++/planner.cpp
+++ b/resource/planner/c++/planner.cpp
@@ -23,6 +23,37 @@ extern "C" {
 
 /****************************************************************************
  *                                                                          *
+ *                     Public Span_t Methods                                *
+ *                                                                          *
+ ****************************************************************************/
+
+bool span_t::operator== (const span_t &o) const
+{
+    if (start != o.start)
+        return false;
+    if (last != o.last)
+        return false;
+    if (span_id != o.span_id)
+        return false;
+    if (planned != o.planned)
+        return false;
+    if (in_system != o.in_system)
+        return false;
+    if ((*(start_p) != *(o.start_p)))
+        return false;
+    if ((*(last_p) != *(o.last_p)))
+        return false;
+
+    return true;
+}
+
+bool span_t::operator!= (const span_t &o) const
+{
+    return !operator == (o);
+}
+
+/****************************************************************************
+ *                                                                          *
  *                     Public Planner Methods                               *
  *                                                                          *
  ****************************************************************************/
@@ -441,21 +472,8 @@ bool planner::span_lookups_equal (const planner &o) const
                 return false;
             if (this_it.first != other->first)
                 return false;
-            if (this_it.second->start != other->second->start)
-                return false;
-            if (this_it.second->last != other->second->last)
-                return false;
-            if (this_it.second->span_id != other->second->span_id)
-                return false;
-            if (this_it.second->planned != other->second->planned)
-                return false;
-            if (this_it.second->in_system != other->second->in_system)
-                return false;
-            if (this_it.second->in_system != other->second->in_system)
-                return false;
-            if (*(this_it.second->start_p) != *(other->second->start_p))
-                return false;
-            if (*(this_it.second->last_p) != *(other->second->last_p))
+            // Compare span_t
+            if (*(this_it.second) != *(other->second))
                 return false;
         }
     }

--- a/resource/planner/c++/planner.cpp
+++ b/resource/planner/c++/planner.cpp
@@ -118,7 +118,7 @@ bool planner::operator== (const planner &o) const
         return false;
     // m_p0 or o.m_p0 could be uninitialized
     if (m_p0 && o.m_p0) {
-        if (!scheduled_points_equal (*m_p0, *(o.m_p0)))
+        if (*m_p0 != *(o.m_p0))
             return false;
     } else if (m_p0 || o.m_p0) {
         return false;
@@ -428,25 +428,6 @@ int planner::copy_maps (const planner &o)
     return rc;
 }
 
-bool planner::scheduled_points_equal (const scheduled_point_t &lhs,
-                                      const scheduled_point_t &rhs) const
-{
-    if (lhs.at != rhs.at)
-        return false;
-    if (lhs.in_mt_resource_tree != rhs.in_mt_resource_tree)
-        return false;
-    if (lhs.new_point != rhs.new_point)
-        return false;
-    if (lhs.ref_count != rhs.ref_count)
-        return false;
-    if (lhs.remaining != rhs.remaining)
-        return false;
-    if (lhs.scheduled != rhs.scheduled)
-        return false;
-
-    return true;
-}
-
 bool planner::span_lookups_equal (const planner &o) const
 {
     if (m_span_lookup.size () != o.m_span_lookup.size ())
@@ -472,11 +453,9 @@ bool planner::span_lookups_equal (const planner &o) const
                 return false;
             if (this_it.second->in_system != other->second->in_system)
                 return false;
-            if (!scheduled_points_equal (*(this_it.second->start_p),
-                                         *(other->second->start_p)))
+            if (*(this_it.second->start_p) != *(other->second->start_p))
                 return false;
-            if (!scheduled_points_equal (*(this_it.second->last_p),
-                                         *(other->second->last_p)))
+            if (*(this_it.second->last_p) != *(other->second->last_p))
                 return false;
         }
     }
@@ -497,8 +476,7 @@ bool planner::avail_time_iters_equal (const planner &o) const
             if (this_it.first != other->first)
                 return false;
             if (this_it.second && other->second) {
-                if (!scheduled_points_equal (*(this_it.second),
-                                             *(other->second)))
+                if (*(this_it.second) != *(other->second))
                     return false;
             } else if (this_it.second || other->second) {
                 return false;
@@ -518,7 +496,7 @@ bool planner::trees_equal (const planner &o) const
         scheduled_point_t *o_pt =
                         o.m_sched_point_tree.get_state (o.m_plan_start);
         while (this_pt) {
-            if (!scheduled_points_equal (*this_pt, *o_pt))
+            if (*this_pt != *o_pt)
                 return false;
             this_pt = m_sched_point_tree.next (this_pt);
             o_pt = o.m_sched_point_tree.next (o_pt);

--- a/resource/planner/c++/planner.cpp
+++ b/resource/planner/c++/planner.cpp
@@ -163,6 +163,11 @@ bool planner::operator== (const planner &o) const
     return true;
 }
 
+bool planner::operator!= (const planner &o) const
+{
+    return !operator == (o);
+}
+
 planner::~planner ()
 {
     // Destructor is nothrow

--- a/resource/planner/c++/planner.hpp
+++ b/resource/planner/c++/planner.hpp
@@ -108,8 +108,6 @@ private:
     // Private class utilities
     int copy_trees (const planner &o);
     int copy_maps (const planner &o);
-    bool scheduled_points_equal (const scheduled_point_t &lhs,
-                                 const scheduled_point_t &rhs) const;
     bool span_lookups_equal (const planner &o) const;
     bool avail_time_iters_equal (const planner &o) const;
     bool trees_equal (const planner &o) const;

--- a/resource/planner/c++/planner.hpp
+++ b/resource/planner/c++/planner.hpp
@@ -23,6 +23,9 @@ struct request_t {
 /*! Node in a span interval tree to enable fast retrieval of intercepting spans.
  */
 struct span_t {
+    bool operator== (const span_t &o) const;
+    bool operator!= (const span_t &o) const;
+
     int64_t start;               /* start time of the span */
     int64_t last;                /* end time of the span */
     int64_t span_id;             /* unique span id */

--- a/resource/planner/c++/planner.hpp
+++ b/resource/planner/c++/planner.hpp
@@ -45,6 +45,7 @@ public:
     planner (const planner &o);
     planner &operator= (const planner &o);
     bool operator== (const planner &o) const;
+    bool operator!= (const planner &o) const;
     ~planner ();
     // Public class utilities
     int erase ();

--- a/resource/planner/c++/planner.hpp
+++ b/resource/planner/c++/planner.hpp
@@ -51,6 +51,7 @@ public:
     int erase ();
     int reinitialize (int64_t base_time, uint64_t duration);
     int restore_track_points ();
+    int update_total (uint64_t resource_total);
     
     // Resources and duration
     int64_t get_total_resources () const;

--- a/resource/planner/c++/planner_internal_tree.cpp
+++ b/resource/planner/c++/planner_internal_tree.cpp
@@ -1,0 +1,49 @@
+/*****************************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+}
+
+#include "planner_internal_tree.hpp"
+
+bool scheduled_point_t::operator== (const scheduled_point_t &o) const
+{
+    if (point_rb != o.point_rb)
+        return false;
+    if (resource_rb != o.resource_rb)
+        return false;
+    if (at != o.at)
+        return false;
+    if (in_mt_resource_tree != o.in_mt_resource_tree)
+        return false;
+    if (new_point != o.new_point)
+        return false;
+    if (ref_count != o.ref_count)
+        return false;
+    if (remaining != o.remaining)
+        return false;
+    if (scheduled != o.scheduled)
+        return false;
+
+    return true;
+}
+
+bool scheduled_point_t::operator!= (const scheduled_point_t &o) const
+{
+    return !operator == (o);
+}
+
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/resource/planner/c++/planner_internal_tree.hpp
+++ b/resource/planner/c++/planner_internal_tree.hpp
@@ -19,6 +19,9 @@
  *  tree.
  */
 struct scheduled_point_t {
+    bool operator== (const scheduled_point_t &o) const;
+    bool operator!= (const scheduled_point_t &o) const;
+
     scheduled_point_rb_node_t point_rb; /* BST node for scheduled point tree */
     mt_resource_rb_node_t resource_rb;  /* BST node for min-time resource tree */
     int64_t at;                  /* Resource-state changing time */

--- a/resource/planner/c++/planner_multi.cpp
+++ b/resource/planner/c++/planner_multi.cpp
@@ -50,7 +50,7 @@ planner_multi::planner_multi (int64_t base_time, uint64_t duration,
            errno = ENOMEM;
            throw std::bad_alloc ();
         }
-        m_iter.counts.push_back (0);
+        m_iter.counts[type] = 0;
         m_types_totals_planners.push_back ({type, resource_totals[i], p});
     }
     m_span_counter = 0;
@@ -82,8 +82,8 @@ planner_multi::planner_multi (const planner_multi &o)
         m_types_totals_planners.push_back ({iter.resource_type,
                                             iter.resource_total, np});
     }
-    m_span_lookup = o.m_span_lookup;
     m_iter = o.m_iter;
+    m_span_lookup = o.m_span_lookup;
     m_span_lookup_iter = o.m_span_lookup_iter;
     m_span_counter = o.m_span_counter;
 }
@@ -119,8 +119,8 @@ planner_multi &planner_multi::operator= (const planner_multi &o)
         m_types_totals_planners.push_back ({iter.resource_type,
                                             iter.resource_total, np});
     }
-    m_span_lookup = o.m_span_lookup;
     m_iter = o.m_iter;
+    m_span_lookup = o.m_span_lookup;
     m_span_lookup_iter = o.m_span_lookup_iter;
     m_span_counter = o.m_span_counter;
 

--- a/resource/planner/c++/planner_multi.cpp
+++ b/resource/planner/c++/planner_multi.cpp
@@ -178,6 +178,11 @@ bool planner_multi::operator== (const planner_multi &o) const
     return true;
 }
 
+bool planner_multi::operator!= (const planner_multi &o) const
+{
+    return !operator == (o);
+}
+
 void planner_multi::erase ()
 {
     if (!m_planners.empty ()) {

--- a/resource/planner/c++/planner_multi.hpp
+++ b/resource/planner/c++/planner_multi.hpp
@@ -12,6 +12,7 @@
 #define PLANNER_MULTI_HPP
 
 #include "planner.hpp"
+#include <unordered_map>
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/member.hpp>
 #include <boost/multi_index/random_access_index.hpp>
@@ -20,7 +21,7 @@
 struct request_multi {
     int64_t on_or_after = 0;
     uint64_t duration = 0;
-    std::vector<int64_t> counts;
+    std::unordered_map<std::string, int64_t> counts;
 };
 
 struct planner_multi_meta {

--- a/resource/planner/c++/planner_multi.hpp
+++ b/resource/planner/c++/planner_multi.hpp
@@ -13,6 +13,7 @@
 
 #include "planner.hpp"
 #include <unordered_map>
+#include <unordered_set>
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/member.hpp>
 #include <boost/multi_index/random_access_index.hpp>
@@ -65,6 +66,9 @@ public:
     // Public getters and setters
     planner_t *get_planner_at (size_t i) const;
     planner_t *get_planner_at (const char *type) const;
+    void update_planner_index (const char *type, size_t i);
+    int update_planner_total (uint64_t total, size_t i);
+    bool planner_at (const char *type) const;
     size_t get_planners_size () const;
     int64_t get_resource_total_at (size_t i) const;
     int64_t get_resource_total_at (const char *type) const;
@@ -81,6 +85,12 @@ public:
     uint64_t get_span_counter ();
     void set_span_counter (uint64_t sc);
     void incr_span_counter ();
+    void add_planner (int64_t base_time, uint64_t duration,
+                      const uint64_t resource_total,
+                      const char *resource_type, size_t i);
+    // Assuming small number of resources,
+    // could try set, too
+    void delete_planners (const std::unordered_set<std::string> &rtypes);
 
 private:
     multi_container m_types_totals_planners;

--- a/resource/planner/c++/planner_multi.hpp
+++ b/resource/planner/c++/planner_multi.hpp
@@ -28,6 +28,7 @@ public:
     planner_multi (const planner_multi &o);
     planner_multi &operator= (const planner_multi &o);
     bool operator== (const planner_multi &o) const;
+    bool operator!= (const planner_multi &o) const;
     void erase ();
     ~planner_multi ();
 

--- a/resource/planner/c++/planner_multi.hpp
+++ b/resource/planner/c++/planner_multi.hpp
@@ -12,12 +12,41 @@
 #define PLANNER_MULTI_HPP
 
 #include "planner.hpp"
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/random_access_index.hpp>
+#include <boost/multi_index/hashed_index.hpp>
 
 struct request_multi {
     int64_t on_or_after = 0;
     uint64_t duration = 0;
     std::vector<int64_t> counts;
 };
+
+struct planner_multi_meta {
+    std::string resource_type;
+    mutable uint64_t resource_total; // Not an index; can mutate
+    planner_t *planner;
+};
+
+/* tags for accessing the corresponding indices of planner_multi_meta */
+struct idx {};
+struct res_type {};
+
+using boost::multi_index_container;
+using namespace boost::multi_index;
+typedef multi_index_container<
+    planner_multi_meta, // container data
+    indexed_by< // list of indexes
+        random_access< // analogous to vector
+            tag<idx> // index nametag
+        >,
+        hashed_unique<  // unordered_set-like; faster than ordered_unique in testing
+            tag<res_type>, // index nametag
+            member<planner_multi_meta, std::string, &planner_multi_meta::resource_type> // index's key
+        >
+    >
+> multi_container;
 
 class planner_multi {
 public:
@@ -33,15 +62,12 @@ public:
     ~planner_multi ();
 
     // Public getters and setters
-    planner_t *get_planners_at (size_t i);
-    std::vector<planner_t *> &get_planners ();
-    size_t get_planners_size ();
-    void resource_totals_push_back (const uint64_t resource_total);
-    uint64_t get_resource_totals_at (size_t i);
-    void resource_types_push_back (const char * resource_type);
-    const std::vector<const char *> get_resource_types ();
-    const char *get_resource_types_at (size_t i);
-    size_t get_resource_types_size ();
+    planner_t *get_planner_at (size_t i) const;
+    planner_t *get_planner_at (const char *type) const;
+    size_t get_planners_size () const;
+    int64_t get_resource_total_at (size_t i) const;
+    int64_t get_resource_total_at (const char *type) const;
+    const char *get_resource_type_at (size_t i) const;
     struct request_multi &get_iter ();
     // Span lookup functions
     std::map<uint64_t, std::vector<int64_t>> &get_span_lookup ();
@@ -55,13 +81,8 @@ public:
     void set_span_counter (uint64_t sc);
     void incr_span_counter ();
 
-    // These need to be public to pass references, otherwise
-    // need to pass tmp variables by reference.
-    std::vector<const char *> m_resource_types;
-    std::vector<uint64_t> m_resource_totals;
-    std::vector<planner_t *> m_planners;
-
 private:
+    multi_container m_types_totals_planners;
     struct request_multi m_iter;
     std::map<uint64_t, std::vector<int64_t>> m_span_lookup;
     std::map<uint64_t, std::vector<int64_t>>::iterator m_span_lookup_iter;

--- a/resource/planner/c++/scheduled_point_tree.cpp
+++ b/resource/planner/c++/scheduled_point_tree.cpp
@@ -64,6 +64,18 @@ bool operator<(const int64_t lhs, const scheduled_point_rb_node_t &rhs) {
     return lhs < rhs.get_point ()->at;
 }
 
+bool scheduled_point_rb_node_t::operator== (
+         const scheduled_point_rb_node_t &other) const
+{
+    return this->get_point ()->at == other.get_point ()->at;
+}
+
+bool scheduled_point_rb_node_t::operator!= (
+         const scheduled_point_rb_node_t &other) const
+{
+    return !operator == (other);
+}
+
 
 /*******************************************************************************
  *                                                                             *

--- a/resource/planner/c++/scheduled_point_tree.hpp
+++ b/resource/planner/c++/scheduled_point_tree.hpp
@@ -43,6 +43,8 @@ struct scheduled_point_rb_node_t
            : public rb_node_base_t,
              public ygg::RBTreeNodeBase<scheduled_point_rb_node_t> {
     bool operator< (const scheduled_point_rb_node_t &other) const;
+    bool operator== (const scheduled_point_rb_node_t &other) const;
+    bool operator!= (const scheduled_point_rb_node_t &other) const;
 };
 
 using scheduled_point_rb_tree_t = ygg::RBTree<scheduled_point_rb_node_t,

--- a/resource/planner/c/planner.h
+++ b/resource/planner/c/planner.h
@@ -229,6 +229,19 @@ int64_t planner_span_resource_count (planner_t *ctx, int64_t span_id);
 */
 bool planners_equal (planner_t *lhs, planner_t *rhs);
 
+/*! Update the resource count to support elasticity.
+ *
+ *  \param ctx          opaque planner context returned from planner_new.
+ *  \param resource_total
+ *                      64-bit unsigned integer of
+ *                      the total count of available resources
+ *                      of the resource type.
+ *  \return             0 on success; -1 on an error with errno set as follows:
+ *                          EINVAL: invalid argument.
+ */
+int planner_update_total (planner_t *ctx,
+                          uint64_t resource_total);
+
 #ifdef __cplusplus
 }
 #endif

--- a/resource/planner/c/planner_c_interface.cpp
+++ b/resource/planner/c/planner_c_interface.cpp
@@ -698,6 +698,12 @@ extern "C" bool planners_equal (planner_t *lhs, planner_t *rhs)
     return (*(lhs->plan) == *(rhs->plan));
 }
 
+extern "C" int planner_update_total (planner_t *ctx,
+                                     uint64_t resource_total)
+{
+    return ctx->plan->update_total (resource_total);
+}
+
 /*
  * vi: ts=4 sw=4 expandtab
  */

--- a/resource/planner/c/planner_multi.h
+++ b/resource/planner/c/planner_multi.h
@@ -292,6 +292,28 @@ size_t planner_multi_span_size (planner_multi_t *ctx);
 */
 bool planner_multis_equal (planner_multi_t *lhs, planner_multi_t *rhs);
 
+/*! Update the counts and resource types to support elasticity.
+ *
+ *  \param ctx          opaque multi-planner context returned
+ *                      from planner_multi_new.
+ *  \param resource_totals
+ *                      64-bit unsigned integer array of size len where each
+ *                      element contains the total count of available resources
+ *                      of a single resource type.
+ *  \param resource_types
+ *                      string array of size len where each element contains
+ *                      the resource type corresponding to each corresponding
+ *                      element in the resource_totals array.
+ *  \param len          length of resource_counts and resource_types arrays.
+ *  \return             0 on success; -1 on an error with errno set as follows:
+ *                          EINVAL: invalid argument.
+ */
+int planner_multi_update (planner_multi_t *ctx,
+                          const uint64_t *resource_totals,
+                          const char **resource_types,
+                          size_t len);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/resource/planner/c/planner_multi.h
+++ b/resource/planner/c/planner_multi.h
@@ -83,7 +83,7 @@ void planner_multi_assign (planner_multi_t *lhs, planner_multi_t *rhs);
 int64_t planner_multi_base_time (planner_multi_t *ctx);
 int64_t planner_multi_duration (planner_multi_t *ctx);
 size_t planner_multi_resources_len (planner_multi_t *ctx);
-const char **planner_multi_resource_types (planner_multi_t *ctx);
+const char *planner_multi_resource_type_at (planner_multi_t *ctx, unsigned int i);
 const uint64_t *planner_multi_resource_totals (planner_multi_t *ctx);
 int64_t planner_multi_resource_total_at (planner_multi_t *ctx, unsigned int i);
 int64_t planner_multi_resource_total_by_type (planner_multi_t *ctx,

--- a/resource/planner/c/planner_multi_c_interface.cpp
+++ b/resource/planner/c/planner_multi_c_interface.cpp
@@ -32,7 +32,8 @@ static void fill_iter_request (planner_multi_t *ctx, struct request_multi *iter,
     iter->on_or_after = at;
     iter->duration = duration;
     for (i = 0; i < len; ++i)
-        iter->counts[i] = resources[i];
+        iter->counts[ctx->plan_multi->get_resource_type_at (i)] =
+                resources[i];
 }
 
 extern "C" planner_multi_t *planner_multi_new (
@@ -261,6 +262,7 @@ extern "C" int64_t planner_multi_avail_time_next (planner_multi_t *ctx)
     size_t i = 0;
     int unmet = 0;
     int64_t t = -1;
+    std::string type;
 
     if (!ctx) {
         errno = EINVAL;
@@ -272,9 +274,10 @@ extern "C" int64_t planner_multi_avail_time_next (planner_multi_t *ctx)
                         ctx->plan_multi->get_planner_at (static_cast<size_t> (0)))) == -1)
             break;
         for (i = 1; i < ctx->plan_multi->get_planners_size (); ++i) {
+            type = ctx->plan_multi->get_resource_type_at (i);
             if ((unmet = planner_avail_during (ctx->plan_multi->get_planner_at (i), t,
                                                ctx->plan_multi->get_iter ().duration,
-                                               ctx->plan_multi->get_iter ().counts[i])) == -1)
+                                               ctx->plan_multi->get_iter ().counts.at (type))) == -1)
                 break;
         }
     } while (unmet);

--- a/resource/planner/test/planner_test01.cpp
+++ b/resource/planner/test/planner_test01.cpp
@@ -569,6 +569,9 @@ static int test_resource_service_flow ()
     }
     ok (!bo, "reserve %d jobs for global/local planners", depth);
 
+    for (auto &type : global_types)
+        free ((void *)type);
+
     planner_destroy (&global1);
     planner_destroy (&global2);
     planner_destroy (&global3);
@@ -639,6 +642,8 @@ static int test_more_add_remove ()
     bo = (bo || span6 == -1);
 
     ok (!bo, "more add-remove-add test works");
+
+    planner_destroy (&ctx);
     return 0;
 }
 

--- a/resource/planner/test/planner_test01.cpp
+++ b/resource/planner/test/planner_test01.cpp
@@ -584,7 +584,8 @@ static int test_resource_service_flow ()
 static int test_more_add_remove ()
 {
     int rc;
-    int64_t span1, span2, span3, span4, span5, span6;
+    int64_t span1 = -1, span2 = -1, span3 = -1, span4 = -1, span5 = -1,
+            span6 = -1;
     bool bo = false;
     uint64_t resource_total = 100000;
     uint64_t resource1 = 36;
@@ -660,7 +661,7 @@ static int test_constructors_and_overload ()
     uint64_t resource5 = 2304;
     uint64_t resource6 = 468;
     const char resource_type[] = "core";
-    planner_t *ctx, *ctx2, *ctx3, *ctx4 = NULL;
+    planner_t *ctx = NULL, *ctx2 = NULL, *ctx3 = NULL, *ctx4 = NULL;
 
     ctx = planner_new (0, INT64_MAX, resource_total, resource_type);
 
@@ -742,7 +743,7 @@ static int test_update ()
     uint64_t resource6 = 50000;
     int64_t avail, avail1 = 0;
     const char resource_type[] = "core";
-    planner_t *ctx, *ctx2 = NULL;
+    planner_t *ctx = NULL, *ctx2 = NULL;
 
     ctx = planner_new (0, INT64_MAX, resource_total, resource_type);
     // Add some spans

--- a/resource/planner/test/planner_test02.cpp
+++ b/resource/planner/test/planner_test02.cpp
@@ -556,9 +556,10 @@ static int test_constructors_and_overload ()
     const uint64_t request1[] = {1, 0, 0, 0, 0};
     const uint64_t request2[] = {0, 2, 0, 0, 0};
     const uint64_t request3[] = {0, 0, 3, 0, 0};
-    planner_multi_t *ctx, *ctx2, *ctx3, *ctx4 = NULL;
+    planner_multi_t *ctx = NULL, *ctx2 = NULL, *ctx3 = NULL, *ctx4 = NULL;
 
-    ctx = planner_multi_new (0, INT64_MAX, resource_totals, resource_types, len);
+    ctx = planner_multi_new (0, INT64_MAX, resource_totals, resource_types,
+                             len);
 
     planner_multi_add_span (ctx, 0, 1000, request1, len);
     span = planner_multi_add_span (ctx, 1000, 1000, request2, len);

--- a/resource/planner/test/planner_test02.cpp
+++ b/resource/planner/test/planner_test02.cpp
@@ -295,6 +295,7 @@ static int test_multi_strictly_larger ()
     ok ((t == -1 && errno == ENOENT), "avail_time_next for (%s)",
          ss.str ().c_str ());
 
+    planner_multi_destroy (&ctx);
     return 0;
 }
 
@@ -405,6 +406,7 @@ static int test_multi_partially_larger ()
     ok ((t == -1 && errno == ENOENT), "avail_time_next for (%s)",
          ss.str ().c_str ());
 
+    planner_multi_destroy (&ctx);
     return 0;
 }
 
@@ -483,6 +485,8 @@ static int test_multi_many_spans ()
     t = planner_multi_avail_time_next (ctx);
     bo = (bo || !(t == -1 && errno == ENOENT));
     ok (!bo, "avail_time_next for (%s)", ss.str ().c_str ());
+
+    planner_multi_destroy (&ctx);
     return 0;
 }
 
@@ -535,6 +539,7 @@ static int test_multi_add_remove ()
     size = planner_multi_span_size (ctx);
     ok ((size == 2), "planner_multi_span_size works");
 
+    planner_multi_destroy (&ctx);
     return 0;
 
 }

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -510,10 +510,11 @@ int dfu_impl_t::count_relevant_types (planner_multi_t *plan,
 {
     int rc = 0;
     size_t len = planner_multi_resources_len (plan);
-    const char **resource_types = planner_multi_resource_types (plan);
+    const char *type = nullptr;
     for (unsigned int i = 0; i < len; ++i) {
-        if (lookup.find (resource_types[i]) != lookup.end ()) {
-            uint64_t n = (uint64_t)lookup.at (resource_types[i]);
+        type = planner_multi_resource_type_at (plan, i);
+        if (lookup.find (type) != lookup.end ()) {
+            uint64_t n = (uint64_t)lookup.at (type);
             resource_counts.push_back (n);
         } else {
             resource_counts.push_back (0);

--- a/t/t5000-valgrind.t
+++ b/t/t5000-valgrind.t
@@ -7,7 +7,7 @@ test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 . `dirname $0`/sharness.sh
 
 #  Do not run valgrind test by default unless FLUX_ENABLE_VALGRIND_TEST
-#   is set in environment (e.g. by CI), or the test run run with -d, --debug
+#  is set in environment (e.g. by CI), or the test run run with -d, --debug
 #
 if test -z "$FLUX_ENABLE_VALGRIND_TEST" && test "$debug" = ""; then
     skip_all='skipping valgrind tests since FLUX_ENABLE_VALGRIND_TEST not set'
@@ -23,7 +23,7 @@ if ! test_have_prereq NO_ASAN; then
     test_done
 fi
 
-# Do not run test by default unless valgrind/valgrind.h was found, since
+#  Do not run test by default unless valgrind/valgrind.h was found, since
 #  this has been known to introduce false positives (#1097). However, allow
 #  run to be forced on the cmdline with -d, --debug.
 #
@@ -48,7 +48,7 @@ test_expect_success \
 	run_timeout 900 \
 	flux start -s ${VALGRIND_NBROKERS} \
 		--killer-timeout=120 \
-		--wrap=libtool,e,${VALGRIND} \
+		--wrap=${VALGRIND} \
 		--wrap=--tool=memcheck \
 		--wrap=--leak-check=full \
 		--wrap=--gen-suppressions=all \
@@ -60,4 +60,42 @@ test_expect_success \
 		--wrap=--suppressions=$VALGRIND_SUPPRESSIONS \
 		 ${VALGRIND_WORKLOAD}
 '
+
+# The Valgrind test above doesn't detect memory leaks in planner or schema
+test_expect_success \
+  "valgrind reports no new errors on planner test 01" '
+		${VALGRIND} \
+		--tool=memcheck \
+		--leak-check=full \
+		--error-exitcode=1 \
+		${SHARNESS_BUILD_DIRECTORY}/resource/planner/test/planner_test01
+'
+
+test_expect_success \
+  "valgrind reports no new errors on planner test 02" '
+		${VALGRIND} \
+		--tool=memcheck \
+		--leak-check=full \
+		--error-exitcode=1 \
+		${SHARNESS_BUILD_DIRECTORY}/resource/planner/test/planner_test02
+'
+
+test_expect_success \
+  "valgrind reports no new errors on schema test 01" '
+		${VALGRIND} \
+		--tool=memcheck \
+		--leak-check=full \
+		--error-exitcode=1 \
+		${SHARNESS_BUILD_DIRECTORY}/resource/schema/test/schema_test01
+'
+
+test_expect_success \
+  "valgrind reports no new errors on schema test 02" '
+		${VALGRIND} \
+		--tool=memcheck \
+		--leak-check=full \
+		--error-exitcode=1 \
+		${SHARNESS_BUILD_DIRECTORY}/resource/schema/test/schema_test02
+'
+
 test_done


### PR DESCRIPTION
Edit: this PR has grown in scope to enable updates to `planner` and `planner_multi`

To update the Fluxion resource graph, its traverser will need to be reinitialized. The initialization process assembles vectors of resource counts and types via graph traversal to update the `planner_multi` pruning filters. Currently, counts and types are stored as separate vectors in `planner_multi` under the assumption that their order and size don't change. The index of a count must be the same as the index of the corresponding resource type string. This assumption is valid as long as the resource graph is static, but allowing the resource graph to change without updating the planners and their metadata will cause scheduling inconsistency (e.g., incorrect traversal pruning) because of incorrect resource types and counts.

This PR adds comparison operators for fundamental `planner` member data classes to scope the comparison to the correct part of the code. The rescoping avoids relying on awkward class functions for comparison of member data objects and their data.

The PR also restructures `planner_multi` to use `boost::multi_index` container to replace and simplify `planner_multi` member data. The `boost::multi_index` container has the important capability of searching and comparing by multiple indices which can be vector-like (`random_access`), and hash-like (`hashed_unique`). Adding two indexes for lookups enables support for altering resource types, counts, and their orders (indices) in a natural way. Performing these transformations with `vectors` would be higher complexity both in time and lines of code.

Finally, the PR enables the update functionality in the `planner` and `planner_multi` C interfaces and creates unit tests for  updating `planner` and `planner_multi`.

Edit: this PR also re-enables the Valgrind tests and fixes UB in planner unit tests.