### PR TITLE
Fix `resource_pool_t` ctor and JGF reader

### DIFF
--- a/resource/readers/resource_reader_jgf.cpp
+++ b/resource/readers/resource_reader_jgf.cpp
@@ -139,6 +139,7 @@ void fetch_helper_t::scrub ()
     size = -1;
     uniq_id = -1;
     exclusive = -1;
+    status = resource_pool_t::status_t::UP;
     type = NULL;
     name = NULL;
     unit = NULL;

--- a/resource/schema/resource_data.cpp
+++ b/resource/schema/resource_data.cpp
@@ -41,6 +41,7 @@ resource_pool_t::resource_pool_t (const resource_pool_t &o)
     id = o.id;
     uniq_id = o.uniq_id;
     rank = o.rank;
+    status = o.status;
     size = o.size;
     unit = o.unit;
     schedule = o.schedule;
@@ -57,6 +58,7 @@ resource_pool_t &resource_pool_t::operator= (const resource_pool_t &o)
     id = o.id;
     uniq_id = o.uniq_id;
     rank = o.rank;
+    status = o.status;
     size = o.size;
     unit = o.unit;
     schedule = o.schedule;

--- a/t/t3025-resource-find.t
+++ b/t/t3025-resource-find.t
@@ -11,6 +11,7 @@ full_job="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/find/full.yaml"
 cmd_dir="${SHARNESS_TEST_SRCDIR}/data/resource/commands/find"
 exp_dir="${SHARNESS_TEST_SRCDIR}/data/resource/expected/find"
 grugs="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/tiny.graphml"
+jgf="${SHARNESS_TEST_SRCDIR}/data/resource/jgfs/tiny.json"
 query="../../resource/utilities/resource-query"
 
 skip_all_unless_have jq
@@ -307,6 +308,22 @@ EOF
     grep -v INFO down20.out > down20.filt.out &&
     core=$(cat down20.filt.out | jq " .[].children.core ") &&
     test ${core} = "\"0\""
+'
+
+test_expect_success 'setting vertex down in JGF same as set-status' '
+    cat > cmds021 <<-EOF &&
+	set-status /tiny0/rack0/node0/socket0/core0 down
+	find status=down
+	quit
+EOF
+    cat > cmds022 <<-EOF &&
+	find status=down
+	quit
+EOF
+    ${query} -L ${jgf} -f jgf -S CA -P high -t down21.out < cmds021 &&
+    sed "/\"uniq_id\": 8,/a \ \ \ \ \ \ \ \ \ \ \"status\": 1," ${jgf} > down21.json &&
+    ${query} -L ./down21.json -f jgf -S CA -P high -t down22.out < cmds022 &&
+    test_cmp down21.out down22.out
 '
 
 test_done


### PR DESCRIPTION
Problem: issue #1121 reported unexpected vertex status behavior when initializing resource graphs from JGF and rv1exec. The `resource_pool_t` ctor is missing the `status` member, which causes the default value of UP to be assigned when the ctor is called upon graph resizing during graph initialization.

Add the `status` member to the ctor to address the problem. 

Edit: the PR doesn't completely address `rv1exec` as that behavior is also due to the default `status` value being `UP`.

The JGF reader doesn't currently scrub the fetcher's `status` member. The missing reset causes vertices that are fetched after one that specifies a `status` in the JGF will inherit that vertex's status.

Add the capability to reset the fetcher `status`.