### PR TITLE
ion-resource: add meaningful error message when subcommand is missing

### DIFF
--- a/src/cmd/flux-ion-resource.py
+++ b/src/cmd/flux-ion-resource.py
@@ -643,6 +643,13 @@ def main():
     #
     try:
         args = parser.parse_args()
+
+        # A subcommand is required
+        if not hasattr(args, "func"):
+            parser.print_help()
+            print("\nA subcommand is required.")
+            sys.exit(1)
+
         args.func(args)
 
     except (IOError, EnvironmentError) as exc:


### PR DESCRIPTION
Problem: a subcommand "func" is always required for ion resource, yet the current client spits out an error if the user types the command without help, subcommand, or other args.
Solution: if the func (subcommand) is missing, print the parser help and provide a meaningful message to the user.

## Details

I am starting to test out flux ion-resource (to learn about interaction with fluxion and the queue manager) and very naively I built and ran the command and saw this:

```bash
$ flux ion-resource
```
```console
Traceback (most recent call last):
  File "/usr/libexec/flux/cmd/py-runner.py", line 94, in <module>
    runpy.run_path(sys.argv[0], run_name="__main__")
  File "<frozen runpy>", line 291, in run_path
  File "<frozen runpy>", line 98, in _run_module_code
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/libexec/flux/cmd/flux-ion-resource.py", line 673, in <module>
    main()
  File "/usr/libexec/flux/cmd/flux-ion-resource.py", line 653, in main
    args.func(args)
    ^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'func'
```
It's pretty common for the user to try out a command by typing it first, with or without help, and expecting it to dump out usage. So that's what I've updated it to do here. The "func" argument that is missing is a subcommand, so we can check if the attribute is defined on the parser, and if not, print the parser help, and a clear message to the user that a subcommand is required. Here is the new interaction:

```bash
$ flux ion-resource
```
```console
usage: flux-ion-resource.py [-h] [-v]
                            {match,update,info,stats,stats-cancel,cancel,partial-cancel,find,status,set-status,set-property,get-property,ns-info,params}
                            ...

Front-end command for sched-fluxion-resource module for testing. Provide 4 sub-commands. For
sub-command usage, flux-ion-resource.py <sub-command> --help

options:
  -h, --help            show this help message and exit
  -v, --verbose         be verbose

Available Commands:
  Valid commands

  {match,update,info,stats,stats-cancel,cancel,partial-cancel,find,status,set-status,set-property,get-property,ns-info,params}
                        Additional help
    match               Find the best matching resources for a jobspec.
    update              Update the resource database.
    info                Print info on a single job.
    stats               Print overall performance statistics.
    stats-cancel        Clear overall performance statistics.
    cancel              Cancel an allocated or reserved job.
    partial-cancel      Partially cancel an allocated job.
    find                Find resources matching with a criteria.
    status              Display resource status.
    set-status          Set up/down status of a resource vertex.
    set-property        Set property-key=value for specified resource.
    get-property        Get value for specified resource and property-key.
    ns-info             Get remapped ID given raw ID seen by the reader.
    params              Display the module's parameter values.

A subcommand is required.
```
That should be a fairly straight forward update if the fix is desired. Note that I have not tested nothing else yet - I am going to bed so likely won't until tomorrow. Looking forward to trying it out!