### PR TITLE
qpolicy/base: schedulable on reconsider

### DIFF
--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -179,6 +179,7 @@ public:
         m_pending_reconsider = false;
         m_pending.merge (m_blocked);
         assert (m_blocked.size () == 0);
+        set_schedulability (true);
     }
 
     /// @brief move any jobs in blocked state to pending


### PR DESCRIPTION
This is related to the hang when processing 100+ batch submissions on blocked resources. On my dev machine it consistently processes all jobs after this, but it means we sometimes backfill more aggressively than the q depth would imply. We need to decide which result is right. @milroy, @grondo. 