### PR TITLE
Update build and ci to enforce compiler versions, bump to C++23, remove vestigial deps, and generate images matching core

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,6 @@ jobs:
       DOCKER_USERNAME: travisflux
       DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_TRAVISFLUX_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    timeout-minutes: 30
     strategy:
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
       fail-fast: false
@@ -128,6 +127,7 @@ jobs:
         docker run --rm --privileged aptman/qus -s -- -p --credential aarch64
 
     - name: docker-run-checks
+      timeout-minutes: ${{matrix.timeout_minutes}}
       env: ${{matrix.env}}
       run: ${{matrix.command}}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -183,10 +183,7 @@ jobs:
         (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')
       run: |
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        # maybe bring back later: fluxrm/flux-sched:bookworm-386
-        docker manifest create fluxrm/flux-sched:bookworm fluxrm/flux-sched:bookworm-amd64 fluxrm/flux-sched:bookworm-arm64
-        docker manifest push fluxrm/flux-sched:bookworm
-        for d in noble fedora40 ; do
+        for d in el9 noble alpine bookworm ; do
           docker manifest create fluxrm/flux-sched:$d fluxrm/flux-sched:$d-amd64 fluxrm/flux-sched:$d-arm64
           docker manifest push fluxrm/flux-sched:$d
         done

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,22 +39,6 @@ jobs:
     - name: format and linting checks
       run: pre-commit run --all-files --show-diff-on-failure
 
-  python-lint:
-    name: python lint
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/setup-python@v5
-      with:
-        python-version: 3.8
-    - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-        fetch-depth: 0
-    - name: install pylint
-      run: python3 -m pip install 'pylint==2.4.4' --force-reinstall
-    - name: run pylint
-      run: ./scripts/pylint
-
   generate-matrix:
     # https://stackoverflow.com/questions/59977364
     name: Generate build matrix

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,13 +15,16 @@ repos:
       - id: trailing-whitespace
       - id: mixed-line-ending
 
-  - repo: local
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.1
     hooks:
-      - id: black
-        name: black
-        language: python
-        types: [python]
-        entry: black
+      # Run the linter.
+      - id: ruff
+        types_or: [ python, pyi ]
+        args: [ --fix ]
+      # Run the formatter.
+      - id: ruff-format
+        types_or: [ python, pyi ]
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
     # this is the release of 18.1.6

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,18 @@
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.8
+target-version = "py38"
+
+[lint]
+# Enable Pyflakes (`F`), style handled by formatting, ruff includes black
+select = ["E4", "E7", "E9", "F"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,25 @@ set(CMAKE_CXX_STANDARD 20 CACHE STRING "The C++ standard to use")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# check compiler versions
+if(NOT FLUX_IGNORE_COMPILER_SUPPORT_AND_FIX_THIS_MYSELF)
+  set(CLANG_VER "15")
+  set(GCC_VER "12")
+  set(COMPILER_MESSAGE "\
+  Insufficient compiler version, gcc@${GCC_VER} or clang@${CLANG_VER}
+  or higher are the supported compilers.  To ignore these requirements
+  (at your own peril) set FLUX_IGNORE_COMPILER_SUPPORT_AND_FIX_THIS_MYSELF=On")
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${GCC_VER})
+      message(FATAL_ERROR ${COMPILER_MESSAGE})
+    endif()
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${CLANG_VER})
+      message(FATAL_ERROR ${COMPILER_MESSAGE})
+    endif()
+  endif()
+endif()
+
 configure_file(config.h.in config.h)
 
 include( GNUInstallDirs ) # convenience names for gnu-style directories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,10 +109,8 @@ set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.66 REQUIRED COMPONENTS
-  system
-  filesystem
   graph
-  regex)
+  )
 message(STATUS "Boost version: ${Boost_VERSION}")
 
 # Install paths

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ if(POLICY CMP0140)
   cmake_policy(SET CMP0140 NEW)
 endif()
 
-set(CMAKE_CXX_STANDARD 20 CACHE STRING "The C++ standard to use")
+set(CMAKE_CXX_STANDARD 23 CACHE STRING "The C++ standard to use")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/README.md
+++ b/README.md
@@ -54,11 +54,8 @@ Fluxion also requires the following packages to build:
 **redhat**                | **ubuntu**              | **version**       | **note**
 ----------                | ----------              | -----------       | --------
 hwloc-devel               | libhwloc-dev            | >= 1.11.1         |
