### PR TITLE
Improve sched.resource-status RPC and search performance

### DIFF
--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -1421,9 +1421,12 @@ static std::shared_ptr<f_resource_graph_t> create_filtered_graph (
         edg_infra_map_t emap = get (&resource_relation_t::idata, g);
 
         // Set vertex and edge filters based on subsystems to use
+        int subsys_size = ctx->db->metadata.roots.size ();
         const multi_subsystemsS &filter = ctx->matcher->subsystemsS ();
-        subsystem_selector_t<vtx_t, f_vtx_infra_map_t> vtxsel (vmap, filter);
-        subsystem_selector_t<edg_t, f_edg_infra_map_t> edgsel (emap, filter);
+        subsystem_selector_t<vtx_t, f_vtx_infra_map_t> vtxsel (vmap, filter,
+                                                               subsys_size);
+        subsystem_selector_t<edg_t, f_edg_infra_map_t> edgsel (emap, filter,
+                                                               subsys_size);
         fg = std::make_shared<f_resource_graph_t> (g, edgsel, vtxsel);
     } catch (std::bad_alloc &e) {
         errno = ENOMEM;

--- a/resource/modules/resource_match_opts.hpp
+++ b/resource/modules/resource_match_opts.hpp
@@ -35,6 +35,7 @@ public:
     const int get_reserve_vtx_vec () const;
     const std::string &get_prune_filters () const;
     const resource_prop_t &get_resource_prop () const;
+    const int get_update_interval () const;
 
     void set_load_file (const std::string &o);
     bool set_load_format (const std::string &o);
@@ -45,6 +46,7 @@ public:
     void set_reserve_vtx_vec (const int i);
     void set_prune_filters (const std::string &o);
     void add_to_prune_filters (const std::string &o);
+    void set_update_interval (const int i);
 
     bool is_load_file_set () const;
     bool is_load_format_set () const;
@@ -54,6 +56,7 @@ public:
     bool is_match_subsystems_set () const;
     bool is_reserve_vtx_vec_set () const;
     bool is_prune_filters_set () const;
+    bool is_update_interval_set () const;
 
     json_t *jsonify () const;
 
@@ -66,6 +69,7 @@ private:
     std::string m_match_subsystems = RESOURCE_OPTS_UNSET_STR;
     int m_reserve_vtx_vec = 0;
     std::string m_prune_filters = RESOURCE_OPTS_UNSET_STR;
+    int m_update_interval = 0;
 };
 
 
@@ -82,6 +86,7 @@ public:
         MATCH_SUBSYSTEMS          = 50, // subsystem
         RESERVE_VTX_VEC           = 60, // reserve-vtx-vec
         PRUNE_FILTERS             = 70, // prune-filter
+        UPDATE_INTERVAL           = 80, // update-interval
         UNKNOWN                   = 5000
     };
 
@@ -102,6 +107,7 @@ public:
     const int get_reserve_vtx_vec () const;
     const std::string &get_prune_filters () const;
     const resource_prop_t &get_resource_prop () const;
+    const int get_update_interval () const;
 
     void set_load_file (const std::string &o);
     bool set_load_format (const std::string &o);
@@ -111,6 +117,7 @@ public:
     void set_match_subsystems (const std::string &o);
     void set_reserve_vtx_vec (const int i);
     void set_prune_filters (const std::string &o);
+    void set_update_interval (const int i);
 
     bool is_load_file_set () const;
     bool is_load_format_set () const;
@@ -120,6 +127,7 @@ public:
     bool is_match_subsystems_set () const;
     bool is_reserve_vtx_vec_set () const;
     bool is_prune_filters_set () const;
+    bool is_update_interval_set () const;
 
     /*! Canonicalize the option set -- apply the general resource properties
      */

--- a/resource/reapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli_impl.hpp
@@ -310,12 +310,15 @@ std::shared_ptr<f_resource_graph_t> resource_query_t::create_filtered_graph ()
     std::shared_ptr<f_resource_graph_t> fg = nullptr;
 
     resource_graph_t &g = db->resource_graph;
