### PR TITLE
testsuite: prepare for flux_job_wait(3) change

### DIFF
--- a/t/t1023-multiqueue-constraints.t
+++ b/t/t1023-multiqueue-constraints.t
@@ -95,6 +95,9 @@ test_expect_success 'a job with multiple constraints works in both queues' '
 test_expect_success 'stop queues' '
 	flux queue stop --all
 '
+test_expect_success 'consume wait status so far' '
+	test_might_fail flux job wait --all
+'
 test_expect_success 'submit a held job to the first queue' '
 	flux submit --flags=waitable \
 	    --queue=debug --urgency=hold /bin/true >job3.out


### PR DESCRIPTION
Problem: some tests presume that only jobs submitted with the 'waitable' flag will contribute to the return value of flux job wait --all, but flux-framework/flux-core#8357 proposes to make all jobs waitable, regardless of the flag.

Ensure that t1023-multiqueue-constraints.t consumes residual wait state before starting the array of waitable jobs.