### PR TITLE
batch consume messages, immediately process cancellation

### DIFF
--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -526,7 +526,7 @@ static std::shared_ptr<qmanager_ctx_t> qmanager_new (flux_t *h)
             ctx = nullptr;
             goto done;
         }
-        if (!(ctx->prep = flux_prepare_watcher_create (
+        if (!(ctx->prep = flux_check_watcher_create (
                               reactor,
                               &qmanager_safe_cb_t::prep_watcher_cb,
                               std::static_pointer_cast<
@@ -535,8 +535,10 @@ static std::shared_ptr<qmanager_ctx_t> qmanager_new (flux_t *h)
             ctx = nullptr;
             goto done;
         }
-        if (!(ctx->check = flux_check_watcher_create (
+        if (!(ctx->check = flux_timer_watcher_create (
                                reactor,
+                               0.0,
+                               0.0,
                                &qmanager_safe_cb_t::check_watcher_cb,
                                std::static_pointer_cast<
                                    qmanager_ctx_t> (ctx).get ()))) {
@@ -561,7 +563,6 @@ static std::shared_ptr<qmanager_ctx_t> qmanager_new (flux_t *h)
             goto done;
         }
         flux_watcher_start (ctx->prep);
-        flux_watcher_start (ctx->check);
 
     } catch (std::bad_alloc &e) {
         errno = ENOMEM;

--- a/qmanager/modules/qmanager_callbacks.hpp
+++ b/qmanager/modules/qmanager_callbacks.hpp
@@ -27,6 +27,7 @@ struct qmanager_cb_ctx_t {
     flux_watcher_t *idle{nullptr};
     bool pls_sched_loop {false};
     bool pls_post_loop {false};
+    bool check_active {false};
 
     schedutil_t *schedutil{nullptr};
     Flux::opts_manager::optmgr_composer_t<

--- a/qmanager/policies/queue_policy_bf_base.hpp
+++ b/qmanager/policies/queue_policy_bf_base.hpp
@@ -24,6 +24,7 @@ class queue_policy_bf_base_t : public queue_policy_base_t
 public:
     virtual ~queue_policy_bf_base_t ();
     virtual int run_sched_loop (void *h, bool use_alloced_queue);
+    int cancel_sched_loop () override;
     virtual int reconstruct_resource (void *h, std::shared_ptr<job_t> job,
                                       std::string &R_out);
     virtual int apply_params ();
@@ -33,6 +34,7 @@ protected:
     unsigned int m_max_reservation_depth = MAX_RESERVATION_DEPTH;
 
 private:
+    void init_sched_loop ();
     int cancel_completed_jobs (void *h);
     int cancel_reserved_jobs (void *h);
     int allocate_orelse_reserve_jobs (void *h, bool use_alloced_queue);


### PR DESCRIPTION
This is in progress, but so far takes the 10,000 allocs and 10,000 cancels from some terrifyingly long amount of time to 36 and a half seconds.  It's using a combination of @garlick's batching suggestion and immediately processing cancels by interrupting the scheduling loop if necessary.  Pauses may be too long, probably needs tuning, but _clearly_ better.  Popping it up here before we hop on the plane back from sweden this morning, so I'll be in and out of communication today.