### PR TITLE
docker-run-checks: export INSTALL_ONLY

### DIFF
--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -175,6 +175,7 @@ export UNIT_TEST_ONLY
 export BUILD_DIR
 export COVERAGE
 export chain_lint
+export INSTALL_ONLY
 
 docker run --rm \
     --workdir=$WORKDIR \


### PR DESCRIPTION
problem: the install-only checks were accidentally running checks instead of only installing

solution: export the INSTALL_ONLY variable so it propagates appropriately

This is a bit of a facepalm mistake.  It only actually causes a failure on the arm runners because they run out of time.