### PR TITLE
qmanager: send partial-ok with sched.hello

### DIFF
--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -551,9 +551,14 @@ static std::shared_ptr<qmanager_ctx_t> qmanager_new (flux_t *h)
             ctx = nullptr;
             goto done;
         }
+        int schedutil_flags = 0;
+#ifdef SCHEDUTIL_HELLO_PARTIAL_OK
+        // flag was added in flux-core 0.70.0
+        schedutil_flags |= SCHEDUTIL_HELLO_PARTIAL_OK;
+#endif
         if (!(ctx->schedutil =
                   schedutil_create (ctx->h,
-                                    0,
+                                    schedutil_flags,
                                     &ops,
                                     std::static_pointer_cast<qmanager_cb_ctx_t> (ctx).get ()))) {
             flux_log_error (ctx->h, "%s: schedutil_create", __FUNCTION__);

--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -553,7 +553,7 @@ static std::shared_ptr<qmanager_ctx_t> qmanager_new (flux_t *h)
         }
         if (!(ctx->schedutil =
                   schedutil_create (ctx->h,
-                                    SCHEDUTIL_FREE_NOLOOKUP,
+                                    0,
                                     &ops,
                                     std::static_pointer_cast<qmanager_cb_ctx_t> (ctx).get ()))) {
             flux_log_error (ctx->h, "%s: schedutil_create", __FUNCTION__);

--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -280,7 +280,6 @@ out:
 
 static void status_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_t *msg, void *arg)
 {
-    size_t len = 0;
     const char *payload;
     flux_future_t *f = NULL;
 
@@ -288,12 +287,12 @@ static void status_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_
         flux_log_error (h, "%s: flux_rpc (sched-fluxion-resource.status)", __FUNCTION__);
         goto out;
     }
