### PR TITLE
pruner: don't track own type for pruning

### DIFF
--- a/resource/policies/base/matcher.cpp
+++ b/resource/policies/base/matcher.cpp
@@ -295,8 +295,10 @@ bool matcher_util_api_t::get_my_pruning_types (const std::string &subsystem,
         if (anchor_type != ANY_RESOURCE_TYPE
             && s.find (ANY_RESOURCE_TYPE) != s.end ()) {
             auto &m = s.at (ANY_RESOURCE_TYPE);
-            for (auto &k : m)
-                out.push_back (k);
+            for (auto &k : m) {
+                if (anchor_type != k)
+                    out.push_back (k);
+            }
         }
     } catch (std::out_of_range &e) {
         rc = false;


### PR DESCRIPTION
problem: the ALL resource type in the pruner specification was including the type of the anchor vertex, so in common uses like "ALL:core" all core vertices allocate a planner to track the number of cores they contain

solution: if the anchor and the target type match, don't track it

This saved roughly 600MB with a 16k node graph with 64 cores per node.  Also kinda trivial.  Looking for other low-hanging fruit.