### PR TITLE
Resolve issues with Alpine linux and build release containers for amd64 and arm64

### DIFF
--- a/cmake/config_testing.cmake
+++ b/cmake/config_testing.cmake
@@ -34,6 +34,7 @@ function(flux_config_test)
     "${options}" "${oneValueArgs}" "${multiValueArgs}")
   set_property(TEST ${ARG_NAME} PROPERTY ENVIRONMENT "${TEST_ENV}")
 endfunction()
+find_program(TEST_SHELL NAMES bash zsh sh)
 function(flux_add_test)
   # This odd construction is as close as we can get to
   # generic argument forwarding
@@ -55,7 +56,7 @@ function(flux_add_test)
   cmake_language(EVAL CODE "
   add_test(
       NAME ${ARG_NAME}
-      COMMAND /usr/bin/bash ${CMAKE_SOURCE_DIR}/t/scripts/maybe-installtest ${ARG_COMMAND}
+      COMMAND ${TEST_SHELL} ${CMAKE_SOURCE_DIR}/t/scripts/maybe-installtest ${ARG_COMMAND}
       ${__argsQuoted}
     ) ")
     flux_config_test(NAME ${ARG_NAME})

--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -237,7 +237,7 @@ void qmanager_cb_t::jobmanager_stats_get_cb (flux_t *h,
     for (auto &[qname, queue] : ctx->queues) {
         json::value qv;
         queue->to_json_value (qv);
-        if (json_object_set (queues.get (), qname.c_str (), qv.get ()) < 0 && false)
+        if (json_object_set (queues.get (), qname.c_str (), qv.get ()) < 0)
             throw std::system_error ();
     }
     char *resp = json_dumps (stats.get (), 0);

--- a/resource/utilities/test/resource-bench.sh
+++ b/resource/utilities/test/resource-bench.sh
@@ -36,7 +36,7 @@ Options:\n\
  -k, --keep                    Keep intermediate files\n\
 "
 
-GETOPTS=`/usr/bin/getopt -u -o ${short_opts} -l ${long_opts} -n ${prog} -- ${@}`
+GETOPTS=`/usr/bin/env getopt -u -o ${short_opts} -l ${long_opts} -n ${prog} -- ${@}`
 if [[ $? != 0 ]]; then
     die "${usage}"
 fi

--- a/src/test/docker/alpine/Dockerfile
+++ b/src/test/docker/alpine/Dockerfile
@@ -1,0 +1,29 @@
+FROM fluxrm/flux-core:alpine
+
+ARG USER=flux
+ARG UID=1000
+
+# Install extra buildrequires for flux-sched:
+RUN sudo apk add \
+	boost-dev \
+	py3-yaml \
+	yaml-cpp-dev \
+	libedit-dev \
+	ninja-build \
+	cmake \
+	bash \
+	curl
+
+# Add configured user to image with sudo access:
+#
+RUN \
+ if test "$USER" != "flux"; then  \
+      sudo groupadd -g $UID $USER \
+   && sudo useradd -g $USER -u $UID -d /home/$USER -m $USER \
+   && sudo sh -c "printf \"$USER ALL= NOPASSWD: ALL\\n\" >> /etc/sudoers" \
+   && sudo usermod -G wheel $USER; \
+ fi
+
+USER $USER
+WORKDIR /home/$USER
+

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -198,15 +198,14 @@ matrix.add_multiarch_build(
         CHECK_RUN_SOURCE_ENV="/opt/rh/gcc-toolset-13/enable",
     ),
 )
-# TODO: we have test failures here, EPROTO and notify problems
-# matrix.add_multiarch_build(
-#     name="alpine",
-#     default_suffix=" - test-install",
-#     args=common_args,
-#     env=dict(
-#         TEST_INSTALL="t",
-#     ),
-# )
+matrix.add_multiarch_build(
+    name="alpine",
+    default_suffix=" - test-install",
+    args=common_args,
+    env=dict(
+        TEST_INSTALL="t",
+    ),
+)
 # single arch builds that still produce a container
 matrix.add_build(
     name="fedora40 - test-install",

--- a/t/scripts/strerror_symbol
+++ b/t/scripts/strerror_symbol
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+##############################################################
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+"""
+Print the strerror string for the given errno constant name.
+
+For example:
+  grep "flux_future_get: $(strerror_symbol ENOTSUP)" file
+"""
+
+import errno
+import os
+import sys
+
+if len(sys.argv) != 2:
+    print(
+        "requires a single errno constant name or number and converts to strerror string"
+    )
+
+try:
+    print(os.strerror(getattr(errno, sys.argv[1])))
+    sys.exit(0)
+except AttributeError:
+    pass
+
+val = int(sys.argv[1])
+print(os.strerror(getattr(errno, errno.errorcode[val])))

--- a/t/t1005-qmanager-conf.t
+++ b/t/t1005-qmanager-conf.t
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 test_description='Test configuration file support for qmanager'
 
 . `dirname $0`/sharness.sh

--- a/t/t1024-alloc-check.t
+++ b/t/t1024-alloc-check.t
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 test_description='Check that fluxion never double books resources'
 
 . `dirname $0`/sharness.sh

--- a/t/t3301-system-latestart.t
+++ b/t/t3301-system-latestart.t
@@ -55,7 +55,7 @@ test_expect_success 'resource status shows no drained nodes' '
 
 test_expect_success 'flux exec -r 1 fails with EHOSTUNREACH' '
 	test_must_fail run_timeout 30 flux exec -r 1 /bin/true 2>unreach.err &&
-	grep "No route to host" unreach.err
+	grep "$(strerror_symbol EHOSTUNREACH)" unreach.err
 '
 
 test_expect_success 'single node job can run with only rank 0 up' '


### PR DESCRIPTION
This is stacked on top of #1272 and #1273 and adds support for alpine linux on amd64 and arm64, with the attendant ci updates.  This also actually surfaced a very, very hard to repro bug in the jansson code I added for qmanager, so I'm seeing this as pretty useful right now.

(note that most of the changes in the diff are due to the stacking, it's just the alpine commit that's new here)