### PR TITLE
Resource pool status

### DIFF
--- a/src/python/fluxion/resourcegraph/V1.py
+++ b/src/python/fluxion/resourcegraph/V1.py
@@ -35,6 +35,7 @@ class FluxionResourcePoolV1(Node):
         size,
         properties,
         path,
+        status=0,
     ):
         """Constructor
 
@@ -51,26 +52,26 @@ class FluxionResourcePoolV1(Node):
         size -- Amount of individual resources in this resource pool in unit
         properties -- Comma-separated list of property strings
         paths -- Fully qualified paths dictionary
+        status -- Resource status (0 for 'up', 1 for 'down'), defaults to 0
         """
         if not self.constraints(resType):
             raise ValueError(f"resource type={resType} unsupported by RV1")
-
-        super(FluxionResourcePoolV1, self).__init__(
-            vtxId,
-            metadata={
-                "type": resType,
-                "basename": basename,
-                "name": name,
-                "id": iden,
-                "uniq_id": uniqId,
-                "rank": rank,
-                "exclusive": exclusive,
-                "unit": unit,
-                "size": size,
-                "properties": properties,
-                "paths": {"containment": path},
-            },
-        )
+        metadata = {
+            "type": resType,
+            "basename": basename,
+            "name": name,
+            "id": iden,
+            "uniq_id": uniqId,
+            "rank": rank,
+            "exclusive": exclusive,
+            "unit": unit,
+            "size": size,
+            "properties": properties,
+            "paths": {"containment": path},
+        }
+        if status != 0:  # reduce the footprint by only adding status if nonzero
+            metadata["status"] = status
+        super(FluxionResourcePoolV1, self).__init__(vtxId, metadata=metadata)
 
     @staticmethod
     def constraints(resType):

--- a/src/python/fluxion/resourcegraph/V1.py
+++ b/src/python/fluxion/resourcegraph/V1.py
@@ -71,7 +71,7 @@ class FluxionResourcePoolV1(Node):
         }
         if status != 0:  # reduce the footprint by only adding status if nonzero
             metadata["status"] = status
-        super(FluxionResourcePoolV1, self).__init__(vtxId, metadata=metadata)
+        super().__init__(vtxId, metadata=metadata)
 
     @staticmethod
     def constraints(resType):
@@ -88,7 +88,7 @@ class FluxionResourceRelationshipV1(Edge):
         parentId -- Parent vertex Id
         vtxId -- Child vertex Id
         """
-        super(FluxionResourceRelationshipV1, self).__init__(
+        super().__init__(
             parentId,
             vtxId,
             directed=True,
@@ -106,7 +106,7 @@ class FluxionResourceGraphV1(Graph):
         rv1 -- RV1 Dictorary that conforms to Flux RFC 20:
                    Resource Set Specification Version 1
         """
