### PR TITLE
test/match-formats: make jq command valid

### DIFF
--- a/t/t6001-match-formats.t
+++ b/t/t6001-match-formats.t
@@ -41,7 +41,7 @@ test_expect_success HAVE_JQ "--match-format=rv1_nosched and =rlite works" '
     ${query} -L ${tiny_grug} -F rv1_nosched -d -t o7 -P high < in7.txt &&
     ${query} -L ${tiny_grug} -F rlite -d -t o8 -P high < in7.txt &&
     cat o7 | grep -v "INFO:" | jq ".execution.R_lite" > o7.json &&
-    cat o8 | grep -v "INFO:" | jq "" > o8.json &&
+    cat o8 | grep -v "INFO:" | jq "." > o8.json &&
     diff o7.json o8.json
 '
 


### PR DESCRIPTION
problem: somehow we've had an invalid jq command in one of the sched tests for quite some time now

solution: give it the "." pattern rather than ""

This is actually in one of the commits in #1211, but it's driving me crazy not having this fixed in other branches.