### PR TITLE
Update match stats and implement stats-clear

### DIFF
--- a/resource/reapi/bindings/c++/reapi_module_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_module_impl.hpp
@@ -280,7 +280,7 @@ int reapi_module_t::stat (void *h, int64_t &V, int64_t &E,int64_t &J,
         goto out;
     }
 
-    if (!(f = flux_rpc (fh, "sched-fluxion-resource.stat",
+    if (!(f = flux_rpc (fh, "sched-fluxion-resource.stats-get",
                         NULL, FLUX_NODEID_ANY, 0))) {
         goto out;
     }

--- a/src/cmd/flux-ion-resource.py
+++ b/src/cmd/flux-ion-resource.py
@@ -69,7 +69,10 @@ class ResourceModuleInterface:
         return self.handle.rpc("sched-fluxion-resource.info", payload).get()
 
     def rpc_stat(self):
-        return self.handle.rpc("sched-fluxion-resource.stat").get()
+        return self.handle.rpc("sched-fluxion-resource.stats-get").get()
+
+    def rpc_stats_clear(self):
+        return self.handle.rpc("sched-fluxion-resource.stats-clear").get()
 
     def rpc_cancel(self, jobid):
         payload = {"jobid": jobid}
@@ -219,10 +222,23 @@ def stat_action(_):
     print("Num. of Edges: ", resp["E"])
     print("Num. of Vertices by Rank: ", json.dumps(resp["by_rank"]))
     print("Graph Load Time: ", resp["load-time"], "Secs")
-    print("Num. of Jobs Matched: ", resp["njobs"])
+    print("Graph Upime: ", resp["graph-uptime"], "Secs")
+    print("Time Since Stats Reset: ", resp["time-since-reset"], "Secs")
+    print("Num. of Total Jobs Matched: ", resp["njobs"])
+    print("Num. of Jobs Matched Since Reset: ", resp["njobs-reset"])
     print("Min. Match Time: ", resp["min-match"], "Secs")
     print("Max. Match Time: ", resp["max-match"], "Secs")
     print("Avg. Match Time: ", resp["avg-match"], "Secs")
+    print("Match Variance: ", resp["match-variance"], "Secs^2")
+
+
+def stats_clear_action(_):
+    """
+    Action for stats clear sub-command
+    """
+
+    rmod = ResourceModuleInterface()
+    rmod.rpc_stats_clear()
 
 
 def set_property_action(args):
@@ -447,7 +463,8 @@ def main():
     parse_match(mkparser("match", "Find the best matching resources for a jobspec."))
     parse_update(mkparser("update", "Update the resource database."))
     parse_info(mkparser("info", "Print info on a single job."))
-    parser_s = mkparser("stat", "Print overall performance statistics.")
+    parser_s = mkparser("stats", "Print overall performance statistics.")
+    parser_sc = mkparser("stats-cancel", "Clear overall performance statistics.")
     parser_c = mkparser("cancel", "Cancel an allocated or reserved job.")
     parse_find(mkparser("find", "Find resources matching with a criteria."))
     parser_st = mkparser("status", "Display resource status.")
@@ -465,6 +482,11 @@ def main():
     # Action for stat sub-command
     #
     parser_s.set_defaults(func=stat_action)
+
+    #
+    # Action for stats-clear sub-command
+    #
+    parser_sc.set_defaults(func=stats_clear_action)
 
     #
     # Positional argument for cancel sub-command

--- a/src/cmd/flux-ion-resource.py
+++ b/src/cmd/flux-ion-resource.py
@@ -433,6 +433,7 @@ def parse_set_status(parser_ss: argparse.ArgumentParser):
     parser_ss.set_defaults(func=set_status_action)
 
 
+# pylint: disable=too-many-statements
 def main():
     """
     Main entry point

--- a/t/t4000-match-params.t
+++ b/t/t4000-match-params.t
@@ -100,6 +100,14 @@ test_expect_success 'loading resource module with unknown policies is tolerated'
     load_resource policy=bar
 '
 
+test_expect_success 'resource module stats and clear work' '
+    unload_resource &&
+    load_resource &&
+    load_qmanager_sync &&
+    flux module stats sched-fluxion-resource &&
+    flux module stats --clear sched-fluxion-resource
+'
+
 test_expect_success 'removing resource works' '
     remove_resource
 '

--- a/t/t6002-graph-hwloc.t
+++ b/t/t6002-graph-hwloc.t
@@ -30,7 +30,7 @@ test_expect_success 'qmanager: loading resource and qmanager modules works' '
 '
 
 test_expect_success 'qmanager: graph stat as expected' '
-    flux ion-resource stat > stat.out &&
+    flux ion-resource stats > stat.out &&
     test_debug "cat stat.out" &&
     verify stat.out
 '


### PR DESCRIPTION
Gathering match data is important for diagnosing performance problems in Fluxion. This PR updates the `stat` RPC topic to respond to flux-core as expected and implements `clear ()` functionality.

Resolves issue #1166.