### PR TITLE
traverser: fix default job duration when no duration specified

### DIFF
--- a/resource/traversers/dfu.cpp
+++ b/resource/traversers/dfu.cpp
@@ -290,7 +290,9 @@ int dfu_traverser_t::run (Jobspec::Jobspec &jobspec,
     }
 
     int rc = -1;
-    int64_t graph_end = graph_duration.graph_end.time_since_epoch ().count ();
+    int64_t graph_end = std::chrono::duration_cast<std::chrono::seconds>
+                            (graph_duration.graph_end
+                                .time_since_epoch ()).count ();
     detail::jobmeta_t meta;
     vtx_t root = get_graph_db ()->metadata.roots.at (dom);
     bool x = detail::dfu_impl_t::exclusivity (jobspec.resources, root);

--- a/t/t4011-match-duration.t
+++ b/t/t4011-match-duration.t
@@ -9,17 +9,58 @@ test_description='Test that parent duration is inherited according to RFC14'
 #
 test_under_flux 1
 
-test_expect_success HAVE_JQ 'parent duration is inherited when duration=0' '
+export FLUX_URI_RESOLVE_LOCAL=t
+
+# Ensure fluxion modules are loaded under flux-alloc(1)
+test_expect_success 'set FLUX_RC_EXTRA so Fluxion modules are loaded under flux-alloc' '
+	mkdir rc1.d &&
+	cat <<-EOF >rc1.d/rc1-fluxion &&
+	flux module unload -f sched-simple
+	flux module load sched-fluxion-resource
+	flux module load sched-fluxion-qmanager
+	EOF
+	mkdir rc3.d &&
+	cat <<-EOF >rc3.d/rc3-fluxion &&
+	flux module remove -f sched-fluxion-qmanager
+	flux module remove -f sched-fluxion-resource
+	flux module load sched-simple
+	EOF
+	chmod +x rc1.d/rc1-fluxion rc3.d/rc3-fluxion &&
+	export FLUX_RC_EXTRA=$(pwd)
+'
+test_expect_success 'load fluxion modules in parent instance' '
+	flux module remove sched-simple &&
+	load_resource &&
+	load_qmanager &&
+	test_debug "flux dmesg -H | grep version"
+'
+test_expect_success HAVE_JQ 'parent expiration is inherited when duration=0' '
 	cat >get_R.sh <<-EOT &&
 	#!/bin/sh
-
 	flux job info \$FLUX_JOB_ID R
 	EOT
 	chmod +x get_R.sh &&
-	out=$(flux run -t20s -n1 flux start flux run -n1 ./get_R.sh) &&
-	echo "$out" | jq -e ".execution.expiration - .execution.starttime <= 20" &&
-	out=$(flux run -t30s -n1 flux start flux run -n1 ./get_R.sh) &&
-	echo "$out" | jq -e ".execution.expiration - .execution.starttime <= 30"
+	jobid=$(flux alloc -n1 -t5m --bg) &&
+	test_debug "flux proxy $jobid flux dmesg -H | grep version" &&
+	expiration=$(flux job info $jobid R | jq .execution.expiration) &&
+        duration=$(flux job info $jobid R \
+		| jq ".execution | .expiration - .starttime") &&
+	test_debug "echo expiration of alloc job is $expiration duration=$duration" &&
+	R1=$(flux proxy $jobid flux run -n1 ./get_R.sh) &&
+	exp1=$(echo "$R1" | jq .execution.expiration) &&
+	d1=$(echo "$R1" | jq ".execution | .expiration - .starttime") &&
+	test_debug "echo expiration of job is $exp1 duration=$d1" &&
+	echo $exp1 | jq ". == $expiration" &&
+	sleep 1 &&
+	R2=$(flux proxy $jobid flux run -n1 ./get_R.sh) &&
+	exp2=$(echo "$R2" | jq .execution.expiration) &&
+	d2=$(echo "$R2" | jq ".execution | .expiration - .starttime") &&
+	test_debug "echo expiration of second job is $exp2 duration=$d2" &&
+	echo $exp2 | jq ". == $expiration" &&
+	flux shutdown --quiet $jobid
 '
-
+test_expect_success 'unload fluxion modules' '
+	remove_qmanager &&
+	remove_resource
+'
 test_done


### PR DESCRIPTION
When a resource graph has a fixed duration (i.e. a non-zero expiration), Fluxion currently assigns the graph _duration_ to job requests that do not specify a duration. This results in job expirations that exceed the instance lifetime.

This PR fixes that by adjusting unspecified jobspec durations to the _remaining_ graph duration, instead of the entire graph duration. This results in the expiration of these jobs matching that of the instance.

The existing test that checked this behavior was also updated and fixed.
