### PR TITLE
matrix: add explicit python path for el8

### DIFF
--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -220,6 +220,7 @@ else
         -e TAP_DRIVER_QUIET \
         -e FLUX_TEST_TIMEOUT \
         -e FLUX_TEST_SIZE_MAX \
+        -e PYTHON \
         -e PYTHON_VERSION \
         -e PRELOAD \
         -e POISON \

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -201,6 +201,11 @@ matrix.add_build(
     name="el8",
     image="el8",
     docker_tag=True,
+    env=dict(
+        # this is _required_ because of valgrind's new dependency on python3.11
+        # which confuses rhel8 cmake's detection logic
+        PYTHON="/usr/bin/python3.6"
+    ),
 )
 
 # Fedora34


### PR DESCRIPTION
This one is slightly urgent.  None of our CI runs will pass on EL8 until this is dealt with, fallout from rebuilding the fluxrm/testenv image on el8 is it picked up a newer valgrind, which changed the python environment on the system in a way that interacts badly with the older cmake in there.

problem: upstream el8 has added a new version of valgrind, which pulls in python3.11. The older cmake logic on el8 finds the newer python but fails to find any development dependencies for it and errors out.

solution: force cmake to use the system python3.6, it must be an absolute path as well for some reason

