### PR TITLE
github-actions: actually push the flux-sched manifest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -173,16 +173,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ci-checks]
     env:
-      DOCKER_REPO: fluxrm/flux-core
+      DOCKER_REPO: fluxrm/flux-sched
       DOCKER_USERNAME: travisflux
       DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_TRAVISFLUX_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - name: make and push manifest as fluxrm/flux-core
+    - name: make and push manifest as fluxrm/flux-sched
       if: >
         (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')
       run: |
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        # maybe bring back later: fluxrm/flux-core:bookworm-386
-        docker manifest create fluxrm/flux-core:bookworm fluxrm/flux-core:bookworm-amd64 fluxrm/flux-core:bookworm-arm64
-        docker manifest push fluxrm/flux-core:bookworm
+        # maybe bring back later: fluxrm/flux-sched:bookworm-386
+        docker manifest create fluxrm/flux-sched:bookworm fluxrm/flux-sched:bookworm-amd64 fluxrm/flux-sched:bookworm-arm64
+        docker manifest push fluxrm/flux-sched:bookworm


### PR DESCRIPTION
This is a rough one, no clue how we got along this far without it, maybe because the same thing runs on core it's actually just refreshing the correct manifest, not sure. Either way this should be a priority CI fix.

problem: somehow we've been updating the core manifest rather than the sched one, and either not hurting anything or not noticing, not sure which.  Either way, not great.

solution: actually push flux-sched's manifest