### PR TITLE
Dense resource type with DoS protection

### DIFF
--- a/resource/libjobspec/jobspec.cpp
+++ b/resource/libjobspec/jobspec.cpp
@@ -126,7 +126,13 @@ Resource::Resource (const YAML::Node &resnode)
     if (!resnode["type"].IsScalar ()) {
         throw parse_error (resnode["type"], "Value of \"type\" must be a scalar");
     }
-    type = resource_model::resource_type_t{resnode["type"].as<std::string> ()};
+    try {
+        type = resource_model::resource_type_t{resnode["type"].as<std::string> ()};
+    } catch (std::system_error e) {
+        // resource_type must be closed or full
+        throw parse_error (resnode["type"],
+                           "Value of \"type\" must be a resource type known to fluxion");
+    }
     field_count++;
 
     if (!resnode["count"]) {

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -1083,6 +1083,7 @@ static int grow_resource_db (std::shared_ptr<resource_ctx_t> &ctx, json_t *resou
     struct idset *grow_set = NULL;
     json_t *r_lite = NULL;
     json_t *jgf = NULL;
+    auto guard = resource_type_t::storage_t::open_for_scope ();
 
     if ((rc = unpack_resources (resources, &grow_set, &r_lite, &jgf, duration)) < 0) {
         flux_log_error (ctx->h, "%s: unpack_resources", __FUNCTION__);
@@ -1461,6 +1462,10 @@ static int init_resource_graph (std::shared_ptr<resource_ctx_t> &ctx)
             }
         }
     }
+
+    // prevent users from consuming unbounded memory with arbitrary resource types
+    subsystem_t::storage_t::finalize ();
+    resource_type_t::storage_t::finalize ();
     return 0;
 }
 

--- a/resource/schema/data_std.cpp
+++ b/resource/schema/data_std.cpp
@@ -17,6 +17,7 @@ subsystem_t containment_sub{"containment"};
 
 resource_type_t cluster_rt{"cluster"};
 resource_type_t core_rt{"core"};
+resource_type_t socket_rt{"socket"};
 resource_type_t gpu_rt{"gpu"};
 resource_type_t node_rt{"node"};
 resource_type_t rack_rt{"rack"};

--- a/resource/schema/data_std.hpp
+++ b/resource/schema/data_std.hpp
@@ -36,11 +36,12 @@ extern subsystem_t containment_sub;
 
 constexpr uint64_t resource_type_id{1};
 struct resource_type_tag {};
-using resource_type_t = intern::interned_string<intern::rc_storage<resource_type_tag>>;
+using resource_type_t = intern::interned_string<intern::dense_storage<resource_type_tag, uint16_t>>;
 extern resource_type_t slot_rt;
 extern resource_type_t cluster_rt;
 extern resource_type_t rack_rt;
 extern resource_type_t node_rt;
+extern resource_type_t socket_rt;
 extern resource_type_t gpu_rt;
 extern resource_type_t core_rt;
 

--- a/resource/utilities/command.cpp
+++ b/resource/utilities/command.cpp
@@ -429,13 +429,18 @@ static int update_run (std::shared_ptr<resource_context_t> &ctx,
     }
 
     gettimeofday (&st, NULL);
-    if ((rc = ctx->traverser->run (str, ctx->writers, rd, id, at, d)) != 0) {
-        std::cerr << "ERROR: traverser run () returned error " << std::endl;
-        if (ctx->traverser->err_message () != "") {
-            std::cerr << "ERROR: " << ctx->traverser->err_message ();
-            ctx->traverser->clear_err_message ();
+
+    {
+        auto guard = resource_type_t::storage_t::open_for_scope ();
+        if ((rc = ctx->traverser->run (str, ctx->writers, rd, id, at, d)) != 0) {
+            std::cerr << "ERROR: traverser run () returned error " << std::endl;
+            if (ctx->traverser->err_message () != "") {
+                std::cerr << "ERROR: " << ctx->traverser->err_message ();
+                ctx->traverser->clear_err_message ();
+            }
         }
     }
+
     ctx->writers->emit (o);
     std::ostream &out = (ctx->params.r_fname != "") ? ctx->params.r_out : std::cout;
     out << o.str ();

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -587,6 +587,9 @@ static int init_resource_graph (std::shared_ptr<resource_context_t> &ctx)
         return -1;
     }
 
+    // prevent users from consuming unbounded memory with arbitrary resource types
+    subsystem_t::storage_t::finalize ();
+    resource_type_t::storage_t::finalize ();
     return rc;
 }
 

