### PR TITLE
qmanager: always process unblocked jobs and make bf reactive during sched loop

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,81 @@
+BasedOnStyle : google
+SpaceBeforeParens : Always
+IndentWidth : 4
+BreakBeforeBraces : Custom
+BraceWrapping :
+  BeforeElse : false
+  AfterFunction : true
+UseTab: Never
+AllowShortIfStatementsOnASingleLine : false
+ConstructorInitializerAllOnOneLineOrOnePerLine : true
+AllowShortFunctionsOnASingleLine : false
+AllowShortLoopsOnASingleLine : false
+BinPackParameters : false
+BinPackArguments : false
+AllowAllParametersOfDeclarationOnNextLine : false
+AlignTrailingComments : true
+ColumnLimit : 100
+
+# do not put all arguments on one line unless it's the same line as the call
+PenaltyBreakBeforeFirstCallParameter : 10000000
+PenaltyReturnTypeOnItsOwnLine : 65000
+PenaltyBreakString : 10
+
+# preserve formatting of arguments to pack/unpack functions
+# found by running: rg --only-matching --no-filename --no-line-number  '(flux|json)(_[^ ,()]+)?_(un)?pack' | sort -u
+WhitespaceSensitiveMacros :
+  - flux_conf_unpack
+  - flux_event_pack
+  - flux_event_publish_pack
+  - flux_event_unpack
+  - flux_job_result_get_unpack
+  - flux_jobspec1_attr_pack
+  - flux_jobspec1_attr_unpack
+  - flux_jobspec_info_unpack
+  - flux_jobtap_event_post_pack
+  - flux_kvs_lookup_get_unpack
+  - flux_kvs_lookup_unpack
+  - flux_kvs_txn_pack
+  - flux_lookup_get_unpack
+  - flux_mrpc_pack
+  - flux_msg_pack
+  - flux_msg_unpack
+  - flux_plugin_arg_pack
+  - flux_plugin_arg_unpack
+  - flux_plugin_args_unpack
+  - flux_plugin_conf_unpack
+  - flux_request_unpack
+  - flux_respond_pack
+  - flux_rpc_get_unpack
+  - flux_rpc_pack
+  - flux_shell_getopt_unpack
+  - flux_shell_info_unpack
+  - flux_shell_jobspec_info_unpack
+  - flux_shell_rank_info_unpack
+  - flux_shell_rpc_pack
+  - flux_shell_setopt_pack
+  - flux_shell_setopt_unpack
+  - flux_shell_task_info_unpack
+  - json_pack
+  - json_unpack
+
+# treat foreach macros as for loops
+ForEachMacros :
+  - json_array_foreach
+  - json_object_foreach
+
+SortIncludes : false
+BreakBeforeBinaryOperators : NonAssignment
+AlignAfterOpenBracket: Align
+AlignOperands : true
+BreakBeforeTernaryOperators : true
+SpaceBeforeSquareBrackets: false
+IndentPPDirectives: None
+NamespaceIndentation: None
+SpaceAfterTemplateKeyword: false
+DerivePointerAlignment: false
+PointerAlignment: Right
+
+#
+# vi:tabstop=4 shiftwidth=4 expandtab ft=yaml
+#

--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,7 @@ compile_flags.txt
 .vscode
 .idea
 .clangd
+.cache
 
 # Rules to ignore auto-generated test harness scripts
 test_*.t

