### PR TITLE
qmanager-stats: fix jansson refcount issue

### DIFF
--- a/src/common/c++wrappers/jansson.hpp
+++ b/src/common/c++wrappers/jansson.hpp
@@ -119,7 +119,7 @@ inline void to_json (value &jv, const MapT &m)
     for (auto &[k, v] : m) {
         value val;
         to_json (val, v);
-        json_object_set_new (jv.get (), k.c_str (), val.get ());
+        json_object_set (jv.get (), k.c_str (), val.get ());
     }
 }
 }  // namespace json


### PR DESCRIPTION
problem: The `to_json` function for serializing maps with jansson had a refcounting bug in it, which wasn't caught by address sanitizer, valgrind, or testing.  This is what caused the issue @jamescorbett saw in the buildfarm, but only reliably reproduced on alpine.

solution: Temporary solution is to fix the refcount problem, longer term solution is to use something that isn't so insanely hard to use correctly and debug.