### PR TITLE
Excise filter

### DIFF
--- a/resource/evaluators/expr_eval_vtx_target.cpp
+++ b/resource/evaluators/expr_eval_vtx_target.cpp
@@ -96,8 +96,7 @@ done:
 }
 
 void expr_eval_vtx_target_t::initialize (const vtx_predicates_override_t &p,
-                                         const std::shared_ptr<
-                                             const f_resource_graph_t> g,
+                                         const resource_graph_t *g,
                                          vtx_t u)
 {
     m_initialized = true;

--- a/resource/evaluators/expr_eval_vtx_target.hpp
+++ b/resource/evaluators/expr_eval_vtx_target.hpp
@@ -84,9 +84,7 @@ public:
      *  \param u         vertex. g[u] must return the corresponding state.
      *  \return          0 on success; -1 on error
      */
-    void initialize (const vtx_predicates_override_t &p,
-                     const std::shared_ptr<
-                         const f_resource_graph_t> g, vtx_t u);
+    void initialize (const vtx_predicates_override_t &p, const resource_graph_t *g, vtx_t u);
 
     /*! Is this object initialized?
      */
@@ -95,7 +93,7 @@ public:
 private:
     bool m_initialized{false};
     vtx_predicates_override_t m_overridden;
-    std::shared_ptr<const f_resource_graph_t> m_g;
+    const resource_graph_t *m_g;
     vtx_t m_u;
 };
 

