### PR TITLE
interner/res_type: add a refcounted backend for interned strings

### DIFF
--- a/resource/evaluators/test/CMakeLists.txt
+++ b/resource/evaluators/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(expr_eval_test
   ${CMAKE_CURRENT_SOURCE_DIR}/expr_eval_test01.cpp
   )
+add_sanitizers(expr_eval_test)
 target_link_libraries(expr_eval_test PRIVATE
   libtap
   resource

--- a/resource/libjobspec/CMakeLists.txt
+++ b/resource/libjobspec/CMakeLists.txt
@@ -20,9 +20,11 @@ target_link_libraries(jobspec_conv PUBLIC flux::hostlist flux::idset
 add_executable(flux-jobspec-validate
     ${CMAKE_CURRENT_SOURCE_DIR}/flux-jobspec-validate.cpp
     )
+add_sanitizers(flux-jobspec-validate)
 
 target_link_libraries(flux-jobspec-validate PRIVATE jobspec_conv)
 
 add_executable(test_constraint.t test/constraint.cpp)
+add_sanitizers(test_constraint.t)
 target_link_libraries(test_constraint.t jobspec_conv libtap intern)
 flux_add_test(NAME test_constraint COMMAND test_constraint.t)

--- a/resource/schema/data_std.hpp
+++ b/resource/schema/data_std.hpp
@@ -30,11 +30,13 @@ const char *const X_CHECKER_JOBS_STR = "jobs";
 const int64_t X_CHECKER_NJOBS = 0x40000000;
 
 constexpr uint64_t subsystem_id{0};
-using subsystem_t = intern::interned_string<subsystem_id, uint8_t>;
+struct subsystem_tag {};
+using subsystem_t = intern::interned_string<intern::dense_storage<subsystem_tag, uint8_t>>;
 extern subsystem_t containment_sub;
 
 constexpr uint64_t resource_type_id{1};
-using resource_type_t = intern::interned_string<resource_type_id, uint16_t>;
+struct resource_type_tag {};
+using resource_type_t = intern::interned_string<intern::rc_storage<resource_type_tag>>;
 extern resource_type_t slot_rt;
 extern resource_type_t cluster_rt;
 extern resource_type_t rack_rt;

--- a/resource/schema/test/CMakeLists.txt
+++ b/resource/schema/test/CMakeLists.txt
@@ -1,10 +1,12 @@
 add_executable(schema_test01 ./schema_test01.cpp)
+add_sanitizers(schema_test01)
 target_link_libraries(schema_test01 resource libtap)
 flux_add_test(NAME schema_test01 COMMAND schema_test01)
 target_include_directories(schema_test01 PUBLIC ../)
 set_property(TEST schema_test01 APPEND PROPERTY ENVIRONMENT "TESTRESRC_INPUT_FILE=$(CMAKE_SOURCE_DIR)/conf/hype.lua")
 
 add_executable(schema_test02 ./schema_test02.cpp)
+add_sanitizers(schema_test02)
 target_link_libraries(schema_test02 resource libtap)
 flux_add_test(NAME schema_test02 COMMAND schema_test02)
 target_include_directories(schema_test02 PUBLIC ../)

--- a/src/common/libintern/CMakeLists.txt
+++ b/src/common/libintern/CMakeLists.txt
@@ -4,6 +4,7 @@ install(TARGETS intern
         LIBRARY)
 
 add_executable(interned_string_test test/interned_string_test.cpp)
+add_sanitizers(interned_string_test)
 target_link_libraries(interned_string_test intern Catch2::Catch2WithMain)
 catch_discover_tests (interned_string_test)
 target_include_directories(interned_string_test PUBLIC .)

--- a/src/common/libintern/interner.h
+++ b/src/common/libintern/interner.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 typedef struct {
-    uint32_t id;
+    size_t id;
 } interner_t;
 
 typedef struct {
@@ -28,7 +28,7 @@ interner_t interner_new ();
 
 /// Get an interned string identifier from group id and a char * and length, the string need not be
 /// null terminated
-intern_string_t interner_get_str (interner_t group_id, intern_string_view_t s);
+intern_string_t dense_interner_get_str (interner_t group_id, intern_string_view_t s);
 
 /// get the hash of this interned string
 size_t intern_str_hash (intern_string_t s);

--- a/src/common/libintern/test/interned_string_test.cpp
+++ b/src/common/libintern/test/interned_string_test.cpp
@@ -9,8 +9,11 @@
 using namespace intern;
 using namespace std::string_view_literals;
 
-using tt1 = interned_string<0, uint8_t>;
-using tt2 = interned_string<1, uint32_t>;
+struct tag1 {};
+struct tag2 {};
+using tt1 = interned_string<dense_storage<tag1, uint8_t>>;
+using tt2 = interned_string<dense_storage<tag2, uint32_t>>;
+
 TEST_CASE ("interner: intern a single literal, get back the same", "[interner]")
 {
     auto l = tt1 ("test"sv);
@@ -41,12 +44,58 @@ TEST_CASE ("interner: strings with different tags compare different", "[interner
 
 TEST_CASE ("interner: smaller ID limits properly", "[interner]")
 {
-    using tt = intern::interned_string<2, uint8_t>;
+    struct new_tag {};
+    using tt = intern::interned_string<dense_storage<new_tag, uint8_t>>;
     for (int i = 0; i < 254; ++i) {
         std::string s = std::to_string (i);
         tt::make (s);
     }
     auto otm = "one too many"sv;
     CHECK_THROWS (tt::make (otm));
-    REQUIRE_NOTHROW (interner_get_str (tt::interner, {otm.data (), otm.size ()}).id == UINTPTR_MAX);
+    REQUIRE_NOTHROW (
+        dense_interner_get_str (interner_t{tt::storage_t::unique_id ()}, {otm.data (), otm.size ()})
+            .id
+        == UINTPTR_MAX);
+}
+struct rctag1 {};
+struct rctag2 {};
+using trc1 = interned_string<rc_storage<rctag1>>;
+using trc2 = interned_string<rc_storage<rctag2>>;
+TEST_CASE ("interner rc: intern a single literal, get back the same", "[interner]")
+{
+    auto l = trc1 ("test"sv);
+    auto r = trc1 ("test"sv);
+    auto s = trc1 ("test"sv);
+    auto s2 = trc1 ("test2"sv);
+    REQUIRE (l.get () == r.get ());
+    REQUIRE (l.get ().data () == r.get ().data ());
+    REQUIRE (l.id () == r.id ());
+    REQUIRE (l == r);
+    REQUIRE (l.get () == s.get ());
+    REQUIRE (l.get ().data () == s.get ().data ());
+    REQUIRE (l.id () == s.id ());
+    REQUIRE (l == s);
+    REQUIRE (l.get () != s2.get ());
+    REQUIRE (l.id () != s2.id ());
+    REQUIRE (l != s2);
+}
+TEST_CASE ("interner rc: strings with different tags compare different", "[interner]")
+{
+    auto l = trc1 ("test"sv);
+    auto r = trc2 ("test"sv);
+    REQUIRE (l.get () == r.get ());
+    // unlike dense, rc will likely have different IDs between two interners
+    // REQUIRE (l.id () == r.id ());
+    REQUIRE (l.get ().data () != r.get ().data ());
+}
+
+TEST_CASE ("interner rc: strings get removed when unused", "[interner]")
+{
+    REQUIRE_FALSE (trc1::storage_t::contains ("test"sv));
+    REQUIRE_FALSE (trc1::storage_t::contains ("test2"sv));
+    {
+        auto l = trc1 ("test"sv);
+        REQUIRE (trc1::storage_t::contains ("test"sv));
+    }
+    REQUIRE_FALSE (trc1::storage_t::contains ("test"sv));
 }

--- a/src/test/checks_run.sh
+++ b/src/test/checks_run.sh
@@ -28,7 +28,7 @@
 # if make is old, and scl is here, and devtoolset is available and not turned
 # on, re-exec ourself with it active to get a newer make
 if make --version | grep 'GNU Make 4' 2>&1 > /dev/null ; then
-  MAKE="make --output-sync=line --no-print-directory"
+  MAKE="make --no-print-directory"
 else
   MAKE="make" #use this if all else fails
   if test "X$X_SCLS" = "X" ; then

--- a/t/sharness.d/sched-sharness.sh
+++ b/t/sharness.d/sched-sharness.sh
@@ -45,6 +45,12 @@ fi
 #   Accessors 
 #
 
+test_cmp_json() {
+    jq -S "$1" > "$1.tmp"
+    jq -S "$2" > "$2.tmp"
+    test_cmp "$1.tmp" "$1.tmp"
+}
+
 load_qmanager () {
     flux module load sched-fluxion-qmanager "$@"
 }

--- a/t/t1017-rv1-bootstrap.t
+++ b/t/t1017-rv1-bootstrap.t
@@ -43,10 +43,10 @@ test_expect_success 'rv1-bootstrap: resource idempotency preserved' '
     JOBID=$(flux batch -n4 -N4 -c44 -g4 \
 	./nest.sh high 4 4 44 4 nest.json) &&
     $WAITFILE -t 600 -v -p \"R_lite\" nest.json &&
-    jq " del(.execution.starttime, .execution.expiration) " \
+    jq -S " del(.execution.starttime, .execution.expiration) " \
 	nest.json > nest.norm.json &&
     flux job info ${JOBID} R | \
-	jq " del(.execution.starttime, .execution.expiration) " \
+    jq -S " del(.execution.starttime, .execution.expiration) " \
 	> job.norm.json &&
     test_cmp job.norm.json nest.norm.json
 '

--- a/t/t1018-rv1-bootstrap2.t
+++ b/t/t1018-rv1-bootstrap2.t
@@ -47,10 +47,10 @@ test_expect_success 'rv1-bootstrap: resource idempotency preserved' '
     JOBID=$(flux batch -n4 -N4 -c44 -g4 \
 	./nest.sh high 4 4 44 4 nest.json) &&
     $WAITFILE -t 600 -v -p \"R_lite\" nest.json &&
-    jq " del(.execution.starttime, .execution.expiration) " \
+    jq -S " del(.execution.starttime, .execution.expiration) " \
 	nest.json > nest.norm.json &&
     flux job info ${JOBID} R | \
-	jq " del(.execution.starttime, .execution.expiration) " \
+    jq -S " del(.execution.starttime, .execution.expiration) " \
 	> job.norm.json &&
     test_cmp job.norm.json nest.norm.json
 '

--- a/t/t3027-resource-RV.t
+++ b/t/t3027-resource-RV.t
@@ -26,7 +26,7 @@ test_expect_success 'RV1 is correct on rank and node ID order match' '
 	quit
 	EOF
 	${query} -L ${jgf_orig} -f jgf -F rv1_nosched -t R1.out -P high < cmds001 &&
-	test_cmp R1.out ${exp_dir}/R1.out
+	test_cmp_json R1.out ${exp_dir}/R1.out
 '
 
 test_expect_success 'RV1 is correct on core ID modified' '
@@ -35,7 +35,7 @@ test_expect_success 'RV1 is correct on core ID modified' '
 	quit
 	EOF
 	${query} -L ${jgf_mod1} -f jgf -F rv1_nosched -t R2.out -P high < cmds002 &&
-	test_cmp R2.out ${exp_dir}/R2.out
+	test_cmp_json R2.out ${exp_dir}/R2.out
 '
 
 test_expect_success 'RV1 correct on rank/node ID mismatch + core ID modified' '
@@ -44,7 +44,7 @@ test_expect_success 'RV1 correct on rank/node ID mismatch + core ID modified' '
 	quit
 	EOF
 	${query} -L ${jgf_mod2} -f jgf -F rv1_nosched -t R3.out -P high < cmds003 &&
-	test_cmp R3.out ${exp_dir}/R3.out
+	test_cmp_json R3.out ${exp_dir}/R3.out
 '
 
 test_expect_success 'RV1 correct on heterogeneous configuration' '


### PR DESCRIPTION
problem: while subsystems are a very small stable set that users don't
produce input for, resource types are both dynamic and often coming from
untrusted user input, so immortal strings would mean a potential attack
vector for resource exhaustion.

solution:
1. Refactor the interned_string type to accept a "storage" class,
   that provides the actual mechanism for interning. This changes our
   immortal strings as well by caching the address of the relevant table
   for quick lookup during interning and reducing our lock acquisitions.
   A `dense_storage` intern string stores an integer in the range
   0-num-strings in its group, with the group identified by a tag type,
   largely like before but a bit more ergonomic for use in a large
   project.
2. Add a new rc_storage backend that stores a std::shared_ptr<const
   std::string> instead of an integer ID.  The actual string is stored
   as the key of an unordered_map, with the value of the map being a
   `weak_ptr<const std::string>` that refers to the shared_ptr version
   that is passed back to be used in the interned_string by the user.
   The shared_ptr is given a deleter that automatically removes the
   string from the unordered_map when the last copy is destroyed.  The
   overall effect is that we get interned strings that are completely
   reference counted, and can be cleaned up safely either by running out
   of references to them in user code, or by the static table being cleaned up
   at the end of the run.  The end-of-run cleanup is the reason for the
   extra shared_ptr dance in get_sparse_inner_storage, because otherwise
   it was possible for the table to be reclaimed before some long-lived
   rc strings, which caused issues.  The full test suite has been run
   with ASAN to verify no use-after-frees or other issues remain in this
   version (at least that get hit by our test suite)

A note on performance.  Using refcounted strings like this is slower than using non-refcounted immortal ones, especially because the reference counts are atomic.  That said, the difference in performance for the many-points test was small enough to be considered in the noise.  If it comes up, we could swap out for a per-thread refcounting setup or something else, but this lets us avoid rebuilding too much infrastructure.