### PR TITLE
build: resurrect `make deb`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ find_package(Boost 1.50 REQUIRED COMPONENTS
 message(STATUS "Boost version: ${Boost_VERSION}")
 
 # Install paths
-set(FLUX_CMD_DIR "${CMAKE_INSTALL_PREFIX}/libexec/cmd")
+set(FLUX_CMD_DIR "${CMAKE_INSTALL_LIBEXECDIR}/flux/cmd")
 set(FLUX_LIB_DIR "${CMAKE_INSTALL_LIBDIR}/flux")
 set(FLUX_MOD_DIR "${FLUX_LIB_DIR}/modules")
 set(FLUX_SHELL_PLUGIN_DIR "${FLUX_LIB_DIR}/shell/plugins")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,15 +197,25 @@ add_custom_target(check
   )
 add_custom_target(installcheck
   COMMAND env FLUX_SCHED_TEST_INSTALLED=1 ${CMAKE_CTEST_COMMAND} ${CTEST_COMMON_FLAGS})
+add_custom_target(dist
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  COMMAND echo ${FLUX_SCHED_VER} > flux-sched.ver
+  COMMAND git archive --format=tar.gz
+  --prefix=flux-sched-${FLUX_SCHED_VER}/
+  --add-file=flux-sched.ver
+  --output=${CMAKE_BINARY_DIR}/flux-sched-${FLUX_SCHED_VER}.tar.gz
+  HEAD .
+  COMMAND rm flux-sched.ver
+  COMMENT "Generated flux-sched-${FLUX_SCHED_VER}.tar.gz"
+  )
 # run installcheck, if it passes then write out version information and pack up
 # a tarball with the result
 add_custom_target(distcheck
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target all
   COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target check
-  COMMAND git archive --format=tar.gz
-  --add-virtual-file=flux-sched.ver:${FLUX_SCHED_VER}
-  --prefix=flux-sched-${FLUX_SCHED_VER}/
-  --output=${CMAKE_BINARY_DIR}/flux-sched-${FLUX_SCHED_VER}.tar.gz
-  HEAD .
+  COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target dist
+  )
+add_custom_target(deb
+  COMMAND ${CMAKE_SOURCE_DIR}/scripts/debbuild.sh ${CMAKE_SOURCE_DIR}
   )

--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Priority: optional
 Maintainer: Mark A. Grondona <mark.grondona@gmail.com>
 Standards-Version: 4.1.2
 Build-Depends:
+  cmake (>= 3.18),
   debhelper (>= 10),
   flux-core (>= 0.49.0),
   libhwloc-dev,

--- a/debian/rules
+++ b/debian/rules
@@ -18,6 +18,10 @@
 override_dh_autoreconf:
 	@echo not running autogen.sh on dist product
 
+override_dh_auto_configure:
+	dh_auto_configure -- \
+	  -DCMAKE_INSTALL_LIBEXECDIR=/usr/lib/$(DEB_HOST_MULTIARCH)
+
 override_dh_auto_install:
 	dh_auto_install
 	find . -name '*.la' -delete

--- a/debian/rules
+++ b/debian/rules
@@ -13,7 +13,7 @@
 #export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
 %:
-	dh $@
+	dh $@ --buildsystem=cmake
 
 override_dh_autoreconf:
 	@echo not running autogen.sh on dist product

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -12,3 +12,22 @@ install(DIRECTORY fluxion
   DESTINATION "${PYTHON_INSTALL_SITELIB}"
   FILES_MATCHING PATTERN "*.py")
 
+set(PYNAME "python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")
+set(PYDIR "${CMAKE_INSTALL_FULL_LIBDIR}/flux/${PYNAME}")
+set(LINKTARGET "${PYTHON_INSTALL_SITELIB}/fluxion")
+
+INSTALL(CODE "\
+  execute_process( \
+  COMMAND \
+    mkdir -p \$ENV{DESTDIR}/${PYDIR} \
+  )
+  execute_process( \
+  COMMAND \
+    rm -f \$ENV{DESTDIR}/${PYDIR}/fluxion \
+  )
+  MESSAGE (STATUS \
+    \"linking ${PYDIR}/fluxion -> ${PYTHON_INSTALL_SITELIB}/fluxion\")
+  execute_process( \
+  COMMAND \
+    ln -s ${LINKTARGET} \$ENV{DESTDIR}/${PYDIR}/fluxion \
+  )")


### PR DESCRIPTION
This PR brings back the `make deb` target, which we've been using to build and install packages on test systems.

A `make dist` target, required by `scripts/debbuild.sh`, is added (and is now used by `make distcheck`), and `make dist` is fixed to work with slightly older versions of `git-archive` that do not support the `--add-virtual-file` option. Finally, the build system is forced to `cmake` in `debian/rules` since the fake `configure` script doesn't support all the requisite options.

