### PR TITLE
qpolicy/base: schedulable on reconsider

### DIFF
--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -177,8 +177,12 @@ public:
         if (!m_pending_reconsider)
             return;
         m_pending_reconsider = false;
+        auto cnt = m_blocked.size ();
         m_pending.merge (m_blocked);
         assert (m_blocked.size () == 0);
+        if (cnt > 0) {
+            set_schedulability (true);
+        }
     }
 
     /// @brief move any jobs in blocked state to pending


### PR DESCRIPTION
problem: we should always reconsider the queue, run the sched loop, when reconsidering blocked jobs. In some corner cases we did not because they are merged directly rather than being inserted individually.

solution: explicitly set schedulable.

PR redone from #1223 because of branching issue.