### PR TITLE
checks_run: work when no autogen.sh is present

### DIFF
--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -182,7 +182,7 @@ if [[ "$INSTALL_ONLY" == "t" ]]; then
         --volume=$TOP:$WORKDIR \
         ${PLATFORM} \
         ${BUILD_IMAGE} \
-        sh -c "./autogen.sh &&
+        sh -c "( [ -e ./autogen.sh ] && ./autogen.sh || true ) &&
                ./configure --prefix=/usr --sysconfdir=/etc \
                 --with-systemdsystemunitdir=/etc/systemd/system \
                 --localstatedir=/var &&


### PR DESCRIPTION
Apparently we haven't been building the flux-sched arm64 image for a while, this should fix that.

problem: we're unconditionally invoking autogen.sh

solution: don't fail if it's missing