### PR TITLE
traverser: set iter count when request_feasible returns < 0

### DIFF
--- a/resource/traversers/dfu.cpp
+++ b/resource/traversers/dfu.cpp
@@ -151,8 +151,8 @@ int dfu_traverser_t::schedule (Jobspec::Jobspec &jobspec,
     subsystem_t dom = get_match_cb ()->dom_subsystem ();
 
     // precheck to see if enough resources are available for this to be feasible
-    if (request_feasible (meta, op, root, dfv) < 0)
-        return -1;
+    if ((rc = request_feasible (meta, op, root, dfv)) < 0)
+        goto out;
 
     if ((rc = detail::dfu_impl_t::select (jobspec, root, meta, x)) == 0) {
         m_total_preorder = detail::dfu_impl_t::get_preorder_count ();


### PR DESCRIPTION
When diagnosing a recent scheduling problem, the `max-match-iters` count was observed to remain at its default value:

```json
"succeeded": {
   "njobs": 323,
   "njobs-reset": 323,
   "max-match-jobid": 499941450105867264,
   "max-match-iters": -1,
   "stats": {
    "min": 0.001378509,
    "max": 6.2174810100000002,
    "avg": 1.9132730813622281,
    "variance": 2.3300616684658966
   }
  },
```
This early return can prevent the count from getting updated: https://github.com/flux-framework/flux-sched/blob/7f0105fcbcb3173be4d105d7ffabb6fa633e58f6/resource/traversers/dfu.cpp#L155

This PR fixes the behavior with a `goto` to jump to the end of `schedule` and set `perf.tmp_iter_count`.