### PR TITLE
testsuite: improve test event check

### DIFF
--- a/t/t1001-qmanager-basic.t
+++ b/t/t1001-qmanager-basic.t
@@ -63,9 +63,7 @@ test_expect_success 'qmanager: exception during initialization is supported' '
     test_debug "flux job eventlog ${jobid}" &&
     grep "type=\"exec\"" exception.1.out &&
     grep "mock initialization exception generated" exception.1.out &&
-    flux job wait-event -qt 10 ${jobid} clean &&
-    flux job eventlog ${jobid} > eventlog.${jobid}.out &&
-    test_must_fail grep "finish" eventlog.${jobid}.out
+    test_must_fail flux job wait-event -qt 10 ${jobid} finish
 '
 
 test_expect_success 'qmanager: exception during run is supported' '


### PR DESCRIPTION
Problem: when building against the installed flux-core on a system with flux-coral2 installed, one of the 'make check' tests fails.

A grep for "finish" in a job eventlog succeeds where it failed before because the cray-pals port distributor jobtap plugin posts a prolog-finish event.

Aside: the cray-pals jobtap plugin is loaded by an rc script rather than the config file so that it is present in all instances, not just the system instance.

Use 'flux job wait-event finish' instead of dumping the human formatted eventlog to a file and grepping it.  Note that wait-event exits immediately with an error when the eventlog is complete but the requested event is missing.

Fixes #1073