-    if (flux_rpc_get_raw (f, (const void **)&payload, &len) < 0) {
-        flux_log_error (h, "%s: flux_rpc_get_raw", __FUNCTION__);
+    if (flux_rpc_get (f, &payload) < 0) {
+        flux_log_error (h, "%s: flux_rpc_get", __FUNCTION__);
         goto out;
     }
-    if (flux_respond_raw (h, msg, (const void *)payload, len) < 0) {
-        flux_log_error (h, "%s: flux_respond_raw", __FUNCTION__);
+    if (flux_respond (h, msg, payload) < 0) {
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
         goto out;
     }
     flux_future_destroy (f);
@@ -310,25 +309,19 @@ static void feasibility_request_cb (flux_t *h,
                                     const flux_msg_t *msg,
                                     void *arg)
 {
-    size_t size = 0;
     flux_future_t *f = nullptr;
     const char *data = nullptr;
 
-    if (flux_request_decode_raw (msg, nullptr, (const void **)&data, &size) < 0)
+    if (flux_request_decode (msg, nullptr, &data) < 0)
         goto error;
-    if (!(f = flux_rpc_raw (h,
-                            "sched-fluxion-resource.satisfiability",
-                            data,
-                            size,
-                            FLUX_NODEID_ANY,
-                            0))) {
+    if (!(f = flux_rpc (h, "sched-fluxion-resource.satisfiability", data, FLUX_NODEID_ANY, 0))) {
         flux_log_error (h, "%s: flux_rpc (sched-fluxion-resource.satisfiability)", __FUNCTION__);
         goto error;
     }
-    if (flux_rpc_get_raw (f, (const void **)&data, &size) < 0)
+    if (flux_rpc_get (f, &data) < 0)
         goto error;
-    if (flux_respond_raw (h, msg, (const void *)data, size) < 0) {
-        flux_log_error (h, "%s: flux_respond_raw", __FUNCTION__);
+    if (flux_respond (h, msg, data) < 0) {
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
         goto error;
     }
     flux_log (h, LOG_DEBUG, "%s: feasibility succeeded", __FUNCTION__);

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -1559,7 +1559,8 @@ static int parse_R (std::shared_ptr<resource_ctx_t> &ctx,
         flux_log (ctx->h, LOG_ERR, "%s: json_unpack: %s", __FUNCTION__, error.text);
         goto freemem_out;
     }
-    if (version != 1 || tstart < 0 || expiration < tstart) {
+    if (version != 1 || tstart < 0 || expiration < tstart
+        || expiration > static_cast<double> (std::numeric_limits<int64_t>::max ())) {
         rc = -1;
         errno = EPROTO;
         flux_log (ctx->h,

--- a/resource/readers/resource_reader_jgf.hpp
+++ b/resource/readers/resource_reader_jgf.hpp
@@ -34,7 +34,11 @@ struct jgf_updater_data {
     // track count of rank vertices to determine if rank
     // should be removed from by_rank map
     std::unordered_set<int64_t> ranks;
-    bool update = true;  // Updating or partial cancel
+    // track vertices that are skipped because their ranks are freed
+    std::unordered_set<int64_t> skip_vertices;
+    bool update = true;        // Updating or partial cancel
+    bool isect_ranks = false;  // Updating with partial_ok; intersecting with ranks key
+    bool skipped = false;
 };
 
 /*! JGF resource reader class.
@@ -123,7 +127,11 @@ class resource_reader_jgf_t : public resource_reader_base_t {
     virtual bool is_allowlist_supported ();
 
    private:
-    int fetch_jgf (const std::string &str, json_t **jgf_p, json_t **nodes_p, json_t **edges_p);
+    int fetch_jgf (const std::string &str,
+                   json_t **jgf_p,
+                   json_t **nodes_p,
+                   json_t **edges_p,
+                   jgf_updater_data &update_data);
     int unpack_and_remap_vtx (fetch_helper_t &f, json_t *paths, json_t *properties);
     int remap_aware_unpack_vtx (fetch_helper_t &f, json_t *paths, json_t *properties);
     int apply_defaults (fetch_helper_t &f, const char *name);
@@ -192,7 +200,8 @@ class resource_reader_jgf_t : public resource_reader_base_t {
                      std::map<std::string, vmap_val_t> &vmap,
                      std::string &source,
                      std::string &target,
-                     std::string &subsystem);
+                     std::string &subsystem,
+                     jgf_updater_data &update_data);
     int update_src_edge (resource_graph_t &g,
                          resource_graph_metadata_t &m,
                          std::map<std::string, vmap_val_t> &vmap,
@@ -213,7 +222,8 @@ class resource_reader_jgf_t : public resource_reader_base_t {
                       resource_graph_metadata_t &m,
                       std::map<std::string, vmap_val_t> &vmap,
                       json_t *edges,
-                      uint64_t token);
+                      uint64_t token,
+                      jgf_updater_data &update_data);
     int get_subgraph_vertices (resource_graph_t &g, vtx_t node, std::vector<vtx_t> &node_list);
     int get_parent_vtx (resource_graph_t &g, vtx_t node, vtx_t &parent_node);
 };

--- a/t/t1026-rv1-partial-release.t
+++ b/t/t1026-rv1-partial-release.t
@@ -30,24 +30,44 @@ hk_wait_for_running () {
                 sleep 0.1
         done
 }
-
-fluxion_free_cores() {
+# Usage: hk_wait_for_allocated_nnodes count
+hk_wait_for_allocated_nnodes () {
+        count=0
+        while test $(flux housekeeping list -no {allocated.nnodes}) -ne $1; do
+                count=$(($count+1));
+                test $count -eq 300 && return 1 # max 300 * 0.1s sleep = 30s
+                sleep 0.1
+        done
+}
+# Usage: fluxion_free ncores|nnodes
+fluxion_free () {
 	FLUX_RESOURCE_LIST_RPC=sched.resource-status \
-		flux resource list -s free -no {ncores}
+		flux resource list -s free -no {$1}
+}
+# Usage: fluxion_allocated ncores|nnodes
+fluxion_allocated () {
+	FLUX_RESOURCE_LIST_RPC=sched.resource-status \
+		flux resource list -s allocated -no {$1}
 }
 
 
 test_expect_success 'load fluxion modules' '
 	flux module remove -f sched-simple &&
-	flux module load sched-fluxion-resource &&
-	flux module load sched-fluxion-qmanager &&
+	load_resource match-format=rv1_nosched &&
+	load_qmanager_sync &&
 	flux resource list &&
 	FLUX_RESOURCE_LIST_RPC=sched.resource-status flux resource list
 '
+
+# Check job manager hello debug message for +partial-ok flag
+if flux dmesg | grep +partial-ok; then
+    test_set_prereq HAVE_PARTIAL_OK
+fi
+
 test_expect_success 'run a normal job, resources are free' '
 	flux run -vvv -xN4 /bin/true &&
-	test_debug "echo free=\$(fluxion_free_cores)" &&
-	test $(fluxion_free_cores) -eq $TOTAL_NCORES
+	test_debug "echo free=\$(fluxion_free ncores)" &&
+	test $(fluxion_free ncores) -eq $TOTAL_NCORES
 '
 test_expect_success 'run 4 single node jobs, resources are free' '
 	flux submit -v --cc=1-4 -xN1 --wait /bin/true &&
@@ -56,8 +76,8 @@ test_expect_success 'run 4 single node jobs, resources are free' '
 '
 test_expect_success 'run 16 single core jobs, resources are free' '
 	flux submit -v --cc=1-16 -n1 --wait /bin/true &&
-	test_debug "echo free=\$(fluxion_free_cores)" &&
-	test $(fluxion_free_cores) -eq $TOTAL_NCORES
+	test_debug "echo free=\$(fluxion_free ncores)" &&
+	test $(fluxion_free ncores) -eq $TOTAL_NCORES
 '
 test_expect_success 'clear dmesg buffer' '
 	flux dmesg -C
@@ -65,8 +85,8 @@ test_expect_success 'clear dmesg buffer' '
 test_expect_success 'run a job with unequal core distribution, resources are free' '
 	flux run -vvv -n7 -l flux getattr rank &&
 	test_debug "flux job info $(flux job last) R | jq" &&
-	test_debug "echo free=\$(fluxion_free_cores)" &&
-	test $(fluxion_free_cores) -eq $TOTAL_NCORES
+	test_debug "echo free=\$(fluxion_free ncores)" &&
+	test $(fluxion_free ncores) -eq $TOTAL_NCORES
 '
 test_expect_success 'attempt to ensure dmesg buffer synchronized' '
 	flux logger test-sentinel &&
@@ -96,16 +116,91 @@ test_expect_success 'attempt to ensure dmesg buffer synchronized' '
 	dmesg_wait test-sentinel
 '
 test_expect_success 'all resources free' '
-	test_debug "echo free=\$(fluxion_free_cores)" &&
-	test $(fluxion_free_cores) -eq $TOTAL_NCORES
+	test_debug "echo free=\$(fluxion_free ncores)" &&
+	test $(fluxion_free ncores) -eq $TOTAL_NCORES
 '
 test_expect_success 'no errors from fluxion' '
 	flux dmesg -H >log2.out &&
 	test_must_fail grep "free RPC failed to remove all resources" log.out
 '
+test_expect_success HAVE_PARTIAL_OK 'reconfigure housekeeping with sticky node' '
+	flux config load <<-EOF
+	[job-manager.housekeeping]
+	command = [
+	    "sh",
+	    "-c",
+	    "test \$(flux getattr rank) -eq 0 && sleep inf; exit 0"
+	]
+	release-after = "0s"
+	EOF
+'
+test_expect_success HAVE_PARTIAL_OK 'run a job and wait for node to get stuck' '
+	flux run -N4 true &&
+	hk_wait_for_running 1 &&
+	hk_wait_for_allocated_nnodes 1
+'
+test_expect_success HAVE_PARTIAL_OK 'fluxion shows 1 node allocated' '
+	test $(fluxion_allocated nnodes) -eq 1
+'
+test_expect_success HAVE_PARTIAL_OK 'reload fluxion modules' '
+	remove_qmanager &&
+	reload_resource match-format=rv1_nosched &&
+	load_qmanager_sync &&
+	flux resource list &&
+	FLUX_RESOURCE_LIST_RPC=sched.resource-status flux resource list
+'
+test_expect_success HAVE_PARTIAL_OK 'fluxion still shows 1 node allocated' '
+	test $(fluxion_allocated nnodes) -eq 1
+'
+test_expect_success HAVE_PARTIAL_OK 'kill housekeeping' '
+	flux housekeeping kill --all
+'
+test_expect_success HAVE_PARTIAL_OK 'fluxion shows 0 nodes allocated' '
+	hk_wait_for_running 0 &&
+	test $(fluxion_allocated nnodes) -eq 0
+'
+test_expect_success HAVE_PARTIAL_OK 'reload fluxion modules with match-format=rv1' '
+	remove_qmanager &&
+	reload_resource match-format=rv1 &&
+	load_qmanager_sync &&
+	flux resource list &&
+	FLUX_RESOURCE_LIST_RPC=sched.resource-status flux resource list
+'
+test_expect_success HAVE_PARTIAL_OK 'run a job and wait for node to get stuck' '
+	flux run -N4 true &&
+	hk_wait_for_running 1 &&
+	hk_wait_for_allocated_nnodes 1
+'
+test_expect_success HAVE_PARTIAL_OK 'fluxion shows 1 nodes allocated' '
+	test $(fluxion_allocated nnodes) -eq 1
+'
+test_expect_success HAVE_PARTIAL_OK 'run a sleep job on one node' '
+	flux submit --wait-event=alloc -N1 sleep 3600
+'
+test_expect_success HAVE_PARTIAL_OK 'fluxion shows 2 nodes allocated' '
+	test $(fluxion_allocated nnodes) -eq 2
+'
+test_expect_success HAVE_PARTIAL_OK 'reload fluxion modules with match-format=rv1' '
+	remove_qmanager &&
+	reload_resource match-format=rv1 &&
+	load_qmanager_sync &&
+	flux resource list &&
+	FLUX_RESOURCE_LIST_RPC=sched.resource-status flux resource list
+'
+test_expect_success HAVE_PARTIAL_OK 'fluxion still shows 2 nodes allocated' '
+	test $(fluxion_allocated nnodes) -eq 2
+'
+test_expect_success HAVE_PARTIAL_OK 'kill housekeeping' '
+	flux housekeeping kill --all
+'
+test_expect_success HAVE_PARTIAL_OK 'fluxion shows 1 node allocated' '
+	hk_wait_for_running 0 &&
+	test $(fluxion_allocated nnodes) -eq 1
+'
+
 test_expect_success 'unload fluxion modules' '
-	flux module remove sched-fluxion-qmanager &&
-	flux module remove sched-fluxion-resource &&
+	remove_qmanager &&
+	remove_resource &&
 	flux module load sched-simple
 '
 test_done


### PR DESCRIPTION
This changes qmanager to invoke the `sched.hello` request with the flag that tells it to allow partial allocations through.  schedutil then diminishes _R_ in the hello responses by the `free` set (if present) before handing it to the hello callback in qmanager.   We were wondering if fluxion would perhaps just handle this.

flux-framework/flux-core#6445 must be merged before it can work with flux-core master, however, preliminary testing with that branch appears to show a problem.  The sharness test added here fails when I reload the scheduler with one node in housekeeping, and fluxion says:
```
Dec 17 00:52:30.860604 UTC sched-fluxion-resource.err[0]: parse_R: json_unpack
Dec 17 00:52:30.860614 UTC sched-fluxion-resource.err[0]: run_update: parsing R: Invalid argument
Dec 17 00:52:30.860616 UTC sched-fluxion-resource.err[0]: update_request_cb: update failed (id=46825209856): Invalid argument
Dec 17 00:52:30.860730 UTC sched-fluxion-qmanager.err[0]: jobmanager_hello_cb: reconstruct (id=46825209856 queue=default): Invalid argument
Dec 17 00:52:30.860842 UTC sched-fluxion-qmanager.err[0]: error raising fatal exception on f2ELnSXR: job is inactive: No such file or directory
```
So there is a little more work to do here to run that down.  Marking this as a WIP.