### PR TITLE
qmanager: search blocked jobs during pending removal

### DIFF
--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -894,18 +894,25 @@ protected:
         s = m_pending.erase ({static_cast<double> (job->priority),
                               static_cast<double> (job->t_submit),
                               static_cast<double> (job->t_stamps.pending_ts)});
-        if (s == 0) {
-            // job must be in m_pending_provisional in this case
-            s = m_pending_provisional.erase (
-                              {static_cast<double> (job->priority),
-                               static_cast<double> (job->t_submit),
-                               static_cast<double> (job->t_stamps.pending_ts)});
-            if (s == 0) {
-                errno = ENOENT;
-                return -1;
-            }
-            found_in_prov = true;
+        if (s == 1) {
+            return 0;
         }
+        s = m_blocked.erase ({static_cast<double> (job->priority),
+                              static_cast<double> (job->t_submit),
+                              static_cast<double> (job->t_stamps.pending_ts)});
+        if (s == 1) {
+            return 0;
+        }
+        // job must be in m_pending_provisional in this case
+        s = m_pending_provisional.erase (
+                {static_cast<double> (job->priority),
+                static_cast<double> (job->t_submit),
+                static_cast<double> (job->t_stamps.pending_ts)});
+        if (s == 0) {
+            errno = ENOENT;
+            return -1;
+        }
+        found_in_prov = true;
         return 0;
     }
 

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -47,7 +47,7 @@ struct match_perf_t {
     std::chrono::time_point<std::chrono::system_clock> graph_uptime
                                         = std::chrono::system_clock::now ();
     /* Time since stats were last cleared */
-    std::chrono::time_point<std::chrono::system_clock> time_since_reset
+    std::chrono::time_point<std::chrono::system_clock> time_of_last_reset
                                         = std::chrono::system_clock::now ();
     struct time_stats {
         void update_stats (double elapsed) {
@@ -2255,7 +2255,7 @@ static void stat_request_cb (flux_t *h, flux_msg_handler_t *w,
     graph_uptime_s = std::chrono::duration_cast<std::chrono::seconds> (
                         now - ctx->perf.graph_uptime).count ();
     time_since_reset_s = std::chrono::duration_cast<std::chrono::seconds> (
-                        now - ctx->perf.time_since_reset).count ();
+                        now - ctx->perf.time_of_last_reset).count ();
     
     if (flux_respond_pack (h, msg, "{s:I s:I s:o s:f s:I s:I s:{s:O s:O}}",
                         "V", num_vertices (ctx->db->resource_graph),
@@ -2290,6 +2290,7 @@ static void stat_clear_cb (flux_t *h, flux_msg_handler_t *w,
 {
     std::shared_ptr<resource_ctx_t> ctx = getctx ((flux_t *)arg);
 
+    ctx->perf.time_of_last_reset = std::chrono::system_clock::now ();
     // Clear the jobs-related stats and reset time
     ctx->perf.succeeded.njobs_reset = 0;
     ctx->perf.succeeded.min = std::numeric_limits<double>::max ();


### PR DESCRIPTION
problem: if a job is pending and moved into the blocked state, it isn't removed by cancel

solution: if the job is not found in pending, try to remove it from blocked

As a note, I remember writing this logic at some point in the previous PR that added m_blocked.  I don't know when it got lost, but probably when a few other similar searches that we actually don't want got removed.  The job is now cancelled appropriately in this case at least.

fixes #1208