### PR TITLE
update satisfiability RPC to conform with RFC 27

### DIFF
--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -2862,7 +2862,7 @@ static void satisfiability_request_cb (flux_t *h,
         goto error_memfree;
     }
     free ((void *)js_str);
-    if (flux_respond_pack (h, msg, "{s:i}", "errnum", 0) < 0)
+    if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
     return;
 


### PR DESCRIPTION
This simple PR just brings flux-sched into line with the recent addition of the `feasibility` service for handling satsifiability requests in RFC 27.

For now, both the old `sched.feasibility` and `feasibility.check` RPCs are supported so that Fluxion can continue to work with existing flux-core which doesn't yet support `feasibility.check`.

The long term plan I think is to run `feasibility` as a separate module, so this is just a stopgap until that time.