### PR TITLE
reader: fix jgf properties

### DIFF
--- a/resource/readers/resource_reader_jgf.cpp
+++ b/resource/readers/resource_reader_jgf.cpp
@@ -401,6 +401,13 @@ int resource_reader_jgf_t::fill_fetcher (json_t *element, fetch_helper_t &f,
     }
     *properties = json_object_get (metadata, "properties");
     *paths = p;
+    if (*properties && !json_is_object (*properties)) {
+        errno = EINVAL;
+        m_err_msg += __FUNCTION__;
+        m_err_msg += ": key (properties) must be an object or null for ";
+        m_err_msg += std::string (f.vertex_id) + ".\n";
+        goto done;
+    }
     rc = 0;
 done:
     return rc;

--- a/t/python/t10001-resourcegraph.py
+++ b/t/python/t10001-resourcegraph.py
@@ -45,6 +45,17 @@ RV1_2 = {
     },
 }
 
+RV1_3 = {
+    "version": 1,
+    "execution": {
+        "R_lite": [{"rank": "0-19", "children": {"gpu": "0-1", "core": "0-7"}}],
+        "starttime": 0.0,
+        "expiration": 0.0,
+        "nodelist": ["compute[0-19]"],
+        "properties": {"pdebug": "0-9", "pbatch": "10-19"},
+    },
+}
+
 
 class TestResourceGraph(unittest.TestCase):
     """Test for the ResourceGraph class."""
@@ -53,7 +64,7 @@ class TestResourceGraph(unittest.TestCase):
         if metadata["type"] in ("node", "core", "gpu", "cluster"):
             self.assertEqual(metadata["unit"], "")
             self.assertEqual(metadata["size"], 1)
-            self.assertEqual(metadata["properties"], [])
+            self.assertEqual(metadata["properties"], {})
         else:
             raise ValueError(metadata["type"])
 
@@ -78,6 +89,26 @@ class TestResourceGraph(unittest.TestCase):
         self.assertEqual(len(j["graph"]["edges"]), len(graph.get_edges()))
         for node in graph.get_nodes():
             self._check_metadata(node.get_metadata())
+
+    def test_basic_3(self):
+        graph = FluxionResourceGraphV1(RV1_3)
+        self.assertTrue(graph.is_directed())
+        j = graph.to_JSON()
+        self.assertTrue(j["graph"]["directed"])
+        self.assertEqual(len(j["graph"]["nodes"]), len(graph.get_nodes()))
+        self.assertEqual(len(j["graph"]["edges"]), len(graph.get_edges()))
+        for node in graph.get_nodes():
+            metadata = node.get_metadata()
+            if metadata["type"] != "node":
+                self._check_metadata(node.get_metadata())
+            else:
+                self.assertEqual(metadata["unit"], "")
+                self.assertEqual(metadata["size"], 1)
+                self.assertEqual(len(metadata["properties"]), 1)
+                if metadata["id"] < 10:
+                    self.assertEqual(metadata["properties"]["pdebug"], "")
+                else:
+                    self.assertEqual(metadata["properties"]["pbatch"], "")
 
 
 unittest.main(testRunner=TAPTestRunner())

--- a/t/t8001-util-ion-R.t
+++ b/t/t8001-util-ion-R.t
@@ -159,24 +159,24 @@ test_expect_success 'fluxion-R: can detect insufficient nodelist' '
 
 test_expect_success 'fluxion-R: encoding properties on heterogeneity works' '
     cat <<-EOF >expected6 &&
-	/cluster0 -1 []
-	/cluster0/foo2 0 ["arm-v9@core"]
-	/cluster0/foo2/core0 0 []
-	/cluster0/foo2/core1 0 []
-	/cluster0/foo2/gpu0 0 []
-	/cluster0/foo2/gpu1 0 []
-	/cluster0/foo3 2 ["arm-v9@core","amd-mi60@gpu"]
-	/cluster0/foo3/core0 2 []
-	/cluster0/foo3/core1 2 []
-	/cluster0/foo3/gpu0 2 []
-	/cluster0/foo3/gpu1 2 []
-	/cluster0/foo1 3 ["arm-v9@core","amd-mi60@gpu"]
-	/cluster0/foo1/core0 3 []
-	/cluster0/foo1/core1 3 []
-	/cluster0/foo1/gpu0 3 []
-	/cluster0/foo1/gpu1 3 []
-	/cluster0/foo4 1 ["arm-v8@core"]
-	/cluster0/foo4/core0 1 []
+	/cluster0 -1 {}
+	/cluster0/foo2 0 {"arm-v9@core":""}
+	/cluster0/foo2/core0 0 {}
+	/cluster0/foo2/core1 0 {}
+	/cluster0/foo2/gpu0 0 {}
+	/cluster0/foo2/gpu1 0 {}
+	/cluster0/foo3 2 {"arm-v9@core":"","amd-mi60@gpu":""}
+	/cluster0/foo3/core0 2 {}
+	/cluster0/foo3/core1 2 {}
+	/cluster0/foo3/gpu0 2 {}
+	/cluster0/foo3/gpu1 2 {}
+	/cluster0/foo1 3 {"arm-v9@core":"","amd-mi60@gpu":""}
+	/cluster0/foo1/core0 3 {}
+	/cluster0/foo1/core1 3 {}
+	/cluster0/foo1/gpu0 3 {}
+	/cluster0/foo1/gpu1 3 {}
+	/cluster0/foo4 1 {"arm-v8@core":""}
+	/cluster0/foo4/core0 1 {}
 	EOF
     flux R encode -r 0 -c 0-1 -g 0-1 -p "arm-v9@core:0" -H foo2 > out6 &&
     flux R encode -r 1 -c 0 -H foo3 -p "arm-v8@core:1" >> out6 &&


### PR DESCRIPTION
Given this vertex in JGF, resource-query reports it has no properties.

```json
      {
        "id": "35",
        "metadata": {
          "type": "node",
          "basename": "node",
          "name": "compute-01",
          "id": 1,
          "uniq_id": 35,
          "rank": 0,
          "exclusive": true,
          "unit": "",
          "size": 1,
          "properties": ["pdebug"],
          "paths": {
            "containment": "/ElCapitan0/rack0/compute-01"
          }
        }
      }
```

```
resource-query> g /ElCapitan0/rack0/compute-01
No properties were found for /ElCapitan0/rack0/compute-01 (vtx's uniq_id=35).
```

Looking at the reader, I found that it expects properties to be given as a mapping with keys the name of the property. When I changed the vertex in JGF to the following, the property was recognized. It looks like the reader had been silently failing on the type.

```json

      {
        "id": "35",
        "metadata": {
          "type": "node",
          "basename": "node",
          "name": "compute-01",
          "id": 1,
          "uniq_id": 35,
          "rank": 0,
          "exclusive": true,
          "unit": "",
          "size": 1,
          "properties": {
            "pdebug": ""
          },
          "paths": {
            "containment": "/ElCapitan0/rack0/compute-01"
          }
        }
      },
```

```
resource-query> g /ElCapitan0/rack0/compute-01
pdebug=
```