--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -60,6 +60,8 @@ int qmanager_cb_t::post_sched_loop (flux_t *h, schedutil_t *schedutil,
     for (auto& kv: queues) {
         const std::string &queue_name = kv.first;
         std::shared_ptr<queue_policy_base_t> &queue = kv.second;
+        if (queue->is_sched_loop_active ())
+            continue;
         while ( (job = queue->alloced_pop ()) != nullptr) {
             if (schedutil_alloc_respond_success_pack (schedutil, job->msg,
                                                       job->schedule.R.c_str (),
@@ -405,8 +407,7 @@ void qmanager_cb_t::prep_watcher_cb (flux_reactor_t *r, flux_watcher_t *w,
     ctx->pls_post_loop = false;
     for (auto &kv: ctx->queues) {
         std::shared_ptr<queue_policy_base_t> &queue = kv.second;
-        ctx->pls_sched_loop = ctx->pls_sched_loop
-            || queue->is_schedulable ();
+        ctx->pls_sched_loop = ctx->pls_sched_loop || queue->is_schedulable ();
         ctx->pls_post_loop = ctx->pls_post_loop
                               || queue->is_scheduled ();
     }

--- a/qmanager/policies/queue_policy_bf_base.hpp
+++ b/qmanager/policies/queue_policy_bf_base.hpp
@@ -34,14 +34,6 @@ protected:
 private:
     int cancel_completed_jobs (void *h);
     int cancel_reserved_jobs (void *h);
-    std::map<std::vector<double>, flux_jobid_t>::iterator &
-        allocate_orelse_reserve (void *h, std::shared_ptr<job_t> job,
-                                 bool use_alloced_queue,
-                                 std::map<std::vector<double>,
-                                     flux_jobid_t>::iterator &iter);
-    std::map<std::vector<double>, flux_jobid_t>::iterator &
-        allocate (void *h, std::shared_ptr<job_t> job, bool use_alloced_queue,
-        std::map<std::vector<double>, flux_jobid_t>::iterator &iter);
     int allocate_orelse_reserve_jobs (void *h, bool use_alloced_queue);
     std::map<uint64_t, flux_jobid_t> m_reserved;
     unsigned int m_reservation_cnt;

--- a/qmanager/policies/queue_policy_bf_base.hpp
+++ b/qmanager/policies/queue_policy_bf_base.hpp
@@ -36,7 +36,9 @@ private:
     int cancel_reserved_jobs (void *h);
     int allocate_orelse_reserve_jobs (void *h, bool use_alloced_queue);
     std::map<uint64_t, flux_jobid_t> m_reserved;
-    unsigned int m_reservation_cnt;
+    int m_reservation_cnt;
+    int m_scheduled_cnt;
+    decltype (m_pending)::iterator m_in_progress_iter = m_pending.end();
 };
 
 } // namespace Flux::queue_manager::detail

--- a/qmanager/policies/queue_policy_bf_base_impl.hpp
+++ b/qmanager/policies/queue_policy_bf_base_impl.hpp
@@ -19,25 +19,26 @@ namespace detail {
 
 /******************************************************************************
  *                                                                            *
- *                 Private Methods of Queue Policy Backfill Base              *
+ *                 Private Methods of Queue Policy Backfill Base *
  *                                                                            *
  ******************************************************************************/
 
 template<class reapi_type>
-int queue_policy_bf_base_t<reapi_type>::cancel_completed_jobs (void *h)
+int queue_policy_bf_base_t<reapi_type>::cancel_completed_jobs (void* h)
 {
     int rc = 0;
     std::shared_ptr<job_t> job;
 
-    // Pop newly completed jobs (e.g., per a free request from job-manager
-    // as received by qmanager) to remove them from the resource infrastructure.
+    // Pop newly completed jobs (e.g., per a free request from
+    // job-manager as received by qmanager) to remove them from the
+    // resource infrastructure.
     while ((job = complete_pop ()) != nullptr)
         rc += reapi_type::cancel (h, job->id, true);
     return rc;
 }
 
 template<class reapi_type>
-int queue_policy_bf_base_t<reapi_type>::cancel_reserved_jobs (void *h)
+int queue_policy_bf_base_t<reapi_type>::cancel_reserved_jobs (void* h)
 {
     int rc = 0;
     std::map<uint64_t, flux_jobid_t>::const_iterator citer;
@@ -48,89 +49,8 @@ int queue_policy_bf_base_t<reapi_type>::cancel_reserved_jobs (void *h)
 }
 
 template<class reapi_type>
-std::map<std::vector<double>, flux_jobid_t>::iterator &
-queue_policy_bf_base_t<reapi_type>::allocate_orelse_reserve (void *h,
-                                               std::shared_ptr<job_t> job,
-                                               bool use_alloced_queue,
-                                               std::map<std::vector<double>,
-                                                  flux_jobid_t>::iterator &iter)
-
-
-{
-    int64_t at = job->schedule.at;
-    if (reapi_type::match_allocate (h, true, job->jobspec, job->id,
-                                    job->schedule.reserved, job->schedule.R,
-                                    job->schedule.at, job->schedule.ov) == 0) {
-
-        if (job->schedule.reserved) {
-            // High-priority job has been reserved, continue
-            m_reserved.insert (std::pair<uint64_t, flux_jobid_t> (m_oq_cnt++,
-                                                                  job->id));
-	    job->schedule.old_at = at;
-            m_reservation_cnt++;
-            iter++;
-        } else {
-            // move the job to the running queue and make sure the job
-            // is enqueued into allocated job queue as well.
-            // When this is used within a module, it allows the module
-            // to fetch those newly allocated jobs, which have flux_msg_t to
-            // respond to job-manager.
-            iter = to_running (iter, use_alloced_queue);
-        }
-    } else {
-        if (errno != EBUSY) {
-            // The request must be rejected. The job is enqueued into
-            // rejected job queue to the upper layer to react on this.
-            iter = to_rejected (iter, (errno == ENODEV)? "unsatisfiable"
-                                                       : "match error");
-        } else {
-            // This can happen if there are "down" resources.
-            // The semantics of our backfill policies is to skip this job,
-            // add it to the blocked list, and re-consider when resource
-            // status changes
-
-            // copy and advance iterator before extract invalidates it
-            auto next = iter;
-            ++next;
-            m_blocked.insert (m_pending.extract (iter));
-            iter = next;
-        }
-    }
-    return iter;
-}
-
-template<class reapi_type>
-std::map<std::vector<double>, flux_jobid_t>::iterator &
-queue_policy_bf_base_t<reapi_type>::allocate (void *h, std::shared_ptr<job_t> job,
-                                              bool use_alloced_queue,
-                                              std::map<std::vector<double>,
-                                                  flux_jobid_t>::iterator &iter)
-{
-    if (reapi_type::match_allocate (h, false, job->jobspec, job->id,
-                                    job->schedule.reserved, job->schedule.R,
-                                    job->schedule.at, job->schedule.ov) == 0) {
-        // move the job to the running queue and make sure the job
-        // is enqueued into allocated job queue as well.
-        // When this is used within a module, it allows the module
-        // to fetch those newly allocated jobs, which have flux_msg_t to
-        // respond to job-manager.
-        iter = to_running (iter, use_alloced_queue);
-    } else {
-        if (errno != EBUSY) {
-            // The request must be rejected. The job is enqueued into
-            // rejected job queue to the upper layer to react on this.
-            iter = to_rejected (iter, (errno == ENODEV)? "unsatisfiable"
-                                                       : "match error");
-        } else {
-            iter++;
-        }
-    }
-    return iter;
-}
-
-template<class reapi_type>
-int queue_policy_bf_base_t<reapi_type>::allocate_orelse_reserve_jobs (void *h,
-                                            bool use_alloced_queue)
+int queue_policy_bf_base_t<reapi_type>::allocate_orelse_reserve_jobs (void* h,
+                                                                      bool use_alloced_queue)
 {
     unsigned int i = 0;
     std::shared_ptr<job_t> job;
@@ -145,35 +65,74 @@ int queue_policy_bf_base_t<reapi_type>::allocate_orelse_reserve_jobs (void *h,
     // Iterate jobs in the pending job queue and try to allocate each
     // until you can't. When you can't allocate a job, you reserve it
     // and then try to backfill later jobs.
-    std::map<std::vector<double>, flux_jobid_t>::iterator iter
-        = m_pending.begin ();
+    std::map<std::vector<double>, flux_jobid_t>::iterator iter = m_pending.begin ();
     m_reservation_cnt = 0;
     int saved_errno = errno;
-    while ((iter != m_pending.end ()) && (i < m_queue_depth)) {
+    for (; (iter != m_pending.end ()) && (i < m_queue_depth); ++i) {
         errno = 0;
         job = m_jobs[iter->second];
-        if (m_reservation_cnt < m_reservation_depth)
-            iter = allocate_orelse_reserve (h, job, use_alloced_queue, iter);
-        else
-            iter = allocate (h, job, use_alloced_queue, iter);
-       i++;
+        bool try_reserve = m_reservation_cnt < m_reservation_depth;
+        int64_t at = job->schedule.at;
+        if (reapi_type::match_allocate (h,
+                                        try_reserve,
+                                        job->jobspec,
+                                        job->id,
+                                        job->schedule.reserved,
+                                        job->schedule.R,
+                                        job->schedule.at,
+                                        job->schedule.ov)
+            == 0) {
+            if (job->schedule.reserved) {
+                // High-priority job has been reserved, continue
+                m_reserved.insert (std::pair<uint64_t, flux_jobid_t> (m_oq_cnt++, job->id));
+                job->schedule.old_at = at;
+                m_reservation_cnt++;
+                iter++;
+            } else {
+                // move the job to the running queue and make sure the
+                // job is enqueued into allocated job queue as well.
+                // When this is used within a module, it allows the
+                // module to fetch those newly allocated jobs, which
+                // have flux_msg_t to respond to job-manager.
+                iter = to_running (iter, use_alloced_queue);
+            }
+        } else if (errno != EBUSY) {
+            // The request must be rejected. The job is enqueued into
+            // rejected job queue to the upper layer to react on this.
+            iter = to_rejected (iter, (errno == ENODEV) ? "unsatisfiable" : "match error");
+        } else {
+            if (!try_reserve) {
+                iter++;
+                continue;
+            }
+            // This can happen if there are "down" resources.
+            // The semantics of our backfill policies is to skip this
+            // job, add it to the blocked list, and re-consider when
+            // resource status changes
+
+            // copy and advance iterator before extract invalidates it
+            auto next = iter;
+            ++next;
+            m_blocked.insert (m_pending.extract (iter));
+            iter = next;
+            // avoid counting this toward queue_depth
+            --i;
+        }
     }
     set_sched_loop_active (false);
     errno = saved_errno;
     return 0;
 }
 
-
 /******************************************************************************
  *                                                                            *
- *                 Public API of Queue Policy Backfill Base                   *
+ *                 Public API of Queue Policy Backfill Base *
  *                                                                            *
  ******************************************************************************/
 
 template<class reapi_type>
 queue_policy_bf_base_t<reapi_type>::~queue_policy_bf_base_t ()
 {
-
 }
 
 template<class reapi_type>
@@ -183,8 +142,7 @@ int queue_policy_bf_base_t<reapi_type>::apply_params ()
 }
 
 template<class reapi_type>
-int queue_policy_bf_base_t<reapi_type>::run_sched_loop (void *h,
-                                                        bool use_alloced_queue)
+int queue_policy_bf_base_t<reapi_type>::run_sched_loop (void* h, bool use_alloced_queue)
 {
     int rc = 0;
     set_schedulability (false);
@@ -195,19 +153,23 @@ int queue_policy_bf_base_t<reapi_type>::run_sched_loop (void *h,
 }
 
 template<class reapi_type>
-int queue_policy_bf_base_t<reapi_type>::reconstruct_resource (
-        void *h, std::shared_ptr< job_t> job, std::string &R_out)
+int queue_policy_bf_base_t<reapi_type>::reconstruct_resource (void* h,
+                                                              std::shared_ptr<job_t> job,
+                                                              std::string& R_out)
 {
-    return reapi_type::update_allocate (h, job->id, job->schedule.R,
+    return reapi_type::update_allocate (h,
+                                        job->id,
+                                        job->schedule.R,
                                         job->schedule.at,
-                                        job->schedule.ov, R_out);
+                                        job->schedule.ov,
+                                        R_out);
 }
 
-} // namespace Flux::queue_manager::detail
-} // namespace Flux::queue_manager
-} // namespace Flux
+}  // namespace detail
+}  // namespace queue_manager
+}  // namespace Flux
 
-#endif // QUEUE_POLICY_BF_BASE_IMPL_HPP
+#endif  // QUEUE_POLICY_BF_BASE_IMPL_HPP
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/qmanager/policies/queue_policy_fcfs.hpp
+++ b/qmanager/policies/queue_policy_fcfs.hpp
@@ -11,6 +11,7 @@
 #ifndef QUEUE_POLICY_FCFS_HPP
 #define QUEUE_POLICY_FCFS_HPP
 
+#include <jansson.h>
 #include "qmanager/policies/base/queue_policy_base.hpp"
 
 namespace Flux {

--- a/qmanager/policies/queue_policy_fcfs_impl.hpp
+++ b/qmanager/policies/queue_policy_fcfs_impl.hpp
@@ -150,6 +150,9 @@ int queue_policy_fcfs_t<reapi_type>::handle_match_failure (int errcode)
         set_schedulability (true);
         m_queue_depth_limit = false;
     }
+    // whatever happened here, a job transition has occurred, we need to run the
+    // post_sched_loop
+    m_scheduled = true;
     return 0;
 }
 

