### PR TITLE
WIP fix: convert strings to boost:flyweight

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,8 @@
         "terminal.integrated.defaultProfile.linux": "bash"
   },
       "extensions": [
-         "ms-vscode.cmake-tools"
+        "ms-vscode.cmake-tools",
+        "ms-vscode.cpptools-extension-pack"
       ]
     }
   },

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,11 @@ pkg_check_modules(HWLOC REQUIRED IMPORTED_TARGET hwloc>=1.11.1)
 pkg_check_modules(JANSSON REQUIRED IMPORTED_TARGET jansson>=2.10)
 pkg_check_modules(UUID REQUIRED IMPORTED_TARGET uuid)
 
+# threads needed for boost flyweight
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads REQUIRED)
+
 set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
@@ -209,6 +214,10 @@ add_custom_target(dist
   COMMAND rm flux-sched.ver
   COMMENT "Generated flux-sched-${FLUX_SCHED_VER}.tar.gz"
   )
+
+add_compile_options(-fsanitize=address)
+add_link_options(-fsanitize=address)
+
 # run installcheck, if it passes then write out version information and pack up
 # a tarball with the result
 add_custom_target(distcheck

--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -24,9 +24,12 @@ extern "C" {
 #include <string>
 #include <memory>
 #include <cstdint>
+#include <boost/flyweight.hpp>
 
 #include "resource/reapi/bindings/c++/reapi.hpp"
 #include "qmanager/config/queue_system_defaults.hpp"
+
+static boost::flyweight<std::string>::initializer  fwinit;
 
 namespace Flux {
 namespace queue_manager {

--- a/resource/CMakeLists.txt
+++ b/resource/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(resource STATIC
     policies/dfu_match_policy_factory.cpp
     jobinfo/jobinfo.cpp
     schema/resource_data.cpp
+    schema/data_std.cpp
     schema/infra_data.cpp
     schema/sched_data.cpp
     schema/color.cpp
@@ -86,8 +87,9 @@ target_link_libraries(resource PUBLIC
     Boost::regex
     jobspec_conv
     Boost::filesystem
+    Threads::Threads
     )
-
+    
 add_subdirectory(modules)
 add_subdirectory(reapi)
 add_subdirectory(evaluators)

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -879,7 +879,7 @@ static int grow_resource_db_hwloc (std::shared_ptr<resource_ctx_t> &ctx,
         flux_log (ctx->h, LOG_ERR, "%s", future_strerror (f, errno));
         goto done;
     }
-    if (db.metadata.roots.find ("containment") == db.metadata.roots.end ()) {
+    if (db.metadata.roots.find (flux_subsystem_containment) == db.metadata.roots.end ()) {
         if (rank != IDSET_INVALID_ID) {
             if (!(hwloc_xml = get_array_string (xml_array, rank)))
                 goto done;
@@ -895,14 +895,14 @@ static int grow_resource_db_hwloc (std::shared_ptr<resource_ctx_t> &ctx,
 
     // If the above grow() does not grow resources in the "containment"
     // subsystem, this condition can still be false
-    if (db.metadata.roots.find ("containment") == db.metadata.roots.end ()) {
+    if (db.metadata.roots.find (flux_subsystem_containment) == db.metadata.roots.end ()) {
         rc = -1;
         errno = EINVAL;
         flux_log (ctx->h, LOG_ERR, "%s: cluster vertex is unavailable",
                   __FUNCTION__);
         goto done;
     }
-    v = db.metadata.roots.at ("containment");
+    v = db.metadata.roots.at (flux_subsystem_containment);
 
     rank = idset_next (ids, rank);
     while (rank != IDSET_INVALID_ID) {
@@ -930,7 +930,7 @@ static int grow_resource_db_rv1exec (std::shared_ptr<resource_ctx_t> &ctx,
     resource_graph_db_t &db = *(ctx->db);
     char *rv1_str = nullptr;
 
-    if (db.metadata.roots.find ("containment") == db.metadata.roots.end ()) {
+    if (db.metadata.roots.find (flux_subsystem_containment) == db.metadata.roots.end ()) {
         if ( (rv1_str = json_dumps (resobj, JSON_INDENT (0))) == NULL) {
             errno = ENOMEM;
             goto done;
@@ -1049,7 +1049,7 @@ static int grow_resource_db_jgf (std::shared_ptr<resource_ctx_t> &ctx,
                         __FUNCTION__);
         goto done;
     }
-    if (db.metadata.roots.find ("containment") == db.metadata.roots.end ()) {
+    if (db.metadata.roots.find (flux_subsystem_containment) == db.metadata.roots.end ()) {
         if ( p_r_lite
              && (rc = remap_jgf_namespace (ctx, r_lite, p_r_lite)) < 0) {
             flux_log_error (ctx->h, "%s: remap_jgf_namespace", __FUNCTION__);
@@ -2726,6 +2726,10 @@ extern "C" int mod_main (flux_t *h, int argc, char **argv)
     int rc = -1;
 
     flux_log (h, LOG_INFO, "version %s", PACKAGE_VERSION);
+
+    // Init flyweight, which is used across the resource module
+    // see resource/schema/data_std.cpp.
+    init_flyweight();
 
     try {
         std::shared_ptr<resource_ctx_t> ctx = nullptr;

--- a/resource/policies/base/matcher.hpp
+++ b/resource/policies/base/matcher.hpp
@@ -16,6 +16,7 @@
 #include <vector>
 #include <set>
 #include <map>
+#include <boost/flyweight.hpp>
 #include "resource/libjobspec/jobspec.hpp"
 #include "resource/schema/data_std.hpp"
 #include "resource/planner/c/planner.h"
@@ -24,7 +25,7 @@
 namespace Flux {
 namespace resource_model {
 
-const std::string ANY_RESOURCE_TYPE = "*";
+extern const boost::flyweight<std::string> &ANY_RESOURCE_TYPE;
 
 enum match_score_t { MATCH_UNMET = 0, MATCH_MET = 1 };
 
@@ -77,7 +78,7 @@ public:
 
 private:
     std::string m_name;
-    subsystem_t m_err_subsystem = "error";
+    subsystem_t m_err_subsystem = flux_error;
     std::vector<subsystem_t> m_subsystems;
     multi_subsystemsS m_subsystems_map;
 };
@@ -170,8 +171,8 @@ private:
     //     in the containment subsystem at any level, please
     //     maintain an aggregate on the available cores under it.
     std::map<subsystem_t,
-             std::map<std::string, std::set<std::string>>> m_pruning_types;
-    std::map<subsystem_t, std::set<std::string>> m_total_set;
+             std::map<boost::flyweight<std::string>, std::set<boost::flyweight<std::string>>>> m_pruning_types;
+    std::map<subsystem_t, std::set<boost::flyweight<std::string>>> m_total_set;
 };
 
 } // namespace resource_model

--- a/resource/readers/resource_reader_grug.cpp
+++ b/resource/readers/resource_reader_grug.cpp
@@ -207,7 +207,7 @@ vtx_t dfs_emitter_t::emit_vertex (ggv_t u, gge_t e, const gg_t &recipe,
 
     vtx_t v = add_vertex (g);;
     std::string pref = "";
-    std::string ssys = recipe[u].subsystem;
+    auto ssys = recipe[u].subsystem;
     int id = 0;
 
     if (src_v == boost::graph_traits<resource_graph_t>::null_vertex ()) {
@@ -232,7 +232,7 @@ vtx_t dfs_emitter_t::emit_vertex (ggv_t u, gge_t e, const gg_t &recipe,
     g[v].id = id;
     g[v].name = recipe[u].basename + istr;
     g[v].paths[ssys] = pref + "/" + g[v].name;
-    g[v].idata.member_of[ssys] = "*";
+    g[v].idata.member_of[ssys] = flux_match_any;
     g[v].uniq_id = v;
     g[v].rank = m_rank;
 

--- a/resource/readers/resource_spec_grug.hpp
+++ b/resource/readers/resource_spec_grug.hpp
@@ -16,6 +16,7 @@
 #include <boost/graph/graphviz.hpp>
 #include <boost/graph/graphml.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/flyweight.hpp>
 
 namespace Flux {
 namespace resource_model {
@@ -34,11 +35,11 @@ struct resource_pool_gen_t {
     int rank;
     long size;
     std::string unit;
-    std::string subsystem;
+    boost::flyweight<std::string> subsystem;
 };
 
 struct relation_gen_t {
-    std::string e_subsystem;
+    boost::flyweight<std::string> e_subsystem;
     std::string relation;
     std::string rrelation;
     int id_scope;
@@ -65,7 +66,9 @@ using vtx_type_map_t = boost::property_map<gg_t, pgen_t>::type;
 using vtx_basename_map_t = boost::property_map<gg_t, pgen_t>::type;
 using vtx_size_map_t = boost::property_map<gg_t, long resource_pool_gen_t::* >::type;
 using vtx_unit_map_t = boost::property_map<gg_t, pgen_t>::type;
-using vtx_subsystem_map_t = boost::property_map<gg_t, pgen_t>::type;
+//using vtx_subsystem_map_t = boost::property_map<gg_t, pgen_t>::type;
+using vtx_subsystem_map_t = boost::property_map<gg_t, decltype(&resource_pool_gen_t::subsystem)>::type;
+
 using edg_e_subsystem_map_t = boost::property_map<gg_t, rgen_t>::type;
 using edg_relation_map_t = boost::property_map<gg_t, rgen_t>::type;
 using edg_rrelation_map_t = boost::property_map<gg_t, rgen_t>::type;

--- a/resource/reapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli_impl.hpp
@@ -23,6 +23,7 @@ extern "C" {
 #include <boost/algorithm/string.hpp>
 #include "resource/reapi/bindings/c++/reapi_cli.hpp"
 #include "resource/readers/resource_reader_factory.hpp"
+#include "boost/flyweight.hpp"
 
 namespace Flux {
 namespace resource_model {
@@ -336,7 +337,8 @@ std::shared_ptr<f_resource_graph_t> resource_query_t::create_filtered_graph ()
 int resource_query_t::subsystem_exist (const std::string &n)
 {
     int rc = 0;
-    if (db->metadata.roots.find (n) == db->metadata.roots.end ())
+    boost::flyweight<std::string> fly_n(n);
+    if (db->metadata.roots.find (fly_n) == db->metadata.roots.end ())
         rc = -1;
     return rc;
 }
@@ -348,66 +350,66 @@ int resource_query_t::set_subsystems_use (const std::string &n)
     const std::string &matcher_type = matcher->matcher_name ();
 
     if (boost::iequals (matcher_type, std::string ("CA"))) {
-        if ( (rc = subsystem_exist ("containment")) == 0)
-            matcher->add_subsystem ("containment", "*");
+        if ( (rc = subsystem_exist (flux_subsystem_containment)) == 0)
+            matcher->add_subsystem (flux_subsystem_containment, flux_match_any);
     } else if (boost::iequals (matcher_type, std::string ("IBA"))) {
-        if ( (rc = subsystem_exist ("ibnet")) == 0)
-            matcher->add_subsystem ("ibnet", "*");
+        if ( (rc = subsystem_exist (flux_subsystem_infiniband_network)) == 0)
+            matcher->add_subsystem (flux_subsystem_infiniband_network, flux_match_any);
     } else if (boost::iequals (matcher_type, std::string ("IBBA"))) {
-        if ( (rc = subsystem_exist ("ibnetbw")) == 0)
-            matcher->add_subsystem ("ibnetbw", "*");
+        if ( (rc = subsystem_exist (flux_subsystem_infiniband_bandwidth)) == 0)
+            matcher->add_subsystem (flux_subsystem_infiniband_bandwidth, flux_match_any);
     } else if (boost::iequals (matcher_type, std::string ("PFS1BA"))) {
-        if ( (rc = subsystem_exist ("pfs1bw")) == 0)
-            matcher->add_subsystem ("pfs1bw", "*");
+        if ( (rc = subsystem_exist (flux_subsystem_parallel_filesystem_bandwidth)) == 0)
+            matcher->add_subsystem (flux_subsystem_parallel_filesystem_bandwidth, flux_match_any);
     } else if (boost::iequals (matcher_type, std::string ("PA"))) {
-        if ( (rc = subsystem_exist ("power")) == 0)
-            matcher->add_subsystem ("power", "*");
+        if ( (rc = subsystem_exist (flux_subsystem_power)) == 0)
+            matcher->add_subsystem (flux_subsystem_power, flux_match_any);
     } else if (boost::iequals (matcher_type, std::string ("C+PFS1BA"))) {
-        if ( (rc = subsystem_exist ("containment")) == 0)
-            matcher->add_subsystem ("containment", "contains");
-        if ( !rc && (rc = subsystem_exist ("pfs1bw")) == 0)
-            matcher->add_subsystem ("pfs1bw", "*");
+        if ( (rc = subsystem_exist (flux_subsystem_containment)) == 0)
+            matcher->add_subsystem (flux_subsystem_containment, flux_relation_contains);
+        if ( !rc && (rc = subsystem_exist (flux_subsystem_parallel_filesystem_bandwidth)) == 0)
+            matcher->add_subsystem (flux_subsystem_parallel_filesystem_bandwidth, flux_match_any);
     } else if (boost::iequals (matcher_type, std::string ("C+IBA"))) {
-        if ( (rc = subsystem_exist ("containment")) == 0)
-            matcher->add_subsystem ("containment", "contains");
-        if ( !rc && (rc = subsystem_exist ("ibnet")) == 0)
-            matcher->add_subsystem ("ibnet", "connected_up");
+        if ( (rc = subsystem_exist (flux_subsystem_containment)) == 0)
+            matcher->add_subsystem (flux_subsystem_containment, flux_relation_contains);
+        if ( !rc && (rc = subsystem_exist (flux_subsystem_infiniband_network)) == 0)
+            matcher->add_subsystem (flux_subsystem_infiniband_network, "connected_up");
     } else if (boost::iequals (matcher_type, std::string ("C+PA"))) {
-        if ( (rc = subsystem_exist ("containment")) == 0)
-            matcher->add_subsystem ("containment", "*");
-        if ( !rc && (rc = subsystem_exist ("power")) == 0)
-            matcher->add_subsystem ("power", "draws_from");
+        if ( (rc = subsystem_exist (flux_subsystem_containment)) == 0)
+            matcher->add_subsystem (flux_subsystem_containment, flux_match_any);
+        if ( !rc && (rc = subsystem_exist (flux_subsystem_power)) == 0)
+            matcher->add_subsystem (flux_subsystem_power, "draws_from");
     } else if (boost::iequals (matcher_type, std::string ("IB+IBBA"))) {
-        if ( (rc = subsystem_exist ("ibnet")) == 0)
-            matcher->add_subsystem ("ibnet", "connected_down");
-        if ( !rc && (rc = subsystem_exist ("ibnetbw")) == 0)
-            matcher->add_subsystem ("ibnetbw", "*");
+        if ( (rc = subsystem_exist (flux_subsystem_infiniband_network)) == 0)
+            matcher->add_subsystem (flux_subsystem_infiniband_network, "connected_down");
+        if ( !rc && (rc = subsystem_exist (flux_subsystem_infiniband_bandwidth)) == 0)
+            matcher->add_subsystem (flux_subsystem_infiniband_bandwidth, flux_match_any);
     } else if (boost::iequals (matcher_type, std::string ("C+P+IBA"))) {
-        if ( (rc = subsystem_exist ("containment")) == 0)
-            matcher->add_subsystem ("containment", "contains");
-        if ( (rc = subsystem_exist ("power")) == 0)
-            matcher->add_subsystem ("power", "draws_from");
-        if ( !rc && (rc = subsystem_exist ("ibnet")) == 0)
-            matcher->add_subsystem ("ibnet", "connected_up");
+        if ( (rc = subsystem_exist (flux_subsystem_containment)) == 0)
+            matcher->add_subsystem (flux_subsystem_containment, flux_relation_contains);
+        if ( (rc = subsystem_exist (flux_subsystem_power)) == 0)
+            matcher->add_subsystem (flux_subsystem_power, "draws_from");
+        if ( !rc && (rc = subsystem_exist (flux_subsystem_infiniband_network)) == 0)
+            matcher->add_subsystem (flux_subsystem_infiniband_network, "connected_up");
     } else if (boost::iequals (matcher_type, std::string ("V+PFS1BA"))) {
-        if ( (rc = subsystem_exist ("virtual1")) == 0)
-            matcher->add_subsystem ("virtual1", "*");
-        if ( !rc && (rc = subsystem_exist ("pfs1bw")) == 0)
-            matcher->add_subsystem ("pfs1bw", "*");
+        if ( (rc = subsystem_exist (flux_subsystem_virtual)) == 0)
+            matcher->add_subsystem (flux_subsystem_virtual, flux_match_any);
+        if ( !rc && (rc = subsystem_exist (flux_subsystem_parallel_filesystem_bandwidth)) == 0)
+            matcher->add_subsystem (flux_subsystem_parallel_filesystem_bandwidth, flux_match_any);
     } else if (boost::iequals (matcher_type, std::string ("VA"))) {
-        if ( (rc = subsystem_exist ("virtual1")) == 0)
-            matcher->add_subsystem ("virtual1", "*");
+        if ( (rc = subsystem_exist (flux_subsystem_virtual)) == 0)
+            matcher->add_subsystem (flux_subsystem_virtual, flux_match_any);
     } else if (boost::iequals (matcher_type, std::string ("ALL"))) {
-        if ( (rc = subsystem_exist ("containment")) == 0)
-            matcher->add_subsystem ("containment", "*");
-        if ( !rc && (rc = subsystem_exist ("ibnet")) == 0)
-            matcher->add_subsystem ("ibnet", "*");
-        if ( !rc && (rc = subsystem_exist ("ibnetbw")) == 0)
-            matcher->add_subsystem ("ibnetbw", "*");
-        if ( !rc && (rc = subsystem_exist ("pfs1bw")) == 0)
-            matcher->add_subsystem ("pfs1bw", "*");
-        if ( (rc = subsystem_exist ("power")) == 0)
-            matcher->add_subsystem ("power", "*");
+        if ( (rc = subsystem_exist (flux_subsystem_containment)) == 0)
+            matcher->add_subsystem (flux_subsystem_containment, flux_match_any);
+        if ( !rc && (rc = subsystem_exist (flux_subsystem_infiniband_network)) == 0)
+            matcher->add_subsystem (flux_subsystem_infiniband_network, flux_match_any);
+        if ( !rc && (rc = subsystem_exist (flux_subsystem_infiniband_bandwidth)) == 0)
+            matcher->add_subsystem (flux_subsystem_infiniband_bandwidth, flux_match_any);
+        if ( !rc && (rc = subsystem_exist (flux_subsystem_parallel_filesystem_bandwidth)) == 0)
+            matcher->add_subsystem (flux_subsystem_parallel_filesystem_bandwidth, flux_match_any);
+        if ( (rc = subsystem_exist (flux_subsystem_power)) == 0)
+            matcher->add_subsystem (flux_subsystem_power, flux_match_any);
     } else {
         rc = -1;
     }

--- a/resource/schema/data_std.cpp
+++ b/resource/schema/data_std.cpp
@@ -20,6 +20,7 @@ boost::flyweight<std::string> flux_error;
 boost::flyweight<std::string> flux_match_any;
 boost::flyweight<std::string> flux_node;
 boost::flyweight<std::string> flux_slot;
+boost::flyweight<std::string> flux_core;
 boost::flyweight<std::string> flux_subsystem_containment;
 boost::flyweight<std::string> flux_subsystem_power;
 boost::flyweight<std::string> flux_subsystem_infiniband_network;
@@ -33,13 +34,12 @@ boost::flyweight<std::string> flux_relation_in;;
 
 
 void init_flyweight ()
-{
-    // This should have a cpp file associated, but it didn't originally
-    // so I'm not adding it
+{    
     flux_error = "error";
     flux_match_any = "*";
     flux_node = "node";
     flux_slot = "slot";
+    flux_core = "core";
     flux_subsystem_containment = "containment";
     flux_subsystem_power = "power";
     flux_subsystem_infiniband_network = "ibnet";

--- a/resource/schema/data_std.cpp
+++ b/resource/schema/data_std.cpp
@@ -1,0 +1,61 @@
+/*****************************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+#include <set>
+#include <string>
+#include <boost/flyweight.hpp>
+
+namespace Flux {
+namespace resource_model {
+
+
+boost::flyweight<std::string> flux_error;
+boost::flyweight<std::string> flux_match_any;
+boost::flyweight<std::string> flux_node;
+boost::flyweight<std::string> flux_slot;
+boost::flyweight<std::string> flux_subsystem_containment;
+boost::flyweight<std::string> flux_subsystem_power;
+boost::flyweight<std::string> flux_subsystem_infiniband_network;
+boost::flyweight<std::string> flux_subsystem_infiniband_bandwidth;
+boost::flyweight<std::string> flux_subsystem_parallel_filesystem_bandwidth;
+boost::flyweight<std::string> flux_subsystem_virtual;
+boost::flyweight<std::string> flux_subsystem_network;
+boost::flyweight<std::string> flux_subsystem_storage;
+boost::flyweight<std::string> flux_relation_contains;
+boost::flyweight<std::string> flux_relation_in;;
+
+
+void init_flyweight ()
+{
+    // This should have a cpp file associated, but it didn't originally
+    // so I'm not adding it
+    flux_error = "error";
+    flux_match_any = "*";
+    flux_node = "node";
+    flux_slot = "slot";
+    flux_subsystem_containment = "containment";
+    flux_subsystem_power = "power";
+    flux_subsystem_infiniband_network = "ibnet";
+    flux_subsystem_infiniband_bandwidth ="ibnetbw";
+    flux_subsystem_parallel_filesystem_bandwidth = "pfs1bw";
+    flux_subsystem_virtual = "virtual1";
+    flux_subsystem_network = "network";
+    flux_subsystem_storage = "storage";
+    flux_relation_contains = "contains";
+    flux_relation_in = "in";
+}
+
+
+} // Flux
+} // Flux::resource_model
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/schema/data_std.hpp
+++ b/resource/schema/data_std.hpp
@@ -13,6 +13,9 @@
 
 #include <set>
 #include <string>
+#include <boost/flyweight.hpp>
+
+#include "resource/schema/data_std.hpp"
 
 namespace Flux {
 namespace resource_model {
@@ -25,9 +28,37 @@ namespace resource_model {
 const char * const X_CHECKER_JOBS_STR = "jobs";
 const int64_t X_CHECKER_NJOBS = 0x40000000;
 
-using subsystem_t = std::string;
-using multi_subsystems_t = std::map<subsystem_t, std::string>;
-using multi_subsystemsS = std::map<subsystem_t, std::set<std::string>>;
+extern boost::flyweight<std::string> flux_error;
+
+// init_flyweight sets the string values for each flyweight defined below
+// if you don't call this in the resource mod_main, you will get segfaults
+// because it tries to atomically increment an atomic var that hasn't been
+// allocated yet.
+extern void init_flyweight();
+
+// Resource types (node, slot, etc)
+extern boost::flyweight<std::string> flux_node;
+extern boost::flyweight<std::string> flux_slot;
+
+// Subsystems
+extern boost::flyweight<std::string> flux_match_any;
+extern boost::flyweight<std::string> flux_subsystem_containment;
+extern boost::flyweight<std::string> flux_subsystem_power;
+extern boost::flyweight<std::string> flux_subsystem_infiniband_network;
+extern boost::flyweight<std::string> flux_subsystem_infiniband_bandwidth;
+extern boost::flyweight<std::string> flux_subsystem_parallel_filesystem_bandwidth;
+extern boost::flyweight<std::string> flux_subsystem_virtual;
+extern boost::flyweight<std::string> flux_subsystem_network;
+extern boost::flyweight<std::string> flux_subsystem_storage;
+
+
+// Relations
+extern boost::flyweight<std::string> flux_relation_contains;
+extern boost::flyweight<std::string> flux_relation_in;
+
+using subsystem_t = boost::flyweight<std::string>;
+using multi_subsystems_t = std::map<subsystem_t, boost::flyweight<std::string>>;
+using multi_subsystemsS = std::map<subsystem_t, std::set<boost::flyweight<std::string>>>;
 
 } // Flux
 } // Flux::resource_model

--- a/resource/schema/data_std.hpp
+++ b/resource/schema/data_std.hpp
@@ -17,6 +17,8 @@
 
 #include "resource/schema/data_std.hpp"
 
+static boost::flyweight<std::string>::initializer  fwinit;
+
 namespace Flux {
 namespace resource_model {
 
@@ -39,6 +41,7 @@ extern void init_flyweight();
 // Resource types (node, slot, etc)
 extern boost::flyweight<std::string> flux_node;
 extern boost::flyweight<std::string> flux_slot;
+extern boost::flyweight<std::string> flux_core;
 
 // Subsystems
 extern boost::flyweight<std::string> flux_match_any;

--- a/resource/schema/infra_data.hpp
+++ b/resource/schema/infra_data.hpp
@@ -14,6 +14,7 @@
 #include <map>
 #include <cstdint>
 #include <limits>
+#include <boost/flyweight.hpp>
 #include "resource/schema/data_std.hpp"
 #include "resource/schema/ephemeral.hpp"
 #include "resource/planner/c/planner_multi.h"

--- a/resource/schema/resource_data.hpp
+++ b/resource/schema/resource_data.hpp
@@ -23,6 +23,7 @@
 #include "resource/schema/sched_data.hpp"
 #include "resource/schema/infra_data.hpp"
 #include "resource/planner/c/planner.h"
+#include "boost/flyweight.hpp"
 
 namespace Flux {
 namespace resource_model {

--- a/resource/schema/resource_graph.hpp
+++ b/resource/schema/resource_graph.hpp
@@ -65,10 +65,13 @@ public:
             multi_subsystemsS::const_iterator i;
             i = m_selector.find (kv.first);
             if (i != m_selector.end ()) {
-                if (kv.second == "*")
+
+                // flux_match_any is the flyweight equivalent of "*" which we need because
+                // the subsystem is also a flyweight (efficient string lookup) type
+                if (kv.second == flux_match_any)
                     return true;
                 else if (i->second.find (kv.second) != i->second.end ()
-                         || i->second.find ("*") != i->second.end ())
+                         || i->second.find (flux_match_any) != i->second.end ())
                     return true;
             }
         }

--- a/resource/schema/test/schema_test02.cpp
+++ b/resource/schema/test/schema_test02.cpp
@@ -172,7 +172,7 @@ static int test_constructors_and_overload ()
 int main (int argc, char *argv[])
 {
     plan (12);
-
+    init_flyweight();
     test_constructors_and_overload ();
 
     done_testing ();

--- a/resource/schema/test/schema_test02.cpp
+++ b/resource/schema/test/schema_test02.cpp
@@ -39,12 +39,12 @@ static int test_constructors_and_overload ()
     infra1->tags[0] = 0;
     infra1->x_spans[0] = 0;
     infra1->job2span[0] = 0;
-    infra1->colors["containment"] = 0;
-    infra1->colors["network"] = 1;
+    infra1->colors[flux_subsystem_containment] = 0;
+    infra1->colors[flux_subsystem_network] = 1;
     infra1->x_checker = planner_new (0, INT64_MAX, resource_total, resource_type);
-    infra1->subplans["containment"] =
+    infra1->subplans[flux_subsystem_containment] =
             planner_multi_new (0, INT64_MAX, resource_totals, resource_types, len);
-    infra1->subplans["network"] =
+    infra1->subplans[flux_subsystem_network] =
             planner_multi_new (0, INT64_MAX, resource_totals, resource_types, len);
 
     infra2 = new pool_infra_t ();
@@ -55,12 +55,12 @@ static int test_constructors_and_overload ()
     infra2->tags[0] = 0;
     infra2->x_spans[0] = 0;
     infra2->job2span[0] = 0;
-    infra2->colors["containment"] = 0;
-    infra2->colors["network"] = 1;
+    infra2->colors[flux_subsystem_containment] = 0;
+    infra2->colors[flux_subsystem_network] = 1;
     infra2->x_checker = planner_new (0, INT64_MAX, resource_total, resource_type);
-    infra2->subplans["containment"] =
+    infra2->subplans[flux_subsystem_containment] =
             planner_multi_new (0, INT64_MAX, resource_totals, resource_types, len);
-    infra2->subplans["network"] =
+    infra2->subplans[flux_subsystem_network] =
             planner_multi_new (0, INT64_MAX, resource_totals, resource_types, len);
     bo = (bo || !(*infra1 == *infra2));
     ok (!bo, "initialized pool_infra_t equal to identically initialized pool_infra_t");
@@ -82,12 +82,12 @@ static int test_constructors_and_overload ()
     infra5->tags[0] = 0;
     infra5->x_spans[0] = 0;
     infra5->job2span[0] = 0;
-    infra5->colors["containment"] = 0;
-    infra5->colors["network"] = 1;
+    infra5->colors[flux_subsystem_containment] = 0;
+    infra5->colors[flux_subsystem_network] = 1;
     infra5->x_checker = planner_new (1, INT64_MAX, resource_total, resource_type);
-    infra5->subplans["containment"] =
+    infra5->subplans[flux_subsystem_containment] =
             planner_multi_new (0, INT64_MAX, resource_totals, resource_types, len);
-    infra5->subplans["network"] =
+    infra5->subplans[flux_subsystem_network] =
             planner_multi_new (0, INT64_MAX, resource_totals, resource_types, len);
     bo = (bo || (*infra5 == *infra1));
     ok (!bo, "pool_infra_t initialized with different x_checker not equal to original pool_infra_t");
@@ -96,12 +96,12 @@ static int test_constructors_and_overload ()
     infra6->tags[0] = 0;
     infra6->x_spans[0] = 0;
     infra6->job2span[0] = 0;
-    infra6->colors["containment"] = 0;
-    infra6->colors["storage"] = 1;
+    infra6->colors[flux_subsystem_containment] = 0;
+    infra6->colors[flux_subsystem_storage] = 1;
     infra6->x_checker = planner_new (0, INT64_MAX, resource_total, resource_type);
-    infra6->subplans["containment"] =
+    infra6->subplans[flux_subsystem_containment] =
             planner_multi_new (0, INT64_MAX, resource_totals, resource_types, len);
-    infra6->subplans["network"] =
+    infra6->subplans[flux_subsystem_network] =
             planner_multi_new (0, INT64_MAX, resource_totals, resource_types, len);
     bo = (bo || (*infra6 == *infra1));
     ok (!bo, "pool_infra_t initialized with different colors not equal to original pool_infra_t");
@@ -110,12 +110,12 @@ static int test_constructors_and_overload ()
     infra7->tags[0] = 0;
     infra7->x_spans[0] = 0;
     infra7->job2span[0] = 0;
-    infra7->colors["containment"] = 0;
-    infra7->colors["network"] = 1;
+    infra7->colors[flux_subsystem_containment] = 0;
+    infra7->colors[flux_subsystem_network] = 1;
     infra7->x_checker = planner_new (0, INT64_MAX, resource_total, resource_type);
-    infra7->subplans["containment"] =
+    infra7->subplans[flux_subsystem_containment] =
             planner_multi_new (0, INT64_MAX, resource_totals, resource_types, len);
-    infra7->subplans["storage"] =
+    infra7->subplans[flux_subsystem_storage] =
             planner_multi_new (0, INT64_MAX, resource_totals, resource_types, len);
     bo = (bo || (*infra7 == *infra1));
     ok (!bo, "pool_infra_t initialized with different subplan systems not equal to original pool_infra_t");
@@ -124,12 +124,12 @@ static int test_constructors_and_overload ()
     infra8->tags[0] = 0;
     infra8->x_spans[0] = 0;
     infra8->job2span[0] = 0;
-    infra8->colors["containment"] = 0;
-    infra8->colors["network"] = 1;
+    infra8->colors[flux_subsystem_containment] = 0;
+    infra8->colors[flux_subsystem_network] = 1;
     infra8->x_checker = planner_new (0, INT64_MAX, resource_total, resource_type);
-    infra8->subplans["containment"] =
+    infra8->subplans[flux_subsystem_containment] =
             planner_multi_new (0, INT64_MAX, resource_totals, resource_types, len);
-    infra8->subplans["network"] =
+    infra8->subplans[flux_subsystem_network] =
             planner_multi_new (1, INT64_MAX, resource_totals, resource_types, len);
     bo = (bo || (*infra8 == *infra1));
     ok (!bo, "pool_infra_t initialized with different subplan planner_multis not equal to original pool_infra_t");
@@ -138,10 +138,10 @@ static int test_constructors_and_overload ()
     infra9->tags[0] = 0;
     infra9->x_spans[0] = 0;
     infra9->job2span[0] = 0;
-    infra9->colors["containment"] = 0;
-    infra9->colors["network"] = 1;
+    infra9->colors[flux_subsystem_containment] = 0;
+    infra9->colors[flux_subsystem_network] = 1;
     infra9->x_checker = planner_new (0, INT64_MAX, resource_total, resource_type);
-    infra9->subplans["containment"] =
+    infra9->subplans[flux_subsystem_containment] =
             planner_multi_new (0, INT64_MAX, resource_totals, resource_types, len);
     bo = (bo || (*infra9 == *infra1));
     ok (!bo, "pool_infra_t initialized with different subplan planner_multis len not equal to original pool_infra_t");

--- a/resource/store/resource_graph_store.cpp
+++ b/resource/store/resource_graph_store.cpp
@@ -16,6 +16,7 @@ extern "C" {
 
 #include "resource/store/resource_graph_store.hpp"
 #include "resource/readers/resource_reader_base.hpp"
+#include "boost/flyweight.hpp"
 
 using namespace Flux;
 using namespace Flux::resource_model;
@@ -37,7 +38,8 @@ void resource_graph_metadata_t::set_graph_duration (
 
 bool resource_graph_db_t::known_subsystem (const std::string &s)
 {
-    return (metadata.roots.find (s) != metadata.roots.end ())? true : false;
+    boost::flyweight<std::string> fly_s(s);
+    return (metadata.roots.find (fly_s) != metadata.roots.end ())? true : false;
 }
 
 int resource_graph_db_t::load (const std::string &str,

--- a/resource/traversers/dfu_impl_update.cpp
+++ b/resource/traversers/dfu_impl_update.cpp
@@ -14,6 +14,7 @@ extern "C" {
 #endif
 }
 
+#include "boost/flyweight.hpp"
 #include "resource/traversers/dfu_impl.hpp"
 
 using namespace Flux::Jobspec;
@@ -303,7 +304,8 @@ int dfu_impl_t::upd_dfv (vtx_t u, std::shared_ptr<match_writers_t> &writers,
 {
     int n_plans = 0;
     std::map<std::string, int64_t> dfu;
-    const std::string &dom = m_match->dom_subsystem ();
+    const boost::flyweight<std::string> &dom = m_match->dom_subsystem ();
+
     f_out_edg_iterator_t ei, ei_end;
     bool mod = modify_traversal (u, emit_shadow);
     excl = excl || mod;
@@ -389,12 +391,14 @@ done:
 int dfu_impl_t::rem_agfilter (vtx_t u, int64_t jobid,
                               const std::string &subsystem)
 {
+
+    boost::flyweight<std::string> fly_subsystem(subsystem);
     int rc = 0;
     int span = -1;
     planner_multi_t *subtree_plan = NULL;
     auto &job2span = (*m_graph)[u].idata.job2span;
 
-    if ((subtree_plan = (*m_graph)[u].idata.subplans[subsystem]) == NULL)
+    if ((subtree_plan = (*m_graph)[u].idata.subplans[fly_subsystem]) == NULL)
         goto done;
     if (job2span.find (jobid) == job2span.end ())
         goto done;
@@ -545,8 +549,8 @@ int dfu_impl_t::update (vtx_t root, std::shared_ptr<match_writers_t> &writers,
 {
     int rc = -1;
     std::map<std::string, int64_t> dfu;
-    const std::string &dom = m_match->dom_subsystem ();
 
+    const boost::flyweight<std::string> &dom = m_match->dom_subsystem ();
     if (m_graph_db->metadata.v_rt_edges[dom].get_trav_token ()
         != m_best_k_cnt) {
         m_err_msg += __FUNCTION__;
@@ -595,7 +599,8 @@ int dfu_impl_t::update (vtx_t root, std::shared_ptr<match_writers_t> &writers,
     unsigned int excl = 0;
     unsigned int needs = 0;
     std::map<std::string, int64_t> dfu;
-    const std::string &dom = m_match->dom_subsystem ();
+    const boost::flyweight<std::string> &dom = m_match->dom_subsystem ();
+
     bool rsv = (jobmeta.alloc_type
                  == jobmeta_t::alloc_type_t::AT_ALLOC_ORELSE_RESERVE);
 

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -757,6 +757,7 @@ static void fini_resource_query (std::shared_ptr<resource_context_t> &ctx)
 
 int main (int argc, char *argv[])
 {
+    init_flyweight();
     std::shared_ptr<resource_context_t> ctx = nullptr;
     if ( !(ctx = init_resource_query (argc, argv))) {
         std::cerr << "ERROR: resource query initialization" << std::endl;

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -26,6 +26,7 @@ extern "C" {
 #include <editline/readline.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/flyweight.hpp>
 #include "resource/utilities/command.hpp"
 #include "resource/store/resource_graph_store.hpp"
 #include "resource/policies/dfu_match_policy_factory.hpp"
@@ -234,7 +235,8 @@ static int subsystem_exist (std::shared_ptr<resource_context_t> &ctx,
                             std::string n)
 {
     int rc = 0;
-    if (ctx->db->metadata.roots.find (n) == ctx->db->metadata.roots.end ())
+    boost::flyweight<std::string> fly_n(n);
+    if (ctx->db->metadata.roots.find (fly_n) == ctx->db->metadata.roots.end ())
         rc = -1;
     return rc;
 }
@@ -248,66 +250,66 @@ static int set_subsystems_use (std::shared_ptr<resource_context_t> &ctx,
     const std::string &matcher_type = matcher.matcher_name ();
 
     if (boost::iequals (matcher_type, std::string ("CA"))) {
-        if ( (rc = subsystem_exist (ctx, "containment")) == 0)
-            matcher.add_subsystem ("containment", "*");
+        if ( (rc = subsystem_exist (ctx, flux_subsystem_containment)) == 0)
+            matcher.add_subsystem (flux_subsystem_containment, "*");
     } else if (boost::iequals (matcher_type, std::string ("IBA"))) {
-        if ( (rc = subsystem_exist (ctx, "ibnet")) == 0)
-            matcher.add_subsystem ("ibnet", "*");
+        if ( (rc = subsystem_exist (ctx, flux_subsystem_infiniband_network)) == 0)
+            matcher.add_subsystem (flux_subsystem_infiniband_network, "*");
     } else if (boost::iequals (matcher_type, std::string ("IBBA"))) {
-        if ( (rc = subsystem_exist (ctx, "ibnetbw")) == 0)
-            matcher.add_subsystem ("ibnetbw", "*");
+        if ( (rc = subsystem_exist (ctx, flux_subsystem_infiniband_bandwidth)) == 0)
+            matcher.add_subsystem (flux_subsystem_infiniband_bandwidth, "*");
     } else if (boost::iequals (matcher_type, std::string ("PFS1BA"))) {
-        if ( (rc = subsystem_exist (ctx, "pfs1bw")) == 0)
-            matcher.add_subsystem ("pfs1bw", "*");
+        if ( (rc = subsystem_exist (ctx, flux_subsystem_parallel_filesystem_bandwidth)) == 0)
+            matcher.add_subsystem (flux_subsystem_parallel_filesystem_bandwidth, "*");
     } else if (boost::iequals (matcher_type, std::string ("PA"))) {
-        if ( (rc = subsystem_exist (ctx, "power")) == 0)
-            matcher.add_subsystem ("power", "*");
+        if ( (rc = subsystem_exist (ctx, flux_subsystem_power)) == 0)
+            matcher.add_subsystem (flux_subsystem_power, "*");
     } else if (boost::iequals (matcher_type, std::string ("C+PFS1BA"))) {
-        if ( (rc = subsystem_exist (ctx, "containment")) == 0)
-            matcher.add_subsystem ("containment", "contains");
-        if ( !rc && (rc = subsystem_exist (ctx, "pfs1bw")) == 0)
-            matcher.add_subsystem ("pfs1bw", "*");
+        if ( (rc = subsystem_exist (ctx, flux_subsystem_containment)) == 0)
+            matcher.add_subsystem (flux_subsystem_containment, "contains");
+        if ( !rc && (rc = subsystem_exist (ctx, flux_subsystem_parallel_filesystem_bandwidth)) == 0)
+            matcher.add_subsystem (flux_subsystem_parallel_filesystem_bandwidth, "*");
     } else if (boost::iequals (matcher_type, std::string ("C+IBA"))) {
-        if ( (rc = subsystem_exist (ctx, "containment")) == 0)
-            matcher.add_subsystem ("containment", "contains");
-        if ( !rc && (rc = subsystem_exist (ctx, "ibnet")) == 0)
-            matcher.add_subsystem ("ibnet", "connected_up");
+        if ( (rc = subsystem_exist (ctx, flux_subsystem_containment)) == 0)
+            matcher.add_subsystem (flux_subsystem_containment, "contains");
+        if ( !rc && (rc = subsystem_exist (ctx, flux_subsystem_infiniband_network)) == 0)
+            matcher.add_subsystem (flux_subsystem_infiniband_network, "connected_up");
     } else if (boost::iequals (matcher_type, std::string ("C+PA"))) {
-        if ( (rc = subsystem_exist (ctx, "containment")) == 0)
-            matcher.add_subsystem ("containment", "*");
-        if ( !rc && (rc = subsystem_exist (ctx, "power")) == 0)
-            matcher.add_subsystem ("power", "draws_from");
+        if ( (rc = subsystem_exist (ctx, flux_subsystem_containment)) == 0)
+            matcher.add_subsystem (flux_subsystem_containment, "*");
+        if ( !rc && (rc = subsystem_exist (ctx, flux_subsystem_power)) == 0)
+            matcher.add_subsystem (flux_subsystem_power, "draws_from");
     } else if (boost::iequals (matcher_type, std::string ("IB+IBBA"))) {
-        if ( (rc = subsystem_exist (ctx, "ibnet")) == 0)
-            matcher.add_subsystem ("ibnet", "connected_down");
-        if ( !rc && (rc = subsystem_exist (ctx, "ibnetbw")) == 0)
-            matcher.add_subsystem ("ibnetbw", "*");
+        if ( (rc = subsystem_exist (ctx, flux_subsystem_infiniband_network)) == 0)
+            matcher.add_subsystem (flux_subsystem_infiniband_network, "connected_down");
+        if ( !rc && (rc = subsystem_exist (ctx, flux_subsystem_infiniband_bandwidth)) == 0)
+            matcher.add_subsystem (flux_subsystem_infiniband_bandwidth, "*");
     } else if (boost::iequals (matcher_type, std::string ("C+P+IBA"))) {
-        if ( (rc = subsystem_exist (ctx, "containment")) == 0)
-            matcher.add_subsystem ("containment", "contains");
-        if ( (rc = subsystem_exist (ctx, "power")) == 0)
-            matcher.add_subsystem ("power", "draws_from");
-        if ( !rc && (rc = subsystem_exist (ctx, "ibnet")) == 0)
-            matcher.add_subsystem ("ibnet", "connected_up");
+        if ( (rc = subsystem_exist (ctx, flux_subsystem_containment)) == 0)
+            matcher.add_subsystem (flux_subsystem_containment, "contains");
+        if ( (rc = subsystem_exist (ctx, flux_subsystem_power)) == 0)
+            matcher.add_subsystem (flux_subsystem_power, "draws_from");
+        if ( !rc && (rc = subsystem_exist (ctx, flux_subsystem_infiniband_network)) == 0)
+            matcher.add_subsystem (flux_subsystem_infiniband_network, "connected_up");
     } else if (boost::iequals (matcher_type, std::string ("V+PFS1BA"))) {
-        if ( (rc = subsystem_exist (ctx, "virtual1")) == 0)
-            matcher.add_subsystem ("virtual1", "*");
-        if ( !rc && (rc = subsystem_exist (ctx, "pfs1bw")) == 0)
-            matcher.add_subsystem ("pfs1bw", "*");
+        if ( (rc = subsystem_exist (ctx, flux_subsystem_virtual)) == 0)
+            matcher.add_subsystem (flux_subsystem_virtual, "*");
+        if ( !rc && (rc = subsystem_exist (ctx, flux_subsystem_parallel_filesystem_bandwidth)) == 0)
+            matcher.add_subsystem (flux_subsystem_parallel_filesystem_bandwidth, "*");
     } else if (boost::iequals (matcher_type, std::string ("VA"))) {
-        if ( (rc = subsystem_exist (ctx, "virtual1")) == 0)
-            matcher.add_subsystem ("virtual1", "*");
+        if ( (rc = subsystem_exist (ctx, flux_subsystem_virtual)) == 0)
+            matcher.add_subsystem (flux_subsystem_virtual, "*");
     } else if (boost::iequals (matcher_type, std::string ("ALL"))) {
-        if ( (rc = subsystem_exist (ctx, "containment")) == 0)
-            matcher.add_subsystem ("containment", "*");
-        if ( !rc && (rc = subsystem_exist (ctx, "ibnet")) == 0)
-            matcher.add_subsystem ("ibnet", "*");
-        if ( !rc && (rc = subsystem_exist (ctx, "ibnetbw")) == 0)
-            matcher.add_subsystem ("ibnetbw", "*");
-        if ( !rc && (rc = subsystem_exist (ctx, "pfs1bw")) == 0)
-            matcher.add_subsystem ("pfs1bw", "*");
-        if ( (rc = subsystem_exist (ctx, "power")) == 0)
-            matcher.add_subsystem ("power", "*");
+        if ( (rc = subsystem_exist (ctx, flux_subsystem_containment)) == 0)
+            matcher.add_subsystem (flux_subsystem_containment, "*");
+        if ( !rc && (rc = subsystem_exist (ctx, flux_subsystem_infiniband_network)) == 0)
+            matcher.add_subsystem (flux_subsystem_infiniband_network, "*");
+        if ( !rc && (rc = subsystem_exist (ctx, flux_subsystem_infiniband_bandwidth)) == 0)
+            matcher.add_subsystem (flux_subsystem_infiniband_bandwidth, "*");
+        if ( !rc && (rc = subsystem_exist (ctx, flux_subsystem_parallel_filesystem_bandwidth)) == 0)
+            matcher.add_subsystem (flux_subsystem_parallel_filesystem_bandwidth, "*");
+        if ( (rc = subsystem_exist (ctx, flux_subsystem_power)) == 0)
+            matcher.add_subsystem (flux_subsystem_power, "*");
     } else {
         rc = -1;
     }
@@ -343,9 +345,10 @@ static void flatten (f_resource_graph_t &fg,
         paths[*vi] += "}";
         subsystems[*vi] = "{";
         for (auto &kv : fg[*vi].idata.member_of) {
+            boost::flyweight<std::string> fly_first(kv.first);
             if (subsystems[*vi].size () > 1)
                 subsystems[*vi] += ",";
-            subsystems[*vi] += kv.first + "=" + kv.second;
+            subsystems[*vi] += kv.first.get() + "=" + kv.second.get();
         }
         subsystems[*vi] += "}";
         properties[*vi] = "{";
@@ -361,7 +364,7 @@ static void flatten (f_resource_graph_t &fg,
         for (auto &kv : fg[*ei].idata.member_of) {
             if (esubsystems[*ei].size () > 0)
                 esubsystems[*ei] += ",";
-            esubsystems[*ei] += kv.first + "=" + kv.second;
+            esubsystems[*ei] += kv.first.get() + "=" + kv.second.get();
         }
         esubsystems[*ei] += "}";
     }


### PR DESCRIPTION
Problem: string comparison is immensely inefficient, taking 6-10% of resources (reported by Tom) for a trace in the scoring module..
Solution: start with the root of the issue in the scoring module and work backwards to convert string types to boost:: flyweight. I tried to have a minimal footprint here but it spread really quickly

Background: [boost::flyweight](https://www.boost.org/doc/libs/1_79_0/libs/flyweight/doc/tutorial/index.html) is a cool type that essentially maps a string to an internal hashmap. @trws chose it because it still works with a lot of native string stuff. The large change was converting the subsystem_t to use it, which bubbles into many places. Design decisions we will need to make:

- Changes to top level interfaces vs. parsing the strings as flyweights (as I do now)
- Creating classes for groups of flyweights (e.g., subsystem, relation) unlike the flattened versions I have
- When to do a conversion vs. a `.get()`

There is a lot of room for improvement, but I'm really new to C++ so I'm trying to keep this as simple as possible to start, and first getting something working, and then make it better. The build currently works, but tests fail.

Opening this as a draft because I need help with debugging tests - we have segfaults that need gdb-fu and I've only used -disas - ping @trws when you have time (or others that might be interested - I mostly need to learn how to do it).

Also [this is how I feel](https://youtu.be/ZC8jwLHyJgA) about C++ strings... :laughing:  (sorry still laughing about Monk / this entire find)! Gotta make the painful things fun, I think. 