### PR TITLE
ci: fix coverage build

### DIFF
--- a/src/test/checks_run.sh
+++ b/src/test/checks_run.sh
@@ -118,14 +118,14 @@ if test "$COVERAGE" = "t"; then
 
 	ARGS="$ARGS --enable-code-coverage"
 	CHECKCMDS="\
-	ENABLE_USER_SITE=1 \
-	COVERAGE_PROCESS_START=$(pwd)/coverage.rc \
+	export ENABLE_USER_SITE=1 && \
+	export COVERAGE_PROCESS_START=$(pwd)/coverage.rc && \
 	${MAKE} -j $JOBS check-code-coverage && \
 	lcov -l flux*-coverage.info && \
 	coverage combine .coverage* && \
-	coverage html && coverage xml &&
-	chmod 444 coverage.xml &&
-	coverage report"
+	(coverage xml || :) &&
+	(chmod 444 coverage.xml || :) &&
+	(coverage report || :)"
 
 # Use make install for T_INSTALL:
 elif test "$TEST_INSTALL" = "t"; then


### PR DESCRIPTION
I noticed that the `coverage` build is always reporting `Warning: make check failed, trying recheck in ./t`. Apparently, this isn't because `make check-code-coverage` is failing, but because one of the subsequent `coverage blah` steps is.

Possibly some change in the cmake `check-code-coverage` target is causing one of these steps to fail, or maybe it was always like this for flux-sched. Anyway, this PR just removes some of the post-check coverage steps and makes a couple others optional to avoid the extra unnecessary work of `make recheck`.