### PR TITLE
[WIP] Add support for expiration update

### DIFF
--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -45,9 +45,12 @@ public:
     int fetch_and_reset_notify_rc ();
     int get_notify_rc () const;
     void set_notify_rc (int rc);
+    int fetch_and_reset_expiration_rc ();
+    void set_expiration_rc (int rc);
     flux_future_t *notify_f{nullptr};
 private:
     int m_notify_rc = 0;
+    int m_expiration_rc = 0;
 };
 
 struct qmanager_ctx_t : public qmanager_cb_ctx_t,
@@ -76,6 +79,18 @@ int fluxion_resource_interface_t::get_notify_rc () const
 void fluxion_resource_interface_t::set_notify_rc (int rc)
 {
     m_notify_rc = rc;
+}
+
+int fluxion_resource_interface_t::fetch_and_reset_expiration_rc ()
+{
+    int rc = m_expiration_rc;
+    m_expiration_rc = 0;
+    return rc;
+}
+
+void fluxion_resource_interface_t::set_expiration_rc (int rc)
+{
+    m_expiration_rc = rc;
 }
 
 static int process_args (std::shared_ptr<qmanager_ctx_t> &ctx,
@@ -229,6 +244,22 @@ out:
     return;
 }
 
+static void resource_expiration_cont (flux_future_t *f, void *arg)
+{
+    int rc = -1;
+    qmanager_ctx_t *ctx = static_cast<qmanager_ctx_t *> (arg);
+
+    if ( (rc = flux_rpc_get (f, NULL)) < 0) {
+        flux_log_error (ctx->h,
+            "%s: sched-fluxion-resource.expiration failure",
+            __FUNCTION__);
+    }
+
+    flux_future_reset (f);
+    ctx->set_expiration_rc (rc);
+    return;
+}
+
 static int handshake_resource (std::shared_ptr<qmanager_ctx_t> &ctx)
 {
     int rc = -1;
@@ -298,6 +329,53 @@ static void status_request_cb (flux_t *h, flux_msg_handler_t *w,
         goto out;
     }
     flux_log (h, LOG_DEBUG, "%s: resource-status succeeded", __FUNCTION__);
+    flux_future_destroy (f);
+    return;
+
+out:
+    flux_future_destroy (f);
+    if (flux_respond_error (h, msg, errno, nullptr) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+static void expiration_request_cb (flux_t *h, flux_msg_handler_t *w,
+                                   const flux_msg_t *msg, void *arg)
+{
+    int size = 0;
+    const char *data = nullptr;
+    void *d{nullptr};
+    std::shared_ptr<qmanager_ctx_t> ctx;
+    flux_future_t *f = NULL;
+
+    if (!(d = flux_aux_get (h, "sched-fluxion-qmanager")))
+        goto out;
+    ctx = *(static_cast<std::shared_ptr<qmanager_ctx_t> *>(d));
+
+    if (flux_request_decode_raw (msg, nullptr, (const void**)&data, &size) < 0)
+        goto out;
+    if ( !(f = flux_rpc_raw (h, "sched-fluxion-resource.expiration",
+                             data, size, FLUX_NODEID_ANY, 0))) {
+        flux_log_error (h, "%s: flux_rpc (sched-fluxion-resource.expiration)",
+                        __FUNCTION__);
+        goto out;
+    }
+
+    resource_expiration_cont (f, ctx.get ());
+    if ( (ctx->fetch_and_reset_expiration_rc ()) < 0) {
+        flux_log_error (h, "%s: resource_expiration_cont",
+                        __FUNCTION__);
+        goto out;
+    }
+    if ( (flux_future_then (f,
+                            -1.0,
+                            resource_expiration_cont,
+                            ctx.get ())) < 0) {
+        flux_log_error (h, "%s: flux_future_then", __FUNCTION__);
+        goto out;
+    }
+
+    flux_log (h, LOG_DEBUG, "%s: expiration update succeeded", __FUNCTION__);
+    flux_respond (h, msg, NULL);
     flux_future_destroy (f);
     return;
 
@@ -596,6 +674,8 @@ static void qmanager_destroy (std::shared_ptr<qmanager_ctx_t> &ctx)
 static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST,
       "sched.resource-status", status_request_cb, FLUX_ROLE_USER },
+    { FLUX_MSGTYPE_REQUEST,
+      "sched.expiration", expiration_request_cb, FLUX_ROLE_USER },
     { FLUX_MSGTYPE_REQUEST,
       "*.feasibility", feasibility_request_cb, FLUX_ROLE_USER },
     { FLUX_MSGTYPE_REQUEST,

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -267,6 +267,9 @@ static void params_request_cb (flux_t *h, flux_msg_handler_t *w,
 static void set_status_request_cb (flux_t *h, flux_msg_handler_t *w,
                                    const flux_msg_t *msg, void *arg);
 
+static void expiration_request_cb (flux_t *h, flux_msg_handler_t *w,
+                                   const flux_msg_t *msg, void *arg);
+
 static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST,
       "sched-fluxion-resource.match", match_request_cb, 0 },
@@ -302,6 +305,8 @@ static const struct flux_msg_handler_spec htab[] = {
       "sched-fluxion-resource.params", params_request_cb, 0 },
     { FLUX_MSGTYPE_REQUEST,
       "sched-fluxion-resource.set_status", set_status_request_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,
+      "sched-fluxion-resource.expiration", expiration_request_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END
 };
 
@@ -1895,6 +1900,20 @@ out:
     return rc;
 }
 
+static int run_expiration (std::shared_ptr<resource_ctx_t> &ctx, int64_t jobid,
+                           int64_t expiration)
+{
+    int rc = -1;
+    dfu_traverser_t &tr = *(ctx->traverser);
+
+    if ((rc = tr.modify (jobid, expiration)) < 0)
+        goto out;
+
+    rc = 0;
+out:
+    return rc;
+}
+
 static void match_request_cb (flux_t *h, flux_msg_handler_t *w,
                               const flux_msg_t *msg, void *arg)
 {
@@ -2713,6 +2732,41 @@ error:
     if (flux_respond_error (h, msg, EINVAL, errmsg.c_str ()) < 0)
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
     return;
+}
+
+static void expiration_request_cb (flux_t *h, flux_msg_handler_t *w,
+                                   const flux_msg_t *msg, void *arg)
+{
+    std::shared_ptr<resource_ctx_t> ctx = getctx ((flux_t *)arg);
+    int64_t jobid = -1;
+    int64_t expiration = -1;
+
+    if (flux_request_unpack (msg, NULL, "{s:I, s:I}",
+                                        "jobid", &jobid,
+                                        "expiration", &expiration) < 0)
+        goto error;
+    if (ctx->allocations.find (jobid) == ctx->allocations.end ()) {
+        errno = ENOENT;
+        flux_log (h, LOG_DEBUG, "%s: nonexistent job (id=%jd)",
+                  __FUNCTION__, (intmax_t)jobid);
+        goto error;
+    }
+
+    if (run_expiration (ctx, jobid, expiration) < 0) {
+        flux_log_error (h, "%s: expiration fails due to match error (id=%jd)",
+                        __FUNCTION__, (intmax_t)jobid);
+        goto error;
+    }
+    if (flux_respond (h, msg, NULL) < 0) {
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+        goto error;
+    }
+
+    return;
+
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }
 
 /******************************************************************************

--- a/resource/planner/c++/planner.cpp
+++ b/resource/planner/c++/planner.cpp
@@ -99,7 +99,6 @@ planner::planner (const planner &o)
     m_current_request = o.m_current_request;
     m_avail_time_iter_set = o.m_avail_time_iter_set;
     m_span_counter = o.m_span_counter;
-    m_start_to_span = o.m_start_to_span;
     // After above copy the SP tree now has the full state of the base point.
     m_p0 = m_sched_point_tree.get_state (m_plan_start);
 }
@@ -128,7 +127,6 @@ planner &planner::operator= (const planner &o)
     m_current_request = o.m_current_request;
     m_avail_time_iter_set = o.m_avail_time_iter_set;
     m_span_counter = o.m_span_counter;
-    m_start_to_span = o.m_start_to_span;
     // After above copy the SP tree now has the full state of the base point.
     m_p0 = m_sched_point_tree.get_state (m_plan_start);
 
@@ -148,8 +146,6 @@ bool planner::operator== (const planner &o) const
     if (m_avail_time_iter_set != o.m_avail_time_iter_set)
         return false;
     if (m_span_counter != o.m_span_counter)
-        return false;
-    if (m_start_to_span != o.m_start_to_span)
         return false;
     // m_p0 or o.m_p0 could be uninitialized
     if (m_p0 && o.m_p0) {
@@ -407,28 +403,6 @@ void planner::set_avail_time_iter_set (int atime_iter_set)
 const int planner::get_avail_time_iter_set () const
 {
     return m_avail_time_iter_set;
-}
-
-void planner::start_to_span_insert (int64_t start, int64_t span_id)
-{
-    m_start_to_span.insert ({start, span_id});
-}
-
-void planner::start_to_span_remove (int64_t start, int64_t span_id)
-{
-    auto iter_range = m_start_to_span.equal_range (start);
-    auto it = iter_range.first;
-    for (; it != iter_range.second; ++it) {
-        if (it->second == span_id) {
-            m_start_to_span.erase (it);
-            break;
-        }
-    }
-}
-
-std::multimap<int64_t, int64_t> &planner::get_start_to_span ()
-{
-    return m_start_to_span;
 }
 
 request_t &planner::get_current_request ()

--- a/resource/planner/c++/planner.cpp
+++ b/resource/planner/c++/planner.cpp
@@ -99,6 +99,7 @@ planner::planner (const planner &o)
     m_current_request = o.m_current_request;
     m_avail_time_iter_set = o.m_avail_time_iter_set;
     m_span_counter = o.m_span_counter;
+    m_start_to_span = o.m_start_to_span;
     // After above copy the SP tree now has the full state of the base point.
     m_p0 = m_sched_point_tree.get_state (m_plan_start);
 }
@@ -127,6 +128,7 @@ planner &planner::operator= (const planner &o)
     m_current_request = o.m_current_request;
     m_avail_time_iter_set = o.m_avail_time_iter_set;
     m_span_counter = o.m_span_counter;
+    m_start_to_span = o.m_start_to_span;
     // After above copy the SP tree now has the full state of the base point.
     m_p0 = m_sched_point_tree.get_state (m_plan_start);
 
@@ -146,6 +148,8 @@ bool planner::operator== (const planner &o) const
     if (m_avail_time_iter_set != o.m_avail_time_iter_set)
         return false;
     if (m_span_counter != o.m_span_counter)
+        return false;
+    if (m_start_to_span != o.m_start_to_span)
         return false;
     // m_p0 or o.m_p0 could be uninitialized
     if (m_p0 && o.m_p0) {
@@ -250,6 +254,16 @@ int planner::update_total (uint64_t resource_total)
             point->remaining = 0;
         point = m_sched_point_tree.next (point);
     }
+    return 0;
+}
+
+int planner::update_span (int64_t span_id, int64_t duration)
+{
+    auto span_it = m_span_lookup.find (span_id);
+    if (span_it == m_span_lookup.end ())
+        return -1;
+    span_it->second->last += duration;
+
     return 0;
 }
 
@@ -393,6 +407,28 @@ void planner::set_avail_time_iter_set (int atime_iter_set)
 const int planner::get_avail_time_iter_set () const
 {
     return m_avail_time_iter_set;
+}
+
+void planner::start_to_span_insert (int64_t start, int64_t span_id)
+{
+    m_start_to_span.insert ({start, span_id});
+}
+
+void planner::start_to_span_remove (int64_t start, int64_t span_id)
+{
+    auto iter_range = m_start_to_span.equal_range (start);
+    auto it = iter_range.first;
+    for (; it != iter_range.second; ++it) {
+        if (it->second == span_id) {
+            m_start_to_span.erase (it);
+            break;
+        }
+    }
+}
+
+const std::multimap<int64_t, int64_t> &planner::get_start_to_span () const
+{
+    return m_start_to_span;
 }
 
 request_t &planner::get_current_request ()

--- a/resource/planner/c++/planner.cpp
+++ b/resource/planner/c++/planner.cpp
@@ -426,7 +426,7 @@ void planner::start_to_span_remove (int64_t start, int64_t span_id)
     }
 }
 
-const std::multimap<int64_t, int64_t> &planner::get_start_to_span () const
+std::multimap<int64_t, int64_t> &planner::get_start_to_span ()
 {
     return m_start_to_span;
 }

--- a/resource/planner/c++/planner.hpp
+++ b/resource/planner/c++/planner.hpp
@@ -93,7 +93,7 @@ public:
 
     void start_to_span_insert (int64_t start, int64_t span_id);
     void start_to_span_remove (int64_t start, int64_t span_id);
-    const std::multimap<int64_t, int64_t> &get_start_to_span () const;
+    std::multimap<int64_t, int64_t> &get_start_to_span ();
 
     // Request functions
     request_t &get_current_request ();

--- a/resource/planner/c++/planner.hpp
+++ b/resource/planner/c++/planner.hpp
@@ -52,6 +52,7 @@ public:
     int reinitialize (int64_t base_time, uint64_t duration);
     int restore_track_points ();
     int update_total (uint64_t resource_total);
+    int update_span (int64_t span_id, int64_t duration);
     
     // Resources and duration
     int64_t get_total_resources () const;
@@ -89,6 +90,11 @@ public:
     void clear_avail_time_iter ();
     void set_avail_time_iter_set (int atime_iter_set);
     const int get_avail_time_iter_set () const;
+
+    void start_to_span_insert (int64_t start, int64_t span_id);
+    void start_to_span_remove (int64_t start, int64_t span_id);
+    const std::multimap<int64_t, int64_t> &get_start_to_span () const;
+
     // Request functions
     request_t &get_current_request ();
     const request_t &get_current_request_const () const;
@@ -107,6 +113,7 @@ private:
     std::map<int64_t, std::shared_ptr<span_t> > m_span_lookup; /* span lookup */
     std::map<int64_t, std::shared_ptr<span_t> >::iterator m_span_lookup_iter;
     std::map<int64_t, scheduled_point_t *> m_avail_time_iter; /* MT node track */
+    std::multimap<int64_t, int64_t> m_start_to_span;
     int m_avail_time_iter_set = 0;  /* iterator set flag */
     request_t m_current_request;   /* the req copy for avail time iteration */
     uint64_t m_span_counter = 0;   /* current span counter */

--- a/resource/planner/c++/planner.hpp
+++ b/resource/planner/c++/planner.hpp
@@ -91,10 +91,6 @@ public:
     void set_avail_time_iter_set (int atime_iter_set);
     const int get_avail_time_iter_set () const;
 
-    void start_to_span_insert (int64_t start, int64_t span_id);
-    void start_to_span_remove (int64_t start, int64_t span_id);
-    std::multimap<int64_t, int64_t> &get_start_to_span ();
-
     // Request functions
     request_t &get_current_request ();
     const request_t &get_current_request_const () const;
@@ -113,7 +109,6 @@ private:
     std::map<int64_t, std::shared_ptr<span_t> > m_span_lookup; /* span lookup */
     std::map<int64_t, std::shared_ptr<span_t> >::iterator m_span_lookup_iter;
     std::map<int64_t, scheduled_point_t *> m_avail_time_iter; /* MT node track */
-    std::multimap<int64_t, int64_t> m_start_to_span;
     int m_avail_time_iter_set = 0;  /* iterator set flag */
     request_t m_current_request;   /* the req copy for avail time iteration */
     uint64_t m_span_counter = 0;   /* current span counter */

--- a/resource/planner/c/planner.h
+++ b/resource/planner/c/planner.h
@@ -242,6 +242,9 @@ bool planners_equal (planner_t *lhs, planner_t *rhs);
 int planner_update_total (planner_t *ctx,
                           uint64_t resource_total);
 
+int planner_update_span (planner_t *ctx, int64_t span_id,
+                         int64_t expiration);
+
 #ifdef __cplusplus
 }
 #endif

--- a/resource/planner/c/planner_c_interface.cpp
+++ b/resource/planner/c/planner_c_interface.cpp
@@ -92,20 +92,6 @@ static void fetch_overlap_points (planner_t *ctx, int64_t at, uint64_t duration,
     }
 }
 
