### PR TITLE
pre-commit: show diff on failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
     - name: install linting and formatting deps
       run: pip install -r scripts/requirements-dev.txt
     - name: format and linting checks
-      run: pre-commit run --all-files
+      run: pre-commit run --all-files --show-diff-on-failure
 
   python-lint:
     name: python lint


### PR DESCRIPTION
problem: in CI we can't see what formatting was changed by the hooks

solution: add the `--show-diff-on-failure` flag so we can see what happened in case it doesn't repro easily elsewhere