### PR TITLE
Fix overflow in `calc_factor`

### DIFF
--- a/resource/policies/dfu_match_multilevel_id_impl.hpp
+++ b/resource/policies/dfu_match_multilevel_id_impl.hpp
@@ -55,7 +55,7 @@ int64_t multilevel_id_t<FOLD>::score_factor_t::calc_factor (
         return -1;
     }
     mul = add * m_multiply_by;
-    tie =  break_tie % m_multiply_by - 1;
+    tie = abs (break_tie % static_cast<int64_t> (m_multiply_by) - 1);
 
     if (mul > (std::numeric_limits<int64_t>::max () - tie)) {
         errno = EOVERFLOW;

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -80,6 +80,7 @@ set(ALL_TESTS
   t4011-match-duration.t
   t4012-set-status.t
   t5000-valgrind.t
+  t5100-issues-test-driver.t
   t6000-graph-size.t
   t6001-match-formats.t
   t6002-graph-hwloc.t

--- a/t/issues/t1035-fluxion-reload.sh
+++ b/t/issues/t1035-fluxion-reload.sh
@@ -16,8 +16,7 @@ fi
 test $(flux resource list -no {nnodes}) -eq 4 || die "test requires 4 nodes"
 
 log "Unloading modules..."
-flux module remove sched-fluxion-qmanager
-flux module remove sched-fluxion-resource
+flux module remove sched-simple
 flux module remove resource
 
 log "Amending instance resource set with properties: batch, debug..."

--- a/t/issues/t1129-match-overflow.sh
+++ b/t/issues/t1129-match-overflow.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+#  Ensure fluxion calc_factor executes without overflow
+#
+
+log() { printf "issue#1129: $@\n" >&2; }
+
+TEST_SIZE=${TEST_SIZE:-900}
+
+log "Unloading modules..."
+flux module remove sched-simple
+flux module remove resource
+
+flux config load <<EOF
+[sched-fluxion-qmanager]
+queue-policy = "easy"
+
+[resource]
+noverify = true
+norestrict = true
+
+[[resource.config]]
+hosts = "test[1-${TEST_SIZE}]"
+cores = "0-112"
+gpus = "0-8"
+EOF
+
+flux module load resource monitor-force-up
+flux module load sched-fluxion-resource
+flux module load sched-fluxion-qmanager
+flux queue start --all --quiet
+flux resource list
+flux resource status
+
+log "Running test job."
+flux run -vvv -N${TEST_SIZE} -n${TEST_SIZE} \
+	--setattr=exec.test.run_duration=1ms \
+	true
+
+log "reloading sched-simple..."
+flux module remove sched-fluxion-qmanager
+flux module remove sched-fluxion-resource
+flux module load sched-simple


### PR DESCRIPTION
In issue #1129 @grondo reported `EOVERFLOW` errors for match requests for thousands of CPUs and GPUs. 

Currently, `calc_factor` computes the tie breaking factor with modular arithmetic. The computation returns -1 when `break_tie` is divisible by `m_multiply_by` (or in other circumstances in modular arithmetic).

The negative value of `tie` causes `std::numeric_limits<int64_t>::max () - tie` to overflow in the following integer check, generating a spurious `EOVERFLOW` errno: https://github.com/flux-framework/flux-sched/blob/3d953e34c8da698276c1ad8e17c14173c36580c5/resource/policies/dfu_match_multilevel_id_impl.hpp#L60

This PR fixes the computation to ensure `tie` is strictly positive by using `abs()`.