-        super(FluxionResourceGraphV1, self).__init__()
+        super().__init__()
         self._uniqId = 0
         self._rv1NoSched = rv1
         self._encode()

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -85,6 +85,7 @@ set(ALL_TESTS
   t6002-graph-hwloc.t
   t8001-util-ion-R.t
   t9001-golang-basic.t
+  python/t10001-resourcegraph.py
   )
 foreach(test ${ALL_TESTS})
   flux_add_test(NAME ${test}

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -102,7 +102,8 @@ TESTS = \
     t6001-match-formats.t \
     t6002-graph-hwloc.t \
     t8001-util-ion-R.t \
-    t9001-golang-basic.t
+    t9001-golang-basic.t \
+    python/t10001-resourcegraph.py
 
 check_SCRIPTS = $(TESTS)
 

--- a/t/python/pycotap/__init__.py
+++ b/t/python/pycotap/__init__.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+# Copyright (c) 2015 Remko Tronçon (https://el-tramo.be)
+# Released under the MIT license
+# See COPYING for details
+
+
+import base64
+import sys
+import unittest
+
+if sys.hexversion >= 0x03000000:
+    from io import StringIO
+else:
+    from StringIO import StringIO
+
+# Log modes
+class LogMode(object):
+    LogToError, LogToDiagnostics, LogToYAML, LogToAttachment = range(4)
+
+
+class TAPTestResult(unittest.TestResult):
+    def __init__(self, output_stream, error_stream, message_log, test_output_log):
+        super(TAPTestResult, self).__init__(self, output_stream)
+        self.output_stream = output_stream
+        self.error_stream = error_stream
+        self.orig_stdout = None
+        self.orig_stderr = None
+        self.message = error_stream
+        self.test_output = None
+        self.message_log = message_log
+        self.test_output_log = test_output_log
+        self.output_stream.write("TAP version 13\n")
+
+    def print_raw(self, text):
+        self.output_stream.write(text)
+        self.output_stream.flush()
+
+    def print_result(self, result, test, directive=None):
+        self.output_stream.write("%s %d %s" % (result, self.testsRun, test.id()))
+        if directive:
+            self.output_stream.write(" # " + directive)
+        self.output_stream.write("\n")
+        self.output_stream.flush()
+
+    def ok(self, test, directive=None):
+        self.print_result("ok", test, directive)
+
+    def not_ok(self, test):
+        self.print_result("not ok", test)
+
+    def startTest(self, test):
+        self.orig_stdout = sys.stdout
+        self.orig_stderr = sys.stderr
+        if self.message_log == LogMode.LogToError:
+            self.message = self.error_stream
+        else:
+            self.message = StringIO()
+        if self.test_output_log == LogMode.LogToError:
+            self.test_output = self.error_stream
+        else:
+            self.test_output = StringIO()
+
+        if self.message_log == self.test_output_log:
+            self.test_output = self.message
+
+        sys.stdout = sys.stderr = self.test_output
+        super(TAPTestResult, self).startTest(test)
+
+    def stopTest(self, test):
+        super(TAPTestResult, self).stopTest(test)
+        sys.stdout = self.orig_stdout
+        sys.stderr = self.orig_stderr
+        if self.message_log == self.test_output_log:
+            logs = [(self.message_log, self.message, "output")]
+        else:
+            logs = [
+                (self.test_output_log, self.test_output, "test_output"),
+                (self.message_log, self.message, "message"),
+            ]
+        for log_mode, log, log_name in logs:
+            if log_mode != LogMode.LogToError:
+                output = log.getvalue()
+                if len(output):
+                    if log_mode == LogMode.LogToYAML:
+                        self.print_raw("  ---\n")
+                        self.print_raw("    " + log_name + ": |\n")
+                        self.print_raw(
+                            "      " + output.rstrip().replace("\n", "\n      ") + "\n"
+                        )
+                        self.print_raw("  ...\n")
+                    elif log_mode == LogMode.LogToAttachment:
+                        self.print_raw("  ---\n")
+                        self.print_raw("    " + log_name + ":\n")
+                        self.print_raw("      File-Name: " + log_name + ".txt\n")
+                        self.print_raw("      File-Type: text/plain\n")
+                        self.print_raw(
+                            "      File-Content: " + base64.b64encode(output) + "\n"
+                        )
+                        self.print_raw("  ...\n")
+                    else:
+                        self.print_raw(
+                            "# " + output.rstrip().replace("\n", "\n# ") + "\n"
+                        )
+
+    def addSuccess(self, test):
+        super(TAPTestResult, self).addSuccess(test)
+        self.ok(test)
+
+    def addError(self, test, err):
+        super(TAPTestResult, self).addError(test, err)
+        self.message.write(self.errors[-1][1] + "\n")
+        self.not_ok(test)
+
+    def addFailure(self, test, err):
+        super(TAPTestResult, self).addFailure(test, err)
+        self.message.write(self.failures[-1][1] + "\n")
+        self.not_ok(test)
+
+    def addSkip(self, test, reason):
+        super(TAPTestResult, self).addSkip(test, reason)
+        self.ok(test, "SKIP " + reason)
+
+    def addExpectedFailure(self, test, err):
+        super(TAPTestResult, self).addExpectedFailure(test, err)
+        self.message.write(self.expectedFailures[-1][1] + "\n")
+        self.ok(test)
+
+    def addUnexpectedSuccess(self, test):
+        super(TAPTestResult, self).addUnexpectedSuccess(self, test)
+        self.not_ok(test)
+
+    def printErrors(self):
+        self.print_raw("1..%d\n" % self.testsRun)
+
+
+class TAPTestRunner(unittest.TextTestRunner):
+    def __init__(
+        self,
+        message_log=LogMode.LogToYAML,
+        test_output_log=LogMode.LogToDiagnostics,
+        output_stream=sys.stdout,
+        error_stream=sys.stderr,
+    ):
+        self.output_stream = output_stream
+        self.error_stream = error_stream
+        self.message_log = message_log
+        self.test_output_log = test_output_log
+
+    def run(self, test):
+        result = TAPTestResult(
+            self.output_stream,
+            self.error_stream,
+            self.message_log,
+            self.test_output_log,
+        )
+        test(result)
+        result.printErrors()
+
+        return result

--- a/t/python/t10001-resourcegraph.py
+++ b/t/python/t10001-resourcegraph.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+
+import unittest
+import json
+import sys
+import pathlib
+
+from pycotap import TAPTestRunner
+
+# add fluxion to sys.path
+sys.path.insert(0, str(pathlib.Path(__file__).absolute().parents[2] / "src" / "python"))
+
+from fluxion.resourcegraph.V1 import (
+    FluxionResourceGraphV1,
+    FluxionResourcePoolV1,
+    FluxionResourceRelationshipV1,
+)
+
+RV1 = {
+    "version": 1,
+    "execution": {
+        "R_lite": [{"rank": "0", "children": {"core": "0-4"}}],
+        "starttime": 0.0,
+        "expiration": 0.0,
+        "nodelist": ["compute01"],
+    },
+}
+
+RV1_2 = {
+    "version": 1,
+    "execution": {
+        "R_lite": [{"rank": "0-10", "children": {"gpu": "0-1", "core": "0-7"}}],
+        "starttime": 0.0,
+        "expiration": 0.0,
+        "nodelist": ["compute[0-10]"],
+    },
+}
+
+
+class TestResourceGraph(unittest.TestCase):
+    """Test for the ResourceGraph class."""
+
+    def _check_metadata(self, metadata):
+        if metadata["type"] in ("node", "core", "gpu", "cluster"):
+            self.assertEqual(metadata["unit"], "")
+            self.assertEqual(metadata["size"], 1)
+            self.assertEqual(metadata["properties"], [])
+        else:
+            raise ValueError(metadata["type"])
+
+    def test_basic(self):
+        graph = FluxionResourceGraphV1(RV1)
+        self.assertTrue(graph.is_directed())
+        j = graph.to_JSON()
+        json.dumps(j)  # make sure it doesn't throw an error
+        self.assertTrue(j["graph"]["directed"])
+        self.assertEqual(len(j["graph"]["nodes"]), len(graph.get_nodes()))
+        self.assertEqual(len(j["graph"]["edges"]), len(graph.get_edges()))
+        for node in graph.get_nodes():
+            self._check_metadata(node.get_metadata())
+
+    def test_basic_2(self):
+        graph = FluxionResourceGraphV1(RV1_2)
+        self.assertTrue(graph.is_directed())
+        j = graph.to_JSON()
+        json.dumps(j)
+        self.assertTrue(j["graph"]["directed"])
+        self.assertEqual(len(j["graph"]["nodes"]), len(graph.get_nodes()))
+        self.assertEqual(len(j["graph"]["edges"]), len(graph.get_edges()))
+        for node in graph.get_nodes():
+            self._check_metadata(node.get_metadata())
+
+
+unittest.main(testRunner=TAPTestRunner())


### PR DESCRIPTION
Problem: the FluxionResourcePoolV1 does not support setting
vertex status. However, some resources, such as rabbits, should
be initialized as down, and are only known to Fluxion through
JGF produced by the FluxResourcePool class.

Add a 'status' parameter to the FluxionResourcePoolV1 constructor,
with a default of 'up' to maintain backwards compatibility.



It sounds like there's a chance we'll change the JGF reader's default to 'down' in which case we'd want to change the behavior of the ResourceGraph class as well, I think.