### PR TITLE
t: update job.exception output checks

### DIFF
--- a/t/t1006-qmanager-multiqueue.t
+++ b/t/t1006-qmanager-multiqueue.t
@@ -142,7 +142,7 @@ test_expect_success 'reconfigure with one queue and load qmanager' '
 '
 test_expect_success 'job submitted with no queue gets fatal exception' '
 	test_must_fail flux job attach $(cat noqueue.jobid) 2>noqueue.err &&
-	grep "job.exception type=alloc severity=0" noqueue.err
+	grep "job.exception" noqueue.err | grep "type=alloc severity=0"
 '
 test_expect_success 'unload qmanager' '
 	remove_qmanager
@@ -157,7 +157,7 @@ test_expect_success 'deconfigure queues and load qmanager' '
 '
 test_expect_success 'job submitted with queue gets fatal exception' '
 	test_must_fail flux job attach $(cat withqueue.jobid) 2>foo.err &&
-	grep "job.exception type=alloc severity=0 queue" foo.err
+	grep "job.exception" foo.err | grep "type=alloc severity=0 queue"
 '
 
 test_expect_success 'cleanup active jobs' '

--- a/t/t1024-alloc-check.t
+++ b/t/t1024-alloc-check.t
@@ -41,10 +41,10 @@ test_expect_success 'submit node-exclusive jobs that exceed their time limit' '
 	done) 2>joberr
 '
 test_expect_success 'some jobs received timeout exception' '
-	grep "job.exception type=timeout" joberr
+	grep "job.exception" joberr | grep "type=timeout"
 '
 test_expect_success 'no jobs received alloc-check exception' '
-	test_must_fail grep "job.exception type=alloc-check" joberr
+	test_must_fail grep "job.exception.*type=alloc-check" joberr
 '
 test_expect_success 'clean up' '
 	flux cancel --all &&
@@ -57,10 +57,10 @@ test_expect_success 'submit non-exclusive jobs that exceed their time limit' '
 	done) 2>joberr2
 '
 test_expect_success 'some jobs received timeout exception' '
-	grep "job.exception type=timeout" joberr2
+	grep "job.exception" joberr2 | grep "type=timeout"
 '
 test_expect_success 'no jobs received alloc-check exception' '
-	test_must_fail grep "job.exception type=alloc-check" joberr2
+	test_must_fail grep "job.exception.*type=alloc-check" joberr2
 '
 test_expect_success 'clean up' '
 	flux cancel --all &&


### PR DESCRIPTION
Problem: In the near future, the job.exception output in flux-core will change, resulting in failures in tests that expect a specific format.

Update the job.exception parsing in t1006-qmanager-multiqueue.t and t1024-alloc-check.t to be more flexible to future output changes.

----

in preparation for change in https://github.com/flux-framework/flux-core/pull/6453