--- a/resource/policies/base/dfu_match_cb.cpp
+++ b/resource/policies/base/dfu_match_cb.cpp
@@ -51,7 +51,7 @@ dfu_match_cb_t::~dfu_match_cb_t ()
 int dfu_match_cb_t::dom_finish_graph (
     const subsystem_t &subsystem,
     const std::vector<Flux::Jobspec::Resource> &resources,
-    const f_resource_graph_t &g,
+    const resource_graph_t &g,
     scoring_api_t &dfu)
 {
     return 0;
@@ -68,7 +68,7 @@ int dfu_match_cb_t::dom_discover_vtx (
     vtx_t u,
     const subsystem_t &subsystem,
     const std::vector<Flux::Jobspec::Resource> &resources,
-    const f_resource_graph_t &g)
+    const resource_graph_t &g)
 {
     m_trav_level++;
     return 0;
@@ -78,7 +78,7 @@ int dfu_match_cb_t::dom_finish_vtx (
     vtx_t u,
     const subsystem_t &subsystem,
     const std::vector<Flux::Jobspec::Resource> &resources,
-    const f_resource_graph_t &g,
+    const resource_graph_t &g,
     scoring_api_t &dfu)
 {
     m_trav_level--;
@@ -89,7 +89,7 @@ int dfu_match_cb_t::aux_discover_vtx (
     vtx_t u,
     const subsystem_t &subsystem,
     const std::vector<Flux::Jobspec::Resource> &resources,
-    const f_resource_graph_t &g)
+    const resource_graph_t &g)
 
 {
     m_trav_level++;
@@ -100,7 +100,7 @@ int dfu_match_cb_t::aux_finish_vtx (
     vtx_t u,
     const subsystem_t &subsystem,
     const std::vector<Flux::Jobspec::Resource> &resources,
-    const f_resource_graph_t &g,
+    const resource_graph_t &g,
     scoring_api_t &dfu)
 {
     m_trav_level--;

--- a/resource/policies/base/dfu_match_cb.hpp
+++ b/resource/policies/base/dfu_match_cb.hpp
@@ -52,7 +52,7 @@ public:
     virtual int dom_finish_graph (const subsystem_t &subsystem,
                                   const std::vector<
                                             Flux::Jobspec::Resource> &resources,
-                                  const f_resource_graph_t &g,
+                                  const resource_graph_t &g,
                                   scoring_api_t &dfu);
 
     /*!
@@ -80,7 +80,7 @@ public:
                                   const subsystem_t &subsystem,
                                   const std::vector<
                                             Flux::Jobspec::Resource> &resources,
-                                  const f_resource_graph_t &g);
+                                  const resource_graph_t &g);
 
     /*!
      *  Called back on each postorder visit of the dominant subsystem.
@@ -102,7 +102,7 @@ public:
                                 const subsystem_t &subsystem,
                                 const std::vector<
                                           Flux::Jobspec::Resource> &resources,
-                                const f_resource_graph_t &g,
+                                const resource_graph_t &g,
                                 scoring_api_t &dfu);
 
     /*! Called back on each pre-up visit of an auxiliary subsystem.
@@ -120,7 +120,7 @@ public:
                                   const subsystem_t &subsystem,
                                   const std::vector<
                                             Flux::Jobspec::Resource> &resources,
-                                  const f_resource_graph_t &g);
+                                  const resource_graph_t &g);
 
     /*
      *  Called back on each post-up visit of the auxiliary subsystem.
@@ -141,7 +141,7 @@ public:
                                 const subsystem_t &subsystem,
                                 const std::vector<
                                           Flux::Jobspec::Resource> &resources,
-                                const f_resource_graph_t &g,
+                                const resource_graph_t &g,
                                 scoring_api_t &dfu);
 
     /*

--- a/resource/policies/dfu_match_locality.cpp
+++ b/resource/policies/dfu_match_locality.cpp
@@ -52,7 +52,7 @@ greater_interval_first_t::~greater_interval_first_t ()
 int greater_interval_first_t::dom_finish_graph (
     const subsystem_t &subsystem,
     const std::vector<Flux::Jobspec::Resource> &resources,
-    const f_resource_graph_t &g, scoring_api_t &dfu)
+    const resource_graph_t &g, scoring_api_t &dfu)
 {
     using namespace boost::icl;
     int score = MATCH_MET;
@@ -90,7 +90,7 @@ int greater_interval_first_t::dom_finish_vtx (
     vtx_t u,
     const subsystem_t &subsystem,
     const std::vector<Flux::Jobspec::Resource> &resources,
-    const f_resource_graph_t &g, scoring_api_t &dfu)
+    const resource_graph_t &g, scoring_api_t &dfu)
 {
     int64_t score = MATCH_MET;
     int64_t overall;

--- a/resource/policies/dfu_match_locality.hpp
+++ b/resource/policies/dfu_match_locality.hpp
@@ -35,11 +35,11 @@ struct greater_interval_first_t : public dfu_match_cb_t
 
     int dom_finish_graph (const subsystem_t &subsystem,
                           const std::vector<Flux::Jobspec::Resource> &resources,
-                          const f_resource_graph_t &g, scoring_api_t &dfu);
+                          const resource_graph_t &g, scoring_api_t &dfu);
 
     int dom_finish_vtx (vtx_t u, const subsystem_t &subsystem,
                         const std::vector<Flux::Jobspec::Resource> &resources,
-                        const f_resource_graph_t &g, scoring_api_t &dfu);
+                        const resource_graph_t &g, scoring_api_t &dfu);
 
     int dom_finish_slot (const subsystem_t &subsystem, scoring_api_t &dfu);
 };

--- a/resource/policies/dfu_match_multilevel_id.hpp
+++ b/resource/policies/dfu_match_multilevel_id.hpp
@@ -43,7 +43,7 @@ public:
      */
     int dom_finish_graph (const subsystem_t &subsystem,
                           const std::vector<Flux::Jobspec::Resource> &resources,
-                          const f_resource_graph_t &g, scoring_api_t &dfu);
+                          const resource_graph_t &g, scoring_api_t &dfu);
 
     /*! Please see its overriding method within
      *  dfu_match_cb_t@base/dfu_match_cb.hpp
@@ -56,14 +56,14 @@ public:
     int dom_discover_vtx (vtx_t u,
                           const subsystem_t &subsystem,
                           const std::vector<Flux::Jobspec::Resource> &resources,
-                          const f_resource_graph_t &g);
+                          const resource_graph_t &g);
 
     /*! Please see its overriding method within
      *  dfu_match_cb_t@base/dfu_match_cb.hpp
      */
     int dom_finish_vtx (vtx_t u, const subsystem_t &subsystem,
                         const std::vector<Flux::Jobspec::Resource> &resources,
-                        const f_resource_graph_t &g, scoring_api_t &dfu);
+                        const resource_graph_t &g, scoring_api_t &dfu);
 
     /*! Please see its overriding method within
      *  dfu_match_cb_t@base/dfu_match_cb.hpp

--- a/resource/policies/dfu_match_multilevel_id_impl.hpp
+++ b/resource/policies/dfu_match_multilevel_id_impl.hpp
@@ -114,7 +114,7 @@ int multilevel_id_t<FOLD>::dom_finish_graph (
                                const subsystem_t &subsystem,
                                const std::vector< 
                                          Flux::Jobspec::Resource> &resources,
-                               const f_resource_graph_t &g,
+                               const resource_graph_t &g,
                                scoring_api_t &dfu)
 {
     int64_t score = MATCH_MET;
@@ -150,7 +150,7 @@ int multilevel_id_t<FOLD>::dom_discover_vtx (
                                const subsystem_t &subsystem,
                                const std::vector<
                                          Flux::Jobspec::Resource> &resources,
-                               const f_resource_graph_t &g)
+                               const resource_graph_t &g)
 {
     if (m_multilevel_factors.find (g[u].type) != m_multilevel_factors.end ()) {
         if (g[u].id < -1)
@@ -171,7 +171,7 @@ int multilevel_id_t<FOLD>::dom_finish_vtx (
                                const subsystem_t &subsystem,
                                const std::vector<
                                          Flux::Jobspec::Resource> &resources,
-                               const f_resource_graph_t &g,
+                               const resource_graph_t &g,
                                scoring_api_t &dfu)
 {
     int64_t score = MATCH_MET;

--- a/resource/policies/dfu_match_var_aware.cpp
+++ b/resource/policies/dfu_match_var_aware.cpp
@@ -52,7 +52,7 @@ var_aware_t::~var_aware_t ()
 int var_aware_t::dom_finish_graph (
     const subsystem_t &subsystem,
     const std::vector<Flux::Jobspec::Resource> &resources,
-    const f_resource_graph_t &g, scoring_api_t &dfu)
+    const resource_graph_t &g, scoring_api_t &dfu)
 {
     int score = MATCH_MET;
     fold::less comp;
@@ -86,7 +86,7 @@ int var_aware_t::dom_finish_vtx (
     vtx_t u,
     const subsystem_t &subsystem,
     const std::vector<Flux::Jobspec::Resource> &resources,
-    const f_resource_graph_t &g, scoring_api_t &dfu)
+    const resource_graph_t &g, scoring_api_t &dfu)
 {
     int64_t score = MATCH_MET;
     int64_t overall;

--- a/resource/policies/dfu_match_var_aware.hpp
+++ b/resource/policies/dfu_match_var_aware.hpp
@@ -33,10 +33,10 @@ struct var_aware_t : public dfu_match_cb_t
 
     int dom_finish_graph (const subsystem_t &subsystem,
                           const std::vector<Flux::Jobspec::Resource> &resources,
-                          const f_resource_graph_t &g, scoring_api_t &dfu);
+                          const resource_graph_t &g, scoring_api_t &dfu);
     int dom_finish_vtx (vtx_t u, const subsystem_t &subsystem,
                         const std::vector<Flux::Jobspec::Resource> &resources,
-                        const f_resource_graph_t &g, scoring_api_t &dfu);
+                        const resource_graph_t &g, scoring_api_t &dfu);
 
     int dom_finish_slot (const subsystem_t &subsystem, scoring_api_t &dfu);
 };

--- a/resource/reapi/bindings/c++/reapi_cli.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli.hpp
@@ -110,12 +110,10 @@ private:
     std::shared_ptr<dfu_match_cb_t> matcher; /* Match callback object */
     std::shared_ptr<dfu_traverser_t> traverser; /* Graph traverser object */
     std::shared_ptr<resource_graph_db_t> db;    /* Resource graph data store */
-    std::shared_ptr<f_resource_graph_t> fgraph; /* Filtered graph */
     match_perf_t perf;           /* Match performance stats */
     std::map<uint64_t, std::shared_ptr<job_info_t>> jobs; /* Jobs table */
     std::map<uint64_t, uint64_t> allocations;  /* Allocation table */
     std::map<uint64_t, uint64_t> reservations; /* Reservation table */
-    std::shared_ptr<f_resource_graph_t> create_filtered_graph ();
 
     /************************************************************************
      *                                                                      *

--- a/resource/schema/data_std.hpp
+++ b/resource/schema/data_std.hpp
@@ -11,6 +11,7 @@
 #ifndef DATA_STD_H
 #define DATA_STD_H
 
+#include <map>
 #include <set>
 #include <string>
 

--- a/resource/schema/resource_graph.hpp
+++ b/resource/schema/resource_graph.hpp
@@ -14,7 +14,6 @@
 #include "resource/schema/resource_data.hpp"
 #include <boost/config.hpp>
 #include <boost/graph/adjacency_list.hpp>
-#include <boost/graph/filtered_graph.hpp>
 #include <boost/graph/graphml.hpp>
 #include <boost/graph/graphviz.hpp>
 
@@ -96,19 +95,14 @@ using edg_t = boost::graph_traits<resource_graph_t>::edge_descriptor;
 using vtx_iterator_t = boost::graph_traits<resource_graph_t>::vertex_iterator;
 using edg_iterator_t = boost::graph_traits<resource_graph_t>::edge_iterator;
 using out_edg_iterator_t = boost::graph_traits<resource_graph_t>::out_edge_iterator;
-using f_resource_graph_t = boost::filtered_graph<resource_graph_t,
-                                                 subsystem_selector_t<edg_t,
-                                                               edg_infra_map_t>,
-                                                 subsystem_selector_t<vtx_t,
-                                                               vtx_infra_map_t>>;
-using f_edg_infra_map_t = boost::property_map<f_resource_graph_t, rinfra_t>::type;
-using f_vtx_infra_map_t = boost::property_map<f_resource_graph_t, pinfra_t>::type;
-using f_res_name_map_t = boost::property_map<f_resource_graph_t, pname_t>::type;
-using f_rel_name_map_t = boost::property_map<f_resource_graph_t, rname_t>::type;
-using f_vtx_infra_map_t = boost::property_map<f_resource_graph_t, pinfra_t>::type;
-using f_vtx_iterator_t = boost::graph_traits<f_resource_graph_t>::vertex_iterator;
-using f_edg_iterator_t = boost::graph_traits<f_resource_graph_t>::edge_iterator;
-using f_out_edg_iterator_t = boost::graph_traits<f_resource_graph_t>::out_edge_iterator;
+using f_edg_infra_map_t = boost::property_map<resource_graph_t, rinfra_t>::type;
+using f_vtx_infra_map_t = boost::property_map<resource_graph_t, pinfra_t>::type;
+using f_res_name_map_t = boost::property_map<resource_graph_t, pname_t>::type;
+using f_rel_name_map_t = boost::property_map<resource_graph_t, rname_t>::type;
+using f_vtx_infra_map_t = boost::property_map<resource_graph_t, pinfra_t>::type;
+using f_vtx_iterator_t = boost::graph_traits<resource_graph_t>::vertex_iterator;
+using f_edg_iterator_t = boost::graph_traits<resource_graph_t>::edge_iterator;
+using f_out_edg_iterator_t = boost::graph_traits<resource_graph_t>::out_edge_iterator;
 
 template<class name_map, class graph_entity>
 class label_writer_t {

--- a/resource/traversers/dfu.cpp
+++ b/resource/traversers/dfu.cpp
@@ -167,10 +167,9 @@ dfu_traverser_t::dfu_traverser_t ()
 
 }
 
-dfu_traverser_t::dfu_traverser_t (std::shared_ptr<f_resource_graph_t> g,
-                                  std::shared_ptr<resource_graph_db_t> db,
+dfu_traverser_t::dfu_traverser_t ( std::shared_ptr<resource_graph_db_t> db,
                                   std::shared_ptr<dfu_match_cb_t> m)
-    : detail::dfu_impl_t (g, db, m)
+    : detail::dfu_impl_t (db, m)
 {
 
 }
@@ -192,8 +191,7 @@ dfu_traverser_t::~dfu_traverser_t ()
 
 }
 
-const std::shared_ptr<const f_resource_graph_t> dfu_traverser_t::
-                                                    get_graph () const
+const resource_graph_t *dfu_traverser_t::get_graph () const
 {
    return detail::dfu_impl_t::get_graph ();
 }
@@ -223,11 +221,6 @@ const unsigned int dfu_traverser_t::get_total_preorder_count () const
 const unsigned int dfu_traverser_t::get_total_postorder_count () const
 {
     return m_total_postorder;
-}
-
-void dfu_traverser_t::set_graph (std::shared_ptr<f_resource_graph_t> g)
-{
-    detail::dfu_impl_t::set_graph (g);
 }
 
 void dfu_traverser_t::set_graph_db (std::shared_ptr<resource_graph_db_t> g)
@@ -277,11 +270,9 @@ int dfu_traverser_t::initialize ()
     return rc;
 }
 
-int dfu_traverser_t::initialize (std::shared_ptr<f_resource_graph_t> g,
-                                 std::shared_ptr<resource_graph_db_t> db,
+int dfu_traverser_t::initialize (std::shared_ptr<resource_graph_db_t> db,
                                  std::shared_ptr<dfu_match_cb_t> m)
 {
-    set_graph (g);
     set_graph_db (db);
     set_match_cb (m);
     return initialize ();

--- a/resource/traversers/dfu.hpp
+++ b/resource/traversers/dfu.hpp
@@ -27,8 +27,7 @@ class dfu_traverser_t : protected detail::dfu_impl_t
 {
 public:
     dfu_traverser_t ();
-    dfu_traverser_t (std::shared_ptr<f_resource_graph_t> g,
-                     std::shared_ptr<resource_graph_db_t> db,
+    dfu_traverser_t (std::shared_ptr<resource_graph_db_t> db,
                      std::shared_ptr<dfu_match_cb_t> m);
     dfu_traverser_t (const dfu_traverser_t &o);
     dfu_traverser_t (dfu_traverser_t &&o) = default;
@@ -36,14 +35,13 @@ public:
     dfu_traverser_t &operator= (dfu_traverser_t &&o) = default;
     ~dfu_traverser_t ();
 
-    const std::shared_ptr<const f_resource_graph_t> get_graph () const;
+    const resource_graph_t *get_graph () const;
     const std::shared_ptr<const resource_graph_db_t> get_graph_db () const;
     const std::shared_ptr<const dfu_match_cb_t> get_match_cb () const;
     const std::string &err_message () const;
     const unsigned int get_total_preorder_count () const;
     const unsigned int get_total_postorder_count () const;
 
-    void set_graph (std::shared_ptr<f_resource_graph_t> g);
     void set_graph_db (std::shared_ptr<resource_graph_db_t> db);
     void set_match_cb (std::shared_ptr<dfu_match_cb_t> m);
     void clear_err_message ();
@@ -75,7 +73,7 @@ public:
      *  provides an interface to tell this initializer what subtree resources
      *  to track at higher-level resource vertices.
      *
-     *  \param g         resource graph of f_resource_graph_t type.
+     *  \param g         resource graph of resource_graph_t type.
      *  \param roots     map of root vertices, each is a root of a subsystem.
      *  \param m         match callback object of dfu_match_cb_t type.
      *  \return          0 on success; -1 on error.
@@ -83,8 +81,7 @@ public:
      *                       ENOTSUP: roots does not contain a subsystem
      *                                the match callback uses.
      */
-    int initialize (std::shared_ptr<f_resource_graph_t> g,
-                    std::shared_ptr<resource_graph_db_t> db,
+    int initialize (std::shared_ptr<resource_graph_db_t> db,
                     std::shared_ptr<dfu_match_cb_t> m);
 
     /*! Begin a graph traversal for the jobspec and allocate,

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -993,54 +993,25 @@ int dfu_impl_t::enforce (const subsystem_t &subsystem, scoring_api_t &dfu)
 // DFU Traverser Implementation Public API Definitions
 ////////////////////////////////////////////////////////////////////////////////
 
-dfu_impl_t::dfu_impl_t ()
-{
-
-}
-
-dfu_impl_t::dfu_impl_t (std::shared_ptr<f_resource_graph_t> g,
-                        std::shared_ptr<resource_graph_db_t> db,
+dfu_impl_t::dfu_impl_t () = default;
+dfu_impl_t::dfu_impl_t (std::shared_ptr<resource_graph_db_t> db,
                         std::shared_ptr<dfu_match_cb_t> m)
-    : m_graph (g), m_graph_db (db), m_match (m)
+    : m_graph_db (db), m_match (m)
 {
 
 }
+dfu_impl_t::dfu_impl_t (const dfu_impl_t &o) = default;
+dfu_impl_t &dfu_impl_t::operator= (const dfu_impl_t &o) = default;
+dfu_impl_t::dfu_impl_t (dfu_impl_t &&o) = default;
+dfu_impl_t &dfu_impl_t::operator= (dfu_impl_t &&o) = default;
+dfu_impl_t::~dfu_impl_t () = default;
 
-dfu_impl_t::dfu_impl_t (const dfu_impl_t &o)
-{
-    m_color = o.m_color;
-    m_best_k_cnt = o.m_best_k_cnt;
-    m_trav_level = o.m_trav_level;
-    m_graph = o.m_graph;
-    m_graph_db = o.m_graph_db;
-    m_match = o.m_match;
-    m_err_msg = o.m_err_msg;
-}
-
-dfu_impl_t &dfu_impl_t::operator= (const dfu_impl_t &o)
-{
-    m_color = o.m_color;
-    m_best_k_cnt = o.m_best_k_cnt;
-    m_trav_level = o.m_trav_level;
-    m_graph = o.m_graph;
-    m_graph_db = o.m_graph_db;
-    m_match = o.m_match;
-    m_err_msg = o.m_err_msg;
-    return *this;
-}
-
-dfu_impl_t::~dfu_impl_t ()
-{
-
-}
-
-const std::shared_ptr<const f_resource_graph_t> dfu_impl_t::get_graph () const
+const resource_graph_t *dfu_impl_t::get_graph () const
 {
     return m_graph;
 }
 
-const std::shared_ptr<const
-                      resource_graph_db_t> dfu_impl_t::get_graph_db () const
+const std::shared_ptr<const resource_graph_db_t> dfu_impl_t::get_graph_db () const
 {
     return m_graph_db;
 }
@@ -1070,14 +1041,10 @@ const std::set<std::string> &dfu_impl_t::get_exclusive_resource_types () const
     return m_match->get_exclusive_resource_types ();
 }
 
-void dfu_impl_t::set_graph (std::shared_ptr<f_resource_graph_t> g)
-{
-    m_graph = g;
-}
-
 void dfu_impl_t::set_graph_db (std::shared_ptr<resource_graph_db_t> db)
 {
     m_graph_db = db;
+    m_graph = &db->resource_graph;
 }
 
 void dfu_impl_t::set_match_cb (std::shared_ptr<dfu_match_cb_t> m)

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -110,17 +110,16 @@ private:
 class dfu_impl_t {
 public:
     dfu_impl_t ();
-    dfu_impl_t (std::shared_ptr<f_resource_graph_t> g,
-                std::shared_ptr<resource_graph_db_t> db,
+    dfu_impl_t (std::shared_ptr<resource_graph_db_t> db,
                 std::shared_ptr<dfu_match_cb_t> m);
     dfu_impl_t (const dfu_impl_t &o);
-    dfu_impl_t (dfu_impl_t &&o) = default;
+    dfu_impl_t (dfu_impl_t &&o);
     dfu_impl_t &operator= (const dfu_impl_t &o);
-    dfu_impl_t &operator= (dfu_impl_t &&o) = default;
+    dfu_impl_t &operator= (dfu_impl_t &&o);
     ~dfu_impl_t ();
 
     //! Accessors
-    const std::shared_ptr<const f_resource_graph_t> get_graph () const;
+    const resource_graph_t *get_graph () const;
     const std::shared_ptr<const resource_graph_db_t> get_graph_db () const;
     const std::shared_ptr<const dfu_match_cb_t> get_match_cb () const;
     const std::string &err_message () const;
@@ -129,7 +128,6 @@ public:
     const unsigned int get_postorder_count () const;
     const std::set<std::string> &get_exclusive_resource_types () const;
 
-    void set_graph (std::shared_ptr<f_resource_graph_t> g);
     void set_graph_db (std::shared_ptr<resource_graph_db_t> db);
     void set_match_cb (std::shared_ptr<dfu_match_cb_t> m);
     void clear_err_message ();
@@ -497,7 +495,7 @@ private:
     unsigned int m_preorder = 0;
     unsigned int m_postorder = 0;
     std::shared_ptr<std::map<subsystem_t, vtx_t>> m_roots = nullptr;
-    std::shared_ptr<f_resource_graph_t> m_graph = nullptr;
+    resource_graph_t *m_graph = nullptr;
     std::shared_ptr<resource_graph_db_t> m_graph_db = nullptr;
     std::shared_ptr<dfu_match_cb_t> m_match = nullptr;
     expr_eval_api_t m_expr_eval;

--- a/resource/utilities/README.md
+++ b/resource/utilities/README.md
@@ -444,7 +444,7 @@ method argument `resources`).
 ```c++
  84     int dom_finish_vtx (vtx_t u, const subsystem_t &subsystem,
  85                         const std::vector<Flux::Jobspec::Resource> &resources,
- 86                         const f_resource_graph_t &g, scoring_api_t &dfu)
+ 86                         const resource_graph_t &g, scoring_api_t &dfu)
  87     {
  88         int64_t score = MATCH_MET;
  89         int64_t overall;

--- a/resource/utilities/command.cpp
+++ b/resource/utilities/command.cpp
@@ -451,7 +451,7 @@ static int attach (std::shared_ptr<resource_context_t> &ctx,
         std::cerr << "ERROR: " << rd->err_message ();
         return -1;
     }
-    if (ctx->traverser->initialize (ctx->fgraph, ctx->db, ctx->matcher) != 0) {
+    if (ctx->traverser->initialize (ctx->db, ctx->matcher) != 0) {
         std::cerr << "ERROR: can't reinitialize traverser after attach"
                   << std::endl;
         return -1;

--- a/resource/utilities/command.hpp
+++ b/resource/utilities/command.hpp
@@ -55,7 +55,7 @@ struct resource_context_t {
     std::shared_ptr<dfu_match_cb_t> matcher; /* Match callback object */
     std::shared_ptr<dfu_traverser_t> traverser; /* Graph traverser object */
     std::shared_ptr<resource_graph_db_t> db;    /* Resource graph data store */
-    std::shared_ptr<f_resource_graph_t> fgraph; /* Filtered graph */
+    std::shared_ptr<resource_graph_t> fgraph; /* Filtered graph */
     std::shared_ptr<match_writers_t> writers;  /* Vertex/Edge writers */
     match_perf_t perf;           /* Match performance stats */
     std::map<uint64_t, std::shared_ptr<job_info_t>> jobs; /* Jobs table */

--- a/resource/utilities/test/resource-bench.sh
+++ b/resource/utilities/test/resource-bench.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#set -x
+set -x
 
 NJOBS=4096
 NNODES=256

--- a/resource/writers/match_writers.cpp
+++ b/resource/writers/match_writers.cpp
@@ -142,7 +142,7 @@ int sim_match_writers_t::emit (std::stringstream &out)
 }
 
 int sim_match_writers_t::emit_vtx (const std::string &prefix,
-                                   const f_resource_graph_t &g, const vtx_t &u,
+                                   const resource_graph_t &g, const vtx_t &u,
                                    unsigned int needs, bool exclusive)
 {
     std::string mode = (exclusive)? "x" : "s";
@@ -258,7 +258,7 @@ ret:
 }
 
 int jgf_match_writers_t::emit_vtx (const std::string &prefix,
-                                   const f_resource_graph_t &g, const vtx_t &u,
+                                   const resource_graph_t &g, const vtx_t &u,
                                    unsigned int needs, bool exclusive)
 {
     int rc = 0;
@@ -306,7 +306,7 @@ out:
 }
 
 int jgf_match_writers_t::emit_edg (const std::string &prefix,
-                                   const f_resource_graph_t &g, const edg_t &e)
+                                   const resource_graph_t &g, const edg_t &e)
 {
     int rc = 0;
     json_t *o = NULL;
@@ -396,7 +396,7 @@ ret:
     return rc;
 }
 
