### PR TITLE
Build reapi_cli as a shared library

### DIFF
--- a/cmake/GolangSimple.cmake
+++ b/cmake/GolangSimple.cmake
@@ -11,11 +11,8 @@ function(BUILD_GO_PROGRAM NAME MAIN_SRC CGO_CFLAGS CGO_LIBRARY_FLAGS)
   get_filename_component(MAIN_SRC_ABS ${MAIN_SRC} ABSOLUTE)
   add_custom_target(${NAME})
 
-  # IMPORTANT: the trick to getting *spaces* to render in COMMAND is to convert them to ";"
-  # string(REPLACE <match-string> <replace-string> <out-var> <input>...)
-  STRING(REPLACE " " ";" CGO_LIBRARY_FLAGS ${CGO_LIBRARY_FLAGS})  
   add_custom_command(TARGET ${NAME}
-                    COMMAND GOPATH=${GOPATH}:${CUSTOM_GO_PATH} GOOS=linux G0111MODULE=off CGO_CFLAGS="${CGO_CFLAGS}" CGO_LDFLAGS='${CGO_LIBRARY_FLAGS}' go build -ldflags '-w'
+                    COMMAND GOPATH=${GOPATH}:${CUSTOM_GO_PATH} GOOS=linux G0111MODULE=off CGO_CFLAGS="${CGO_CFLAGS}" CGO_LDFLAGS="${CGO_LIBRARY_FLAGS}" go build -ldflags '-w'
                     -o "${CMAKE_CURRENT_SOURCE_DIR}/${NAME}"
                     ${CMAKE_GO_FLAGS} ${MAIN_SRC}
                     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}

--- a/resource/reapi/bindings/CMakeLists.txt
+++ b/resource/reapi/bindings/CMakeLists.txt
@@ -1,21 +1,25 @@
-add_library ( reapi_cli STATIC
+add_library ( reapi_cli SHARED
     c++/reapi.hpp
     c++/reapi_cli.hpp
     c++/reapi_cli_impl.hpp
     c/reapi_cli.cpp
     c/reapi_cli.h
     )
-target_link_libraries(reapi_cli PRIVATE
+target_link_libraries( reapi_cli PRIVATE
+    resource
+    jobspec_conv
     flux::core
     )
-add_library ( reapi_module STATIC
+install(TARGETS reapi_cli LIBRARY DESTINATION "${FLUX_LIB_DIR}")
+
+add_library (reapi_module STATIC
     c++/reapi.hpp
     c++/reapi_module.hpp
     c++/reapi_module_impl.hpp
     c/reapi_module.cpp
     c/reapi_module.h
     )
-target_link_libraries(reapi_module PRIVATE
+target_link_libraries( reapi_module PRIVATE
     flux::core
     )
 

--- a/resource/reapi/bindings/go/src/test/CMakeLists.txt
+++ b/resource/reapi/bindings/go/src/test/CMakeLists.txt
@@ -3,15 +3,24 @@ set(SRCS main.go)
 set(CGO_CFLAGS "-I${CMAKE_BINARY_DIR}/resource/reapi/bindings/c")
 
 # This is currently passed but not used because when passed into add_custom_command the spaces are escaped
-set(CGO_LIBRARY_FLAGS "-Wl,-R ${CMAKE_BINARY_DIR}/resource -L${CMAKE_BINARY_DIR}/resource/reapi/bindings -L${CMAKE_BINARY_DIR}/resource/libjobspec -ljobspec_conv -lreapi_cli -L${CMAKE_BINARY_DIR}/resource -lresource -L${CMAKE_BINARY_DIR}/resource/planner/c -lplanner -L${CMAKE_BINARY_DIR}/resource/planner/c++ -lplanner_cxx -lflux-idset -lstdc++ -lczmq -ljansson -lhwloc -lboost_system -lflux-hostlist -lboost_graph -lyaml-cpp")
+set(CGO_LIBRARY_FLAGS -Wl,-R
+    -lflux-idset
+    -lstdc++
+    -lczmq
+    -ljansson
+    -lhwloc
+    -lboost_system
+    -lflux-hostlist
+    -lboost_graph
+    -lyaml-cpp
+    -L${CMAKE_BINARY_DIR}/resource/reapi/bindings -lreapi_cli
+    )
 
 # This ensures the main binary is cleaned up
 set_directory_properties(
     PROPERTIES
-      ADDITIONAL_CLEAN_FILES "${CMAKE_CURRENT_BINARY_DIR}/main"
+    ADDITIONAL_CLEAN_FILES "${CMAKE_CURRENT_BINARY_DIR}/main"
   )
 
-# GO_GET(go_redis github.com/hoisie/redis)
-#                          main      main.go  
 # We add the dependencies at the end so the build can run in parallel and we don't try to build this before they are ready!
-BUILD_GO_PROGRAM(${TARGET} ${SRCS} "${CGO_CFLAGS}" "${CGO_LIBRARY_FLAGS}" jobspec_conv reapi_module reapi_cli resource flux::core)
+BUILD_GO_PROGRAM(${TARGET} ${SRCS} "${CGO_CFLAGS}" "${CGO_LIBRARY_FLAGS}" reapi_cli)

--- a/t/t9001-golang-basic.t
+++ b/t/t9001-golang-basic.t
@@ -14,6 +14,8 @@ if ! which go >/dev/null; then
     test_done
 fi
 
+export LD_LIBRARY_PATH=../../resource/reapi/bindings
+
 exp_dir="${SHARNESS_TEST_SRCDIR}/data/resource/expected/golang"
 jgf="${SHARNESS_TEST_SRCDIR}/data/resource/jgfs/tiny.json"
 jobspec1="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/basics/test001.yaml"


### PR DESCRIPTION
PR #1094 Updated Fluxion to be build as a static library. Some projects like Fluence are clients of Fluxion and its REAPI and need to link Fluxion libraries as shared libraries to preserve license boundaries. This PR adds the capability to build the necessary shared libraries.