### PR TITLE
Add sanitizers

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -2,6 +2,7 @@
 # do not check testing data
 [files]
 extend-exclude = [
+  "cmake/sanitizers-cmake/*",
   "config/*",
   "m4/*",
   "src/common/libutil/json.hpp",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,6 @@ if("${isSystemDir}" STREQUAL "-1")
   set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 endif("${isSystemDir}" STREQUAL "-1")
 
-
 # Setting the include directory for the application to find config.h
 include_directories( ${CMAKE_BINARY_DIR} )
 # Since we have created a config.h add a global define for it
@@ -46,10 +45,11 @@ add_definitions( "-DPACKAGE_VERSION=\"${FLUX_SCHED_VER}\"" )
 # We build a lot of shared libs, build them all with PIC
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# variable to store paths to add to module path for tests
-
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/sanitizers-cmake/cmake)
 list(APPEND CMAKE_PREFIX_PATH ${CMAKE_INSTALL_PREFIX})
+
+include(FindSanitizers)
 
 # external dependencies
 find_package(PkgConfig REQUIRED)
@@ -147,6 +147,7 @@ function(flux_add_plugin TargetName PluginType)
     )
   target_link_options(${TargetName} PRIVATE
     "LINKER:--version-script=${CMAKE_SOURCE_DIR}/flux-plugin.map" ${LinkerOpts})
+  add_sanitizers(${TargetName})
   target_link_libraries(${TargetName} PRIVATE flux::core)
   if (NOT ARG_NOINSTALL)
     install(TARGETS ${TargetName}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,81 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 23,
+    "patch": 0
+  },
+  "include": [
+    "otherThings.json",
+    "moreThings.json"
+  ],
+  "configurePresets": [
+    {
+      "name": "default",
+      "displayName": "Default Config",
+      "description": "Default build using Ninja generator",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/default",
+      "cacheVariables": {},
+      "environment": {},
+      "vendor": {}
+    },
+    {
+      "name": "asan",
+      "displayName": "Debug with address sanitizer",
+      "description": "ASAN build using Ninja generator",
+      "inherits": "default",
+      "binaryDir": "${sourceDir}/build/asan",
+      "cacheVariables": {
+        "SANITIZE_ADDRESS": "ON"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default"
+    },
+    {
+      "name": "asan",
+      "configurePreset": "asan"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default",
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "noTestsAction": "error",
+        "stopOnFailure": true
+      }
+    },
+    {
+      "name": "Asan",
+      "configurePreset": "asan",
+      "output": {
+        "outputOnFailure": true,
+        "verbosity": "verbose"
+      },
+      "environment": {
+        "ASAN_OPTIONS": "detect_leaks=0,start_deactivated=true,replace_str=true,verify_asan_link_order=false"
+      },
+      "execution": {
+        "noTestsAction": "error",
+        "stopOnFailure": true
+      }
+    }
+  ],
+  "packagePresets": [
+    {
+      "name": "default",
+      "configurePreset": "default",
+      "generators": []
+    }
+  ],
+  "workflowPresets": [],
+  "vendor": {}
+}

--- a/cmake/sanitizers-cmake/.gitignore
+++ b/cmake/sanitizers-cmake/.gitignore
@@ -1,0 +1,3 @@
+# out-of-source build top-level folders.
+build/
+_build/

--- a/cmake/sanitizers-cmake/CMakeLists.txt
+++ b/cmake/sanitizers-cmake/CMakeLists.txt
@@ -1,0 +1,51 @@
+# This file is part of CMake-sanitizers.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#
+# Copyright (c)
+#   2013-2015 Matt Arsenault
+#   2015      RWTH Aachen University, Federal Republic of Germany
+#
+
+
+#
+# project information
+#
+
+# minimum required cmake version
+cmake_minimum_required(VERSION 2.8.12)
+
+# project name
+project("CMake-sanitizers")
+
+
+
+#
+# cmake configuration
+#
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+
+
+
+#
+# add tests
+#
+enable_testing()
+add_subdirectory(tests)