-json_t *jgf_match_writers_t::emit_vtx_base (const f_resource_graph_t &g,
+json_t *jgf_match_writers_t::emit_vtx_base (const resource_graph_t &g,
                                             const vtx_t &u,
                                             unsigned int needs, bool exclusive)
 {
@@ -490,7 +490,7 @@ out:
     return rc;
 }
 
-int jgf_match_writers_t::emit_edg_meta (json_t *o, const f_resource_graph_t &g,
+int jgf_match_writers_t::emit_edg_meta (json_t *o, const resource_graph_t &g,
                                         const edg_t &e)
 {
     int rc = 0;
@@ -664,7 +664,7 @@ int rlite_match_writers_t::emit (std::stringstream &out)
 }
 
 int rlite_match_writers_t::emit_vtx (const std::string &prefix,
-                                     const f_resource_graph_t &g,
+                                     const resource_graph_t &g,
                                      const vtx_t &u,
                                      unsigned int needs,
                                      bool exclusive)
@@ -754,7 +754,7 @@ ret:
     return rc;
 }
 
-int rlite_match_writers_t::emit_gatherer (const f_resource_graph_t &g,
+int rlite_match_writers_t::emit_gatherer (const resource_graph_t &g,
                                           const vtx_t &u)
 {
     int rc = 0;
@@ -1072,7 +1072,7 @@ ret:
 }
 
 int rv1_match_writers_t::emit_vtx (const std::string &prefix,
-                                   const f_resource_graph_t &g,
+                                   const resource_graph_t &g,
                                    const vtx_t &u,
                                    unsigned int needs,
                                    bool exclusive)
@@ -1084,7 +1084,7 @@ int rv1_match_writers_t::emit_vtx (const std::string &prefix,
 }
 
 int rv1_match_writers_t::emit_edg (const std::string &prefix,
-                                   const f_resource_graph_t &g,
+                                   const resource_graph_t &g,
                                    const edg_t &e)
 {
     int rc = 0;
@@ -1196,7 +1196,7 @@ ret:
 }
 
 int rv1_nosched_match_writers_t::emit_vtx (const std::string &prefix,
-                                           const f_resource_graph_t &g,
+                                           const resource_graph_t &g,
                                            const vtx_t &u,
                                            unsigned int needs,
                                            bool exclusive)
@@ -1256,7 +1256,7 @@ int pretty_sim_match_writers_t::emit (std::stringstream &out)
 }
 
 int pretty_sim_match_writers_t::emit_vtx (const std::string &prefix,
-                                          const f_resource_graph_t &g,
+                                          const resource_graph_t &g,
                                           const vtx_t &u,
                                           unsigned int needs, bool exclusive)
 {

--- a/resource/writers/match_writers.hpp
+++ b/resource/writers/match_writers.hpp
@@ -40,10 +40,10 @@ public:
     virtual int emit_json (json_t **o, json_t **aux = nullptr) = 0;
     virtual int emit (std::stringstream &out) = 0;
     virtual int emit_vtx (const std::string &prefix,
-                          const f_resource_graph_t &g, const vtx_t &u,
+                          const resource_graph_t &g, const vtx_t &u,
                           unsigned int needs, bool exclusive) = 0;
     virtual int emit_edg (const std::string &prefix,
-                          const f_resource_graph_t &g, const edg_t &e) {
+                          const resource_graph_t &g, const edg_t &e) {
         return 0;
     }
     virtual int emit_tm (uint64_t starttime, uint64_t expiration) {
@@ -68,7 +68,7 @@ public:
     virtual int emit_json (json_t **o, json_t **aux = nullptr);
     virtual int emit (std::stringstream &out);
     virtual int emit_vtx (const std::string &prefix,
-                          const f_resource_graph_t &g, const vtx_t &u,
+                          const resource_graph_t &g, const vtx_t &u,
                           unsigned int needs, bool exclusive);
 private:
     std::stringstream m_out;
@@ -89,20 +89,20 @@ public:
     virtual int emit_json (json_t **o, json_t **aux = nullptr);
     virtual int emit (std::stringstream &out);
     virtual int emit_vtx (const std::string &prefix,
-                          const f_resource_graph_t &g, const vtx_t &u,
+                          const resource_graph_t &g, const vtx_t &u,
                           unsigned int needs, bool exclusive);
     virtual int emit_edg (const std::string &prefix,
-                          const f_resource_graph_t &g, const edg_t &e);
+                          const resource_graph_t &g, const edg_t &e);
 private:
-    json_t *emit_vtx_base (const f_resource_graph_t &g, const vtx_t &u,
+    json_t *emit_vtx_base (const resource_graph_t &g, const vtx_t &u,
                            unsigned int needs, bool exclusive);
-    int emit_vtx_prop (json_t *o, const f_resource_graph_t &g,
+    int emit_vtx_prop (json_t *o, const resource_graph_t &g,
                        const vtx_t &u, unsigned int needs, bool exclusive);
-    int emit_vtx_path (json_t *o, const f_resource_graph_t &g,
+    int emit_vtx_path (json_t *o, const resource_graph_t &g,
                        const vtx_t &u, unsigned int needs, bool exclusive);
     int map2json (json_t *o, const std::map<std::string, std::string> &mp,
                   const char *key);
-    int emit_edg_meta (json_t *o, const f_resource_graph_t &g, const edg_t &e);
+    int emit_edg_meta (json_t *o, const resource_graph_t &g, const edg_t &e);
     int alloc_json_arrays ();
     int check_array_sizes ();
 
@@ -126,7 +126,7 @@ public:
     virtual int emit (std::stringstream &out, bool newline);
     virtual int emit (std::stringstream &out);
     virtual int emit_vtx (const std::string &prefix,
-                          const f_resource_graph_t &g, const vtx_t &u,
+                          const resource_graph_t &g, const vtx_t &u,
                           unsigned int needs, bool exclusive);
 private:
     class rank_host_t {
@@ -135,7 +135,7 @@ private:
         std::string host;
     };
     bool m_reducer_set ();
-    int emit_gatherer (const f_resource_graph_t &g, const vtx_t &u);
+    int emit_gatherer (const resource_graph_t &g, const vtx_t &u);
     int get_gatherer_children (std::string &children);
     int fill (json_t *rlite_array, json_t *host_array, json_t *props);
     int fill_hosts (std::vector<std::string> &hosts, json_t *host_array);
@@ -157,10 +157,10 @@ public:
     virtual int emit_json (json_t **o, json_t **aux = nullptr);
     virtual int emit (std::stringstream &out);
     virtual int emit_vtx (const std::string &prefix,
-                          const f_resource_graph_t &g, const vtx_t &u,
+                          const resource_graph_t &g, const vtx_t &u,
                           unsigned int needs, bool exclusive);
     virtual int emit_edg (const std::string &prefix,
-                          const f_resource_graph_t &g, const edg_t &e);
+                          const resource_graph_t &g, const edg_t &e);
     virtual int emit_tm (uint64_t start_tm, uint64_t end_tm);
     virtual int emit_attrs (const std::string &k, const std::string &v);
 private:
@@ -183,7 +183,7 @@ public:
     virtual int emit_json (json_t **o, json_t **aux = nullptr);
     virtual int emit (std::stringstream &out);
     virtual int emit_vtx (const std::string &prefix,
-                          const f_resource_graph_t &g, const vtx_t &u,
+                          const resource_graph_t &g, const vtx_t &u,
                           unsigned int needs, bool exclusive);
     virtual int emit_tm (uint64_t start_tm, uint64_t end_tm);
 private:
@@ -202,7 +202,7 @@ public:
     virtual int emit_json (json_t **o, json_t **aux = nullptr);
     virtual int emit (std::stringstream &out);
     virtual int emit_vtx (const std::string &prefix,
-                          const f_resource_graph_t &g, const vtx_t &u,
+                          const resource_graph_t &g, const vtx_t &u,
                           unsigned int needs, bool exclusive);
 private:
     std::list<std::string> m_out;


### PR DESCRIPTION
The filtered_graph buys us basically nothing, but it costs order 30%-80% depending on the operation and how we measure.  I need to run a performance study with and without, but for production cases it should always be a win, and it reduces compile times.  It's most noticeable with the many-time-point test such that there's a _ton_ of matches, but it should make at least a small difference everywhere.

This is stacked on top of #1224 because without it, this change made the race condition much more common and frequently hung one or more tests.

As part of routing out the filtered-graph types, I removed a number of "shared_ptr" arguments.  Overall my intention is that no regular pointer type argument should ever _own_ storage, but we can pass things by pointer when just sharing a reference to state owned by something else.  Ideally these would become references, but that's more disruptive to the code.