-boost-devel               | libboost-dev            | == 1.53 or > 1.58 | *1*
-boost-graph               | libboost-graph-dev      | == 1.53 or > 1.58 | *1*
-boost-system              | libboost-system-dev     | == 1.53 or > 1.58 | *1*
-boost-filesystem          | libboost-filesystem-dev | == 1.53 or > 1.58 | *1*
-boost-regex               | libboost-regex-dev      | == 1.53 or > 1.58 | *1*
+boost-devel               | libboost-dev            | >= 1.66 | *1*
+boost-graph               | libboost-graph-dev      | >= 1.66 | *1*
 libedit-devel             | libedit-dev             | >= 3.0            |
 python3-pyyaml            | python3-yaml            | >= 3.10           |
 yaml-cpp-devel            | libyaml-cpp-dev         | >= 0.5.1          |
@@ -76,14 +73,14 @@ jq                | jq                |
 
 ##### Installing RedHat/CentOS Packages
 ```bash
-sudo dnf install hwloc-devel boost-devel boost-graph boost-system boost-filesystem boost-regex libedit-devel python3-pyyaml yaml-cpp-devel
+sudo dnf install hwloc-devel boost-devel boost-graph libedit-devel python3-pyyaml yaml-cpp-devel
 ```
 
 ##### Installing Ubuntu Packages
 
 ```bash
 sudo apt-get update
-sudo apt install libhwloc-dev libboost-dev libboost-system-dev libboost-filesystem-dev libboost-graph-dev libboost-regex-dev libedit-dev libyaml-cpp-dev python3-yaml
+sudo apt install libhwloc-dev libboost-dev libboost-graph-dev libedit-dev libyaml-cpp-dev python3-yaml
 ```
 
 Clone flux-sched, the repo name for Fluxion, from an upstream repo and prepare for configure:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Fluxion also requires the following packages to build:
 
 **redhat**                | **ubuntu**              | **version**       | **note**
 ----------                | ----------              | -----------       | --------
-hwloc-devel               | libhwloc-dev            | >= 1.11.1         |
+hwloc-devel               | libhwloc-dev            | >= 2         |
 boost-devel               | libboost-dev            | >= 1.66 | *1*
 boost-graph               | libboost-graph-dev      | >= 1.66 | *1*
 libedit-devel             | libedit-dev             | >= 3.0            |

--- a/debian/control
+++ b/debian/control
@@ -10,8 +10,6 @@ Build-Depends:
   libhwloc-dev,
   libboost-dev,
   libboost-graph-dev,
-  libboost-filesystem-dev,
-  libboost-regex-dev,
   libedit-dev,
   libyaml-cpp-dev,
   jq

--- a/resource/CMakeLists.txt
+++ b/resource/CMakeLists.txt
@@ -85,11 +85,8 @@ target_link_libraries(resource PUBLIC
     PkgConfig::JANSSON
     PkgConfig::HWLOC
     PkgConfig::UUID
-    Boost::system
     Boost::graph
-    Boost::regex
     jobspec_conv
-    Boost::filesystem
     fluxion-data
     )
 add_sanitizers(resource)

