### PR TITLE
move feasibility service into sched-fluxion-resource and fix associated test

### DIFF
--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -493,18 +493,6 @@ static int enforce_options (std::shared_ptr<qmanager_ctx_t> &ctx)
     return rc;
 }
 
-static int register_feasibility (flux_t *h)
-{
-    flux_future_t *f;
-    int rc;
-
-    if (!(f = flux_service_register (h, "sched")))
-        return -1;
-    rc = flux_future_get (f, NULL);
-    flux_future_destroy (f);
-    return rc;
-}
-
 static int handshake (std::shared_ptr<qmanager_ctx_t> &ctx)
 {
     int rc = 0;
@@ -521,10 +509,6 @@ static int handshake (std::shared_ptr<qmanager_ctx_t> &ctx)
     }
     flux_log (ctx->h, LOG_DEBUG, "handshaking with job-manager completed");
 
-    /* Register feasibility service for RFC 27 feasibility.check RPC
-     */
-    if ((rc = register_feasibility (ctx->h) < 0))
-        flux_log_error (ctx->h, "failed to register feasibility service");
     return rc;
 }
 
@@ -616,7 +600,6 @@ static void qmanager_destroy (std::shared_ptr<qmanager_ctx_t> &ctx)
 static const struct flux_msg_handler_spec htab[] = {
     {FLUX_MSGTYPE_REQUEST, "sched.resource-status", status_request_cb, FLUX_ROLE_USER},
     {FLUX_MSGTYPE_REQUEST, "*.feasibility", feasibility_request_cb, FLUX_ROLE_USER},
-    {FLUX_MSGTYPE_REQUEST, "feasibility.check", feasibility_request_cb, FLUX_ROLE_USER},
     {FLUX_MSGTYPE_REQUEST, "*.params", params_request_cb, FLUX_ROLE_USER},
     FLUX_MSGHANDLER_TABLE_END,
 };

--- a/t/t1020-qmanager-feasibility.t
+++ b/t/t1020-qmanager-feasibility.t
@@ -21,14 +21,9 @@ subsystems=containment policy=low &&
     load_qmanager
 '
 
-test_expect_success HAVE_JQ 'feasibility: --plugins=feasibility works ' '
+test_expect_success 'feasibility: --plugins=feasibility works ' '
     flux run -n 999 --dry-run hostname | \
         flux job-validator --jobspec-only --plugins=feasibility \
-        | jq -e ".errnum != 0" &&
-    flux run -n 999 --dry-run hostname | \
-        flux job-validator --jobspec-only \
-        --plugins=feasibility \
-        --feasibility-service=sched-fluxion-resource.satisfiability \
         | jq -e ".errnum != 0"
 '
 

--- a/t/t3301-system-latestart.t
+++ b/t/t3301-system-latestart.t
@@ -21,7 +21,7 @@ test_under_flux 2 system
 
 startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
 
-SCHED_MODULE=$(flux module list | awk '$NF == "sched" {print $1}')
+SCHED_MODULE=$(flux module list | awk '$NF ~ /^\s*(\w+,)?sched(,\w+)?\s*$/ { print $1 }')
 
 test_expect_success 'sched service provided by fluxion' '
 	test_debug "echo sched service provided by ${SCHED_MODULE}" &&


### PR DESCRIPTION
This PR fixes a typo identified in https://github.com/flux-framework/flux-core/pull/6223, changes feasibility service registration to occur before the module is forced to the running state, and fixes one test that used a deprecated `flux job-validator` option.

I apologize for the noise. This version has indeed had some testing against the pending flux-core changes. :facepalm: 