### PR TITLE
testsuite: remove trailing ampersands in tests

### DIFF
--- a/t/t4005-match-unsat.t
+++ b/t/t4005-match-unsat.t
@@ -21,7 +21,7 @@ test_under_flux 1
 test_debug '
     echo ${grug} &&
     echo ${jobspec1} &&
-    echo ${jobspec2} &&
+    echo ${jobspec2}
 '
 
 test_expect_success 'loading resource module with a tiny machine config works' '

--- a/t/t4008-match-jgf.t
+++ b/t/t4008-match-jgf.t
@@ -22,7 +22,7 @@ test_under_flux 1
 # print only with --debug
 #
 test_debug '
-    echo ${jgf_4core} &&
+    echo ${jgf_4core}
 '
 
 # Test using the full resource matching service


### PR DESCRIPTION
Problem: there are two tests that have trailing `&&` in the test_debug calls, and when these tests are run with the --debug flag in GitLab CI, they error out.

Remove those trailing ampersands.