### PR TITLE
qmanager: split remove to separate pending

### DIFF
--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -316,7 +316,7 @@ void qmanager_cb_t::jobmanager_cancel_cb (flux_t *h, const flux_msg_t *msg,
     if ((job = queue->lookup (id)) == nullptr
         || !job->is_pending ())
         return;
-    if (queue->remove (id) < 0) {
+    if (queue->remove_pending (job.get ()) < 0) {
         flux_log_error (h, "%s: remove job (%jd)", __FUNCTION__,
                        static_cast<intmax_t> (id));
         return;

--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -101,7 +101,8 @@ class queue_policy_base_impl_t
 {
 public:
     int insert (std::shared_ptr<job_t> job);
-    int remove (flux_jobid_t id);
+    int remove_pending(job_t *job);
+    int remove(flux_jobid_t id);
     const std::shared_ptr<job_t> lookup (flux_jobid_t id);
     bool is_schedulable ();
     void set_schedulability (bool scheduable);
@@ -116,7 +117,7 @@ protected:
     int process_provisional_cancel ();
     int process_provisional_reprio ();
     int insert_pending_job (std::shared_ptr<job_t> &job, bool into_provisional);
-    int erase_pending_job (std::shared_ptr<job_t> &job, bool &found_in_prov);
+    int erase_pending_job (job_t *job, bool &found_in_prov);
     std::shared_ptr<job_t> pending_pop ();
     std::shared_ptr<job_t> alloced_pop ();
     std::shared_ptr<job_t> rejected_pop ();
@@ -269,6 +270,17 @@ public:
      *                       EINVAL: invalid argument.
      */
     int insert (std::shared_ptr<job_t> pending_job);
+
+    /*! Remove a job whose jobid is id from the pending or maybe_pending queues.
+     * If succeeds, it changes the pending queue or resource state. This queue
+     * becomes "schedulable" if pending job queue is not empty: i.e.,
+     * is_schedulable() returns true;
+     *
+     *  \param id        jobid of flux_jobid_t type.
+     *  \return          0 on success; -1 on error.
+     *                       ENOENT: unknown id.
+     */
+    int remove_pending (job_t *job);
 
     /*! Remove a job whose jobid is id from any internal queues
      *  (e.g., pending queue, running queue, and alloced queue.)

--- a/t/t1024-alloc-check.t
+++ b/t/t1024-alloc-check.t
@@ -61,8 +61,32 @@ test_expect_success 'no jobs received alloc-check exception' '
 	test_must_fail grep "job.exception type=alloc-check" joberr2
 '
 test_expect_success 'clean up' '
+	flux cancel --all &&
+	flux queue idle &&
+	(flux resource undrain 0 || true)
+'
+
+send_sched_cancel() {
+	local JOB_ID=$1
+	shift
+	flux python -c "import flux; from flux.job.JobID import id_parse; flux.Flux().rpc('sched.cancel', {'id': id_parse('$JOB_ID')})"
+}
+
+# ensure sched.cancel doesn't free resources when an epilog is pending
+test_expect_success 'submit a job that cannot run, cancel it during epilog, submit another ' '
+    (flux submit -N 1 --flags=waitable --wait-event epilog-start -c 4 /command/that/does/not/exist > ji1 || true ) &&
+	send_sched_cancel $(cat ji1) &&
+    flux submit -N 1 --exclusive hostname > ji2 &&
+	(flux job wait-event $(cat ji1) epilog-finish || true) &&
+	(flux job info $(cat ji1) eventlog | grep epilog-finish | jq ".timestamp" > time1) &&
+	(flux job info $(cat ji2) eventlog | grep alloc | jq ".timestamp" > time2) &&
+	awk -vt1=$(cat time1) -vt2=$(cat time2) "BEGIN {exit (t1 < t2) ? 0 : 1}"
+'
+
+test_expect_success 'clean up' '
 	cleanup_active_jobs
 '
+
 test_expect_success 'remove fluxion modules' '
 	remove_qmanager &&
 	remove_resource


### PR DESCRIPTION
problem: The "remove" method was used for both handling the `free` and `cancel` RPCs. Under some code paths, remove de-allocates resources, so using it for a pending cancellation, even if it seems to be protected by checks, is unnecessarily dangerous.  Given the recent double-booking issue and a lack so far of other theories on how we get there, this is a possible culprit.

solution: Re-factor queue_policy_base_t remove into remove and remove_pending, the latter of which only operates on the pending states and has no code-paths that can result in a resource.cancel RPC being sent.  The remove_pending is used for both the cancel RPC and the part of the free RPC where the code was used before, should be a pure refactor.