### PR TITLE
docker-run-checks: ensure we match user's home

### DIFF
--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -13,7 +13,7 @@ BASE_DOCKER_REPO=fluxrm/flux-core
 WORKDIR=/usr/src
 IMAGE=bookworm
 JOBS=2
-MOUNT_HOME_ARGS="--volume=$HOME:/home/$USER -e HOME"
+MOUNT_HOME_ARGS="--volume=$HOME:$HOME -e HOME"
 
 if test "$PROJECT" = "flux-core"; then
   FLUX_SECURITY_VERSION=0.9.0
@@ -160,7 +160,7 @@ checks_group "Building image $IMAGE for user $USER $(id -u) group=$(id -g)" \
     || die "docker build failed"
 
 if [[ -n "$MOUNT_HOME_ARGS" ]]; then
-    echo "mounting $HOME as /home/$USER"
+    echo "mounting $HOME as $HOME"
 fi
 echo "mounting $TOP as $WORKDIR"
 


### PR DESCRIPTION
problem: docker-run-checks.sh currently assumes that mounting $HOME to /home/$USER will match the outer system. Sometimes that is not the case. Example, my lima-managed vm uses /home/$USER.linux as the home directory for the vm user, which causes strange errors because of the mismatch.

solution: map $HOME to $HOME