### PR TITLE
cmake: look for ver file in source directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.18)
-set(VER_FILE ${CMAKE_BINARY_DIR}/flux-sched.ver)
+set(VER_FILE ${CMAKE_SOURCE_DIR}/flux-sched.ver)
 if(DEFINED FLUX_SCHED_VER)
   # do nothing, user said so
 elseif(DEFINED ENV{FLUX_SCHED_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,13 +201,13 @@ add_custom_target(installcheck
   COMMAND env FLUX_SCHED_TEST_INSTALLED=1 ${CMAKE_CTEST_COMMAND} ${CTEST_COMMON_FLAGS})
 add_custom_target(dist
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  COMMAND echo ${FLUX_SCHED_VER} > flux-sched.ver
+  COMMAND echo ${FLUX_SCHED_VER} > ${CMAKE_BINARY_DIR}/flux-sched.ver
   COMMAND git archive --format=tar.gz
   --prefix=flux-sched-${FLUX_SCHED_VER}/
-  --add-file=flux-sched.ver
+  --add-file=${CMAKE_BINARY_DIR}/flux-sched.ver
   --output=${CMAKE_BINARY_DIR}/flux-sched-${FLUX_SCHED_VER}.tar.gz
   HEAD .
-  COMMAND rm flux-sched.ver
+  COMMAND rm ${CMAKE_BINARY_DIR}/flux-sched.ver
   COMMENT "Generated flux-sched-${FLUX_SCHED_VER}.tar.gz"
   )
 # run installcheck, if it passes then write out version information and pack up


### PR DESCRIPTION
problem: cmake was looking for the version file in the build directory rather than the source directory, causing it not to be found in some common configurations.

solution: have it look in the source directory instead