### PR TITLE
configure: drop src/shell requirements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -193,7 +193,6 @@ AC_CONFIG_FILES([Makefile
   src/cmd/Makefile
   src/python/Makefile
   src/python/fluxion/Makefile
-  src/shell/Makefile
   resource/Makefile
   resource/planner/Makefile
   resource/planner/c/Makefile


### PR DESCRIPTION
Problem: autotools borks because it goes looking for a Makefile for the fluxion shell, but support for that was dropped in #1102.

Drop it from the configure script as well.