+    int subsys_size = db->metadata.roots.size ();
     vtx_infra_map_t vmap = get (&resource_pool_t::idata, g);
     edg_infra_map_t emap = get (&resource_relation_t::idata, g);
     const multi_subsystemsS &filter = 
                         matcher->subsystemsS ();
-    subsystem_selector_t<vtx_t, f_vtx_infra_map_t> vtxsel (vmap, filter);
-    subsystem_selector_t<edg_t, f_edg_infra_map_t> edgsel (emap, filter);
+    subsystem_selector_t<vtx_t, f_vtx_infra_map_t> vtxsel (vmap, filter,
+                                                           subsys_size);
+    subsystem_selector_t<edg_t, f_edg_infra_map_t> edgsel (emap, filter,
+                                                           subsys_size);
 
     try {
         fg = std::make_shared<f_resource_graph_t> (g, edgsel, vtxsel);

--- a/resource/schema/resource_graph.hpp
+++ b/resource/schema/resource_graph.hpp
@@ -45,13 +45,19 @@ class subsystem_selector_t {
 public:
     subsystem_selector_t () {}
     ~subsystem_selector_t () {}
-    subsystem_selector_t (inframap &im, const multi_subsystemsS &sel)
+    subsystem_selector_t (inframap &im, const multi_subsystemsS &sel,
+                          int subsys_size)
     {
         // must be lightweight -- e.g., bundled property map.
         m_imap = im;
         m_selector = sel;
+        m_single_subsystem = (subsys_size == 1) ? true : false;
     }
     bool operator () (const graph_entity &ent) const {
+        // Short circuit for single subsystem. This will be a common case.
+        // TODO: make systems ints or enums for faster comparison and search.
+        if (m_single_subsystem)
+           return true;
         typedef typename boost::property_traits<inframap>::value_type infra_type;
         const infra_type &inf = get (m_imap, ent);
         const multi_subsystems_t &subsystems = inf.member_of;
@@ -72,6 +78,7 @@ public:
 private:
     multi_subsystemsS m_selector;
     inframap m_imap;
+    bool m_single_subsystem;
 };
 
 using vtx_infra_map_t = boost::property_map<resource_graph_t, pinfra_t>::type;

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -525,11 +525,14 @@ static std::shared_ptr<f_resource_graph_t> create_filtered_graph (
     std::shared_ptr<f_resource_graph_t> fg = nullptr;
 
     resource_graph_t &g = ctx->db->resource_graph;
+    int subsys_size = ctx->db->metadata.roots.size ();
     vtx_infra_map_t vmap = get (&resource_pool_t::idata, g);
     edg_infra_map_t emap = get (&resource_relation_t::idata, g);
     const multi_subsystemsS &filter = ctx->matcher->subsystemsS ();
-    subsystem_selector_t<vtx_t, f_vtx_infra_map_t> vtxsel (vmap, filter);
-    subsystem_selector_t<edg_t, f_edg_infra_map_t> edgsel (emap, filter);
+    subsystem_selector_t<vtx_t, f_vtx_infra_map_t> vtxsel (vmap, filter,
+                                                           subsys_size);
+    subsystem_selector_t<edg_t, f_edg_infra_map_t> edgsel (emap, filter,
+                                                           subsys_size);
 
     try {
         fg = std::make_shared<f_resource_graph_t> (g, edgsel, vtxsel);


### PR DESCRIPTION
As reported in issue #1137, the `sched.resource-status` RPC is so slow that Fluxion becomes unusable at large scale (16K simulated nodes).

This PR improves performance by implementing caching of `R all`, `R down`, and `R alloc` payloads. It also improves traversal performance for single-subsystem resource graphs by short-circuiting subsystem selector and edge comparisons.

Note that the search performance improvement applies to `find` searches as well as other traversals like `match allocate`.