### PR TITLE
up the required C++ standard to 20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ if(POLICY CMP0140)
   cmake_policy(SET CMP0140 NEW)
 endif()
 
-set(CMAKE_CXX_STANDARD 14 CACHE STRING "The C++ standard to use")
+set(CMAKE_CXX_STANDARD 20 CACHE STRING "The C++ standard to use")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/resource/planner/c++/planner_multi.hpp
+++ b/resource/planner/c++/planner_multi.hpp
@@ -35,6 +35,19 @@ struct planner_multi_meta {
 struct idx {};
 struct res_type {};
 
+template<typename T>
+struct polyfill_allocator : std::allocator<T> {
+        using std::allocator<T>::allocator;
+        template<typename U>
+        struct rebind {
+            using other = polyfill_allocator<U>;
+        };
+        using pointer = T*;
+        using const_pointer = T const*;
+        using reference = T&;
+        using const_reference = T const&;
+};
+
 using boost::multi_index_container;
 using namespace boost::multi_index;
 typedef multi_index_container<
@@ -47,7 +60,8 @@ typedef multi_index_container<
             tag<res_type>, // index nametag
             member<planner_multi_meta, std::string, &planner_multi_meta::resource_type> // index's key
         >
-    >
+    >,
+    polyfill_allocator<planner_multi_meta>
 > multi_container;
 
 class planner_multi {


### PR DESCRIPTION
I realize this is odd timing for this, but it's been sitting for a while, and I keep tripping over myself trying to use interfaces that I know exist but don't in C++14.  IIRC @grondo did a test that we can build with gcc12+ everywhere we care about through the devtoolset to build our RPMs, it would help me a lot if we could finish this through as long as it doesn't cause deployment concerns.

problem: Many interfaces are made more cumbersome or slower by forcing the use of only up to c++14.

solution: As previously discussed, up the required C++ standard to 20 since we have devtoolset gcc everywhere that can compile to that standard.