### PR TITLE
cmake: use GNUInstallDirs to normalize libexecdir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ find_package(Boost 1.50 REQUIRED COMPONENTS
 message(STATUS "Boost version: ${Boost_VERSION}")
 
 # Install paths
-set(FLUX_CMD_DIR "${CMAKE_INSTALL_PREFIX}/libexec/cmd")
+set(FLUX_CMD_DIR "${CMAKE_INSTALL_LIBEXECDIR}/flux/cmd")
 set(FLUX_LIB_DIR "${CMAKE_INSTALL_LIBDIR}/flux")
 set(FLUX_MOD_DIR "${FLUX_LIB_DIR}/modules")
 set(FLUX_SHELL_PLUGIN_DIR "${FLUX_LIB_DIR}/shell/plugins")


### PR DESCRIPTION
fixes: #1083 
Problem: install using wrong libexec directory

Solution: use the libexec directory provided by GNUInstallDirs, add flux intermediary