### PR TITLE
testsuite: add valgrind suppressions for hwloc

### DIFF
--- a/t/valgrind/valgrind.supp
+++ b/t/valgrind/valgrind.supp
@@ -99,3 +99,49 @@
    fun:fd_reify
    ...
 }
+{
+   <core_issue_3522>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   ...
+   obj:*libhwloc.so.15.*.*
+   obj:*libhwloc.so.15.*.*
+   fun:hwloc_topology_load
+   ...
+}
+{
+   <core_issue_3640>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:*alloc
+   obj:*/libnvidia-opencl.so.*
+   ...
+   fun:clGetPlatformIDs
+   obj:*/hwloc_opencl.so
+   obj:*/libhwloc.so.*
+   fun:hwloc_topology_load
+   ...
+}
+{
+   <core_issue_3640>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:XNVCTRLQueryTargetStringAttribute
+   obj:*/hwloc_gl.so
+   obj:*/libhwloc.so.*
+   fun:hwloc_topology_load
+   ...
+}
+{
+   <core_issue_3793>
+   Memcheck:Addr1
+   obj:*/libnvidia-opencl.so.*
+   ...
+   fun:clGetPlatformIDs
+   obj:*/hwloc_opencl.so
+   obj:*/libhwloc.so.*
+   fun:hwloc_topology_load
+   ...
+}


### PR DESCRIPTION
Problem: valgrind tests fail in some environments where hwloc gpu plguins are installed.

For example it's now failing on my desktop which is Ubuntu 22.04 with libhwloc-plugins-2.7.0-2ubuntu1 installed.

Bring some valgrind suppressions we added in flux-core for this.