### PR TITLE
qmanager: Asynchronously communicate with resource in the scheduling loop to allow job updates while matching

### DIFF
--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -60,8 +60,6 @@ int qmanager_cb_t::post_sched_loop (flux_t *h, schedutil_t *schedutil,
     for (auto& kv: queues) {
         const std::string &queue_name = kv.first;
         std::shared_ptr<queue_policy_base_t> &queue = kv.second;
-        if (queue->is_sched_loop_active ())
-            continue;
         while ( (job = queue->alloced_pop ()) != nullptr) {
             if (schedutil_alloc_respond_success_pack (schedutil, job->msg,
                                                       job->schedule.R.c_str (),

--- a/qmanager/policies/queue_policy_bf_base.hpp
+++ b/qmanager/policies/queue_policy_bf_base.hpp
@@ -27,19 +27,25 @@ public:
     virtual int reconstruct_resource (void *h, std::shared_ptr<job_t> job,
                                       std::string &R_out);
     virtual int apply_params ();
+    virtual int handle_match_success (flux_jobid_t jobid, const char *status,
+                                      const char *R, int64_t at, double ov);
+    virtual int handle_match_failure (flux_jobid_t jobid, int errcode);
 
 protected:
     unsigned int m_reservation_depth;
     unsigned int m_max_reservation_depth = MAX_RESERVATION_DEPTH;
 
 private:
+    int next_match_iter ();
     int cancel_completed_jobs (void *h);
     int cancel_reserved_jobs (void *h);
     int allocate_orelse_reserve_jobs (void *h, bool use_alloced_queue);
     std::map<uint64_t, flux_jobid_t> m_reserved;
     int m_reservation_cnt;
     int m_scheduled_cnt;
+    bool m_try_reserve = false;
     decltype (m_pending)::iterator m_in_progress_iter = m_pending.end();
+    void *m_handle = NULL;
 };
 
 } // namespace Flux::queue_manager::detail

--- a/qmanager/policies/queue_policy_bf_base.hpp
+++ b/qmanager/policies/queue_policy_bf_base.hpp
@@ -39,7 +39,7 @@ private:
     int next_match_iter ();
     int cancel_completed_jobs (void *h);
     int cancel_reserved_jobs (void *h);
-    int allocate_orelse_reserve_jobs (void *h, bool use_alloced_queue);
+    int allocate_orelse_reserve_jobs (void *h);
     std::map<uint64_t, flux_jobid_t> m_reserved;
     int m_reservation_cnt;
     int m_scheduled_cnt;

--- a/qmanager/policies/queue_policy_bf_base_impl.hpp
+++ b/qmanager/policies/queue_policy_bf_base_impl.hpp
@@ -84,8 +84,7 @@ int queue_policy_bf_base_t<reapi_type>::next_match_iter () {
 }
 
 template<class reapi_type>
-int queue_policy_bf_base_t<reapi_type>::allocate_orelse_reserve_jobs (void *h,
-                                                                      bool use_alloced_queue)
+int queue_policy_bf_base_t<reapi_type>::allocate_orelse_reserve_jobs (void *h)
 {
     // Iterate jobs in the pending job queue and try to allocate each
     // until you can't. When you can't allocate a job, you reserve it
@@ -229,7 +228,7 @@ int queue_policy_bf_base_t<reapi_type>::run_sched_loop (void *h, bool use_alloce
         if (rc != 0)
             return rc;
     }
-    return allocate_orelse_reserve_jobs (h, use_alloced_queue);
+    return allocate_orelse_reserve_jobs (h);
 }
 
 template<class reapi_type>

--- a/qmanager/policies/queue_policy_bf_base_impl.hpp
+++ b/qmanager/policies/queue_policy_bf_base_impl.hpp
@@ -12,6 +12,8 @@
 #define QUEUE_POLICY_BF_BASE_IMPL_HPP
 
 #include "qmanager/policies/queue_policy_bf_base.hpp"
+#include <jansson.h>
+#include <memory>
 
 namespace Flux {
 namespace queue_manager {
@@ -48,6 +50,33 @@ int queue_policy_bf_base_t<reapi_type>::cancel_reserved_jobs (void *h)
 }
 
 template<class reapi_type>
+int queue_policy_bf_base_t<reapi_type>::next_match_iter () {
+    if (m_in_progress_iter == m_pending.end () || (m_scheduled_cnt >= m_queue_depth)) {
+        // we're at the end, clean up
+        set_sched_loop_active (false);
+        return 0;
+    }
+
+    auto &job = m_jobs[m_in_progress_iter->second];
+    m_try_reserve = m_reservation_cnt < m_reservation_depth;
+    json_t *jobarray_ptr = json_pack ("[{s:I s:s}]", "jobid", job->id, "jobspec", job->jobspec.c_str ());
+    if ( !jobarray_ptr) {
+        errno = ENOMEM;
+        return -1;
+    }
+    auto _jdecref = [](json_t *p) { json_decref (p); };
+    std::unique_ptr<json_t, decltype (_jdecref)> jobarray (jobarray_ptr, _jdecref);
+    char *jobs_ptr = json_dumps (jobarray.get (), JSON_INDENT (0));
+    if ( !jobs_ptr) {
+        errno = ENOMEM;
+        return -1;
+    }
+    auto _free = [](char *p) { free (p); };
+    std::unique_ptr<char, decltype (_free)>  jobs_str (jobs_ptr, _free);
+    return reapi_type::match_allocate_multi (m_handle, m_try_reserve, jobs_str.get (), this);
+}
+
+template<class reapi_type>
 int queue_policy_bf_base_t<reapi_type>::allocate_orelse_reserve_jobs (void *h,
                                                                       bool use_alloced_queue)
 {
@@ -73,76 +102,11 @@ int queue_policy_bf_base_t<reapi_type>::allocate_orelse_reserve_jobs (void *h,
         m_scheduled_cnt = 0;
 
         set_sched_loop_active (true);
+
+        m_handle = h;
+        // now that we've initialized, start the chain
+        return next_match_iter ();
     }
-
-    int saved_errno = errno;
-    for (int i = 0; (m_in_progress_iter != m_pending.end ()) && (m_scheduled_cnt < m_queue_depth);
-         ++m_scheduled_cnt, ++i) {
-        if (i > 5) {
-            // set schedulable so that the callback machinery gets us
-            // back in with prep and check
-            set_schedulability (true);
-            errno = EAGAIN;
-            return -1;
-        }
-        errno = 0;
-        auto &job = m_jobs[m_in_progress_iter->second];
-        bool try_reserve = m_reservation_cnt < m_reservation_depth;
-        int64_t at = job->schedule.at;
-        if (!reapi_type::match_allocate (h,
-                                         try_reserve,
-                                         job->jobspec,
-                                         job->id,
-                                         job->schedule.reserved,
-                                         job->schedule.R,
-                                         job->schedule.at,
-                                         job->schedule.ov)) {
-            if (job->schedule.reserved) {
-                // High-priority job has been reserved, continue
-                m_reserved.insert (std::pair<uint64_t, flux_jobid_t> (m_oq_cnt++, job->id));
-                job->schedule.old_at = at;
-                m_reservation_cnt++;
-                m_in_progress_iter++;
-            } else {
-                // move the job to the running queue and make sure the
-                // job is enqueued into allocated job queue as well.
-                // When this is used within a module, it allows the
-                // module to fetch those newly allocated jobs, which
-                // have flux_msg_t to respond to job-manager.
-                m_in_progress_iter = to_running (m_in_progress_iter, use_alloced_queue);
-            }
-        } else if (errno != EBUSY) {
-            // The request must be rejected. The job is enqueued into
-            // rejected job queue to the upper layer to react on this.
-            m_in_progress_iter = to_rejected (m_in_progress_iter,
-                                              (errno == ENODEV) ? "unsatisfiable" : "match error");
-        } else {
-            // errno is EBUSY and match_allocate returned -1
-
-            // copy iterator before we advance to avoid invalidation
-            auto element_iter = m_in_progress_iter;
-            // if we are allocating and not trying to reserve, as in FCFS for
-            // example, EBUSY means the request failed because not enough
-            // resources are available right now.
-
-            // Regardless we want to move to the next item in the map
-            ++m_in_progress_iter;
-
-            // If we are trying to reserve, then EBUSY means not only can it not
-            // be allocated, but it cannot ever be reserved given current
-            // conditions. This can happen if there are "down" resources.
-            // The semantics of our backfill policies are to skip this
-            // job, add it to the blocked list, and re-consider when
-            // resource status changes
-            if (try_reserve) {
-                m_blocked.insert (m_pending.extract (element_iter));
-                // avoid counting this toward queue_depth
-                --m_scheduled_cnt;
-            }
-        }
-    }
-    set_sched_loop_active (false);
-    errno = saved_errno;
     return 0; 
 }
 
@@ -160,6 +124,89 @@ template<class reapi_type>
 int queue_policy_bf_base_t<reapi_type>::apply_params ()
 {
     return 0;
+}
+
+template<class reapi_type>
+int queue_policy_bf_base_t<reapi_type>::handle_match_success (
+                                         flux_jobid_t jobid, const char *status,
+                                         const char *R, int64_t at, double ov)
+{
+    if (!is_sched_loop_active ()) {
+        errno = EINVAL;
+        return -1;
+    }
+    auto &job = m_jobs[m_in_progress_iter->second];
+    if (job->id != static_cast<flux_jobid_t> (jobid)) {
+        errno = EINVAL;
+        return -1;
+    }
+    auto &sched = job->schedule;
+    sched.reserved = std::string ("RESERVED") == status?  true : false;
+    sched.R = R;
+    sched.old_at = sched.at;
+    sched.at = at;
+    sched.ov = ov;
+    if (job->schedule.reserved) {
+        // High-priority job has been reserved, continue
+        m_reserved.insert (std::pair<uint64_t, flux_jobid_t> (m_oq_cnt++, job->id));
+        m_reservation_cnt++;
+        m_in_progress_iter++;
+        // reply with an annotation
+        m_scheduled = true;
+    } else {
+        // move the job to the running queue and make sure the
+        // job is enqueued into allocated job queue as well.
+        // When this is used within a module, it allows the
+        // module to fetch those newly allocated jobs, which
+        // have flux_msg_t to respond to job-manager.
+        m_in_progress_iter = to_running (m_in_progress_iter, true);
+    }
+    ++m_scheduled_cnt;
+    return next_match_iter ();
+}
+
+template<class reapi_type>
+int queue_policy_bf_base_t<reapi_type>::handle_match_failure (flux_jobid_t jobid, int errcode)
+{
+    if (!is_sched_loop_active ()) {
+        errno = EINVAL;
+        return -1;
+    }
+    errno = errcode;
+    if (errno == ENODATA) {
+        // end of sequence, do nothing with this, at all
+        return 0;
+    } else if (errno != EBUSY) {
+        // The request must be rejected. The job is enqueued into
+        // rejected job queue to the upper layer to react on this.
+        m_in_progress_iter = to_rejected (m_in_progress_iter,
+                (errno == ENODEV) ? "unsatisfiable" : "match error");
+    } else {
+        // errno is EBUSY and match_allocate returned -1
+
+        // copy iterator before we advance to avoid invalidation
+        auto element_iter = m_in_progress_iter;
+        // if we are allocating and not trying to reserve, as in FCFS for
+        // example, EBUSY means the request failed because not enough
+        // resources are available right now.
+
+        // Regardless we want to move to the next item in the map
+        ++m_in_progress_iter;
+
+        // If we are trying to reserve, then EBUSY means not only can it not
+        // be allocated, but it cannot ever be reserved given current
+        // conditions. This can happen if there are "down" resources.
+        // The semantics of our backfill policies are to skip this
+        // job, add it to the blocked list, and re-consider when
+        // resource status changes
+        if (m_try_reserve) {
+            m_blocked.insert (m_pending.extract (element_iter));
+            // avoid counting this toward queue_depth
+            --m_scheduled_cnt;
+        }
+    }
+    ++m_scheduled_cnt;
+    return next_match_iter ();
 }
 
 template<class reapi_type>

--- a/qmanager/policies/queue_policy_fcfs_impl.hpp
+++ b/qmanager/policies/queue_policy_fcfs_impl.hpp
@@ -150,6 +150,7 @@ int queue_policy_fcfs_t<reapi_type>::handle_match_failure (flux_jobid_t jobid, i
         set_schedulability (true);
         m_queue_depth_limit = false;
     }
+    set_sched_loop_active (false);
     // whatever happened here, a job transition has occurred, we need to run the
     // post_sched_loop
     m_scheduled = true;

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -1974,6 +1974,11 @@ static void match_multi_request_cb (flux_t *h, flux_msg_handler_t *w,
                 flux_log_error (ctx->h,
                         "%s: match failed due to match error (id=%jd)",
                         __FUNCTION__, static_cast<intmax_t> (jobid));
+            // The resources couldn't be allocated *or reserved*
+            // Kicking back to qmanager, remove from tracking
+            if (errno == EBUSY) {
+                ctx->jobs.erase (jobid);
+            }
             goto error;
         }
 

--- a/resource/reapi/bindings/c++/reapi_module_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_module_impl.hpp
@@ -103,7 +103,6 @@ void match_allocate_multi_cont (flux_future_t *f, void *arg)
         }
     } else {
         adapter->handle_match_failure (jobid, errno);
-        adapter->set_sched_loop_active (false);
         flux_future_destroy (f);
         return;
     }

--- a/t/t1004-qmanager-optimize.t
+++ b/t/t1004-qmanager-optimize.t
@@ -16,17 +16,17 @@ test_under_flux 1
 exec_test()     { ${jq} '.attributes.system.exec.test = {}'; }
 
 test_expect_success 'qmanager: generate jobspecs of varying requirements' '
-    flux run --dry-run -n8 -t 60m hostname | exec_test > C08.T3600.json && #1
-    flux run --dry-run -n10 -t 60m hostname | exec_test > C10.T3600.json && #2
-    flux run --dry-run -n12 -t 60m hostname | exec_test > C12.T3600.json && #3
-    flux run --dry-run -n14 -t 60m hostname | exec_test > C14.T3600.json && #4
-    flux run --dry-run -n16 -t 60m hostname | exec_test > C16.T3600.json && #5
-    flux run --dry-run -n6 -t 121m hostname | exec_test > C06.T7260.json && #6
-    flux run --dry-run -n4 -t 179m hostname | exec_test > C04.T10800.json && #7
-    flux run --dry-run -n4 -t 239m hostname | exec_test > C04.T14400.json && #8
-    flux run --dry-run -n2 -t 239m hostname | exec_test > C02.T14400.json && #9
-    flux run --dry-run -n2 -t 299m hostname | exec_test > C02.T18000.json && #10
-    flux run --dry-run -n2 -t 59m hostname | exec_test > C02.T3600.json #11
+    flux run --job-name=1 --dry-run -n8 -t 60m hostname | exec_test > C08.T3600.json && #1
+    flux run --job-name=2 --dry-run -n10 -t 60m hostname | exec_test > C10.T3600.json && #2
+    flux run --job-name=3 --dry-run -n12 -t 60m hostname | exec_test > C12.T3600.json && #3
+    flux run --job-name=4 --dry-run -n14 -t 60m hostname | exec_test > C14.T3600.json && #4
+    flux run --job-name=5 --dry-run -n16 -t 60m hostname | exec_test > C16.T3600.json && #5
+    flux run --job-name=6 --dry-run -n6 -t 121m hostname | exec_test > C06.T7260.json && #6
+    flux run --job-name=7 --dry-run -n4 -t 179m hostname | exec_test > C04.T10800.json && #7
+    flux run --job-name=8 --dry-run -n4 -t 239m hostname | exec_test > C04.T14400.json && #8
+    flux run --job-name=9 --dry-run -n2 -t 239m hostname | exec_test > C02.T14400.json && #9
+    flux run --job-name=10 --dry-run -n2 -t 299m hostname | exec_test > C02.T18000.json && #10
+    flux run --job-name=11 --dry-run -n2 -t 59m hostname | exec_test > C02.T3600.json #11
 '
 
 test_expect_success 'load test resources' '
@@ -39,17 +39,17 @@ test_expect_success 'qmanager: loading with easy+queue-depth=5' '
 '
 
 test_expect_success 'qmanager: EASY policy conforms to queue-depth=5' '
-    jobid1=$(flux job submit C08.T3600.json) &&
-    jobid2=$(flux job submit C10.T3600.json) && # reserved
-    jobid3=$(flux job submit C12.T3600.json) &&
-    jobid4=$(flux job submit C14.T3600.json) &&
-    jobid5=$(flux job submit C16.T3600.json) &&
-    jobid6=$(flux job submit C06.T7260.json) && # BF A
+    jobid1=$(flux job submit C08.T3600.json) && # 8 allocated 8 free until 3600
+    jobid2=$(flux job submit C10.T3600.json) && # reserved, switching to BF-only
+    jobid3=$(flux job submit C12.T3600.json) && # can not reserve, EBUSY on ALLOC#1
+    jobid4=$(flux job submit C14.T3600.json) && # can not reserve, EBUSY on ALLOC#2
+    jobid5=$(flux job submit C16.T3600.json) && # can not reserve, EBUSY on ALLOC#3
+    jobid6=$(flux job submit C06.T7260.json) && # BF A, 14 allocated 2 free until 3600
     jobid7=$(flux job submit C04.T10800.json) && # BF B when 6 completes
     jobid8=$(flux job submit C04.T14400.json) && # BF C when 7 completes
-    jobid9=$(flux job submit C02.T14400.json) && # Cannot start because qd
+    jobid9=$(flux job submit C02.T14400.json) && # BF D when 7 completes on second loop
     jobid10=$(flux job submit C02.T18000.json) && # Cannot start because qd
-    jobid11=$(flux job submit C02.T3600.json) &&
+    jobid11=$(flux job submit C02.T3600.json) && # Cannot start because qd
 
     flux job wait-event -t 10 ${jobid1} start &&
     flux job wait-event -t 10 ${jobid6} start &&
@@ -58,7 +58,7 @@ test_expect_success 'qmanager: EASY policy conforms to queue-depth=5' '
     flux cancel ${jobid7} &&
     flux job wait-event -t 10 ${jobid8} start &&
     test $(flux job list --states=active | wc -l) -eq 9 &&
-    test $(flux job list --states=running | wc -l) -eq 2 &&
+    test $(flux job list --states=running | wc -l) -eq 3 &&
     active_jobs=$(flux job list --states=active | jq .id) &&
     for job in ${active_jobs}; do flux cancel ${job}; done &&
     for job in ${active_jobs}; do flux job wait-event -t 10 ${job} clean; done
@@ -85,6 +85,7 @@ test_expect_success 'qmanager: HYBRID policy conforms to queue-depth=5' '
     jobid11=$(flux job submit C02.T3600.json) &&
 
     flux job wait-event -t 10 ${jobid1} start &&
+    flux jobs -a &&
     test $(flux job list --states=active | wc -l) -eq 11 &&
     test $(flux job list --states=running| wc -l) -eq 1 &&
     active_jobs=$(flux job list --states=active | jq .id) &&


### PR DESCRIPTION
This is a replacement for #1226, though it doesn't yet have eager cancellation of the sched loop to immediately process job cancellations. The short version is that this makes our backfill queues completely asynchronous with respect to the resource module, and deals with the 10,000 allocs followed by 10,000 cancels test in about 45 seconds on my laptop. Assuming the numbers are comparable, that's a bit under 100x faster than the time @milroy reported for the test in #1222.

This also _completely_ changes the performance profile of flux under this kind of load.  During a flood of requests like that, match still shows up as something like 30%, but that's all.  The job-injest and qmanager modules rise to almost match it for consumption, and the yaml processing becomes a meaningful cost.  May look and see if some of that can be easily squashed out.

fixes #1222 