### PR TITLE
dfu: add a quick-to-test feasibility precheck to match

### DIFF
--- a/resource/store/resource_graph_store.hpp
+++ b/resource/store/resource_graph_store.hpp
@@ -21,6 +21,7 @@ namespace Flux {
 namespace resource_model {
 
 class resource_reader_base_t;
+struct resource_graph_db_t;
 
 struct graph_duration_t {
     std::chrono::time_point<std::chrono::system_clock> graph_start =
@@ -45,6 +46,7 @@ struct resource_graph_metadata_t {
              std::map<std::pair<uint64_t, int64_t>, edg_t,
                       std::greater<std::pair<uint64_t, int64_t>>>> by_outedges;
     graph_duration_t graph_duration;
+    int64_t nodes_up = 0;
 
     /*! Set the resource graph duration.
      *
@@ -52,6 +54,8 @@ struct resource_graph_metadata_t {
      *                    the graph duration
      */
     void set_graph_duration (graph_duration_t &g_duration);
+    void update_node_stats (int count, resource_pool_t::status_t status);
+    void initialize_node_stats (resource_graph_t const &g);
 };
 
 /*! Resource graph data store.

--- a/resource/traversers/dfu.hpp
+++ b/resource/traversers/dfu.hpp
@@ -186,6 +186,11 @@ private:
     int is_satisfiable (Jobspec::Jobspec &jobspec, detail::jobmeta_t &meta,
                         bool x, vtx_t root,
                         std::unordered_map<std::string, int64_t> &dfv);
+    int request_feasible (detail::jobmeta_t const &meta,
+                          match_op_t op,
+                          vtx_t root,
+                          std::unordered_map<std::string, int64_t> &dfv,
+                          const subsystem_t &dom);
     int schedule (Jobspec::Jobspec &jobspec, detail::jobmeta_t &meta,
                   bool x, match_op_t op, vtx_t root,
                   std::unordered_map<std::string, int64_t> &dfv);

--- a/resource/traversers/dfu_impl_update.cpp
+++ b/resource/traversers/dfu_impl_update.cpp
@@ -664,7 +664,8 @@ int dfu_impl_t::mark (const std::string &root_path,
     }
     for (auto &v : vit_root->second)
         (*m_graph)[v].status = status;
-    
+    m_graph_db->metadata.update_node_stats (vit_root->second.size (), status);
+
     return 0;
 }
 
@@ -677,6 +678,7 @@ int dfu_impl_t::mark (std::set<int64_t> &ranks,
         const std::string &dom = m_match->dom_subsystem ();
         vtx_t subtree_root;
 
+        int total = 0;
         for (auto &rank : ranks) {
             // Now iterate through subgraphs keyed by rank and
             // set status appropriately
@@ -695,7 +697,9 @@ int dfu_impl_t::mark (std::set<int64_t> &ranks,
                 }
             }
             (*m_graph)[subtree_root].status = status;
+            ++total;
         }
+        m_graph_db->metadata.update_node_stats (total, status);
     } catch (std::out_of_range &) {
         errno = ENOENT;
         return -1;


### PR DESCRIPTION
problem: When a large number of possible time points exist, unreservable jobs cause N matches where N is the number of time points. This makes jobs that can't be matched potentially very expensive, and heavy use of constraints make the case common.

solution: iterate over just the node vertices checking for constraint matches, whether they are UP and whether it's possible to allocate them (either at the end of time, or in the case of allocate immediately). If all of those pass, the node is deemed "feasible" and counted. If less nodes are feasible than are required by the request, it's immediately rejected.

In a test with 300 time points, without this patch I get between 5 and 7.5 seconds for each failing match. With this patch the failed match stats in the same test report a minimum of 0.005 and a maximum of 0.008 seconds. This will not help with *successful* matches, but for matches that can't work because of drained nodes, constraints, queues, etc. it should reduce match times massively.

<details>
<summary>
many-point performance test
</summary>
This is the script I used, this is the particularly cruel version where all 302 jobs are constrained to individual nodes.

```sh
#!/usr/bin/env bash
#

test_description='
'

. `dirname $0`/sharness.sh

export TEST_UNDER_FLUX_QUORUM=1
export TEST_UNDER_FLUX_START_MODE=leader
rpc() {
  flux python -c \
    "import flux, json; print(flux.Flux().rpc(\"$1\").get_str())"
}

test_under_flux 16380 system

test_expect_success 'unload sched-simple' '
	flux module remove -f sched-simple
'

test_expect_success 'update configuration' '
	flux config load <<-'EOF'
	[[resource.config]]
	hosts = "fake[0-16380]"
	cores = "0-63"
	gpus = "0-3"

	[[resource.config]]
	hosts = "fake[0-9999]"
	properties = ["compute"]

	[[resource.config]]
	hosts = "fake[10000-16000]"
	properties = ["test"]

	[[resource.config]]
	hosts = "fake[16001-16380]"
	properties = ["debug"]

	[sched-fluxion-qmanager]
	queue-policy = "easy"

	[sched-fluxion-resource]
	match-policy = "firstnodex"
	prune-filters = "ALL:core,ALL:gpu,cluster:node,rack:node"
	match-format = "rv1_nosched"
	EOF
'

test_expect_success 'reload resource with monitor-force-up' '
	flux module reload -f resource noverify monitor-force-up
'
test_expect_success 'drain a few nodes' '
	flux resource drain 1-100 test with drained nodes
'
test_expect_success 'load fluxion modules' '
	flux module load sched-fluxion-resource &&
	flux module load sched-fluxion-qmanager
'
test_expect_success 'wait for fluxion to be ready' '
  time flux python -c \
    "import flux, json; print(flux.Flux().rpc(\"sched.resource-status\").get_str())"
'
test_expect_success 'create a set of jobs with disparate end time points' '
  # time=300 && \
  # for i in $(seq 1 300) ; do \
		# echo submitting $time && \
	flux submit --cc=300-600 \
		--quiet \
		--requires="host:fake[{cc}]" \
		-N 1 --exclusive \
		-t "{cc}s" \
		--progress \
		--jps \
		--wait-event=start \
		--setattr=exec.test.run_duration="600s" \
		sleep 600
		# time=$((time + 1)) ; \
	# done
'
# perf record --call-graph=fp -p $(pgrep flux-broker-0) sleep 10 &
# PID="$!"
test_expect_success 'create a set of 2 unreservable jobs' '
flux jobs -a
flux resource info
flux jobs -a
	flux submit --progress --jps --quiet -N1 \
		--requires="host:fake[5]" \
		--flags=waitable \
		--setattr=exec.test.run_duration=2s \
		sleep 2
	flux submit --progress --jps --quiet -N1 \
		--requires="host:fake[5]" \
		--flags=waitable \
		--setattr=exec.test.run_duration=2s \
		sleep 2
'
# kill -2 $PID
# wait $PID
# cp perf.data /Users/scogland1/Repos/flux/flux-sched/build/mine

test_expect_success 'get match stats' '
  flux module stats sched-fluxion-resource
  # time flux job wait -av || true
'
test_expect_success 'get match stats' '
	flux jobs -Ano "{id} {duration}" && \
	flux resource undrain 1-100 && \
	(time flux job wait -av || true) && \
	flux jobs -Ano "{id} {duration}" && \
	flux dmesg && \
    flux jobs -a && \
	rpc sched-fluxion-resource.stats-get | jq
'
test_expect_success 'unload fluxion' '
	flux module remove sched-fluxion-qmanager &&
	flux module remove sched-fluxion-resource &&
	flux module load sched-simple
'
test_done

```
</details>