--- a/cmake/sanitizers-cmake/LICENSE
+++ b/cmake/sanitizers-cmake/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c)
+    2013 Matthew Arsenault
+    2015-2016 RWTH Aachen University, Federal Republic of Germany
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/cmake/sanitizers-cmake/README.md
+++ b/cmake/sanitizers-cmake/README.md
@@ -1,0 +1,73 @@
+# sanitizers-cmake
+
+ [![](https://img.shields.io/github/issues-raw/arsenm/sanitizers-cmake.svg?style=flat-square)](https://github.com/arsenm/sanitizers-cmake/issues)
+[![MIT](http://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](LICENSE)
+
+CMake module to enable sanitizers for binary targets.
+
+
+## Include into your project
+
+To use [FindSanitizers.cmake](cmake/FindSanitizers.cmake), simply add this repository as git submodule into your own repository
+```Shell
+mkdir externals
+git submodule add git@github.com:arsenm/sanitizers-cmake.git externals/sanitizers-cmake
+```
+and adding ```externals/sanitizers-cmake/cmake``` to your ```CMAKE_MODULE_PATH```
+```CMake
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/externals/sanitizers-cmake/cmake" ${CMAKE_MODULE_PATH})
+```
+
+If you don't use git or dislike submodules you can copy the files in [cmake directory](cmake) into your repository. *Be careful and keep updates in mind!*
+
+Now you can simply run ```find_package``` in your CMake files:
+```CMake
+find_package(Sanitizers)
+```
+
+
+## Usage
+
+You can enable the sanitizers with ``SANITIZE_ADDRESS``, ``SANITIZE_MEMORY``, ``SANITIZE_THREAD`` or ``SANITIZE_UNDEFINED`` options in your CMake configuration. You can do this by passing e.g. ``-DSANITIZE_ADDRESS=On`` on your command line or with your graphical interface.
+
+If sanitizers are supported by your compiler, the specified targets will be build with sanitizer support. If your compiler has no sanitizing capabilities (I asume intel compiler doesn't) you'll get a warning but CMake will continue processing and sanitizing will simply just be ignored.
+
+#### Compiler issues
+
+Different compilers may be using different implementations for sanitizers. If you'll try to sanitize targets with C and Fortran code but don't use gcc & gfortran but clang & gfortran, this will cause linking problems. To avoid this, such problems will be detected and sanitizing will be disabled for these targets.
+
+Even C only targets may cause problems in certain situations. Some problems have been seen with AddressSanitizer for preloading or dynamic linking. In such cases you may try the ``SANITIZE_LINK_STATIC`` to link sanitizers for gcc static.
+
+
+
+## Build targets with sanitizer support
+
+To enable sanitizer support you simply have to add ``add_sanitizers(<TARGET>)`` after defining your target. To provide a sanitizer blacklist file you can use the ``sanitizer_add_blacklist_file(<FILE>)`` function:
+```CMake
+find_package(Sanitizers)
+
+sanitizer_add_blacklist_file("blacklist.txt")
+
+add_executable(some_exe foo.c bar.c)
+add_sanitizers(some_exe)
+
+add_library(some_lib foo.c bar.c)
+add_sanitizers(some_lib)
+```
+
+## Run your application
+
+The sanitizers check your program, while it's running. In some situations (e.g. LD_PRELOAD your target) it might be required to preload the used AddressSanitizer library first. In this case you may use the ``asan-wrapper`` script defined in ``ASan_WRAPPER`` variable to execute your application with ``${ASan_WRAPPER} myexe arg1 ...``.
+
+
+## Contribute
+
+Anyone is welcome to contribute. Simply fork this repository, make your changes **in an own branch** and create a pull-request for your change. Please do only one change per pull-request.
+
+You found a bug? Please fill out an [issue](https://github.com/arsenm/sanitizers-cmake/issues) and include any data to reproduce the bug.
+
+
+#### Contributors
+
+* [Matt Arsenault](https://github.com/arsenm)
+* [Alexander Haase](https://github.com/alehaa)

--- a/cmake/sanitizers-cmake/cmake/FindASan.cmake
+++ b/cmake/sanitizers-cmake/cmake/FindASan.cmake
@@ -1,0 +1,62 @@
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+option(SANITIZE_ADDRESS "Enable AddressSanitizer for sanitized targets." Off)
+
+set(FLAG_CANDIDATES
+    # MSVC uses
+    "/fsanitize=address"
+
+    # Clang 3.2+ use this version. The no-omit-frame-pointer option is optional.
+    "-g -fsanitize=address -fno-omit-frame-pointer"
+    "-g -fsanitize=address"
+
+    # Older deprecated flag for ASan
+    "-g -faddress-sanitizer"
+)
+
+
+if (SANITIZE_ADDRESS AND (SANITIZE_THREAD OR SANITIZE_MEMORY))
+    message(FATAL_ERROR "AddressSanitizer is not compatible with "
+        "ThreadSanitizer or MemorySanitizer.")
+endif ()
+
+
+include(sanitize-helpers)
+
+if (SANITIZE_ADDRESS)
+    sanitizer_check_compiler_flags("${FLAG_CANDIDATES}" "AddressSanitizer"
+        "ASan")
+
+    find_program(ASan_WRAPPER "asan-wrapper" PATHS ${CMAKE_MODULE_PATH})
+	mark_as_advanced(ASan_WRAPPER)
+endif ()
+
+function (add_sanitize_address TARGET)
+    if (NOT SANITIZE_ADDRESS)
+        return()
+    endif ()
+
+    sanitizer_add_flags(${TARGET} "AddressSanitizer" "ASan")
+endfunction ()

--- a/cmake/sanitizers-cmake/cmake/FindMSan.cmake
+++ b/cmake/sanitizers-cmake/cmake/FindMSan.cmake
@@ -1,0 +1,60 @@
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+option(SANITIZE_MEMORY "Enable MemorySanitizer for sanitized targets." Off)
+
+set(FLAG_CANDIDATES
+    # MSVC uses
+    "/fsanitize=memory"
+    # GNU/Clang
+    "-g -fsanitize=memory"
+)
+
+
+include(sanitize-helpers)
+
+if (SANITIZE_MEMORY)
+    if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+        message(WARNING "MemorySanitizer disabled for target ${TARGET} because "
+            "MemorySanitizer is supported for Linux systems only.")
+        set(SANITIZE_MEMORY Off CACHE BOOL
+            "Enable MemorySanitizer for sanitized targets." FORCE)
+    elseif (NOT ${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+        message(WARNING "MemorySanitizer disabled for target ${TARGET} because "
+            "MemorySanitizer is supported for 64bit systems only.")
+        set(SANITIZE_MEMORY Off CACHE BOOL
+            "Enable MemorySanitizer for sanitized targets." FORCE)
+    else ()
+        sanitizer_check_compiler_flags("${FLAG_CANDIDATES}" "MemorySanitizer"
+            "MSan")
+    endif ()
+endif ()
+
+function (add_sanitize_memory TARGET)
+    if (NOT SANITIZE_MEMORY)
+        return()
+    endif ()
+
+    sanitizer_add_flags(${TARGET} "MemorySanitizer" "MSan")
+endfunction ()

--- a/cmake/sanitizers-cmake/cmake/FindSanitizers.cmake
+++ b/cmake/sanitizers-cmake/cmake/FindSanitizers.cmake
@@ -1,0 +1,93 @@
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 3.13)	# target_link_options()
+
+# If any of the used compiler is a GNU compiler, add a second option to static
+# link against the sanitizers.
+option(SANITIZE_LINK_STATIC "Try to link static against sanitizers." Off)
+
+# Highlight this module has been loaded.
+set(Sanitizers_FOUND TRUE)
+
+set(FIND_QUIETLY_FLAG "")
+if (DEFINED Sanitizers_FIND_QUIETLY)
+    set(FIND_QUIETLY_FLAG "QUIET")
+endif ()
+
+find_package(ASan ${FIND_QUIETLY_FLAG})
+find_package(TSan ${FIND_QUIETLY_FLAG})
+find_package(MSan ${FIND_QUIETLY_FLAG})
+find_package(UBSan ${FIND_QUIETLY_FLAG})
+
+function(sanitizer_add_blacklist_file FILE)
+    if(NOT IS_ABSOLUTE ${FILE})
+        set(FILE "${CMAKE_CURRENT_SOURCE_DIR}/${FILE}")
+    endif()
+    get_filename_component(FILE "${FILE}" REALPATH)
+
+    sanitizer_check_compiler_flags("-fsanitize-blacklist=${FILE}"
+        "SanitizerBlacklist" "SanBlist")
+endfunction()
+
+function(add_sanitizers)
+    # If no sanitizer is enabled, return immediately.
+    if (NOT (SANITIZE_ADDRESS OR SANITIZE_MEMORY OR SANITIZE_THREAD OR
+        SANITIZE_UNDEFINED))
+        return()
+    endif ()
+
+    foreach (TARGET ${ARGV})
+        # Check if this target will be compiled by exactly one compiler. Other-
+        # wise sanitizers can't be used and a warning should be printed once.
+        get_target_property(TARGET_TYPE ${TARGET} TYPE)
+        if (TARGET_TYPE STREQUAL "INTERFACE_LIBRARY")
+            message(WARNING "Can't use any sanitizers for target ${TARGET}, "
+                    "because it is an interface library and cannot be "
+                    "compiled directly.")
+            return()
+        endif ()
+        sanitizer_target_compilers(${TARGET} TARGET_COMPILER)
+        list(LENGTH TARGET_COMPILER NUM_COMPILERS)
+        if (NUM_COMPILERS GREATER 1)
+            message(WARNING "Can't use any sanitizers for target ${TARGET}, "
+                    "because it will be compiled by incompatible compilers. "
+                    "Target will be compiled without sanitizers.")
+            return()
+
+        elseif (NUM_COMPILERS EQUAL 0)
+            # If the target is compiled by no known compiler, give a warning.
+            message(WARNING "Sanitizers for target ${TARGET} may not be"
+                    " usable, because it uses no or an unknown compiler. "
+                    "This is a false warning for targets using only "
+                    "object lib(s) as input.")
+        endif ()
+
+        # Add sanitizers for target.
+        add_sanitize_address(${TARGET})
+        add_sanitize_thread(${TARGET})
+        add_sanitize_memory(${TARGET})
+        add_sanitize_undefined(${TARGET})
+    endforeach ()
+endfunction(add_sanitizers)

--- a/cmake/sanitizers-cmake/cmake/FindTSan.cmake
+++ b/cmake/sanitizers-cmake/cmake/FindTSan.cmake
@@ -1,0 +1,68 @@
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+option(SANITIZE_THREAD "Enable ThreadSanitizer for sanitized targets." Off)
+
+set(FLAG_CANDIDATES
+    # MSVC uses
+    "/fsanitize=thread"
+    # GNU/Clang
+    "-g -fsanitize=thread"
+)
+
+
+# ThreadSanitizer is not compatible with MemorySanitizer.
+if (SANITIZE_THREAD AND SANITIZE_MEMORY)
+    message(FATAL_ERROR "ThreadSanitizer is not compatible with "
+        "MemorySanitizer.")
+endif ()
+
+
+include(sanitize-helpers)
+
+if (SANITIZE_THREAD)
+  if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND
+      NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+        message(WARNING "ThreadSanitizer disabled for target ${TARGET} because "
+          "ThreadSanitizer is supported for Linux systems and macOS only.")
+        set(SANITIZE_THREAD Off CACHE BOOL
+            "Enable ThreadSanitizer for sanitized targets." FORCE)
+    elseif (NOT ${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+        message(WARNING "ThreadSanitizer disabled for target ${TARGET} because "
+            "ThreadSanitizer is supported for 64bit systems only.")
+        set(SANITIZE_THREAD Off CACHE BOOL
+            "Enable ThreadSanitizer for sanitized targets." FORCE)
+    else ()
+        sanitizer_check_compiler_flags("${FLAG_CANDIDATES}" "ThreadSanitizer"
+            "TSan")
+    endif ()
+endif ()
+
+function (add_sanitize_thread TARGET)
+    if (NOT SANITIZE_THREAD)
+        return()
+    endif ()
+
+    sanitizer_add_flags(${TARGET} "ThreadSanitizer" "TSan")
+endfunction ()

--- a/cmake/sanitizers-cmake/cmake/FindUBSan.cmake
+++ b/cmake/sanitizers-cmake/cmake/FindUBSan.cmake
@@ -1,0 +1,49 @@
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+option(SANITIZE_UNDEFINED
+    "Enable UndefinedBehaviorSanitizer for sanitized targets." Off)
+
+set(FLAG_CANDIDATES
+    # MSVC uses
+    "/fsanitize=undefined"
+    # GNU/Clang
+    "-g -fsanitize=undefined"
+)
+
+
+include(sanitize-helpers)
+
+if (SANITIZE_UNDEFINED)
+    sanitizer_check_compiler_flags("${FLAG_CANDIDATES}"
+        "UndefinedBehaviorSanitizer" "UBSan")
+endif ()
+
+function (add_sanitize_undefined TARGET)
+    if (NOT SANITIZE_UNDEFINED)
+        return()
+    endif ()
+
+    sanitizer_add_flags(${TARGET} "UndefinedBehaviorSanitizer" "UBSan")
+endfunction ()

--- a/cmake/sanitizers-cmake/cmake/asan-wrapper
+++ b/cmake/sanitizers-cmake/cmake/asan-wrapper
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# This script is a wrapper for AddressSanitizer. In some special cases you need
+# to preload AddressSanitizer to avoid error messages - e.g. if you're
+# preloading another library to your application. At the moment this script will
+# only do something, if we're running on a Linux platform. OSX might not be
+# affected.
+
+
+# Exit immediately, if platform is not Linux.
+if [ "$(uname)" != "Linux" ]
+then
+    exec $@
+fi
+
+
+# Get the used libasan of the application ($1). If a libasan was found, it will
+# be prepended to LD_PRELOAD.
+libasan=$(ldd $1 | grep libasan | sed "s/^[[:space:]]//" | cut -d' ' -f1)
+if [ -n "$libasan" ]
+then
+    if [ -n "$LD_PRELOAD" ]
+    then
+        export LD_PRELOAD="$libasan:$LD_PRELOAD"
+    else
+        export LD_PRELOAD="$libasan"
+    fi
+fi
+
+# Execute the application.
+exec $@

--- a/cmake/sanitizers-cmake/cmake/sanitize-helpers.cmake
+++ b/cmake/sanitizers-cmake/cmake/sanitize-helpers.cmake
@@ -1,0 +1,178 @@
+# The MIT License (MIT)
+#
+# Copyright (c)
+#   2013 Matthew Arsenault
+#   2015-2016 RWTH Aachen University, Federal Republic of Germany
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Helper function to get the language of a source file.
+function (sanitizer_lang_of_source FILE RETURN_VAR)
+    get_filename_component(LONGEST_EXT "${FILE}" EXT)
+    # If extension is empty return. This can happen for extensionless headers
+    if("${LONGEST_EXT}" STREQUAL "")
+       set(${RETURN_VAR} "" PARENT_SCOPE)
+       return()
+    endif()
+    # Get shortest extension as some files can have dot in their names
+    string(REGEX REPLACE "^.*(\\.[^.]+)$" "\\1" FILE_EXT ${LONGEST_EXT})
+    string(TOLOWER "${FILE_EXT}" FILE_EXT)
+    string(SUBSTRING "${FILE_EXT}" 1 -1 FILE_EXT)
+
+    get_property(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
+    foreach (LANG ${ENABLED_LANGUAGES})
+        list(FIND CMAKE_${LANG}_SOURCE_FILE_EXTENSIONS "${FILE_EXT}" TEMP)
+        if (NOT ${TEMP} EQUAL -1)
+            set(${RETURN_VAR} "${LANG}" PARENT_SCOPE)
+            return()
+        endif ()
+    endforeach()
+
+    set(${RETURN_VAR} "" PARENT_SCOPE)
+endfunction ()
+
+
+# Helper function to get compilers used by a target.
+function (sanitizer_target_compilers TARGET RETURN_VAR)
+    # Check if all sources for target use the same compiler. If a target uses
+    # e.g. C and Fortran mixed and uses different compilers (e.g. clang and
+    # gfortran) this can trigger huge problems, because different compilers may
+    # use different implementations for sanitizers.
+    set(BUFFER "")
+    get_target_property(TSOURCES ${TARGET} SOURCES)
+    foreach (FILE ${TSOURCES})
+        # If expression was found, FILE is a generator-expression for an object
+        # library. Object libraries will be ignored.
+        string(REGEX MATCH "TARGET_OBJECTS:([^ >]+)" _file ${FILE})
+        if ("${_file}" STREQUAL "")
+            sanitizer_lang_of_source(${FILE} LANG)
+            if (LANG)
+                list(APPEND BUFFER ${CMAKE_${LANG}_COMPILER_ID})
+            endif ()
+        endif ()
+    endforeach ()
+
+    list(REMOVE_DUPLICATES BUFFER)
+    set(${RETURN_VAR} "${BUFFER}" PARENT_SCOPE)
+endfunction ()
+
+
+# Helper function to check compiler flags for language compiler.
+function (sanitizer_check_compiler_flag FLAG LANG VARIABLE)
+
+    if (${LANG} STREQUAL "C")
+        include(CheckCCompilerFlag)
+        check_c_compiler_flag("${FLAG}" ${VARIABLE})
+
+    elseif (${LANG} STREQUAL "CXX")
+        include(CheckCXXCompilerFlag)
+        check_cxx_compiler_flag("${FLAG}" ${VARIABLE})
+
+    elseif (${LANG} STREQUAL "Fortran")
+        # CheckFortranCompilerFlag was introduced in CMake 3.x. To be compatible
+        # with older Cmake versions, we will check if this module is present
+        # before we use it. Otherwise we will define Fortran coverage support as
+        # not available.
+        include(CheckFortranCompilerFlag OPTIONAL RESULT_VARIABLE INCLUDED)
+        if (INCLUDED)
+            check_fortran_compiler_flag("${FLAG}" ${VARIABLE})
+        elseif (NOT CMAKE_REQUIRED_QUIET)
+            message(STATUS "Performing Test ${VARIABLE}")
+            message(STATUS "Performing Test ${VARIABLE}"
+                " - Failed (Check not supported)")
+        endif ()
+    endif()
+
+endfunction ()
+
+
+# Helper function to test compiler flags.
+function (sanitizer_check_compiler_flags FLAG_CANDIDATES NAME PREFIX)
+    set(CMAKE_REQUIRED_QUIET ${${PREFIX}_FIND_QUIETLY})
+
+    get_property(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
+    foreach (LANG ${ENABLED_LANGUAGES})
+        # Sanitizer flags are not dependend on language, but the used compiler.
+        # So instead of searching flags foreach language, search flags foreach
+        # compiler used.
+        set(COMPILER ${CMAKE_${LANG}_COMPILER_ID})
+        if (COMPILER AND NOT DEFINED ${PREFIX}_${COMPILER}_FLAGS)
+            foreach (FLAG ${FLAG_CANDIDATES})
+                if(NOT CMAKE_REQUIRED_QUIET)
+                    message(STATUS "Try ${COMPILER} ${NAME} flag = [${FLAG}]")
+                endif()
+
+                set(CMAKE_REQUIRED_FLAGS "${FLAG}")
+                unset(${PREFIX}_FLAG_DETECTED CACHE)
+                sanitizer_check_compiler_flag("${FLAG}" ${LANG}
+                    ${PREFIX}_FLAG_DETECTED)
+
+                if (${PREFIX}_FLAG_DETECTED)
+                    # If compiler is a GNU compiler, search for static flag, if
+                    # SANITIZE_LINK_STATIC is enabled.
+                    if (SANITIZE_LINK_STATIC AND (${COMPILER} STREQUAL "GNU"))
+                        string(TOLOWER ${PREFIX} PREFIX_lower)
+                        sanitizer_check_compiler_flag(
+                            "-static-lib${PREFIX_lower}" ${LANG}
+                            ${PREFIX}_STATIC_FLAG_DETECTED)
+
+                        if (${PREFIX}_STATIC_FLAG_DETECTED)
+                            set(FLAG "-static-lib${PREFIX_lower} ${FLAG}")
+                        endif ()
+                    endif ()
+
+                    set(${PREFIX}_${COMPILER}_FLAGS "${FLAG}" CACHE STRING
+                        "${NAME} flags for ${COMPILER} compiler.")
+                    mark_as_advanced(${PREFIX}_${COMPILER}_FLAGS)
+                    break()
+                endif ()
+            endforeach ()
+
+            if (NOT ${PREFIX}_FLAG_DETECTED)
+                set(${PREFIX}_${COMPILER}_FLAGS "" CACHE STRING
+                    "${NAME} flags for ${COMPILER} compiler.")
+                mark_as_advanced(${PREFIX}_${COMPILER}_FLAGS)
+
+                message(WARNING "${NAME} is not available for ${COMPILER} "
+                        "compiler. Targets using this compiler will be "
+                        "compiled without ${NAME}.")
+            endif ()
+        endif ()
+    endforeach ()
+endfunction ()
+
+
+# Helper to assign sanitizer flags for TARGET.
+function (sanitizer_add_flags TARGET NAME PREFIX)
+    # Get list of compilers used by target and check, if sanitizer is available
+    # for this target. Other compiler checks like check for conflicting
+    # compilers will be done in add_sanitizers function.
+    sanitizer_target_compilers(${TARGET} TARGET_COMPILER)
+    list(LENGTH TARGET_COMPILER NUM_COMPILERS)
+    if ("${${PREFIX}_${TARGET_COMPILER}_FLAGS}" STREQUAL "")
+        return()
+    endif()
+
+    separate_arguments(flags_list UNIX_COMMAND "${${PREFIX}_${TARGET_COMPILER}_FLAGS} ${SanBlist_${TARGET_COMPILER}_FLAGS}")
+    target_compile_options(${TARGET} PUBLIC ${flags_list})
+
+    separate_arguments(flags_list UNIX_COMMAND "${${PREFIX}_${TARGET_COMPILER}_FLAGS}")
+    target_link_options(${TARGET} PUBLIC ${flags_list})
+
+endfunction ()

--- a/cmake/sanitizers-cmake/tests/CMakeLists.txt
+++ b/cmake/sanitizers-cmake/tests/CMakeLists.txt
@@ -1,0 +1,67 @@
+# This file is part of CMake-sanitizers.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#
+# Copyright (c)
+#   2013-2015 Matt Arsenault
+#   2015      RWTH Aachen University, Federal Republic of Germany
+#
+
+# Function to add testcases.
+function(add_testcase TESTNAME SOURCEFILES)
+	# remove ${TESTNAME} from ${ARGV} to use ${ARGV} as ${SOURCEFILES}
+	list(REMOVE_AT ARGV 0)
+
+	# add a new executable
+	add_executable(${TESTNAME} ${ARGV})
+
+	# add a testcase for executable
+	add_test(${TESTNAME} ${TESTNAME})
+endfunction(add_testcase)
+
+# Function to add testcases with asan enabled.
+function(add_sanitized_testcase TESTNAME SOURCEFILES)
+	add_testcase(${TESTNAME} ${SOURCEFILES})
+	add_sanitizers(${TESTNAME})
+endfunction(add_sanitized_testcase)
+
+
+
+set(SANITIZE_ADDRESS TRUE)
+
+#
+# search for sanitizers
+#
+find_package(Sanitizers)
+
+
+#
+# add testcases
+#
+add_sanitized_testcase("asan_test_cpp" asan_test.cpp)
+add_sanitized_testcase("shortest_ext_test_cpp" shortest.ext.test.cpp)
+
+set_tests_properties(
+	"asan_test_cpp"
+	"shortest_ext_test_cpp"
+PROPERTIES
+	WILL_FAIL TRUE
+)
+

--- a/cmake/sanitizers-cmake/tests/asan_test.cpp
+++ b/cmake/sanitizers-cmake/tests/asan_test.cpp
@@ -1,0 +1,40 @@
+/* This file is part of CMake-sanitizers.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ * Copyright (c)
+ *  2013-2015 Matt Arsenault
+ *  2015      RWTH Aachen University, Federal Republic of Germany
+ */
+
+
+int
+main(int argc, char **argv)
+{
+	// Allocate a new array and delete it.
+	int *array = new int[argc + 1];
+	array[argc] = 0;
+	delete[] array;
+
+	/* Access element of the deleted array. This will cause an memory error with
+	 * address sanitizer.
+	 */
+	return array[argc];
+}

--- a/cmake/sanitizers-cmake/tests/shortest.ext.test.cpp
+++ b/cmake/sanitizers-cmake/tests/shortest.ext.test.cpp
@@ -1,0 +1,40 @@
+/* This file is part of CMake-sanitizers.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ * Copyright (c)
+ *  2013-2015 Matt Arsenault
+ *  2015      RWTH Aachen University, Federal Republic of Germany
+ */
+
+
+int
+main(int argc, char **argv)
+{
+	// Allocate a new array and delete it.
+	int *array = new int[argc + 1];
+	array[argc] = 0;
+	delete[] array;
+
+	/* Access element of the deleted array. This will cause an memory error with
+	 * address sanitizer.
+	 */
+	return array[argc];
+}

--- a/cmake/update-sanitizers-cmake.sh
+++ b/cmake/update-sanitizers-cmake.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# first version pulled from commit 3f0542e on April 19
+# add command: git subtree add --prefix=cmake/sanitizers-cmake --squash https://github.com/arsenm/sanitizers-cmake master
+#
+# To rebase across an update, use `git rebase --rebase-merges --strategy subtree
+# if the rebase stops and says "refusing to merge unrelated histories" then use
+# the add command above or pull or similar to re-create the merge commit
+git subtree pull --prefix cmake/sanitizers-cmake https://github.com/arsenm/sanitizers-cmake master --squash

--- a/resource/CMakeLists.txt
+++ b/resource/CMakeLists.txt
@@ -87,6 +87,7 @@ target_link_libraries(resource PUBLIC
     jobspec_conv
     Boost::filesystem
     )
+add_sanitizers(resource)
 
 add_subdirectory(modules)
 add_subdirectory(reapi)

--- a/resource/libjobspec/CMakeLists.txt
+++ b/resource/libjobspec/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library ( jobspec_conv STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/rank_constraint.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rank_constraint.hpp
     )
+add_sanitizers(jobspec_conv)
 target_link_libraries(jobspec_conv PUBLIC flux::hostlist flux::idset
     flux::core yaml-cpp PkgConfig::JANSSON 
     PkgConfig::UUID

--- a/resource/planner/c++/CMakeLists.txt
+++ b/resource/planner/c++/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(planner_cxx STATIC
 	./planner_internal_tree.hpp
 	./scheduled_point_tree.hpp
  )
+add_sanitizers(planner_cxx) 
 target_link_libraries(planner_cxx yggdrasil)
 
 

--- a/resource/planner/c/CMakeLists.txt
+++ b/resource/planner/c/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(planner STATIC
 	./planner.h
 	./planner_multi.h
 )
+add_sanitizers(planner)
 target_include_directories(planner PUBLIC ./)
 target_link_libraries(planner PUBLIC planner_cxx)
 

--- a/resource/planner/test/CMakeLists.txt
+++ b/resource/planner/test/CMakeLists.txt
@@ -1,9 +1,11 @@
 add_executable(planner_test01 planner_test01.cpp)
+add_sanitizers(planner_test01)
 target_link_libraries(planner_test01 planner libtap)
 flux_add_test(NAME planner_test01 COMMAND planner_test01)
 set_property(TEST planner_test01 PROPERTY ENVIRONMENT "TESTRESRC_INPUT_FILE=$(CMAKE_SOURCE_DIR)/conf/hype.lua")
 
 add_executable(planner_test02 planner_test02.cpp)
+add_sanitizers(planner_test02)
 target_link_libraries(planner_test02 planner libtap)
 flux_add_test(NAME planner_test02 COMMAND planner_test02)
 set_property(TEST planner_test02 PROPERTY ENVIRONMENT "TESTRESRC_INPUT_FILE=$(CMAKE_SOURCE_DIR)/conf/hype.lua")

--- a/resource/policies/base/test/CMakeLists.txt
+++ b/resource/policies/base/test/CMakeLists.txt
@@ -4,4 +4,5 @@ add_executable(matcher_util_api_test
 target_link_libraries(matcher_util_api_test PRIVATE libtap resource
   PkgConfig::JANSSON
   )
+add_sanitizers(matcher_util_api_test)
 flux_add_test(NAME matcher_util_api_test COMMAND matcher_util_api_test)

--- a/resource/utilities/CMakeLists.txt
+++ b/resource/utilities/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(grug2dot
   grug2dot.cpp
   )
+add_sanitizers(grug2dot)
 target_link_libraries(grug2dot
   resource
   Boost::headers
@@ -11,6 +12,7 @@ add_executable(resource-query
   command.cpp
   command.hpp
   )
+add_sanitizers(resource-query)
 target_link_libraries(resource-query
   resource
   PkgConfig::LIBEDIT
@@ -23,6 +25,7 @@ add_executable(rq2
   rq2.cpp
   rq2.hpp
   )
+add_sanitizers(rq2)
 target_link_libraries(rq2
   resource
   PkgConfig::LIBEDIT


### PR DESCRIPTION
What it says on the tin, adding support for using sanitizers so we can leverage those to find issues with fluxion.  Also adds a first copy of a CMakePresets.json file so we can have a common set of known build and test configurations that we can all share.  For now this is just default and asan, but I think others could be worthwhile.