### PR TITLE
docs/cmake:stop constantly rebuilding manpages

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -21,7 +21,6 @@ if(SPHINX AND ENABLE_DOCS)
 
     add_custom_command(
         OUTPUT ${man5_outputs}
-        ALL
         DEPENDS
         man5/index.rst
         ${man5_inputs}


### PR DESCRIPTION
problem: manpages rebuild on every invocation of the build

solution: remove the accidental ALL from the add_custom_command for manpages, that was causing cmake to constantly rebuild them trying to create a file named "ALL"