### PR TITLE
Don't add pruning filter for leaf vertices

### DIFF
--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -1103,6 +1103,14 @@ int dfu_impl_t::prime_pruning_filter (const subsystem_t &s,
 
     (*m_graph)[u].idata.colors[s] = m_color.gray ();
     accum_if (s, type, (*m_graph)[u].size, to_parent);
+
+    // Don't create and prime a pruning filter if this is
+    // a leaf vertex
+    if (out_degree (u, *m_graph) == 0) {
+        rc = 0;
+        goto done;
+    }
+
     if (prime_exp (s, u, dfv) != 0)
         goto done;
 


### PR DESCRIPTION
When `ALL` is specified for prune-filters of a leaf vertex type, other leaf vertices maintain a pruning filter for that resource type. For example, the default `ALL:core` adds `core` filters to `gpu` vertices. Since a leaf vertex is the terminus of a depth-first search of a single-subsystem graph, the extra pruning filters increase memory consumption unnecessarily.

Add a check that exits the pruning-filter priming function for leaf vertices.