### PR TITLE
matrix: add el8 tag and make it test-install

### DIFF
--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -265,13 +265,15 @@ matrix.add_build(
 
 # RHEL8 clone
 matrix.add_build(
-    name="el8",
+    name="el8 - test-install",
     image="el8",
     env=dict(
+        TEST_INSTALL="t",
         # this is _required_ because of valgrind's new dependency on python3.11
         # which confuses rhel8 cmake's detection logic
-        PYTHON="/usr/bin/python3.6"
+        PYTHON="/usr/bin/python3.6",
     ),
+    docker_tag=True,
 )
 
 print(matrix)


### PR DESCRIPTION
problem: we're not hooking up to the el8 container from core properly

solution: tag the container after the test, and match the core container with test-install

This is meant to match with #flux-core/6401 and ensure we propagate the el8 container all the way through.