### PR TITLE
Improve match performance with node constrains when feasibility is enabled

### DIFF
--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -209,6 +209,14 @@ int dfu_impl_t::prune (const jobmeta_t &meta, bool exclusive,
         rc = -1;
         goto done;
     }
+    //  RFC 31 constraints only match against type == "node"
+    //  unspecified constraint matches everything
+    if (meta.constraint != nullptr
+        && (*m_graph)[u].type == "node"
+        && !meta.constraint->match ((*m_graph)[u])) {
+        rc = -1;
+        goto done;
+    }
     // if rack has been allocated exclusively, no reason to descend further.
     if ( (rc = by_avail (meta, s, u, resources)) == -1)
         goto done;
@@ -704,13 +712,6 @@ int dfu_impl_t::dom_dfv (const jobmeta_t &meta, vtx_t u,
         dom_exp (meta, u, next, check_pres, &x_inout, dfu);
     *excl = x_in;
     (*m_graph)[u].idata.colors[dom] = m_color.black ();
-
-    //  RFC 31 constraints only match against type == "node"
-    //  unspecified constraint matches everything
-    if (meta.constraint != nullptr
-        && (*m_graph)[u].type == "node"
-        && !meta.constraint->match ((*m_graph)[u]))
-        goto done;
 
     p = (*m_graph)[u].schedule.plans;
     if ( (avail = planner_avail_resources_during (p, at, duration)) == 0) {


### PR DESCRIPTION
Matching jobspecs with node constraints is currently implemented in such a way that the recursive `dom_*` call occurs before constraint checking.

This PR moves the node constraint check within the prune function to prevent unnecessary recursive dom_* calls, speeding up feasibility checks.

The following are comparative performance tests run on a laptop. The following test configuration is used to test without feasibility checking:
```bash
flux config load config.toml
flux module load resource noverify monitor-force-up
flux module load sched-fluxion-resource
flux module load sched-fluxion-qmanager
```

and the following is is contents of `config.toml`:
```toml
[resource]
noverify = true
norestrict = true

[[resource.config]]
hosts = "test[1-16384]"
cores = "0-63"
gpus = "0-8"

[sched-fluxion-qmanager]
# easy backfill
queue-policy = "easy"

[sched-fluxion-resource]
match-policy = "firstnodex"
match-format = "rv1_nosched"
prune-filters = "ALL:core,ALL:gpu,cluster:node,rack:node"
```
### Test results without the change in this PR:

- Feasibility enabled:
```bash
time for i in {1..100}; do flux submit -N 16 -n 64 --requires="hosts:test[16001-16016]" hostname; done
real	0m27.414s
```
- Feasibility disabled:
```bash
time for i in {1..100}; do flux submit -N 16 -n 64 --requires="hosts:test[16001-16016]" hostname; done
real	0m7.360s
```
- Feasibility enabled:
```bash
time for i in {1..100}; do flux submit -N 16 -n 64 hostname; done
real	0m8.184s
```
- Feasibility disabled:
```bash
time for i in {1..100}; do flux submit -N 16 -n 64 hostname; done
real	0m7.136s
```
### Test results WITH the change in this PR:

- Feasibility enabled:
```bash
time for i in {1..100}; do flux submit -N 16 -n 64 --requires="hosts:test[16001-16016]" hostname; done
real	0m10.710s
```
- Feasibility disabled:
```bash
time for i in {1..100}; do flux submit -N 16 -n 64 --requires="hosts:test[16001-16016]" hostname; done
real	0m7.344s
```
- Feasibility enabled:
```bash
time for i in {1..100}; do flux submit -N 16 -n 64 hostname; done
real	0m8.155s
```
- Feasibility disabled:
```bash
time for i in {1..100}; do flux submit -N 16 -n 64 hostname; done
real	0m7.231s
```