--- a/src/test/checks_run.sh
+++ b/src/test/checks_run.sh
@@ -28,7 +28,7 @@
 # if make is old, and scl is here, and devtoolset is available and not turned
 # on, re-exec ourself with it active to get a newer make
 if make --version | grep 'GNU Make 4' 2>&1 > /dev/null ; then
-  MAKE="make --output-sync=target --no-print-directory"
+  MAKE="make --output-sync=line --no-print-directory"
 else
   MAKE="make" #use this if all else fails
   if test "X$X_SCLS" = "X" ; then


### PR DESCRIPTION
fixes #1210

This is a bit of a big one, and may benefit from having each commit reviewed separately.  If anyone prefers a stacked push I can do that.

The main changes here are:
* Jobs that are determined to be blocked, cannot be reserved, do not count toward the queue_depth.  This means if there are 1000 blocked jobs, and two at the end, we will consider 1002 jobs even if the queue_depth is only 32. The observed behavior is substantially better than otherwise however, because it means we should always make progress on work that can run, where before the two jobs at the end would block forever if the 1000 blocked jobs stay blocked forever.
* The qmanager's backfill implementation now re-enters the reactor after processing a certain number of matches while leaving the scheduling loop active. It's a relatively straightforward approach that stores the loop state and re-enters it in a prep/check pair as needed that mostly re-uses existing machinery.

I would really appreciate extra eyes on this, and testing if anyone has time.  It should not only fix the blocking issue, but also our responsiveness issue (at least up to a point, async would be better, still working on that).