### PR TITLE
debbuild: fix Python purelib paths on Debian systems

### DIFF
--- a/scripts/debbuild.sh
+++ b/scripts/debbuild.sh
@@ -5,6 +5,19 @@ DEBFULLNAME=$USER
 EMAIL=$(git config --get user.email)
 DEBEMAIL=$EMAIL
 
+# On Debian based systems, the system Python is installed using a
+# 'posix_local' scheme, which causes sysconfig to return /usr/local
+# paths even if prefix=/usr. We want to ensure that Fluxion Python
+# modules are installed to the same base as flux-core, so set the
+# the environment variable DEB_PYTHON_INSTALL_LAYOUT=deb as described
+# at https://gitlab.kitware.com/cmake/cmake/-/issues/25113.
+#
+# There is probably a more correct way to do this, but since these
+# packages are currently just meant for testing, we do it this way
+# for now:
+DEB_PYTHON_INSTALL_LAYOUT=deb
+
+
 SRCDIR=${1:-$(pwd)}
 
 die() { echo "debbuild: $@" >&2; exit 1; }
@@ -32,7 +45,7 @@ log "Creating debian directory and files"
 cd ${PACKAGE}-${version}
 cp -a ${SRCDIR}/debian . || die "failed to copy debian dir"
 
-export DEBEMAIL DEBFULLNAME
+export DEBEMAIL DEBFULLNAME DEB_PYTHON_INSTALL_LAYOUT
 log "Creating debian/changelog"
 dch --create --package=$PACKAGE --newversion $version build tree release
 


### PR DESCRIPTION
Problem: Debian based systems may use the 'posix_local' scheme for Python installations, which causes `make deb` to break because the 'purelib' path is returned under /usr/local even when the flux-core prefix is /usr.

Use the workaround described in

 https://gitlab.kitware.com/cmake/cmake/-/issues/25113

and set DEB_PYTHON_INSTALL_LAYOUT=deb to fix `make deb`.

There is probably some standard way to actually fix this issue, but since the deb builds are purely for testing at this time, this solution works for now.