--- a/resource/readers/resource_spec_grug.cpp
+++ b/resource/readers/resource_spec_grug.cpp
@@ -29,7 +29,6 @@ extern "C" {
 #endif
 
 #include <boost/graph/graphml.hpp>
-#include <boost/filesystem.hpp>
 #include "resource/readers/resource_spec_grug.hpp"
 
 using namespace Flux::resource_model;

--- a/resource/readers/resource_spec_grug.hpp
+++ b/resource/readers/resource_spec_grug.hpp
@@ -15,7 +15,6 @@
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/graphviz.hpp>
 #include <boost/graph/graphml.hpp>
-#include <boost/filesystem.hpp>
 #include <schema/data_std.hpp>
 
 namespace Flux {

--- a/resource/utilities/CMakeLists.txt
+++ b/resource/utilities/CMakeLists.txt
@@ -5,7 +5,6 @@ add_sanitizers(grug2dot)
 target_link_libraries(grug2dot
   resource
   Boost::headers
-  Boost::filesystem
   )
 add_executable(resource-query
   resource-query.cpp
@@ -18,7 +17,6 @@ target_link_libraries(resource-query
   PkgConfig::LIBEDIT
   PkgConfig::JANSSON
   PkgConfig::UUID
-  Boost::filesystem
   Boost::headers
   )
 add_executable(rq2

--- a/resource/utilities/grug2dot.cpp
+++ b/resource/utilities/grug2dot.cpp
@@ -15,6 +15,7 @@ extern "C" {
 }
 
 #include <iostream>
+#include <filesystem>
 #include <getopt.h>
 #include "resource/readers/resource_spec_grug.hpp"
 
@@ -68,7 +69,7 @@ int main (int argc, char *argv[])
 
     resource_gen_spec_t gspec;
     std::string fn (argv[optind]);
-    boost::filesystem::path path = fn;
+    std::filesystem::path path = fn;
     std::string base = path.stem ().string ();
 
     if (gspec.read_graphml (fn) != 0) {

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -25,12 +25,12 @@ extern "C" {
 #include <memory>
 #include <editline/readline.h>
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include "resource/utilities/command.hpp"
 #include "resource/store/resource_graph_store.hpp"
 #include "resource/policies/dfu_match_policy_factory.hpp"
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 using namespace Flux::resource_model;
 using boost::tie;
 

--- a/resource/utilities/rq2.cpp
+++ b/resource/utilities/rq2.cpp
@@ -15,10 +15,10 @@
 #include <getopt.h>
 #include <string.h>
 #include <jansson.h>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <editline/readline.h>
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 using namespace Flux;
 using namespace Flux::resource_model;
 using namespace Flux::resource_model::detail;

--- a/src/common/libintern/interner.hpp
+++ b/src/common/libintern/interner.hpp
@@ -158,7 +158,7 @@ struct rc_storage {
 /// A convenience wrapper of an interned string
 template<class Storage>
 class interned_string {
-    using Id = Storage::id_instance_t;
+    using Id = typename Storage::id_instance_t;
     Id _id;
 
     // Not at all safe, verified by a pre-condition check in get_by_id

--- a/src/test/checks_run.sh
+++ b/src/test/checks_run.sh
@@ -40,6 +40,7 @@ else
 fi
 
 if test -n "$CHECK_RUN_SOURCE_ENV" ; then
+	echo Sourcing $CHECK_RUN_SOURCE_ENV
 	source "$CHECK_RUN_SOURCE_ENV"
 fi
 
@@ -131,6 +132,11 @@ if test "$COVERAGE" = "t"; then
 	(chmod 444 coverage.xml || :) &&
 	(coverage report || :)"
 
+# Use make install for installonly
+elif test "$INSTALL_ONLY" = "t"; then
+    ARGS="$ARGS --prefix=/usr --sysconfdir=/etc"
+    CHECKCMDS="sudo make install"
+
 # Use make install for T_INSTALL:
 elif test "$TEST_INSTALL" = "t"; then
     ARGS="$ARGS --prefix=/usr --sysconfdir=/etc"
@@ -183,6 +189,7 @@ if test -n "$BUILD_DIR" ; then
   cd "$BUILD_DIR"
 fi
 
+pwd
 checks_group "configure ${ARGS}"  /usr/src/configure ${ARGS} \
 	|| (printf "::error::configure failed\n"; cat config.log; exit 1)
 checks_group "make clean..." make clean

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -202,6 +202,7 @@ else
         -e CXX \
         -e LDFLAGS \
         -e CFLAGS \
+        -e CXXFLAGS \
         -e CPPFLAGS \
         -e GCOV \
         -e CCACHE_CPP2 \

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -176,71 +176,55 @@ export BUILD_DIR
 export COVERAGE
 export chain_lint
 
-if [[ "$INSTALL_ONLY" == "t" ]]; then
-    docker run --rm \
-        --workdir=$WORKDIR \
-        --volume=$TOP:$WORKDIR \
-        ${PLATFORM} \
-        ${BUILD_IMAGE} \
-        sh -c "( [ -e ./autogen.sh ] && ./autogen.sh || true ) &&
-               ./configure --prefix=/usr --sysconfdir=/etc \
-                --with-systemdsystemunitdir=/etc/systemd/system \
-                --localstatedir=/var &&
-               make clean &&
-               make -j${JOBS}"
-    RC=$?
-    docker rm tmp.$$
-    test $RC -ne 0 &&  die "docker run of 'make install' failed"
-else
-    docker run --rm \
-        --workdir=$WORKDIR \
-        --volume=$TOP:$WORKDIR \
-        ${PLATFORM} \
-        $MOUNT_HOME_ARGS \
-        -e PLATFORM \
-        -e CC \
-        -e CXX \
-        -e LDFLAGS \
-        -e CFLAGS \
-        -e CXXFLAGS \
-        -e CPPFLAGS \
-        -e GCOV \
-        -e CCACHE_CPP2 \
-        -e CCACHE_READONLY \
-        -e COVERAGE \
-        -e TEST_INSTALL \
-        -e CPPCHECK \
-        -e DISTCHECK \
-        -e RECHECK \
-        -e UNIT_TEST_ONLY \
-        -e chain_lint \
-        -e JOBS \
-        -e USER \
-        -e PROJECT \
-        -e CI \
-        -e TAP_DRIVER_QUIET \
-        -e FLUX_TEST_TIMEOUT \
-        -e FLUX_TEST_SIZE_MAX \
-        -e PYTHON \
-        -e PYTHON_VERSION \
-        -e PRELOAD \
-        -e POISON \
-        -e INCEPTION \
-        -e ASAN_OPTIONS \
-        -e BUILD_DIR \
-        -e S3_ACCESS_KEY_ID \
-        -e S3_SECRET_ACCESS_KEY \
-        -e S3_HOSTNAME \
-        -e S3_BUCKET \
-        -e WITH_GO \
-        --cap-add SYS_PTRACE \
-        --tty \
-        ${INTERACTIVE:+--interactive} \
-        --network=host \
-        ${BUILD_IMAGE} \
-        ${INTERACTIVE:-./src/test/checks_run.sh ${CONFIGURE_ARGS}} \
-    || die "docker run failed"
-fi
+docker run --rm \
+    --workdir=$WORKDIR \
+    --volume=$TOP:$WORKDIR \
+    ${PLATFORM} \
+    $MOUNT_HOME_ARGS \
+    -e PLATFORM \
+    -e CC \
+    -e CXX \
+    -e LDFLAGS \
+    -e CFLAGS \
+    -e CXXFLAGS \
+    -e CPPFLAGS \
+    -e GCOV \
+    -e CCACHE_CPP2 \
+    -e CCACHE_READONLY \
+    -e COVERAGE \
+    -e TEST_INSTALL \
+    -e INSTALL_ONLY \
+    -e CPPCHECK \
+    -e DISTCHECK \
+    -e RECHECK \
+    -e UNIT_TEST_ONLY \
+    -e chain_lint \
+    -e JOBS \
+    -e USER \
+    -e PROJECT \
+    -e CI \
+    -e TAP_DRIVER_QUIET \
+    -e FLUX_TEST_TIMEOUT \
+    -e FLUX_TEST_SIZE_MAX \
+    -e PYTHON \
+    -e PYTHON_VERSION \
+    -e PRELOAD \
+    -e POISON \
+    -e INCEPTION \
+    -e ASAN_OPTIONS \
+    -e BUILD_DIR \
+    -e S3_ACCESS_KEY_ID \
+    -e S3_SECRET_ACCESS_KEY \
+    -e S3_HOSTNAME \
+    -e S3_BUCKET \
+    -e WITH_GO \
+    --cap-add SYS_PTRACE \
+    --tty \
+    ${INTERACTIVE:+--interactive} \
+    --network=host \
+    ${BUILD_IMAGE} \
+    ${INTERACTIVE:-./src/test/checks_run.sh ${CONFIGURE_ARGS}} \
+|| die "docker run failed"
 
 if test -n "$TAG"; then
     # Re-run 'make install' in fresh image, otherwise we get all

--- a/src/test/docker/el8/Dockerfile
+++ b/src/test/docker/el8/Dockerfile
@@ -10,7 +10,6 @@ RUN sudo dnf -y install \
 	boost-system \
 	boost-filesystem \
 	boost-regex \
-	readline-devel \
 	python3-pyyaml \
 	yaml-cpp-devel \
 	libedit-devel \

--- a/src/test/docker/el9/Dockerfile
+++ b/src/test/docker/el9/Dockerfile
@@ -10,7 +10,6 @@ RUN sudo dnf -y install \
 	boost-system \
 	boost-filesystem \
 	boost-regex \
-	readline-devel \
 	python3-pyyaml \
 	yaml-cpp-devel \
 	libedit-devel \

--- a/src/test/docker/el9/Dockerfile
+++ b/src/test/docker/el9/Dockerfile
@@ -2,6 +2,7 @@ FROM fluxrm/flux-core:el9
 
 ARG USER=flux
 ARG UID=1000
+USER root
 
 # Install extra buildrequires for flux-sched:
 RUN sudo dnf -y install \

--- a/src/test/docker/el9/Dockerfile
+++ b/src/test/docker/el9/Dockerfile
@@ -6,6 +6,8 @@ USER root
 
 # Install extra buildrequires for flux-sched:
 RUN sudo dnf -y install \
+	# We need this to allow curl or others to upgrade base packages
+	--allowerasing \
 	boost-devel \
 	boost-graph \
 	boost-system \
@@ -15,6 +17,7 @@ RUN sudo dnf -y install \
 	yaml-cpp-devel \
 	libedit-devel \
 	ninja-build \
+	gcc-toolset-13-{gcc,gcc-c++,gdb} \
 	cmake \
 	curl
 
@@ -30,3 +33,4 @@ RUN \
 
 USER $USER
 WORKDIR /home/$USER
+ENV CHECK_RUN_SOURCE_ENV=/opt/rh/gcc-toolset-13/enable

--- a/src/test/docker/fedora34/Dockerfile
+++ b/src/test/docker/fedora34/Dockerfile
@@ -13,7 +13,6 @@ RUN sudo yum -y update \
 	boost-system \
 	boost-filesystem \
 	boost-regex \
-	readline-devel \
 	python3-pyyaml \
 	yaml-cpp-devel \
 	libedit-devel \

--- a/src/test/docker/fedora38/Dockerfile
+++ b/src/test/docker/fedora38/Dockerfile
@@ -13,7 +13,6 @@ RUN sudo yum -y update \
 	boost-system \
 	boost-filesystem \
 	boost-regex \
-	readline-devel \
 	python3-pyyaml \
 	yaml-cpp-devel \
 	libedit-devel \

--- a/src/test/docker/fedora40/Dockerfile
+++ b/src/test/docker/fedora40/Dockerfile
@@ -12,7 +12,6 @@ RUN sudo dnf -y install \
 	boost-system \
 	boost-filesystem \
 	boost-regex \
-	readline-devel \
 	python3-pyyaml \
 	yaml-cpp-devel \
 	libedit-devel \

--- a/src/test/docker/noble/Dockerfile
+++ b/src/test/docker/noble/Dockerfile
@@ -2,6 +2,7 @@ FROM fluxrm/flux-core:noble
 
 ARG USER=flux
 ARG UID=1000
+USER root
 
 # Install extra buildrequires for flux-sched:
 RUN sudo apt-get update

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -196,6 +196,7 @@ matrix.add_multiarch_build(
     args=common_args,
     env=dict(
         TEST_INSTALL="t",
+        CHECK_RUN_SOURCE_ENV="/opt/rh/gcc-toolset-13/enable",
     ),
 )
 # TODO: we have test failures here, EPROTO and notify problems

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -3,7 +3,6 @@
 #  Generate a build matrix for use with github workflows
 #
 
-from copy import deepcopy
 import json
 import os
 import re

--- a/t/python/t10001-resourcegraph.py
+++ b/t/python/t10001-resourcegraph.py
@@ -21,8 +21,6 @@ sys.path.insert(0, str(pathlib.Path(__file__).absolute().parents[2] / "src" / "p
 
 from fluxion.resourcegraph.V1 import (
     FluxionResourceGraphV1,
-    FluxionResourcePoolV1,
-    FluxionResourceRelationshipV1,
 )
 
 RV1 = {

--- a/t/scripts/flux-jsonschemalint.py
+++ b/t/scripts/flux-jsonschemalint.py
@@ -6,7 +6,6 @@
 #
 
 import argparse
-import errno
 import json
 import jsonschema
 

--- a/t/scripts/run_timeout.py
+++ b/t/scripts/run_timeout.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """run command with a timeout, timeout as a float is first argument, rest are command"""
+
 import sys
 import os
 import signal

--- a/t/scripts/y2j.py
+++ b/t/scripts/y2j.py
@@ -1,7 +1,9 @@
 #!/bin/false
 # Usage: flux python y2j <in.yaml >out.json
 
-import sys, yaml, json
+import sys
+import yaml
+import json
 
 try:
     obj = yaml.safe_load(sys.stdin)


### PR DESCRIPTION
This is meant to solve a variety of build and CI issues we're facing, and also bring our requirements more up to date.  We actually barely need any built boost components anymore, so I'm removing them.  We may go the rest of the way, will consider it, but for now it's regex, system and filesystem that are all removed. 

This also explicitly checks compiler versions, note that the default initial gcc and clang for jammy fell off the back _but_ both gcc12 and clang15 are available in standard jammy apt repos, and in fact we had clang-15 pre-installed, so no change to OS requirements.  Since cmake was already checking for minimal C++20 support, this actually checks for explicit versions of gcc and clang, with an escape hatch to build with whatever.  The code currently builds, barely, with gcc11 and clang-14.  The explicitly required versions are gcc12 and clang-15 are the versions where all the features we use are documented to actually work correctly.

fixes #1264 

There's also a tiny fix in here for older clangs that don't support the c++20 removal of need for typename in some cases, and I'm adding a build using clang-15 so we catch things like this in the future.

@vsoch, I think you're making the spack package match these versions, but after this you should get a much more informative/clear message about requirements. 