### PR TITLE
planner/dfu: avoid dereferencing empty vector

### DIFF
--- a/resource/traversers/dfu.cpp
+++ b/resource/traversers/dfu.cpp
@@ -189,7 +189,7 @@ int dfu_traverser_t::schedule (Jobspec::Jobspec &jobspec,
         len = planner_multi_resources_len (p);
         duration = meta.duration;
         detail::dfu_impl_t::count_relevant_types (p, dfv, agg);
-        for (t = planner_multi_avail_time_first (p, t, duration, &agg[0], len);
+        for (t = planner_multi_avail_time_first (p, t, duration, agg.data(), len);
              (t != -1 && rc && !errno); t = planner_multi_avail_time_next (p)) {
             meta.at = t;
             rc = detail::dfu_impl_t::select (jobspec, root, meta, x);

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -182,7 +182,7 @@ int dfu_impl_t::by_subplan (const jobmeta_t &meta, const std::string &s, vtx_t u
     count_relevant_types (p, resource.user_data, aggs);
     errno = 0;
     len = aggs.size ();
-    if ((rc = planner_multi_avail_during (p, at, d, &(aggs[0]), len)) == -1) {
+    if ((rc = planner_multi_avail_during (p, at, d, aggs.data(), len)) == -1) {
         if (errno != 0 && errno != ERANGE) {
             m_err_msg += "by_subplan: planner_multi_avail_during returned -1.\n";
             m_err_msg += strerror (errno);
@@ -1112,8 +1112,8 @@ int dfu_impl_t::prime_pruning_filter (const subsystem_t &s, vtx_t u,
         }
         (*m_graph)[u].idata.subplans[s] = p;
     } else {
-        planner_multi_update ((*m_graph)[u].idata.subplans[s], &avail[0], 
-                               &types[0], types.size ());
+        planner_multi_update ((*m_graph)[u].idata.subplans[s], avail.data(),
+                               types.data(), types.size ());
     }
     rc = 0;
 done:


### PR DESCRIPTION
problem: a few places were using `&(vec[0])` to get an address of the start of a potentially empty vector.  This is almost always actually safe in practice, but it's not allowed and technically could be treated like a null dereference as well.

solution: use the `vec.data()` method that exists specifically for this purpose

@milroy tagging you here since we happened to be talking about this code just the other day.  As far as I know this hasn't been touched recently, but maybe the hardening flags in the buildfarm did. 🤷 