### PR TITLE
resource: ensure all resources start in DOWN state when some ranks are excluded by configuration

### DIFF
--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -1144,14 +1144,10 @@ done:
 static int decode_all (std::shared_ptr<resource_ctx_t> &ctx,
                        std::set<int64_t> &ranks)
 {
-    int64_t size = ctx->db->metadata.by_rank.size();
-    
-    for (int64_t rank = 0; rank < size; ++rank) {
-        auto ret = ranks.insert (rank);
-        if (!ret.second) {
-            errno = EEXIST;
-            return -1;
-        }
+    ranks.clear ();
+    for (auto const& kv: ctx->db->metadata.by_rank) {
+        if (kv.first >= 0)
+            ranks.insert (kv.first);
     }
     return 0;
 }

--- a/t/issues/t1182-exclude-with-down-ranks.sh
+++ b/t/issues/t1182-exclude-with-down-ranks.sh
@@ -1,0 +1,69 @@
+#!/bin/bash -e
+#
+#  Ensure Fluxion marks all ranks down even if some ranks are excluded
+#
+
+log() { printf "issue#1182: $@\n" >&2; }
+
+# Need a few ranks for this test, so start a new instance of size=4
+if test "$ISSUE_1182_ACTIVE" != "t"; then
+    export ISSUE_1182_ACTIVE=t
+    log "Re-launching test script under flux-start"
+    exec flux start -s 4 $0
+fi
+
+cat <<'EOF' >rcheck.py
+import sys
+import flux
+from flux.resource.list import ResourceListRPC
+
+h = flux.Flux()
+
+rpc1 = ResourceListRPC(h, "resource.sched-status", nodeid=0)
+rpc2 = ResourceListRPC(h, "sched.resource-status", nodeid=0)
+
+rset = rpc1.get()
+fluxion = rpc2.get()
+
+def symmetric_diff(a, b):
+    return (a|b) - (a&b)
+
+diff = symmetric_diff(rset.down, fluxion.down)
+if diff.ranks:
+    print("difference detected between fluxion and core down ranks:")
+    print(f"hosts: {diff.nodelist}")
+    print(f"ranks: {diff.ranks}")
+    sys.exit(1)
+sys.exit(0)
+EOF
+
+log "Unloading modules..."
+flux module remove sched-simple
+flux module remove resource
+
+# Exclude rank 0
+flux config load <<EOF
+[resource]
+exclude = "0,2"
+EOF
+
+flux module load resource monitor-force-up
+
+# Drain rank 3. Scheduler should only see rank 1 as up
+log "draining rank 3"
+flux resource drain 3
+
+flux resource status
+
+flux module load sched-fluxion-resource
+flux module load sched-fluxion-qmanager
+
+log "comparing fluxion down ranks with flux-core resource module:"
+flux resource list
+FLUX_RESOURCE_LIST_RPC=sched.resource-status flux resource list
+flux python ./rcheck.py
+
+log "reloading sched-simple..."
+flux module remove sched-fluxion-qmanager
+flux module remove sched-fluxion-resource
+flux module load sched-simple


### PR DESCRIPTION
This PR fixes #1182 and adds a test for the condition (verified that the test fails on current master).

This is a critical issue since currently Fluxion could assign down resources to jobs. The jobs then immediately fail and the next job is scheduled, eating through the entire queue.