### PR TITLE
policies: add firstnodex to the known policies

### DIFF
--- a/resource/policies/dfu_match_policy_factory.cpp
+++ b/resource/policies/dfu_match_policy_factory.cpp
@@ -23,7 +23,7 @@ namespace resource_model {
 bool known_match_policy (const std::string &policy)
 {
     bool rc = true;
-    if (policy != FIRST_MATCH
+    if (policy != FIRST_MATCH && policy != FIRST_NODEX_MATCH
         && policy != HIGH_ID_FIRST && policy != LOW_ID_FIRST
         && policy != LOW_NODE_FIRST && policy != HIGH_NODE_FIRST
         && policy != LOW_NODEX_FIRST && policy != HIGH_NODEX_FIRST


### PR DESCRIPTION
problem: the firstnodex policy was added and tested, but couldn't be selected by users because it wouldn't be seen as a known policy.

solution: accept the firstnodex value as a known policy in `known_match_policy`