### PR TITLE
policy: expose internals of resource module policy factory to allow custom policies

### DIFF
--- a/doc/man5/flux-config-sched-fluxion-resource.rst
+++ b/doc/man5/flux-config-sched-fluxion-resource.rst
@@ -102,6 +102,45 @@ hinodex
 first
     Select the first matching resources and stop the search
 
+firstnodex
+    A node-exclusive scheduling whose behavior is identical to
+    ``first`` except each compute node is exclusively allocated.
+
+
+CUSTOM MATCH POLICIES
+=====================
+Match policies are initialized as collections of individual attributes
+that help the scheduler to select matches. For convenience, these 
+attributes are exposed to users such that they can write custom policies.
+Below is a list of match attributes which can be selected by users.
+
+policy
+    Allowed options are ``low`` or ``high``. If only ``policy=low``
+    or ``policy=high`` is specified, the behavior of the match policy is the
+    same as if ``match-policy=low`` or ``match-policy=high`` were selected,
+    respectively.
+
+node_centric
+    ``true`` or ``false`` are allowed options. Evaluate matches based on the
+    ID of the compute node first. 
+
+node_exclusive
+    ``true`` or ``false`` are allowed options. Exclusively allocate compute
+    nodes when a match is found.
+
+set_stop_on_1_matches
+    ``true`` or ``false`` are allowed options. When a match is found, take
+    it, without evaluating for potentially more optimal matches.
+
+::
+
+    [sched-fluxion-resource]
+
+    # system instance will use node-exclusive
+    # scheduling first-match (with nodes of high node IDs
+    # selected first).
+    match-policy = "policy=high node_exclusive=true set_stop_on_1_matches=true"
+
 
 EXAMPLE
 =======

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -297,9 +297,10 @@ static const struct flux_msg_handler_spec htab[] =
 static void set_default_args (std::shared_ptr<resource_ctx_t> &ctx)
 {
     resource_opts_t ct_opts;
+    std::string e = "";
     ct_opts.set_load_format ("rv1exec");
     ct_opts.set_match_subsystems ("containment");
-    ct_opts.set_match_policy ("first");
+    ct_opts.set_match_policy ("first", e);
     ct_opts.set_prune_filters ("ALL:core");
     ct_opts.set_match_format ("rv1_nosched");
     ct_opts.set_update_interval (0);

--- a/resource/modules/resource_match_opts.cpp
+++ b/resource/modules/resource_match_opts.cpp
@@ -516,7 +516,9 @@ int resource_opts_t::parse (const std::string &k, const std::string &v, std::str
         case static_cast<int> (resource_opts_key_t::MATCH_POLICY):
             if (!m_resource_prop.set_match_policy (v, info)) {
                 info += "Unknown match policy (" + v + ")! ";
-                info += "Using default.";
+                errno = EINVAL;
+                rc = -1;
+                return rc;
             }
             break;
 

--- a/resource/modules/resource_match_opts.cpp
+++ b/resource/modules/resource_match_opts.cpp
@@ -90,9 +90,9 @@ void resource_prop_t::set_load_allowlist (const std::string &p)
     m_load_allowlist = p;
 }
 
-bool resource_prop_t::set_match_policy (const std::string &p)
+bool resource_prop_t::set_match_policy (const std::string &p, std::string &error_str)
 {
-    if (!known_match_policy (p))
+    if (!known_match_policy (p, error_str))
         return false;
     m_match_policy = p;
     return true;
@@ -348,9 +348,9 @@ void resource_opts_t::set_load_allowlist (const std::string &o)
     m_resource_prop.set_load_allowlist (o);
 }
 
-bool resource_opts_t::set_match_policy (const std::string &o)
+bool resource_opts_t::set_match_policy (const std::string &o, std::string &e)
 {
-    return m_resource_prop.set_match_policy (o);
+    return m_resource_prop.set_match_policy (o, e);
 }
 
 bool resource_opts_t::set_match_format (const std::string &o)
@@ -436,8 +436,10 @@ resource_opts_t &resource_opts_t::operator+= (const resource_opts_t &src)
         m_resource_prop.set_load_format (src.m_resource_prop.get_load_format ());
     if (src.m_resource_prop.is_load_allowlist_set ())
         m_resource_prop.set_load_allowlist (src.m_resource_prop.get_load_allowlist ());
-    if (src.m_resource_prop.is_match_policy_set ())
-        m_resource_prop.set_match_policy (src.m_resource_prop.get_match_policy ());
+    if (src.m_resource_prop.is_match_policy_set ()) {
+        std::string e = "";
+        m_resource_prop.set_match_policy (src.m_resource_prop.get_match_policy (), e);
+    }
     if (src.m_resource_prop.is_match_format_set ())
         m_resource_prop.set_match_format (src.m_resource_prop.get_match_format ());
     if (src.m_resource_prop.is_match_subsystems_set ())
@@ -512,7 +514,7 @@ int resource_opts_t::parse (const std::string &k, const std::string &v, std::str
             break;
 
         case static_cast<int> (resource_opts_key_t::MATCH_POLICY):
-            if (!m_resource_prop.set_match_policy (v)) {
+            if (!m_resource_prop.set_match_policy (v, info)) {
                 info += "Unknown match policy (" + v + ")! ";
                 info += "Using default.";
             }

--- a/resource/modules/resource_match_opts.hpp
+++ b/resource/modules/resource_match_opts.hpp
@@ -40,7 +40,7 @@ class resource_prop_t {
     void set_load_file (const std::string &o);
     bool set_load_format (const std::string &o);
     void set_load_allowlist (const std::string &o);
-    bool set_match_policy (const std::string &o);
+    bool set_match_policy (const std::string &o, std::string &e);
     bool set_match_format (const std::string &o);
     void set_match_subsystems (const std::string &o);
     void set_reserve_vtx_vec (const int i);
@@ -111,7 +111,7 @@ class resource_opts_t : public optmgr_parse_t {
     void set_load_file (const std::string &o);
     bool set_load_format (const std::string &o);
     void set_load_allowlist (const std::string &o);
-    bool set_match_policy (const std::string &o);
+    bool set_match_policy (const std::string &o, std::string &e);
     bool set_match_format (const std::string &o);
     void set_match_subsystems (const std::string &o);
     void set_reserve_vtx_vec (const int i);

--- a/resource/policies/base/test/CMakeLists.txt
+++ b/resource/policies/base/test/CMakeLists.txt
@@ -1,3 +1,9 @@
+add_executable(matcher_policy_factory_test
+  ${CMAKE_CURRENT_SOURCE_DIR}/matcher_policy_factory_test02.cpp
+  )
+target_link_libraries(matcher_policy_factory_test PRIVATE libtap resource)
+add_sanitizers(matcher_policy_factory_test)
+flux_add_test(NAME matcher_policy_factory_test COMMAND matcher_policy_factory_test)
 add_executable(matcher_util_api_test
   ${CMAKE_CURRENT_SOURCE_DIR}/matcher_util_api_test01.cpp
   )

--- a/resource/policies/base/test/matcher_policy_factory_test02.cpp
+++ b/resource/policies/base/test/matcher_policy_factory_test02.cpp
@@ -1,0 +1,93 @@
+/*****************************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+/*
+ * Test for the dfu_match_policy class(es). Compares shared pointers
+ * expected values to string inputs to these classes. Strings can be
+ * specified in config for custom policies, or some are provided.
+ */
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+}
+#include <iostream>
+#include <string>
+#include <boost/lexical_cast.hpp>
+#include "resource/policies/dfu_match_policy_factory.hpp"
+#include "src/common/libtap/tap.h"
+
+using namespace Flux;
+using namespace Flux::resource_model;
+
+int test_parsers ()
+{
+    std::map<std::string, bool> container;
+    std::string e = "";
+    bool first = Flux::resource_model::parse_custom_match_policy (
+        "policy=high node_centric=true node_exclusive=true stop_on_1_matches=false blah=4",
+        container,
+        e);
+    ok (first == false, "blah is an unrecognized policy option");
+    ok (e == "invalid policy option: blah\n", "correct error message for invalid option");
+
+    std::map<std::string, bool> container2;
+    std::string e2 = "";
+    bool second = Flux::resource_model::parse_custom_match_policy (
+        "policy=1 node_centric=true node_exclusive=true stop_on_1_matches=false", container2, e2);
+    ok (second == false, "1 is an invalid option, must be high or low");
+    ok (e2 == "policy key within custom policy accepts only low or high\n",
+        "correct error message for high/low");
+
+    std::map<std::string, bool> container3;
+    std::string e3 = "";
+    bool third = Flux::resource_model::
+        parse_custom_match_policy ("policy=high node_centric=true stop_on_1_matches=true",
+                                   container3,
+                                   e3);
+    ok (third == true, "first is a valid policy");
+
+    bool fourth = Flux::resource_model::parse_bool_match_options ("high", container3);
+    ok (fourth == true, "policy first uses option high");
+
+    bool fifth = Flux::resource_model::parse_bool_match_options ("node_centric", container3);
+    ok (fifth == true, "policy first uses option node_centric");
+
+    bool sixth = Flux::resource_model::parse_bool_match_options ("stop_on_1_matches", container3);
+    ok (sixth == true, "policy first uses option stop_on_1_matches");
+
+    bool seventh = Flux::resource_model::parse_bool_match_options ("low", container3);
+    ok (seventh == false, "policy first does not use option low");
+
+    std::map<std::string, bool> container4;
+    std::string e4 = "";
+    bool eighth = Flux::resource_model::
+        parse_custom_match_policy ("policy=high node_centric=true node_exclusive=4",
+                                   container4,
+                                   e4);
+    ok (eighth == false, "node_exclusive accepts only true or false");
+    ok (e4 == "Policy option node_exclusive requires true or false, got 4\n",
+        "correct error msg for options");
+
+    return 0;
+}
+
+int main (int argc, char *argv[])
+{
+    plan (11);
+    test_parsers ();
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/resource/policies/dfu_match_policy_factory.cpp
+++ b/resource/policies/dfu_match_policy_factory.cpp
@@ -13,59 +13,175 @@ extern "C" {
 #include <config.h>
 #endif
 }
-
-#include <string>
+#include <array>
+#include <boost/algorithm/string.hpp>
 #include "resource/policies/dfu_match_policy_factory.hpp"
 
 namespace Flux {
 namespace resource_model {
 
-bool known_match_policy (const std::string &policy)
-{
-    bool rc = true;
-    if (policy != FIRST_MATCH && policy != FIRST_NODEX_MATCH && policy != HIGH_ID_FIRST
-        && policy != LOW_ID_FIRST && policy != LOW_NODE_FIRST && policy != HIGH_NODE_FIRST
-        && policy != LOW_NODEX_FIRST && policy != HIGH_NODEX_FIRST && policy != LOCALITY_AWARE
-        && policy != VAR_AWARE)
-        rc = false;
+const std::map<std::string, std::string> policies =
+    {{"first", "policy=high node_centric=true stop_on_1_matches=true"},
+     {"firstnodex", "policy=high node_centric=true node_exclusive=true stop_on_1_matches=true"},
+     {"high", "policy=high"},
+     {"low", "policy=low"},
+     {"lonode", "policy=low node_centric=true"},
+     {"hinode", "policy=high node_centric=true"},
+     {"lonodex", "policy=low node_centric=true node_exclusive=true"},
+     {"hinodex", "policy=high node_centric=true node_exclusive=true"},
+     {"locality", ""},
+     {"variation", ""}};
 
-    return rc;
+const std::vector<std::string> policy_options = {"policy",
+                                                 "node_centric",
+                                                 "stop_on_1_matches",
+                                                 "node_exclusive"};
+
+/* This takes a string of match policy options, deliniated by
+ * spaces and equals signs, and turns them into a std::map.
+ * It validates that each option is set to either "true" or "false"
+ * and puts the corresponding boolean in the map.
+ */
+bool parse_custom_match_policy (const std::string long_string,
+                                std::map<std::string, bool> &split,
+                                std::string &error_str)
+{
+    std::vector<std::string> options;
+    boost::split (options, long_string, boost::is_any_of (" "));
+    /* After splitting based on term, validate the terms. If invalid,
+     * abort.
+     */
+    for (int i = 0; i < options.size (); i++) {
+        std::vector<std::string> settings;
+        /* This split should take an entire string and split it
+         * on the equals sign. If there's no equals sign, maybe it will
+         * get caught later?
+         */
+        boost::split (settings, options.at (i), boost::is_any_of ("="));
+        /* Place the terms in a map for ease of access. Lots of gross
+         * temporary structures needed here, hopefully they'll get
+         * garbage collected soon.
+         */
+        if (std::find (policy_options.begin (), policy_options.end (), settings.at (0))
+            == policy_options.end ()) {
+            error_str += std::basic_string ("invalid policy option: ") += settings.at (0) +=
+                std::basic_string ("\n");
+            return false;
+        } else {
+            if (settings.at (0).compare ("policy") == 0) {
+                /* This is the one option we want to allow to be something other than "true"
+                 * or "false." It should take "low" or "high." Maybe other things in the
+                 * future, too.
+                 */
+                if (settings.at (1).compare ("high") == 0) {
+                    const auto [it, success] = split.insert ({"high", true});
+                    if (success == false) {
+                        error_str += std::basic_string ("Insertion of ") +=
+                            std::basic_string (it->first) += std::basic_string (" failed\n");
+                    }
+                } else if (settings.at (1).compare ("low") == 0) {
+                    const auto [it, success] = split.insert ({"low", true});
+                    if (success == false) {
+                        error_str += std::basic_string ("Insertion of ") +=
+                            std::basic_string (it->first) += std::basic_string (" failed\n");
+                    }
+                } else {
+                    error_str += "policy key within custom policy accepts only low or high\n";
+                    return false;
+                }
+            } else if (settings.at (1).compare ("true") == 0) {
+                const auto [it, success] = split.insert ({settings.at (0), true});
+                if (success == false) {
+                    error_str += std::basic_string ("Insertion of ") +=
+                        std::basic_string (it->first) += std::basic_string (" failed\n");
+                }
+            } else if (settings.at (1).compare ("false") == 0) {
+                const auto [it, success] = split.insert ({settings.at (0), false});
+                if (success == false) {
+                    error_str += std::basic_string ("Insertion of ") +=
+                        std::basic_string (it->first) += std::basic_string (" failed\n");
+                    return false;
+                }
+            } else {
+                error_str += std::basic_string ("Policy option ") +=
+                    std::basic_string (settings.at (0)) +=
+                    std::basic_string (" requires true or false, got ") +=
+                    std::basic_string (settings.at (1)) += std::basic_string ("\n");
+                return false;
+            }
+        }
+    }
+    return true;
 }
 
-std::shared_ptr<dfu_match_cb_t> create_match_cb (const std::string &policy)
+bool known_match_policy (const std::string &policy, std::string &error_str)
 {
-    std::shared_ptr<dfu_match_cb_t> matcher = nullptr;
+    std::map<std::string, bool> throw_away;
+    if (policies.contains (policy)) {
+        return true;
+    } else if (parse_custom_match_policy (policy, throw_away, error_str) == true) {
+        return true;
+    }
+    return false;
+}
 
-    resource_type_t node_rt ("node");
+bool parse_bool_match_options (const std::string match_option, std::map<std::string, bool> &policy)
+{
+    if ((policy.find (match_option) != policy.end ()) && (policy[match_option] == true)) {
+        return true;
+    }
+    return false;
+}
+
+std::shared_ptr<dfu_match_cb_t> create_match_cb (const std::string &policy_requested)
+{
+    std::map<std::string, bool> policy;
+    std::string error_str;
+    if (policies.contains (policy_requested)) {
+        parse_custom_match_policy (policies.find (policy_requested)->second, policy, error_str);
+    } else {
+        parse_custom_match_policy (policy_requested, policy, error_str);
+    }
+    std::shared_ptr<dfu_match_cb_t> matcher = nullptr;
     try {
-        if (policy == FIRST_MATCH || policy == FIRST_NODEX_MATCH) {
-            std::shared_ptr<high_first_t> ptr = std::make_shared<high_first_t> ();
-            ptr->add_score_factor (node_rt, 1, 10000);
-            ptr->set_stop_on_k_matches (1);
-            if (policy == FIRST_NODEX_MATCH)
-                ptr->add_exclusive_resource_type (node_rt);
-            matcher = ptr;
-        } else if (policy == HIGH_ID_FIRST) {
-            matcher = std::make_shared<high_first_t> ();
-        } else if (policy == LOW_ID_FIRST) {
-            matcher = std::make_shared<low_first_t> ();
-        } else if (policy == LOW_NODE_FIRST || policy == LOW_NODEX_FIRST) {
-            std::shared_ptr<low_first_t> ptr = std::make_shared<low_first_t> ();
-            ptr->add_score_factor (node_rt, 1, 10000);
-            if (policy == LOW_NODEX_FIRST)
-                ptr->add_exclusive_resource_type (node_rt);
-            matcher = ptr;
-        } else if (policy == HIGH_NODE_FIRST || policy == HIGH_NODEX_FIRST) {
-            std::shared_ptr<high_first_t> ptr = std::make_shared<high_first_t> ();
-            ptr->add_score_factor (node_rt, 1, 10000);
-            if (policy == HIGH_NODEX_FIRST)
-                ptr->add_exclusive_resource_type (node_rt);
-            matcher = ptr;
-        } else if (policy == LOCALITY_AWARE) {
+        if (policy_requested == "locality") {
             matcher = std::make_shared<greater_interval_first_t> ();
-        } else if (policy == VAR_AWARE) {
+        }
+        if (policy_requested == "variation") {
             matcher = std::make_shared<var_aware_t> ();
         }
+
+        if (parse_bool_match_options ("high", policy)) {
+            std::shared_ptr<high_first_t> ptr = std::make_shared<high_first_t> ();
+            if (parse_bool_match_options ("node_centric", policy)) {
+                ptr->add_score_factor (node_rt, 1, 10000);
+            }
+
+            if (parse_bool_match_options ("node_exclusive", policy)) {
+                ptr->add_exclusive_resource_type (node_rt);
+            }
+
+            if (parse_bool_match_options ("stop_on_1_matches", policy)) {
+                ptr->set_stop_on_k_matches (1);
+            }
+            matcher = ptr;
+
+        } else if (parse_bool_match_options ("low", policy)) {
+            std::shared_ptr<low_first_t> ptr = std::make_shared<low_first_t> ();
+            if (parse_bool_match_options ("node_centric", policy)) {
+                ptr->add_score_factor (node_rt, 1, 10000);
+            }
+
+            if (parse_bool_match_options ("node_exclusive", policy)) {
+                ptr->add_exclusive_resource_type (node_rt);
+            }
+
+            if (parse_bool_match_options ("stop_on_1_matches", policy)) {
+                ptr->set_stop_on_k_matches (1);
+            }
+            matcher = ptr;
+        }
+
     } catch (std::bad_alloc &e) {
         errno = ENOMEM;
         matcher = nullptr;

--- a/resource/policies/dfu_match_policy_factory.hpp
+++ b/resource/policies/dfu_match_policy_factory.hpp
@@ -13,6 +13,7 @@
 
 #include <string>
 #include <memory>
+#include <map>
 #include "resource/policies/base/dfu_match_cb.hpp"
 #include "resource/policies/dfu_match_high_id_first.hpp"
 #include "resource/policies/dfu_match_low_id_first.hpp"
@@ -24,18 +25,21 @@
 namespace Flux {
 namespace resource_model {
 
-const std::string FIRST_MATCH = "first";
-const std::string FIRST_NODEX_MATCH = "firstnodex";
-const std::string HIGH_ID_FIRST = "high";
-const std::string LOW_ID_FIRST = "low";
-const std::string LOW_NODE_FIRST = "lonode";
-const std::string HIGH_NODE_FIRST = "hinode";
-const std::string LOW_NODEX_FIRST = "lonodex";
-const std::string HIGH_NODEX_FIRST = "hinodex";
-const std::string LOCALITY_AWARE = "locality";
-const std::string VAR_AWARE = "variation";
+bool known_match_policy (const std::string &policy, std::string &error);
 
-bool known_match_policy (const std::string &policy);
+/* Returns true if the custom match policy is valid.
+ * Returns false if it is invalid.
+ * Stores all of the options requested in the map under
+ * key-value pairs.
+ */
+bool parse_custom_match_policy (const std::string long_string,
+                                std::map<std::string, bool> &split,
+                                std::string &error);
+
+/* Included in the header for unit testing.
+ * This is how the map keys get accessed and returned easily.
+ */
+bool parse_bool_match_options (const std::string match_option, std::map<std::string, bool> &policy);
 
 /*! Factory method for creating a matching callback
  *  object, representing a matching policy.

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -67,6 +67,7 @@ set(ALL_TESTS
   t3034-resource-pconstraints.t
   t3035-resource-remove.t
   t3036-rq2.t
+  t3037-resource-custom-policy.t
   t3300-system-dontblock.t
   t3301-system-latestart.t
   t4000-match-params.t

--- a/t/conf.d/09-invalid-policy/sched-fluxion-resource.toml
+++ b/t/conf.d/09-invalid-policy/sched-fluxion-resource.toml
@@ -1,6 +1,6 @@
 [sched-fluxion-resource]
 
-match-policy = "invalid"
+match-policy = "first"
 load-allowlist="node,core,gpu"
 reserve-vtx-vec=200000
 prune-filters="ALL:core,ALL:gpu"

--- a/t/t3037-resource-custom-policy.t
+++ b/t/t3037-resource-custom-policy.t
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+test_description='Test node-locality-aware scheduling'
+
+. $(dirname $0)/sharness.sh
+
+cmd_dir="${SHARNESS_TEST_SRCDIR}/data/resource/commands/nodex"
+exp_dir="${SHARNESS_TEST_SRCDIR}/data/resource/expected/nodex"
+grugs="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/small.graphml"
+query="../../resource/utilities/resource-query"
+
+# Takes policy and cmd outfile prefix
+run_tests_with_policy() {
+    pol=$1
+    prefix=$2
+
+    cmds001="${cmd_dir}/cmds01.in"
+    test001_desc="allocate 7 jobs with node-level constraint (pol=$pol)"
+    test_expect_success "${test001_desc}" '
+        sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds001} > cmds001 &&
+        ${query} -L ${grugs} -S CA -P "${pol}" -t ${prefix}1.R.out < cmds001 &&
+        test_cmp ${prefix}1.R.out ${exp_dir}/${prefix}1.R.out
+    '
+
+    cmds002="${cmd_dir}/cmds02.in"
+    test002_desc="allocate 7 jobs with no node-level constraint (pol=$pol)"
+    test_expect_success "${test002_desc}" '
+        sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds002} > cmds002 &&
+        ${query} -L ${grugs} -S CA -P "${pol}" -t ${prefix}2.R.out < cmds002 &&
+        test_cmp ${prefix}2.R.out ${exp_dir}/${prefix}2.R.out
+    '
+
+    cmds003="${cmd_dir}/cmds03.in"
+    test003_desc="match allocate 7 jobs -- last fails (pol=$pol)"
+    test_expect_success "${test003_desc}" '
+        sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds003} > cmds003 &&
+        ${query} -L ${grugs} -S CA -P "${pol}" -t ${prefix}3.R.out < cmds003 &&
+        test_cmp ${prefix}3.R.out ${exp_dir}/${prefix}3.R.out
+    '
+}
+
+# Selection Policy -- High node first with node exclusivity (-P hinodex)
+#     Selection behavior is identical to hinode except that
+#     it marks each selected node as exclusive even if the
+#     jobspec does not require node exclusivity and
+#     that it selects and emits all of the node-local resources
+#     for each node where at least one node-local resource is selected.
+#
+#     For a jobspec with node[1]->slot[1]->core[1], it selects
+#     36 cores from the selected node if there is a total of
+#     36 cores in that node.
+#
+#     For a jobspec with slot[18]->core[1], it selects
+#     again all 36 cores from the current available highest node.
+#
+
+run_tests_with_policy "policy=high node_centric=true node_exclusive=true" 00
+
+#
+# Selection Policy -- Low node first with node exclusivity (-P lonodex)
+#     Selection behavior is identical to lonode except that
+#     it marks each selected node as exclusive even if the
+#     jobspec does not require node exclusivity and
+#     that it selects and emits all of the node-local resources
+#     for each node where at least one node-local resource is selected.
+#
+#     For a jobspec with node[1]->slot[1]->core[1], it selects
+#     36 cores from the selected node if there is a total of
+#     36 cores in that node.
+#
+#     For a jobspec with slot[18]->core[1], it selects
+#     again all 36 cores from the current available lowest node.
+#
+
+run_tests_with_policy "policy=low node_centric=true node_exclusive=true" 01
+
+run_tests_with_policy "policy=high node_centric=true node_exclusive=true stop_on_1_matches=true" 00
+
+test_done

--- a/t/t4000-match-params.t
+++ b/t/t4000-match-params.t
@@ -93,13 +93,6 @@ test_expect_success 'loading resource module with known policies works' '
     load_resource policy=locality
 '
 
-test_expect_success 'loading resource module with unknown policies is tolerated' '
-    unload_resource &&
-    load_resource policy=foo &&
-    remove_resource &&
-    load_resource policy=bar
-'
-
 test_expect_success 'resource module stats and clear work' '
     unload_resource &&
     load_resource &&
@@ -111,7 +104,13 @@ test_expect_success 'resource module stats and clear work' '
     flux module stats --clear sched-fluxion-resource
 '
 
+test_expect_failure 'loading resource module with unknown policies errors out' '
+    unload_resource &&
+    load_resource policy=foo
+'
+
 test_expect_success 'removing resource works' '
+    load_resource &&
     remove_resource
 '
 

--- a/t/t4010-match-conf.t
+++ b/t/t4010-match-conf.t
@@ -131,11 +131,10 @@ test_expect_success 'resource: sched-fluxion-resource loads with extra keys' '
     check_prune_filters ${outfile} "\"ALL:core,ALL:gpu\""
 '
 
-test_expect_success 'resource: load must tolerate an invalid policy' '
+test_expect_failure 'resource: load must error out on an invalid policy' '
     conf_name="09-invalid-policy" &&
     outfile=${conf_name}.out &&
-    start_resource ${conf_base}/${conf_name} ${outfile} &&
-    check_match_policy ${outfile} "\"first\""
+    start_resource ${conf_base}/${conf_name} ${outfile}
 '
 
 test_expect_success 'resource: load must fail on a bad value' '


### PR DESCRIPTION
Problem: the current fluxion policy matching factory doesn't allow for customizable policies.

Add a custom option and refactor existing policies to behave similarly. Add unit testing for the string parsing convenience functions.

Update documentation for existing and new custom match policies.

Outstanding to-do:

- [x] add an option in the scheduler config to actually pass a custom string in, and probably some validation too