--- a/src/common/libintern/scope_guard.hpp
+++ b/src/common/libintern/scope_guard.hpp
@@ -1,0 +1,176 @@
+/*
+ *  Created on: 13/02/2018
+ *      Author: ricab
+ *
+ * See README.md for documentation of this header's public interface.
+ * SPDX-License-Identifier: Unlicense
+ */
+
+#ifndef SCOPE_GUARD_HPP_
+#define SCOPE_GUARD_HPP_
+
+#include <type_traits>
+#include <utility>
+
+#if __cplusplus >= 201703L
+#define SG_NODISCARD [[nodiscard]]
+#ifdef SG_REQUIRE_NOEXCEPT_IN_CPP17
+#define SG_REQUIRE_NOEXCEPT
+#endif
+#else
+#define SG_NODISCARD
+#endif
+
+namespace sg {
+namespace detail {
+/* --- Some custom type traits --- */
+
+// Type trait determining whether a type is callable with no arguments
+template<typename T, typename = void>
+struct is_noarg_callable_t : public std::false_type {};  // in general, false
+
+template<typename T>
+struct is_noarg_callable_t<T, decltype (std::declval<T &&> () ())> : public std::true_type {
+};  // only true when call expression valid
+
+// Type trait determining whether a no-argument callable returns void
+template<typename T>
+struct returns_void_t : public std::is_same<void, decltype (std::declval<T &&> () ())> {};
+
+/* Type trait determining whether a no-arg callable is nothrow invocable if
+required. This is where SG_REQUIRE_NOEXCEPT logic is encapsulated. */
+template<typename T>
+struct is_nothrow_invocable_if_required_t
+    : public
+#ifdef SG_REQUIRE_NOEXCEPT
+      std::is_nothrow_invocable<T> /* Note: _r variants not enough to
+                                      confirm void return: any return can be
+                                      discarded so all returns are
+                                      compatible with void */
+#else
+      std::true_type
+#endif
+{
+};
+
+// logic AND of two or more type traits
+template<typename A, typename B, typename... C>
+struct and_t : public and_t<A, and_t<B, C...>> {};  // for more than two arguments
+
+template<typename A, typename B>
+struct and_t<A, B> : public std::conditional<A::value, B, A>::type {};  // for two arguments
+
+// Type trait determining whether a type is a proper scope_guard callback.
+template<typename T>
+struct is_proper_sg_callback_t : public and_t<is_noarg_callable_t<T>,
+                                              returns_void_t<T>,
+                                              is_nothrow_invocable_if_required_t<T>,
+                                              std::is_nothrow_destructible<T>> {};
+
+/* --- The actual scope_guard template --- */
+
+template<typename Callback,
+         typename = typename std::enable_if<is_proper_sg_callback_t<Callback>::value>::type>
+class scope_guard;
+
+/* --- Now the friend maker --- */
+
+template<typename Callback>
+detail::scope_guard<Callback> make_scope_guard (Callback &&callback) noexcept (
+    std::is_nothrow_constructible<Callback, Callback &&>::value); /*
+we need this in the inner namespace due to MSVC bugs preventing
+sg::detail::scope_guard from befriending a sg::make_scope_guard
+template instance in the parent namespace (see https://is.gd/xFfFhE). */
+
+/* --- The template specialization that actually defines the class --- */
+
+template<typename Callback>
+class SG_NODISCARD scope_guard<Callback> final {
+   public:
+    typedef Callback callback_type;
+
+    scope_guard (scope_guard &&other) noexcept (
+        std::is_nothrow_constructible<Callback, Callback &&>::value);
+
+    ~scope_guard () noexcept;  // highlight noexcept dtor
+
+    void dismiss () noexcept;
+
+   public:
+    scope_guard () = delete;
+    scope_guard (const scope_guard &) = delete;
+    scope_guard &operator= (const scope_guard &) = delete;
+    scope_guard &operator= (scope_guard &&) = delete;
+
+   private:
+    explicit scope_guard (Callback &&callback) noexcept (
+        std::is_nothrow_constructible<Callback, Callback &&>::value); /*
+                                                meant for friends only */
+
+    friend scope_guard<Callback> make_scope_guard<Callback> (Callback &&) noexcept (
+        std::is_nothrow_constructible<Callback, Callback &&>::value); /*
+only make_scope_guard can create scope_guards from scratch (i.e. non-move)
+*/
+
+   private:
+    Callback m_callback;
+    bool m_active;
+};
+
+}  // namespace detail
+
+/* --- Now the single public maker function --- */
+
+using detail::make_scope_guard;  // see comment on declaration above
+
+}  // namespace sg
+
+////////////////////////////////////////////////////////////////////////////////
+template<typename Callback>
+sg::detail::scope_guard<Callback>::scope_guard (Callback &&callback) noexcept (
+    std::is_nothrow_constructible<Callback, Callback &&>::value)
+    : m_callback (std::forward<Callback> (callback)) /* use () instead of {} because
+        of DR 1467 (https://is.gd/WHmWuo), which still impacts older compilers
+        (e.g. GCC 4.x and clang <=3.6, see https://godbolt.org/g/TE9tPJ and
+        https://is.gd/Tsmh8G) */
+      ,
+      m_active{true}
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////
+template<typename Callback>
+sg::detail::scope_guard<Callback>::scope_guard::~scope_guard () noexcept /*
+need the extra injected-class-name here to make different compilers happy */
+{
+    if (m_active)
+        m_callback ();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+template<typename Callback>
+sg::detail::scope_guard<Callback>::scope_guard (scope_guard &&other) noexcept (
+    std::is_nothrow_constructible<Callback, Callback &&>::value)
+    : m_callback (std::forward<Callback> (other.m_callback))  // idem
+      ,
+      m_active{std::move (other.m_active)}
+{
+    other.m_active = false;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+template<typename Callback>
+inline void sg::detail::scope_guard<Callback>::dismiss () noexcept
+{
+    m_active = false;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+template<typename Callback>
+inline auto sg::detail::make_scope_guard (Callback &&callback) noexcept (
+    std::is_nothrow_constructible<Callback, Callback &&>::value) -> detail::scope_guard<Callback>
+{
+    return detail::scope_guard<Callback>{std::forward<Callback> (callback)};
+}
+
+#endif /* SCOPE_GUARD_HPP_ */

--- a/t/data/resource/expected/satisfiability/002.R.out
+++ b/t/data/resource/expected/satisfiability/002.R.out
@@ -37,16 +37,3 @@ INFO: =============================
 INFO: =============================
 INFO: Unsatisfiable request
 INFO: =============================
-INFO: =============================
-INFO: No matching resources found
-INFO: Unsatisfiable request
-INFO: JOBID=7
-INFO: =============================
-INFO: =============================
-INFO: No matching resources found
-INFO: Unsatisfiable request
-INFO: JOBID=8
-INFO: =============================
-INFO: =============================
-INFO: Unsatisfiable request
-INFO: =============================

--- a/t/data/resource/jobspecs/basics/bad_res_type.yaml
+++ b/t/data/resource/jobspecs/basics/bad_res_type.yaml
@@ -1,0 +1,30 @@
+version: 9999
+resources:
+    - type: cluster
+      count: 1
+      with:
+        - type: rack
+          count: 1
+          with:
+            - type: node
+              count: 1
+              with:
+                  - type: slot
+                    count: 1
+                    label: default
+                    with:
+                      - type: invalid_res_type
+                        count: 1
+                        with:
+                          - type: core
+                            count: 1
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: [ "app" ]
+    slot: default
+    count:
+      per_slot: 1
+

--- a/t/t4001-match-allocate.t
+++ b/t/t4001-match-allocate.t
@@ -56,6 +56,11 @@ test_expect_success 'handling of a malformed jobspec works' '
     test_expect_code 2 flux ion-resource match allocate ${malform}
 '
 
+test_expect_success 'handling of an invalid resource type works' '
+    test_expect_code 1 flux ion-resource match allocate \
+        "${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/basics/bad_res_type.yaml"
+'
+
 test_expect_success 'invalid duration is caught' '
     test_must_fail flux ion-resource match allocate ${duration_too_large} &&
     test_must_fail flux ion-resource match allocate ${duration_negative}


### PR DESCRIPTION
I'm still debating this change to be honest.  The refcounted strings for resource types are showing up as a meaningful cost in comparisons and refcounting, it's not terrible but it's also not great.  This solves the issue by making it so that dense storage interners have a notion of being "final" or placed in a state where new strings can't be added anymore. It also adds an interface to "open" a finalized interner for updates, on a per-thread basis, so that we can do things like database updates. To my surprise, this passed all but one of our tests without re-opening the interners, and that last one by re-opening them in update_resource.

The upside is that after this change, and without using it to optimize any of the type maps or anything like that, we get another 20-30% improvement in throughput for some of my tests.  I've seen as much as 250 jobs/s.  The downside is that the interface is a little bit odd for this, and at the moment the only way we have to signal the thing is closed is to throw an exception.  Given that the only source of new resource types after init should be jobspec though, which already throws exceptions for any parse errors (which is basically what this would be, if the resource type doesn't exist it can't match) I'm not sure how bad that is. Would love input on this.  Might be easier to use if it worked with a lock/unlock pair so lock_guard would work, not sure.

I _think_ this
fixes #1298