### PR TITLE
docker: avoid sudo in Dockerfile for arm runner

### DIFF
--- a/src/test/docker/bookworm/Dockerfile
+++ b/src/test/docker/bookworm/Dockerfile
@@ -2,10 +2,11 @@ FROM fluxrm/flux-core:bookworm
 
 ARG USER=flux
 ARG UID=1000
+USER root
 
 # Install extra buildrequires for flux-sched:
-RUN sudo apt-get update
-RUN sudo apt-get -qq install -y --no-install-recommends \
+RUN apt-get update
+RUN apt-get -qq install -y --no-install-recommends \
 	libboost-graph-dev \
 	libboost-system-dev \
 	libboost-filesystem-dev \
@@ -19,10 +20,10 @@ RUN sudo apt-get -qq install -y --no-install-recommends \
 #
 RUN \
  if test "$USER" != "flux"; then  \
-      sudo groupadd -g $UID $USER \
-   && sudo useradd -g $USER -u $UID -d /home/$USER -m $USER \
-   && sudo sh -c "printf \"$USER ALL= NOPASSWD: ALL\\n\" >> /etc/sudoers" \
-   && sudo adduser $USER sudo ; \
+      groupadd -g $UID $USER \
+   && useradd -g $USER -u $UID -d /home/$USER -m $USER \
+   && sh -c "printf \"$USER ALL= NOPASSWD: ALL\\n\" >> /etc/sudoers" \
+   && adduser $USER sudo ; \
  fi
 
 USER $USER


### PR DESCRIPTION
Problem: Github actions build for arm is dying on a nosuid mounted filesystem under the container trying to use sudo

Solution: Set user to root, avoid sudo.  We may want to do this on more Dockerfiles, but it has only showed up in the arm build so far.

This specifically came up here: https://github.com/flux-framework/flux-sched/actions/runs/6189435988/job/16803524042

Apparently overlayfs honors nosetuid in mounts, why this only shows up in the virtualized runner I have no idea but it's easier to fix it this way than try and debug the runners themselves.