### PR TITLE
Corrects typo 'becuase' into 'because'.

### DIFF
--- a/resource/traversers/dfu.hpp
+++ b/resource/traversers/dfu.hpp
@@ -107,7 +107,7 @@ public:
      *                                match callback uses.
      *                       EBUSY: cannot match because resources/devices
      *                              are currently in use.
-     *                       ENODEV: unsatifiable jobspec becuase no
+     *                       ENODEV: unsatifiable jobspec because no
      *                               resources/devices can satisfy the request.
      */
     int run (Jobspec::Jobspec &jobspec,


### PR DESCRIPTION
Corrects typo 'becuase' into 'because' in file resource/traversers/dfu.hpp. 

Closes #1154 