-static void fetch_overlap_points (planner_t *ctx, int64_t at, uint64_t duration,
-                                  std::queue<int64_t> &queue)
-{
-    scheduled_point_t *point = ctx->plan->sp_tree_get_state (at);
-    while (point) {
-        if (point->at >= static_cast<int64_t> (at + duration))
-            break;
-        // Use greater than to avoid adding same point
-        else if (point->at >= at)
-            queue.push (point->at);
-        point = ctx->plan->sp_tree_next (point);
-    }
-}
-
 static int update_points_add_span (planner_t *ctx,
                                    std::list<scheduled_point_t *> &list,
                                    std::shared_ptr<span_t> &span)
@@ -288,8 +274,6 @@ static std::shared_ptr<span_t> span_new (planner_t *ctx, int64_t start_time,
 
         // errno = EEXIST condition already checked above
         ctx->plan->span_lookup_insert (span->span_id, span);
-        // insert into tracking multimap for start time to span_ids
-        ctx->plan->start_to_span_insert (span->start, span->span_id);
     }
     catch (std::bad_alloc &e) {
         errno = ENOMEM;
@@ -297,31 +281,6 @@ static std::shared_ptr<span_t> span_new (planner_t *ctx, int64_t start_time,
 
 done:
     return span;
-}
-
-static int span_move (planner_t *ctx, std::shared_ptr<span_t> &span, int64_t delta)
-{
-    std::multimap<int64_t, int64_t> &start_to_span = ctx->plan->get_start_to_span ();
-    std::cout << "INOUT TREE\n";
-    if (span->start_p->in_mt_resource_tree) {
-        ctx->plan->mt_tree_remove (span->start_p);
-        span->start += delta;
-        span->start_p->at += delta;
-    }
-    std::cout << "INOUT TREE 1\n";
-    if (span->start_p->ref_count && !(span->start_p->in_mt_resource_tree))
-        ctx->plan->mt_tree_insert (span->start_p);
-    if (span->last_p->in_mt_resource_tree) {
-        ctx->plan->mt_tree_remove (span->last_p);
-        span->last += delta;
-        span->last_p->at += delta;
-    }
-    std::cout << "INOUT TREE 2\n";
-    if (span->last_p->ref_count && !(span->last_p->in_mt_resource_tree))
-        ctx->plan->mt_tree_insert (span->last_p);
-    std::cout << "INOUT TREE END\n";
-    start_to_span.insert ({span->start, span->span_id});
-    return 0;
 }
 
 
@@ -604,8 +563,6 @@ extern "C" int planner_rem_span (planner_t *ctx, int64_t span_id)
     fetch_overlap_points (ctx, span->start, duration, list);
     update_points_subtract_span (ctx, list, span);
     update_mintime_resource_tree (ctx, list);
-    // remove from m_start_to_span map
-    ctx->plan->start_to_span_remove (span->start, span->span_id);
     span->in_system = 0;
 
     if (span->start_p->ref_count == 0) {
@@ -653,9 +610,6 @@ extern "C" int planner_update_span (planner_t *ctx, int64_t span_id,
     }
     // update the span end time
     int64_t prev_last = span->last;
-    std::queue<int64_t> pt_queue;
-    fetch_overlap_points (ctx, prev_last, expiration, pt_queue);
-    std::cout << "Pre last: " << prev_last << "\n";
     span->last = expiration;
     // update the point
     span->last_p->at = expiration;
@@ -664,54 +618,6 @@ extern "C" int planner_update_span (planner_t *ctx, int64_t span_id,
         ctx->plan->mt_tree_remove (span->last_p);
     if (span->last_p->ref_count && !(span->last_p->in_mt_resource_tree))
         ctx->plan->mt_tree_insert (span->last_p);
-
-    // Exit function if reducing span
-    if (delta < 0)
-        return 0;
-    // If not, could cause interference with requests
-    // if (pt_queue.size () > 1) {
-    //     errno = EINVAL;
-    //     return -1;
-    // }
-    std::cout << "Queue length: " << pt_queue.size () << "\n";
-    int64_t tmp_pt = 0;
-    int64_t pt_duration = 0;
-    std::multimap<int64_t, int64_t> &start_to_span = ctx->plan->get_start_to_span ();
-    //std::cout << "Start_to_span size: " << start_to_span.size () << "\n";
-    for (auto i : start_to_span)
-        std::cout << "Start to span: " << i.first << " " << i.second << "\n";
-    while (!pt_queue.empty ()) {
-        tmp_pt = pt_queue.front ();
-        std::cout << "Front point at: " << tmp_pt << "\n";
-        auto equal_range = start_to_span.equal_range (tmp_pt);
-        // May want to return -1 if overlapping points
-        //std::cout << "Equal range: " << (equal_range.first == equal_range.second) << " " << equal_range.first->second << "\n";
-        //auto it = equal_range.first;
-        for (auto it2 = equal_range.first; it2 != equal_range.second; ) {
-            // it->first is span_id
-            std::cout << "IT data: " << it2->first << " ID: " << it2->second << "\n";
-            std::map<int64_t, std::shared_ptr<span_t>>::iterator span_it = ctx->plan->get_span_lookup ().find (it2->second);
-            std::cout << "span data: " << span_it->first << " ID: " << span_it->second->span_id << "\n";
-            if (span_it == ctx->plan->get_span_lookup ().end ()) {
-                errno = EINVAL;
-                return -1;
-            }
-            pt_duration = span_it->second->last - span_it->second->start;
-            if (!span_ok (ctx, span_it->second->start_p, pt_duration, span_it->second->planned)) {
-                std::cout << "Span not ok; span data: " << span_it->first << " ID: " << span_it->second->span_id << "\n";
-                prev_last = span_it->second->last;
-                it2 = start_to_span.erase (it2);
-                span_move (ctx, span_it->second, delta);
-                std::cout << "SPAN MOVE\n";
-                fetch_overlap_points (ctx, prev_last, span_it->second->last, pt_queue);
-                std::cout << "FETCH OVERLAP\n";
-            } else {
-                ++it2;
-            }
-        }
-        pt_queue.pop ();
-        std::cout << "Queue length after pop: " << pt_queue.size () << "\n";
-    }
 
     return 0;
 }

--- a/resource/planner/c/planner_multi.h
+++ b/resource/planner/c/planner_multi.h
@@ -278,6 +278,9 @@ int64_t planner_multi_add_span (planner_multi_t *ctx, int64_t start_time,
  */
 int planner_multi_rem_span (planner_multi_t *ctx, int64_t span_id);
 
+int planner_multi_update_span (planner_multi_t *ctx, int64_t span_id,
+                               int64_t expiration);
+
 //! Span iterators -- there is no specific iteration order
 //  return -1 when you no longer can iterate: EINVAL when ctx is NULL.
 //  ENOENT when you reached the end of the spans

--- a/resource/planner/c/planner_multi_c_interface.cpp
+++ b/resource/planner/c/planner_multi_c_interface.cpp
@@ -415,6 +415,32 @@ done:
     return rc;
 }
 
+extern "C" int planner_multi_update_span (planner_multi_t *ctx,
+                                          int64_t span_id,
+                                          int64_t expiration)
+{
+    size_t i;
+    int rc = -1;
+
+    if (!ctx || span_id < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    auto it = ctx->plan_multi->get_span_lookup ().find (span_id);
+    if (it == ctx->plan_multi->get_span_lookup ().end ()) {
+        errno = ENOENT;
+        goto done;
+    }
+    for (i = 0; i < it->second.size (); ++i) {
+        if (planner_update_span (ctx->plan_multi->get_planner_at (i),
+                                 it->second[i], expiration) == -1)
+            goto done;
+    }
+    rc  = 0;
+done:
+    return rc;
+}
+
 int64_t planner_multi_span_first (planner_multi_t *ctx)
 {
     int64_t rc = -1;

--- a/resource/traversers/dfu.cpp
+++ b/resource/traversers/dfu.cpp
@@ -380,6 +380,21 @@ int dfu_traverser_t::remove (int64_t jobid)
     return detail::dfu_impl_t::remove (root, jobid);
 }
 
+int dfu_traverser_t::modify (int64_t jobid, int64_t expiration)
+{
+    const subsystem_t &dom = get_match_cb ()->dom_subsystem ();
+    if (!get_graph () || !get_graph_db ()
+        || get_graph_db ()->metadata.roots.find (dom)
+           == get_graph_db ()->metadata.roots.end ()
+        || !get_match_cb ()) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    vtx_t root = get_graph_db ()->metadata.roots.at (dom);
+    return detail::dfu_impl_t::modify (root, jobid, expiration);
+}
+
 int dfu_traverser_t::mark (const std::string &root_path, 
                            resource_pool_t::status_t status)
 {

--- a/resource/traversers/dfu.hpp
+++ b/resource/traversers/dfu.hpp
@@ -167,6 +167,16 @@ public:
      */
     int remove (int64_t jobid);
 
+    /*! Modify the allocation/reservation referred to by jobid and update
+     *  the resource state.
+     *
+     *  \param jobid      job id.
+     *  \param expiration new expiration time.
+     *  \return           0 on success; -1 on error.
+     *                       EINVAL: graph, roots or match callback not set.
+     */
+    int modify (int64_t jobid, int64_t expiration);
+
     /*! Mark the resource status up|down|etc starting at subtree_root.
      *
      *  \param root_path     path to the root of the subtree to update.

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -293,6 +293,15 @@ public:
      */
     int remove (vtx_t root, int64_t jobid);
 
+    /*! Modify the allocation/reservation referred to by jobid and update
+     *  the resource state.
+     *
+     *  \param root      root resource vertex.
+     *  \param jobid     job id.
+     *  \return          0 on success; -1 on error.
+     */
+    int modify (vtx_t root, int64_t jobid, int64_t expiration);
+
     /*! Update the resource status to up|down|etc starting at subtree_root.
      *
      *  \param root_path     path to the root of the subtree to update.
@@ -476,13 +485,16 @@ private:
                  bool full, std::map<std::string, int64_t> &to_parent,
                  bool emit_shadow);
 
-    int rem_txfilter (vtx_t u, int64_t jobid, bool &stop);
-    int rem_agfilter (vtx_t u, int64_t jobid, const std::string &s);
-    int rem_idata (vtx_t u, int64_t jobid, const std::string &s, bool &stop);
-    int rem_plan (vtx_t u, int64_t jobid);
-    int rem_upv (vtx_t u, int64_t jobid);
-    int rem_dfv (vtx_t u, int64_t jobid);
-    int rem_exv (int64_t jobid);
+    int mod_txfilter (vtx_t u, int64_t jobid, int64_t expiration,
+                      bool &stop, bool remove);
+    int mod_agfilter (vtx_t u, int64_t jobid, int64_t expiration,
+                      const std::string &s, bool remove);
+    int mod_idata (vtx_t u, int64_t jobid, int64_t expiration,
+                   const std::string &s, bool &stop, bool remove);
+    int mod_plan (vtx_t u, int64_t jobid, int64_t expiration, bool remove);
+    int mod_upv (vtx_t u, int64_t jobid, int64_t expiration, bool remove);
+    int mod_dfv (vtx_t u, int64_t jobid, int64_t expiration, bool remove);
+    int mod_exv (int64_t jobid, int64_t expiration, bool remove);
 
 
     /************************************************************************

--- a/resource/utilities/command.cpp
+++ b/resource/utilities/command.cpp
@@ -50,6 +50,8 @@ command_t commands[] = {
 "resource-query> find status=down and sched-now=allocated" },
     { "cancel", "c", cmd_cancel, "Cancel an allocation or reservation: "
 "resource-query> cancel jobid" },
+    { "expiration", "z", cmd_expiration, "Modify the expiration of a job: "
+"resource-query> expiration jobid new-expiration-time" },
     { "set-property", "p", cmd_set_property, "Add a property to a resource: "
 "resource-query> set-property resource PROPERTY=VALUE" },
 { "get-property", "g", cmd_get_property, "Get all properties of a resource: "
@@ -78,6 +80,18 @@ static int do_remove (std::shared_ptr<resource_context_t> &ctx, int64_t jobid)
            info->state = job_lifecycle_t::CANCELED;
         }
     } else {
+        std::cout << ctx->traverser->err_message ();
+        ctx->traverser->clear_err_message ();
+    }
+    return rc;
+}
+
+static int do_expiration (std::shared_ptr<resource_context_t> &ctx,
+                          int64_t jobid, int64_t expiration)
+{
+    int rc = -1;
+    if ( (rc = ctx->traverser->modify ((int64_t)jobid,
+                                       (int64_t)expiration)) != 0) {
         std::cout << ctx->traverser->err_message ();
         ctx->traverser->clear_err_message ();
     }
@@ -582,6 +596,36 @@ int cmd_cancel (std::shared_ptr<resource_context_t> &ctx,
         std::cerr << "ERROR: error encountered while removing job "
                   << jobid << std::endl;
     }
+
+done:
+    return 0;
+}
+
+int cmd_expiration (std::shared_ptr<resource_context_t> &ctx,
+                    std::vector<std::string> &args)
+{
+    if (args.size () != 3) {
+        std::cerr << "ERROR: malformed command" << std::endl;
+        return 0;
+    }
+
+    int rc = -1;
+    std::string jobid_str = args[1];
+    std::string expiration_str = args[2];
+    uint64_t jobid = (uint64_t)std::strtoll (jobid_str.c_str (), NULL, 10);
+    uint64_t expiration = (uint64_t)std::strtoll (expiration_str.c_str (),
+                                                  NULL, 10);
+
+    if (ctx->allocations.find (jobid) == ctx->allocations.end ()) {
+        std::cerr << "ERROR: allocation jobid not found " << jobid << "\n";
+        goto done;
+    }
+
+    rc = do_expiration (ctx, jobid, expiration);
+
+    if (rc != 0)
+        std::cerr << "ERROR: error encountered while changing job expiration "
+                  << jobid << "\n";
 
 done:
     return 0;

--- a/resource/utilities/command.hpp
+++ b/resource/utilities/command.hpp
@@ -81,6 +81,8 @@ int cmd_find (std::shared_ptr<resource_context_t> &ctx,
                 std::vector<std::string> &args);
 int cmd_cancel (std::shared_ptr<resource_context_t> &ctx,
                 std::vector<std::string> &args);
+int cmd_expiration (std::shared_ptr<resource_context_t> &ctx,
+                std::vector<std::string> &args);
 int cmd_set_property (std::shared_ptr<resource_context_t> &ctx,
                       std::vector<std::string> &args);
 int cmd_get_property (std::shared_ptr<resource_context_t> &ctx,


### PR DESCRIPTION
This PR adds functionality to update an allocated job's expiration. To do so, we add `modify` functionality within the traverser to update a jobid rather than remove it. The PR adds functionality to update planner scheduled points to extend the `last` and `last_p->at` times. When merged, this PR will resolve issue #1079.

This PR is WIP as it isn't clear whether the simple modification of an allocation's expiration will work when there are queue policies that create reservations.