### PR TITLE
qmanager: reconsider blocked jobs on reprioritize

### DIFF
--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -775,6 +775,9 @@ public:
             if (insert_pending_job (job, found_in_prov) < 0)
                 return -1;
             m_schedulable = true;
+            // in case this job is now lower priority than one it was blocking,
+            // reconsider blocked jobs
+            reconsider_blocked_jobs ();
         }
         return 0;
     }
@@ -877,6 +880,9 @@ protected:
                 m_schedulable = true;
             }
         }
+        // in case this job is now lower priority than one it was blocking,
+        // reconsider blocked jobs
+        reconsider_blocked_jobs ();
         m_pending_reprio_provisional.clear ();
         return 0;
     }

--- a/t/t1013-qmanager-priority.t
+++ b/t/t1013-qmanager-priority.t
@@ -4,6 +4,9 @@ test_description='Fluxion takes into account urgency and t_submit'
 
 . `dirname $0`/sharness.sh
 
+export TEST_UNDER_FLUX_QUORUM=1
+export TEST_UNDER_FLUX_START_MODE=leader
+
 hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 1 node, 2 sockets, 44 cores (22 per socket), 4 gpus (2 per socket)
 excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers-sierra2"
@@ -11,7 +14,7 @@ excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers-sierra2"
 skip_all_unless_have jq
 
 export FLUX_SCHED_MODULE=none
-test_under_flux 1
+test_under_flux 10 system
 
 test_expect_success 'load test resources' '
     load_test_resources ${excl_1N1B}
@@ -62,6 +65,74 @@ test_expect_success 'priority: cancel all jobs' '
     flux cancel ${jobid2} &&
     flux job wait-event -t 10 ${jobid4} clean &&
     flux job wait-event -t 10 ${jobid2} release
+'
+
+test_expect_success 'cleanup active jobs' '
+    flux cancel --all &&
+    flux queue idle
+'
+
+test_expect_success 'update configuration' '
+flux config load <<-'EOF'
+[[resource.config]]
+hosts = "fake[0-10]"
+cores = "0-63"
+gpus = "0-3"
+
+[[resource.config]]
+hosts = "fake[0-10]"
+properties = ["compute"]
+
+[sched-fluxion-qmanager]
+queue-policy = "conservative"
+
+[sched-fluxion-resource]
+match-policy = "firstnodex"
+prune-filters = "ALL:core,ALL:gpu,cluster:node,rack:node"
+match-format = "rv1_nosched"
+EOF
+'
+
+test_expect_success 'reload resource with monitor-force-up' '
+    flux module reload -f resource noverify monitor-force-up
+'
+test_expect_success 'load fluxion modules' '
+    flux module load sched-fluxion-resource &&
+    flux module load sched-fluxion-qmanager
+'
+test_expect_success 'wait for fluxion to be ready' '
+  flux python -c \
+    "import flux, json; print(flux.Flux().rpc(\"sched.resource-status\").get_str())"
+'
+test_expect_success 'start a single long job to reserve a node' '
+    jobid1=$(flux submit -N1 \
+        -t 300s \
+        --flags=waitable \
+        --setattr=exec.test.run_duration=30s \
+        sleep 300) &&
+    flux job wait-event -t 10 ${jobid1} start
+'
+test_expect_success 'submit a job with normal priority that needs all resources' '
+  # must not have a time, so it reserves until the end of time
+    jobid2=$(flux submit -N11 \
+        --setattr=exec.test.run_duration=30s \
+        sleep 300)
+'
+test_expect_success 'submit a job with low priority that only needs one node, must end up blocked' '
+    jobid3=$(flux submit -N1 \
+        --flags=waitable \
+        --urgency=8 \
+        -t 400s \
+        --setattr=exec.test.run_duration=30s \
+        sleep 400) &&
+    test_must_fail flux job wait-event -t 1 ${jobid3} start
+'
+test_expect_success 'priority: change older job to lower urgency' '
+    flux job urgency ${jobid2} 7 &&
+    flux job wait-event -t 10 ${jobid2} priority
+'
+test_expect_success 'wait for blocked job to start' '
+    flux job wait-event -t 1 ${jobid3} start
 '
 
 test_expect_success 'cleanup active jobs' '


### PR DESCRIPTION
problem: if a job in reserved state, still pending in qmanager, gets reprioritized it's possible that it could unblock a job in the blocked queue and without doing a reconsideration it's possible we could get a priority inversion

solution: reconsider blocked jobs when a pending job is reprioritized

I have yet to make a reproducer that reliably needs this, but I'm pretty sure if we can do this sequence it will happen:

1. start a long-running job that uses a node
2. enqueue a high priority job that requires one of the resources used by the first so that it's reserved
3. enqueue a lower priority job that could run immediately, but wont because it's blocked by the reservation
4. reprioritize the reserved job to have a lower priority than the third