### PR TITLE
Add a set-status RPC for marking vertices up or down

### DIFF
--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -77,6 +77,7 @@ set(ALL_TESTS
   t4009-match-update.t
   t4010-match-conf.t
   t4011-match-duration.t
+  t4012-set-status.t
   t5000-valgrind.t
   t6000-graph-size.t
   t6001-match-formats.t

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -95,6 +95,7 @@ TESTS = \
     t4009-match-update.t \
     t4010-match-conf.t \
     t4011-match-duration.t \
+    t4012-set-status.t \
     t5000-valgrind.t \
     t5100-issues-test-driver.t \
     t6000-graph-size.t \

--- a/t/scripts/flux-ion-resource.py
+++ b/t/scripts/flux-ion-resource.py
@@ -94,6 +94,10 @@ class ResourceModuleInterface:
     def rpc_status(self):
         return self.f.rpc("sched-fluxion-resource.status").get()
 
+    def rpc_set_status(self, resource_path, status):
+        payload = {"resource_path": resource_path, "status": status}
+        return self.f.rpc("sched-fluxion-resource.set_status", payload).get()
+
     def rpc_namespace_info(self, rank, type_name, identity):
         payload = {"rank": rank, "type-name": type_name, "id": identity}
         return self.f.rpc("sched-fluxion-resource.ns-info", payload).get()
@@ -289,6 +293,16 @@ def status_action(args):
 
 
 """
+    Action for set-status sub-command
+"""
+
+
+def set_status_action(args):
+    r = ResourceModuleInterface()
+    r.rpc_set_status(args.resource_path, args.status)
+
+
+"""
     Action for ns-info sub-command
 """
 
@@ -341,6 +355,7 @@ def main():
     cstr = "Cancel an allocated or reserved job."
     fstr = "Find resources matching with a crieria."
     ststr = "Display resource status."
+    ssstr = "Set up/down status of a resource vertex."
     pstr = "Set property-key=value for specified resource."
     gstr = "Get value for specified resource and property-key."
     nstr = "Get remapped ID given raw ID seen by the reader."
@@ -352,6 +367,7 @@ def main():
     parser_c = subpar.add_parser("cancel", help=cstr, description=cstr)
     parser_f = subpar.add_parser("find", help=fstr, description=fstr)
     parser_st = subpar.add_parser("status", help=ststr, description=ststr)
+    parser_ss = subpar.add_parser("set-status", help=ssstr, description=ssstr)
     parser_sp = subpar.add_parser("set-property", help=pstr, description=pstr)
     parser_gp = subpar.add_parser("get-property", help=gstr, description=gstr)
     parser_n = subpar.add_parser("ns-info", help=nstr, description=nstr)
@@ -418,6 +434,18 @@ def main():
     #
     st_help = "Resource status"
     parser_st.set_defaults(func=status_action)
+
+    # Positional argument for set-status sub-command
+    #
+    parser_ss.add_argument(
+        "resource_path",
+        help="path to vertex",
+    )
+    parser_ss.add_argument(
+        "status",
+        help="status of vertex",
+    )
+    parser_ss.set_defaults(func=set_status_action)
 
     #
     # Positional argument for match allocate sub-command

--- a/t/scripts/flux-ion-resource.py
+++ b/t/scripts/flux-ion-resource.py
@@ -4,7 +4,6 @@
 #   FLUX_EXEC_PATH or `flux python flux-ion-resource` if not to
 #   avoid python version mismatch
 #
-from __future__ import print_function
 import argparse
 import errno
 import yaml
@@ -353,7 +352,7 @@ def main():
     istr = "Print info on a single job."
     sstr = "Print overall performance statistics."
     cstr = "Cancel an allocated or reserved job."
-    fstr = "Find resources matching with a crieria."
+    fstr = "Find resources matching with a criteria."
     ststr = "Display resource status."
     ssstr = "Set up/down status of a resource vertex."
     pstr = "Set property-key=value for specified resource."

--- a/t/scripts/flux-jsonschemalint.py
+++ b/t/scripts/flux-jsonschemalint.py
@@ -4,7 +4,6 @@
 #   FLUX_EXEC_PATH or `flux python flux-jsonschemalint` if not to
 #   avoid python version mismatch
 #
-from __future__ import print_function
 
 import argparse
 import errno

--- a/t/t4012-set-status.t
+++ b/t/t4012-set-status.t
@@ -1,0 +1,84 @@
+#!/bin/sh
+#set -x
+
+test_description='Test the basic functionality of properties (get/set) within resource
+'
+
+. `dirname $0`/sharness.sh
+
+grug="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/tiny.graphml"
+jobspec="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/basics/test008.yaml"
+
+#
+# test_under_flux is under sharness.d/
+#
+test_under_flux 1
+
+#
+# print only with --debug
+#
+
+test_debug '
+	echo ${grug}
+'
+
+test_expect_success 'loading resource module with a tiny machine config works' '
+	load_resource \
+load-file=${grug} load-format=grug \
+prune-filters=ALL:core subsystems=containment policy=high
+'
+
+test_expect_success 'set-status basic test works' '
+	flux ion-resource find status=down | grep null &&
+	flux ion-resource set-status /tiny0/rack0/node0 down &&
+	flux ion-resource find status=down | grep node0 &&
+	flux ion-resource set-status /tiny0/rack0/node0 up &&
+	flux ion-resource find status=down | grep null
+'
+
+test_expect_success 'bad resource path produces an error' '
+	test_must_fail flux ion-resource set-status /foobar/not/a/vertex down
+'
+
+test_expect_success 'bad status produces an error' '
+	test_must_fail flux ion-resource set-status /tiny0/rack0/node0 foobar
+'
+
+test_expect_success 'set-status not-so-basic test works' '
+	flux ion-resource find status=down | grep null &&
+	flux ion-resource set-status /tiny0/rack0/node0 down &&
+	flux ion-resource find status=down | grep node0 &&
+	flux ion-resource set-status /tiny0/rack0/node1 down &&
+	flux ion-resource find status=down | grep "node\[0-1\]" &&
+	flux ion-resource set-status /tiny0/rack0/node0 up &&
+	flux ion-resource find status=down | grep node1 &&
+	flux ion-resource set-status /tiny0/rack0/node1 up &&
+	flux ion-resource find status=down | grep null
+'
+
+test_expect_success 'jobs fail when all nodes are marked down' '
+	flux ion-resource set-status /tiny0/rack0/node0 down &&
+	flux ion-resource set-status /tiny0/rack0/node1 down &&
+	flux ion-resource find status=up | grep null &&	
+	flux ion-resource match satisfiability $jobspec &&
+	test_must_fail flux ion-resource match allocate $jobspec &&
+	flux ion-resource set-status /tiny0/rack0/node0 up &&
+	flux ion-resource set-status /tiny0/rack0/node1 up &&
+	flux ion-resource find status=down | grep null
+'
+
+test_expect_success 'jobs fail when all racks are marked down' '
+	flux ion-resource find status=down | grep null &&
+	flux ion-resource set-status /tiny0/rack0 down &&
+	flux ion-resource find status=up | grep null &&	
+	flux ion-resource match satisfiability $jobspec &&
+	test_must_fail flux ion-resource match allocate $jobspec &&
+	flux ion-resource set-status /tiny0/rack0 up &&
+	flux ion-resource find status=down | grep null
+'
+
+test_expect_success 'removing resource works' '
+	remove_resource
+'
+
+test_done


### PR DESCRIPTION
The motivation for this PR comes from [this flux-coral2 issue](https://github.com/flux-framework/flux-coral2/issues/99). Rabbits can (and very often do) go down, and fluxion needs to avoid scheduling rabbit jobs on dead rabbits. Rabbit status is monitored by HPE software and reported in kubernetes objects, which flux-coral2 software checks. The flux-coral2 software needs a way to report to Fluxion that a rabbit has died (or resurrected).

This PR provides a way to do that. Flux-coral2 can now send a RPC like `sched-fluxion-resource.set_status /path/to/rabbit down` to mark a rabbit as down, and similarly to mark it up.

However, I did notice that marking all the nodes or racks in the resource graph didn't prevent jobs from running, hence the test failures. @milroy do you know whether this is expected? Is marking a resource as 'down' purely informational--does it have no effect on actual resource choices?

As an aside, one tricky aspect is that with this PR, flux-coral2 will need to know the resource graph layout. It will know the hostname of the rabbit that has gone down, but it won't necessarily know that the rabbit 'rzvernal201' is '/rzvernal/rack3/rzvernal201` in the resource graph. I think I can work around this though--the resource graph is already written out to a file (because it needs to contain information about rabbit locality) so the flux-coral2 software can read in that graph and figure things out.