### PR TITLE
Support and handle optional "final" flag in .free RPC

### DIFF
--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -335,13 +335,15 @@ void qmanager_cb_t::jobmanager_free_cb (flux_t *h, const flux_msg_t *msg, const 
 {
     flux_jobid_t id;
     json_t *Res;
+    int final = 0;
     const char *Rstr = NULL;
     qmanager_cb_ctx_t *ctx = nullptr;
     ctx = static_cast<qmanager_cb_ctx_t *> (arg);
     std::shared_ptr<queue_policy_base_t> queue;
     std::string queue_name;
 
-    if (flux_request_unpack (msg, NULL, "{s:I s:O}", "id", &id, "R", &Res) < 0) {
+    if (flux_request_unpack (msg, NULL, "{s:I s:O s?b}", "id", &id, "R", &Res, "final", &final)
+        < 0) {
         flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
         return;
     }
@@ -357,7 +359,7 @@ void qmanager_cb_t::jobmanager_free_cb (flux_t *h, const flux_msg_t *msg, const 
                         static_cast<intmax_t> (id));
         goto done;
     }
-    if ((queue->remove (static_cast<void *> (h), id, Rstr)) < 0) {
+    if ((queue->remove (static_cast<void *> (h), id, final, Rstr)) < 0) {
         flux_log_error (h,
                         "%s: remove (queue=%s id=%jd)",
                         __FUNCTION__,

--- a/qmanager/policies/queue_policy_bf_base.hpp
+++ b/qmanager/policies/queue_policy_bf_base.hpp
@@ -36,6 +36,7 @@ class queue_policy_bf_base_t : public queue_policy_base_t {
                 const char *R,
                 bool noent_ok,
                 bool &full_removal) override;
+    int cancel (void *h, flux_jobid_t id, bool noent_ok) override;
 
    protected:
     unsigned int m_reservation_depth;

--- a/qmanager/policies/queue_policy_bf_base_impl.hpp
+++ b/qmanager/policies/queue_policy_bf_base_impl.hpp
@@ -113,6 +113,12 @@ int queue_policy_bf_base_t<reapi_type>::cancel (void *h,
     return reapi_type::cancel (h, id, R, noent_ok, full_removal);
 }
 
+template<class reapi_type>
+int queue_policy_bf_base_t<reapi_type>::cancel (void *h, flux_jobid_t id, bool noent_ok)
+{
+    return reapi_type::cancel (h, id, noent_ok);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Public API of Queue Policy Backfill Base
 ////////////////////////////////////////////////////////////////////////////////

--- a/qmanager/policies/queue_policy_fcfs.hpp
+++ b/qmanager/policies/queue_policy_fcfs.hpp
@@ -39,6 +39,7 @@ class queue_policy_fcfs_t : public queue_policy_base_t {
                 const char *R,
                 bool noent_ok,
                 bool &full_removal) override;
+    int cancel (void *h, flux_jobid_t id, bool noent_ok) override;
 
    private:
     int pack_jobs (json_t *jobs);

--- a/qmanager/policies/queue_policy_fcfs_impl.hpp
+++ b/qmanager/policies/queue_policy_fcfs_impl.hpp
@@ -150,6 +150,12 @@ int queue_policy_fcfs_t<reapi_type>::cancel (void *h,
     return reapi_type::cancel (h, id, R, noent_ok, full_removal);
 }
 
+template<class reapi_type>
+int queue_policy_fcfs_t<reapi_type>::cancel (void *h, flux_jobid_t id, bool noent_ok)
+{
+    return reapi_type::cancel (h, id, noent_ok);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Public API of Queue Policy FCFS
 ////////////////////////////////////////////////////////////////////////////////

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -1931,6 +1931,12 @@ static int run_remove (std::shared_ptr<resource_ctx_t> &ctx,
             std::shared_ptr<job_info_t> info = ctx->jobs[jobid];
             info->state = job_lifecycle_t::ERROR;
         }
+        flux_log (ctx->h,
+                  LOG_ERR,
+                  "%s: dfu_traverser_t::remove (id=%jd): %s",
+                  __FUNCTION__,
+                  static_cast<intmax_t> (jobid),
+                  ctx->traverser->err_message ().c_str ());
         goto out;
     }
     if (full_removal && is_existent_jobid (ctx, jobid))

--- a/resource/traversers/dfu_impl_update.cpp
+++ b/resource/traversers/dfu_impl_update.cpp
@@ -368,11 +368,13 @@ int dfu_impl_t::rem_exclusive_filter (vtx_t u, int64_t jobid, const modify_data_
 
     auto span_it = (*m_graph)[u].idata.x_spans.find (jobid);
     if (span_it == (*m_graph)[u].idata.x_spans.end ()) {
-        if (mod_data.mod_type != job_modify_t::PARTIAL_CANCEL) {
+        if (mod_data.mod_type == job_modify_t::VTX_CANCEL) {
             m_err_msg += __FUNCTION__;
             m_err_msg += ": jobid isn't found in x_spans table.\n ";
             goto done;
         } else {
+            // Valid for CANCEL if clearing inconsistency between
+            // core and sched.
             rc = 0;
             goto done;
         }

--- a/t/issues/t6179-flux-core-housekeeping.sh
+++ b/t/issues/t6179-flux-core-housekeeping.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+#
+#  Ensure fluxion conforms to updated RFC 27 and behaves as desired if resource state
+#  discrepancies exit between flux-core and -sched.
+#
+
+log() { printf "flux-coreissue#6179: $@\n" >&2; }
+
+cat <<'EOF' >free.py
+import flux
+import json
+import sys
+import subprocess as sp
+from flux.job import JobID
+
+jobid = JobID(sys.argv[1])
+r_obj=json.loads(sp.check_output(['flux', 'job', 'info', sys.argv[1], 'R']).decode())
+obj = {'id': jobid, 'R': r_obj, 'final': True}
+flux.Flux().rpc('sched.free', obj)
+sys.exit(0)
+EOF
+
+cat <<'EOF' >incomplete-free.py
+import flux
+import json
+import sys
+import subprocess as sp
+from flux.job import JobID
+
+jobid = JobID(sys.argv[1])
+R_str = '{"version": 1, "execution": {"R_lite": [{"rank": "1", "children": {"core": "0-15", "gpu": "0-3"}}], "nodelist": ["node1"]}}'
+r_obj = json.loads(R_str)
+obj = {'id': jobid, 'R': r_obj, 'final': True}
+flux.Flux().rpc('sched.free', obj)
+sys.exit(0)
+EOF
+
+cat <<EOF >flux.config
+[sched-fluxion-resource]
+match-policy = "lonodex"
+match-format = "rv1_nosched"
+
+[resource]
+noverify = true
+norestrict = true
+
+[[resource.config]]
+hosts = "node[0-1]"
+cores = "0-15"
+gpus = "0-3"
+EOF
+
+log "Unloading modules..."
+flux module remove sched-simple
+flux module remove resource
+
+flux config load flux.config
+
+flux module load resource monitor-force-up
+flux module load sched-fluxion-resource
+flux module load sched-fluxion-qmanager queue-policy="easy"
+flux queue start --all --quiet
+flux resource list
+flux resource status
+flux module list
+
+log "Running test job 1"
+jobid1=$(flux submit --wait-event=alloc -N2 -t 1h --setattr=exec.test.run_duration=1m sleep inf)
+log "Sending final RPC for job 1"
+flux python ./free.py ${jobid1}
+state=$( flux ion-resource find "sched-now=allocated" )
+if [[ ${state} != *"null"* ]]; then
+    # retry since ./free.py isn't blocking
+    state=$( flux ion-resource find "sched-now=allocated" )
+    if [[ ${state} != *"null"* ]]; then
+        # .free didn't release all resources
+        exit 1
+    fi
+fi
+
+# Need to execute cancel to remove from job manager
+flux cancel ${jobid1}
+flux job wait-event -t 5 ${jobid1} release
+
+log "Running test job 2"
+jobid2=$(flux submit --wait-event=alloc -N2 -t 1h --setattr=exec.test.run_duration=1m sleep inf)
+log "Sending final RPC for job 2"
+flux python ./incomplete-free.py ${jobid2}
+state=$( flux ion-resource find "sched-now=allocated" )
+if [[ ${state} != *"null"* ]]; then
+    # retry since ./free.py isn't blocking
+    state=$( flux ion-resource find "sched-now=allocated" )
+    if [[ ${state} != *"null"* ]]; then
+        # .free didn't release all resources
+        exit 1
+    fi
+fi
+
+# Need to execute cancel to remove from job manager
+flux cancel ${jobid2}
+flux job wait-event -t 5 ${jobid2} release
+flux jobs -a
+
+log "reloading sched-simple..."
+flux module remove sched-fluxion-qmanager
+flux module remove sched-fluxion-resource
+flux module load sched-simple
+
+log "Unloading modules for FCFS test..."
+flux module remove sched-simple
+flux module remove resource
+
+flux config load flux.config
+
+flux module load resource monitor-force-up
+flux module load sched-fluxion-resource
+flux module load sched-fluxion-qmanager queue-policy="fcfs"
+flux queue start --all --quiet
+flux resource list
+flux resource status
+flux module list
+
+log "Running test job 3"
+jobid3=$(flux submit --wait-event=alloc -N2 -t 1h --setattr=exec.test.run_duration=1m sleep inf)
+log "Sending final RPC for job 3"
+flux python ./free.py ${jobid3}
+state=$( flux ion-resource find "sched-now=allocated" )
+if [[ ${state} != *"null"* ]]; then
+    # retry since ./free.py isn't blocking
+    state=$( flux ion-resource find "sched-now=allocated" )
+    if [[ ${state} != *"null"* ]]; then
+        # .free didn't release all resources
+        exit 1
+    fi
+fi
+
+# Need to execute cancel to remove from job manager
+flux cancel ${jobid3}
+flux job wait-event -t 5 ${jobid3} release
+
+log "Running test job 4"
+jobid4=$(flux submit --wait-event=alloc -N2 -t 1h --setattr=exec.test.run_duration=1m sleep inf)
+log "Sending final RPC for job 4"
+flux python ./incomplete-free.py ${jobid4}
+state=$( flux ion-resource find "sched-now=allocated" )
+if [[ ${state} != *"null"* ]]; then
+    # retry since ./free.py isn't blocking
+    state=$( flux ion-resource find "sched-now=allocated" )
+    if [[ ${state} != *"null"* ]]; then
+        # .free didn't release all resources
+        exit 1
+    fi
+fi
+
+# Need to execute cancel to remove from job manager
+flux cancel ${jobid4}
+flux job wait-event -t 5 ${jobid4} release
+flux jobs -a
+
+log "reloading sched-simple..."
+flux module remove sched-fluxion-qmanager
+flux module remove sched-fluxion-resource
+flux module load sched-simple
+


### PR DESCRIPTION
Recently, a large job on a large system was considered allocated by Fluxion, but was complete and released in flux-core (https://github.com/flux-framework/flux-core/issues/6179). The proposed solution was to amend RFC 27 to include an optional "final" boolean flag in the `.free` RPC. That flag can be used by Fluxion to determine if there is an allocation state discrepancy between flux-core and sched and take action based on that information.

This PR adds support to handle the optional "final" flag in the `.free` RPC. ~The current implementation only logs an error when a state discrepancy is detected, but doing a full cancellation of the job would be a straightforward addition to this PR.~ After further thought, executing a full cancel when a discrepancy exists between flux-core and -sched seems like a better approach since this state may go unnoticed by administrators.