### PR TITLE
avoid using std::vector as a map key

### DIFF
--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -11,6 +11,7 @@
 #ifndef QUEUE_POLICY_BASE_HPP
 #define QUEUE_POLICY_BASE_HPP
 
+#include <flux/core/job.h>
 extern "C" {
 #if HAVE_CONFIG_H
 #include "config.h"
@@ -21,7 +22,6 @@ extern "C" {
 #include <cassert>
 #include <map>
 #include <algorithm>
-#include <vector>
 #include <unordered_map>
 #include <string>
 #include <memory>
@@ -68,6 +68,19 @@ struct t_stamps_t {
     uint64_t canceled_ts = 0;
 };
 
+/*! Helper struct for use as a key in job state maps
+ */
+struct pending_key {
+    unsigned int priority = 0;
+    double t_submit = 0.0;
+    uint64_t pending_ts = 0;
+    auto operator<=>(const pending_key&) const = default;
+    bool operator==(const pending_key&) const = default;
+};
+
+using job_map_t = std::map<pending_key, flux_jobid_t>;
+using job_map_iter = job_map_t::iterator;
+
 /*! Type to store a job's attributes.
  */
 class job_t {
@@ -84,13 +97,21 @@ public:
     job_t& operator= (const job_t &s) = default;
 
     bool is_pending () { return state == job_state_kind_t::PENDING; }
+    pending_key get_key () {
+        return {
+            .priority = priority,
+            .t_submit = t_submit,
+            .pending_ts = t_stamps.pending_ts
+        };
+    }
+
 
     flux_msg_t *msg = NULL;
     job_state_kind_t state = job_state_kind_t::INIT;
     flux_jobid_t id = 0;
     uint32_t userid = 0;
     unsigned int priority = 0;
-    double t_submit = 0.0f;;
+    double t_submit = 0.0f;
     std::string jobspec = "";
     std::string note = "";
     t_stamps_t t_stamps;
@@ -168,7 +189,7 @@ public:
     void reconsider_blocked_jobs () {
         m_pending_reconsider = true;
         if (!is_sched_loop_active ()) {
-            process_provisional_reconsider();
+            process_provisional_reconsider ();
         }
     }
 
@@ -382,10 +403,7 @@ public:
         }
         job->state = job_state_kind_t::PENDING;
         job->t_stamps.pending_ts = m_pq_cnt++;
-        m_pending_provisional.insert (std::pair<std::vector<double>, flux_jobid_t> (
-            {static_cast<double> (job->priority),
-             static_cast<double> (job->t_submit),
-             static_cast<double> (job->t_stamps.pending_ts)}, job->id));
+        m_pending_provisional.emplace (job->get_key (), job->id);
         m_jobs.insert (std::pair<flux_jobid_t, std::shared_ptr<job_t>> (job->id,
                                                                         job));
         m_schedulable = true;
@@ -568,8 +586,8 @@ public:
      *  resource API. When a match succeeds, this method is called back
      *  by reapi_t.
      */
-    virtual int handle_match_success (int64_t jobid, const char *status,
-                                      const char *R, int64_t at, double ov) {
+    int handle_match_success (flux_jobid_t jobid, const char *status,
+                              const char *R, int64_t at, double ov) override {
         return 0;
     }
 
@@ -578,8 +596,8 @@ public:
      *  resource API. When a match fails, this method is called back
      *  by reapi_t.
      */
-    virtual int handle_match_failure (int errcode) {
-        return 0;        
+    int handle_match_failure (flux_jobid_t jobid, int errcode) override {
+        return 0;
     }
 
 
@@ -599,9 +617,7 @@ public:
         if (m_jobs.find (id) == m_jobs.end ())
             return nullptr;
         job = m_jobs[id];
-        m_pending.erase ({static_cast<double> (job->priority),
-                          static_cast<double> (job->t_submit),
-                          static_cast<double> (job->t_stamps.pending_ts)});
+        m_pending.erase (job->get_key ());
         m_jobs.erase (id);
         return job;
     }
@@ -685,9 +701,7 @@ public:
     /* This doesn't appear to be used anywhere */
     std::shared_ptr<job_t> reserved_pop ();
 
-    std::map<std::vector<double>, flux_jobid_t>::iterator
-        to_running (std::map<std::vector<double>,
-                             flux_jobid_t>::iterator pending_iter,
+    job_map_iter to_running (job_map_iter pending_iter,
                     bool use_alloced_queue)
     {
         flux_jobid_t id = pending_iter->second;
@@ -771,6 +785,7 @@ public:
 
 
 protected:
+
 
     /*! Reconstruct the queue.
      *
@@ -874,28 +889,11 @@ protected:
     int insert_pending_job (std::shared_ptr<job_t> &job,
                                                   bool into_provisional)
     {
-        if (into_provisional) {
-            auto res = m_pending_provisional.insert (
-                           std::pair<std::vector<double>, flux_jobid_t> (
-                               {static_cast<double> (job->priority),
-                                static_cast<double> (job->t_submit),
-                                static_cast<double> (job->t_stamps.pending_ts)},
-                               job->id));
-            if (!res.second) {
-                errno = EEXIST;
-                return -1;
-            }
-        } else {
-            auto res = m_pending.insert (
-                           std::pair<std::vector<double>, flux_jobid_t> (
-                               {static_cast<double> (job->priority),
-                                static_cast<double> (job->t_submit),
-                                static_cast<double> (job->t_stamps.pending_ts)},
-                               job->id));
-            if (!res.second) {
-                errno = EEXIST;
-                return -1;
-            }
+        auto &pending_map = into_provisional ? m_pending_provisional : m_pending;
+        auto res = pending_map.emplace (job->get_key (), job->id);
+        if (!res.second) {
+            errno = EEXIST;
+            return -1;
         }
         return 0;
     }
@@ -903,23 +901,16 @@ protected:
     int erase_pending_job (job_t *job, bool &found_in_prov)
     {
         size_t s;
-        s = m_pending.erase ({static_cast<double> (job->priority),
-                              static_cast<double> (job->t_submit),
-                              static_cast<double> (job->t_stamps.pending_ts)});
+        s = m_pending.erase (job->get_key ());
         if (s == 1) {
             return 0;
         }
-        s = m_blocked.erase ({static_cast<double> (job->priority),
-                              static_cast<double> (job->t_submit),
-                              static_cast<double> (job->t_stamps.pending_ts)});
+        s = m_blocked.erase (job->get_key ());
         if (s == 1) {
             return 0;
         }
         // job must be in m_pending_provisional in this case
-        s = m_pending_provisional.erase (
-                {static_cast<double> (job->priority),
-                static_cast<double> (job->t_submit),
-                static_cast<double> (job->t_stamps.pending_ts)});
+        s = m_pending_provisional.erase (job->get_key ());
         if (s == 0) {
             errno = ENOENT;
             return -1;
@@ -950,9 +941,7 @@ protected:
         return m_running.erase (running_iter);
     }
 
-    std::map<std::vector<double>, flux_jobid_t>::iterator
-        to_rejected (std::map<std::vector<double>,
-                              flux_jobid_t>::iterator pending_iter,
+    job_map_iter to_rejected (job_map_iter pending_iter,
                      const std::string &note)
     {
         flux_jobid_t id = pending_iter->second;
@@ -990,9 +979,9 @@ protected:
     unsigned int m_queue_depth = DEFAULT_QUEUE_DEPTH;
     unsigned int m_max_queue_depth = MAX_QUEUE_DEPTH;
     /// jobs that need to wait for resource state updates
-    std::map<std::vector<double>, flux_jobid_t> m_blocked;
-    std::map<std::vector<double>, flux_jobid_t> m_pending;
-    std::map<std::vector<double>, flux_jobid_t> m_pending_provisional;
+    std::map<pending_key, flux_jobid_t> m_blocked;
+    std::map<pending_key, flux_jobid_t> m_pending;
+    std::map<pending_key, flux_jobid_t> m_pending_provisional;
     std::map<uint64_t, flux_jobid_t> m_pending_cancel_provisional;
     bool m_pending_reconsider = false;
     std::map<uint64_t, std::pair<flux_jobid_t,
@@ -1005,7 +994,6 @@ protected:
     std::map<flux_jobid_t, std::shared_ptr<job_t>> m_jobs;
     std::unordered_map<std::string, std::string> m_qparams;
     std::unordered_map<std::string, std::string> m_pparams;
-
 
 private:
 
@@ -1074,7 +1062,7 @@ private:
         return i == num_str.end ();
     }
 
-    std::map<std::vector<double>, flux_jobid_t>::iterator m_pending_iter;
+    job_map_iter m_pending_iter;
     bool m_iter_valid = false;
 };
 

--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -26,6 +26,7 @@ extern "C" {
 #include <string>
 #include <memory>
 #include <cstdint>
+#include <tuple>
 
 #include "resource/reapi/bindings/c++/reapi.hpp"
 #include "qmanager/config/queue_system_defaults.hpp"
@@ -68,15 +69,10 @@ struct t_stamps_t {
     uint64_t canceled_ts = 0;
 };
 
-/*! Helper struct for use as a key in job state maps
+/*! Helper typedef for use as a key in job state maps
  */
-struct pending_key {
-    unsigned int priority = 0;
-    double t_submit = 0.0;
-    uint64_t pending_ts = 0;
-    auto operator<=>(const pending_key&) const = default;
-    bool operator==(const pending_key&) const = default;
-};
+
+using pending_key = std::tuple<unsigned int, double, uint64_t>;
 
 using job_map_t = std::map<pending_key, flux_jobid_t>;
 using job_map_iter = job_map_t::iterator;
@@ -99,9 +95,9 @@ public:
     bool is_pending () { return state == job_state_kind_t::PENDING; }
     pending_key get_key () {
         return {
-            .priority = priority,
-            .t_submit = t_submit,
-            .pending_ts = t_stamps.pending_ts
+            priority,
+            t_submit,
+            t_stamps.pending_ts
         };
     }
 

--- a/qmanager/policies/queue_policy_bf_base.hpp
+++ b/qmanager/policies/queue_policy_bf_base.hpp
@@ -12,6 +12,7 @@
 #define QUEUE_POLICY_BF_BASE_HPP
 
 #include "qmanager/policies/base/queue_policy_base.hpp"
+#include <flux/core/job.h>
 
 namespace Flux {
 namespace queue_manager {

--- a/qmanager/policies/queue_policy_fcfs.hpp
+++ b/qmanager/policies/queue_policy_fcfs.hpp
@@ -27,16 +27,16 @@ public:
     virtual int reconstruct_resource (void *h, std::shared_ptr<job_t> job,
                                       std::string &R_out);
     virtual int apply_params ();
-    virtual int handle_match_success (int64_t jobid, const char *status,
+    virtual int handle_match_success (flux_jobid_t jobid, const char *status,
                                       const char *R, int64_t at, double ov);
-    virtual int handle_match_failure (int errcode);
+    virtual int handle_match_failure (flux_jobid_t jobid, int errcode);
 
 private:
     int cancel_completed_jobs (void *h);
     int pack_jobs (json_t *jobs);
     int allocate_jobs (void *h, bool use_alloced_queue);
     bool m_queue_depth_limit = false;
-    std::map<std::vector<double>, flux_jobid_t>::iterator m_iter;
+    job_map_iter m_iter;
 };
 
 } // namespace Flux::queue_manager::detail

--- a/qmanager/policies/queue_policy_fcfs_impl.hpp
+++ b/qmanager/policies/queue_policy_fcfs_impl.hpp
@@ -13,6 +13,7 @@
 
 #include "qmanager/policies/queue_policy_fcfs.hpp"
 #include "qmanager/policies/base/queue_policy_base.hpp"
+#include <flux/core/job.h>
 
 namespace Flux {
 namespace queue_manager {
@@ -73,7 +74,7 @@ int queue_policy_fcfs_t<reapi_type>::allocate_jobs (void *h,
 {
     json_t *jobs = nullptr;
     char *jobs_str = nullptr;
-    std::map<std::vector<double>, flux_jobid_t>::iterator iter;
+    job_map_iter iter;
 
     // move jobs in m_pending_provisional queue into
     // m_pending. Note that c++11 doesn't have a clean way
@@ -110,7 +111,7 @@ int queue_policy_fcfs_t<reapi_type>::allocate_jobs (void *h,
 
 template<class reapi_type>
 int queue_policy_fcfs_t<reapi_type>::handle_match_success (
-                                         int64_t jobid, const char *status,
+                                         flux_jobid_t jobid, const char *status,
                                          const char *R, int64_t at, double ov)
 {
     if (!is_sched_loop_active ()) {
@@ -131,7 +132,7 @@ int queue_policy_fcfs_t<reapi_type>::handle_match_success (
 }
 
 template<class reapi_type>
-int queue_policy_fcfs_t<reapi_type>::handle_match_failure (int errcode)
+int queue_policy_fcfs_t<reapi_type>::handle_match_failure (flux_jobid_t jobid, int errcode)
 {
     if (!is_sched_loop_active ()) {
         errno = EINVAL;

--- a/resource/reapi/bindings/c++/reapi.hpp
+++ b/resource/reapi/bindings/c++/reapi.hpp
@@ -11,6 +11,7 @@
 #ifndef REAPI_HPP
 #define REAPI_HPP
 
+#include <flux/core/job.h>
 extern "C" {
 #if HAVE_CONFIG_H
 #include "config.h"
@@ -47,7 +48,7 @@ public:
      *                   of the elapse time to complete the match operation.
      *  \return          0 on success; -1 on error.
      */
-    virtual int handle_match_success (int64_t jobid, const char *status,
+    virtual int handle_match_success (flux_jobid_t jobid, const char *status,
                                       const char *R, int64_t at, double ov) = 0;
 
     /*! When a match failed (e.g., unsatisfiable jobspec, resource
@@ -66,7 +67,7 @@ public:
      *                       Others: one that can raised from match_multi RPC
      *  \return          0 when the loop must terminate; -1 on error.
      */
-    virtual int handle_match_failure (int errcode) = 0;
+    virtual int handle_match_failure (flux_jobid_t jobid, int errcode) = 0;
 
     /*! Return true if the scheduling loop is active under asynchronous
      *  execution; otherwise false.

--- a/resource/reapi/bindings/c++/reapi_module_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_module_impl.hpp
@@ -83,7 +83,7 @@ int reapi_module_t::match_allocate (void *h, bool orelse_reserve,
 
 void match_allocate_multi_cont (flux_future_t *f, void *arg)
 {
-    int64_t rj = -1;
+    int64_t jobid = -1;
     int64_t at;
     double ov;
     const char *rset = nullptr;
@@ -91,18 +91,18 @@ void match_allocate_multi_cont (flux_future_t *f, void *arg)
     queue_adapter_base_t *adapter = static_cast<queue_adapter_base_t *> (arg);
 
     if (flux_rpc_get_unpack (f, "{s:I s:s s:f s:s s:I}",
-                                  "jobid", &rj,
+                                  "jobid", &jobid,
                                   "status", &status,
                                   "overhead", &ov,
                                   "R", &rset,
                                   "at", &at) == 0) {
-        if (adapter->handle_match_success (rj, status, rset, at, ov) < 0) {
+        if (adapter->handle_match_success (jobid, status, rset, at, ov) < 0) {
             adapter->set_sched_loop_active (false);
             flux_future_destroy (f);
             return;
         }
     } else {
-        adapter->handle_match_failure (errno);
+        adapter->handle_match_failure (jobid, errno);
         adapter->set_sched_loop_active (false);
         flux_future_destroy (f);
         return;
@@ -160,7 +160,7 @@ int reapi_module_t::update_allocate (void *h, const uint64_t jobid,
                                     double &ov, std::string &R_out)
 {
     int rc = -1;
-    int64_t rj = -1;
+    int64_t res_jobid = -1;
     flux_t *fh = (flux_t *)h;
     flux_future_t *f = NULL;
     int64_t scheduled_at = -1;
@@ -179,13 +179,13 @@ int reapi_module_t::update_allocate (void *h, const uint64_t jobid,
                                       "R", R.c_str ())))
         goto out;
     if ( (rc = flux_rpc_get_unpack (f, "{s:I s:s s:f s:s s:I}",
-                                           "jobid", &rj,
+                                           "jobid", &res_jobid,
                                            "status", &status,
                                            "overhead", &overhead,
                                            "R", &rset,
                                            "at", &scheduled_at)) < 0)
         goto out;
-    if (rj != static_cast<int64_t> (jobid)
+    if (res_jobid != static_cast<int64_t> (jobid)
         || rset == NULL
         || status == NULL
         || std::string ("ALLOCATED") != status) {

--- a/src/test/docker/focal/Dockerfile
+++ b/src/test/docker/focal/Dockerfile
@@ -10,7 +10,7 @@ RUN sudo apt-get -qq install -y --no-install-recommends \
 	libboost-system-dev \
 	libboost-filesystem-dev \
 	libboost-regex-dev \
-	python-yaml \
+	python3-yaml \
 	libyaml-cpp-dev \
 	libedit-dev \
   ninja-build \


### PR DESCRIPTION
This isn't a _major_ performance issue, but we had been using a vector as a map key for a static set of 3 elements, casted to doubles for some reason, in qmanager.  This means every time we did a lookup, we did at least one, probably more like three, heap allocations and frees.  It made me twitch every time I saw it, so this refactors that out in favor of a simple struct with defaulted comparison operators and a method to construct it with the appropriate values in the job_t type.
