### PR TITLE
qmanager: restart the sched loop on updates

### DIFF
--- a/qmanager/policies/queue_policy_bf_base.hpp
+++ b/qmanager/policies/queue_policy_bf_base.hpp
@@ -24,6 +24,7 @@ class queue_policy_bf_base_t : public queue_policy_base_t
 public:
     virtual ~queue_policy_bf_base_t ();
     virtual int run_sched_loop (void *h, bool use_alloced_queue);
+    int cancel_sched_loop () override;
     virtual int reconstruct_resource (void *h, std::shared_ptr<job_t> job,
                                       std::string &R_out);
     virtual int apply_params ();

--- a/t/t1019-qmanager-async.t
+++ b/t/t1019-qmanager-async.t
@@ -29,7 +29,7 @@ test_expect_success 'load test resources' '
 test_expect_success 'qmanager: loading resource and qmanager modules works' '
     flux module load sched-fluxion-resource prune-filters=ALL:core \
 subsystems=containment policy=low &&
-    load_qmanager
+    load_qmanager queue-policy=easy
 '
 
 test_expect_success 'qmanager: many basic job submitted' '


### PR DESCRIPTION
problem: The sched loop can take a long time to receive new updates like cancellations and reprioritize.

solution: Cancel the sched loop either immediately or when the current iteration is done to allow those to proceed when a cancel, reprio or free has been received.