### PR TITLE
Add jobid and schedule iteration count to match stats; make perf a global variable

### DIFF
--- a/resource/CMakeLists.txt
+++ b/resource/CMakeLists.txt
@@ -16,6 +16,7 @@ set(RESOURCE_HEADERS
     schema/sched_data.hpp
     schema/resource_base.hpp
     schema/resource_data.hpp
+    schema/perf_data.hpp
     schema/color.hpp
     schema/ephemeral.hpp
     traversers/dfu.hpp
@@ -46,6 +47,7 @@ add_library(resource STATIC
     policies/dfu_match_policy_factory.cpp
     jobinfo/jobinfo.cpp
     schema/resource_data.cpp
+    schema/perf_data.cpp
     schema/infra_data.cpp
     schema/sched_data.cpp
     schema/color.cpp

--- a/resource/schema/perf_data.cpp
+++ b/resource/schema/perf_data.cpp
@@ -1,0 +1,29 @@
+/*****************************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+}
+
+#include "resource/schema/perf_data.hpp"
+
+namespace Flux {
+namespace resource_model {
+
+struct match_perf_t perf;
+
+} // Flux::resource_model
+} // Flux
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/schema/perf_data.hpp
+++ b/resource/schema/perf_data.hpp
@@ -1,0 +1,73 @@
+/*****************************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+#ifndef PERF_DATA_HPP
+#define PERF_DATA_HPP
+
+#include <chrono>
+
+namespace Flux {
+namespace resource_model {
+
+struct perf_stats {
+    void update_stats (double elapsed, int64_t jobid, int64_t match_iter_ct) {
+        /* Update using Welford's algorithm */
+        double delta = 0.0;
+        double delta2 = 0.0;
+        njobs++;
+        njobs_reset++;
+        min = (min > elapsed)? elapsed : min;
+        if (max < elapsed) {
+            max = elapsed;
+            max_match_jobid = jobid;
+            match_iter_count = match_iter_ct;
+        }
+        /* Welford's online algorithm for variance */
+        delta = elapsed - avg;
+        avg += delta / (double)njobs;
+        delta2 = elapsed - avg;
+        M2 += delta * delta2;
+    }
+
+    /* Performance data */
+    uint64_t njobs = 0;                /* Total match count */
+    uint64_t njobs_reset = 0;          /* Jobs since match count reset */
+    int64_t max_match_jobid = 0;       /* jobid corresponding to max match time */
+    int64_t match_iter_count = 0;
+    double min = std::numeric_limits<double>::max (); /* Min match time */
+    double max = 0.0;                  /* Max match time */
+    double accum = 0.0;                /* Accumulated match time for resource query */
+    double avg = 0.0;                  /* Average match time */
+    double M2 = 0.0;                   /* Welford's algorithm */
+};
+
+struct match_perf_t {
+    double load = 0.0;                 /* Graph load time */
+    /* Graph uptime in seconds */
+    std::chrono::time_point<std::chrono::system_clock> graph_uptime
+                                        = std::chrono::system_clock::now ();
+    /* Time since stats were last cleared */
+    std::chrono::time_point<std::chrono::system_clock> time_of_last_reset
+                                        = std::chrono::system_clock::now ();
+    perf_stats succeeded;
+    perf_stats failed;
+    int64_t tmp_iter_count = -1;
+};
+
+extern struct match_perf_t perf;
+
+} // namespace resource_model
+} // namespace Flux
+
+#endif // PERF_DATA_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/cmd/flux-ion-resource.py
+++ b/src/cmd/flux-ion-resource.py
@@ -233,6 +233,14 @@ def stat_action(_):
         resp["match"]["succeeded"]["njobs-reset"],
     )
     print(
+        "Jobid corresponding to max match time: ",
+        resp["match"]["succeeded"]["max-match-jobid"],
+    )
+    print(
+        "Match iterations corresponding to max match time: ",
+        resp["match"]["succeeded"]["max-match-iters"],
+    )
+    print(
         "Min. Successful Match Time: ",
         resp["match"]["succeeded"]["stats"]["min"],
         "Secs",
@@ -259,6 +267,14 @@ def stat_action(_):
     print(
         "Num. of Jobs with Failed Matches Since Reset: ",
         resp["match"]["failed"]["njobs-reset"],
+    )
+    print(
+        "Jobid corresponding to max match time: ",
+        resp["match"]["failed"]["max-match-jobid"],
+    )
+    print(
+        "Match iterations corresponding to max match time: ",
+        resp["match"]["failed"]["max-match-iters"],
     )
     print(
         "Min. Match Time of Failed Matches: ",


### PR DESCRIPTION
Match performance variability observed on a large cluster has pointed to the need for storing and reporting jobids corresponding to the max succeeded and failed math times. This WIP also adds the capability to report the number of `select` iterations performed for the jobid corresponding to the max match times.

This PR is WIP as the current implementation for passing the iteration count may not be desirable.