### PR TITLE
Fix match average calculation

### DIFF
--- a/resource/schema/perf_data.hpp
+++ b/resource/schema/perf_data.hpp
@@ -31,7 +31,7 @@ struct perf_stats {
         }
         /* Welford's online algorithm for variance */
         delta = elapsed - avg;
-        avg += delta / (double)njobs;
+        avg += delta / (double)njobs_reset;
         delta2 = elapsed - avg;
         M2 += delta * delta2;
     }


### PR DESCRIPTION
The current calculation of average match times uses the total job count rather than the job count since last reset.

Use the correct count to compute the average (hence downstream calculations, too).