### PR TITLE
Find by jobid and output aggregate filter data

### DIFF
--- a/resource/evaluators/expr_eval_api.cpp
+++ b/resource/evaluators/expr_eval_api.cpp
@@ -309,13 +309,14 @@ int expr_eval_api_t::validate (const std::string &e, const expr_eval_target_base
 {
     int rc = -1;
     pred_op_t op;
-    std::size_t next, at;
+    std::size_t next, at, last_before_space;
 
     if ((rc = validate_paren (e, target, 0, next)) < 0)
         goto done;
     at = next;
 
-    while (at <= e.find_last_not_of (" \t")) {
+    last_before_space = e.find_last_not_of (" \t");
+    while (at <= last_before_space) {
         if ((op = parse_pred_op (e, at, next)) == pred_op_t::UNKNOWN) {
             rc = -1;
             goto done;
@@ -339,14 +340,15 @@ int expr_eval_api_t::evaluate (const std::string &e,
 {
     int rc = -1;
     pred_op_t op;
-    std::size_t next, at;
+    std::size_t next, at, last_before_space;
     bool result1, result2;
 
     if ((rc = evaluate_paren (e, target, 0, next, result1)) < 0)
         goto done;
     at = next;
 
-    while (at <= e.find_last_not_of (" \t")) {
+    last_before_space = e.find_last_not_of (" \t");
+    while (at <= last_before_space) {
         if ((op = parse_pred_op (e, at, next)) == pred_op_t::UNKNOWN) {
             rc = -1;
             goto done;

--- a/resource/evaluators/expr_eval_api.hpp
+++ b/resource/evaluators/expr_eval_api.hpp
@@ -12,6 +12,7 @@
 #define EXPR_EVAL_API_HPP
 
 #include <string>
+#include <vector>
 #include "resource/evaluators/expr_eval_target.hpp"
 
 namespace Flux {
@@ -47,6 +48,19 @@ class expr_eval_api_t {
      */
     int evaluate (const std::string &expr, const expr_eval_target_base_t &target, bool &result);
 
+    /*! Extract jobid and agfilter bool if provided.
+     *
+     *  \param expr      expression string
+     *  \param target    expression evaluation target
+     *  \param jobid     jobid optionally specified in expression
+     *  \param agfilter  bool optionally specified in expression
+     *                   of expr_eval_target_base_t type
+     *  \return          0 on success; -1 on error
+     */
+    int extract (const std::string &expr,
+                 const expr_eval_target_base_t &target,
+                 std::vector<std::pair<std::string, std::string>> &predicates);
+
    private:
     enum class pred_op_t : int { AND = 0, OR = 1, UNKNOWN = 2 };
 
@@ -76,6 +90,15 @@ class expr_eval_api_t {
                         size_t &next,
                         bool &result);
     int evaluate_pred (pred_op_t op, bool result2, bool &result1) const;
+    /* Extract methods */
+    int extract_leaf (const std::string &expr,
+                      const expr_eval_target_base_t &target,
+                      std::vector<std::pair<std::string, std::string>> &predicates);
+    int extract_paren (const std::string &expr,
+                       const expr_eval_target_base_t &target,
+                       size_t at,
+                       size_t &next,
+                       std::vector<std::pair<std::string, std::string>> &predicates);
 };
 
 }  // namespace resource_model

--- a/resource/evaluators/expr_eval_target.hpp
+++ b/resource/evaluators/expr_eval_target.hpp
@@ -12,6 +12,7 @@
 #define EXPR_EVAL_TARGET_HPP
 
 #include <string>
+#include <vector>
 
 namespace Flux {
 namespace resource_model {
@@ -47,6 +48,19 @@ class expr_eval_target_base_t {
      *  \return          0 on success; -1 on error
      */
     virtual int evaluate (const std::string &p, const std::string &x, bool &result) const = 0;
+
+    /*! Extract jobid and agfilter bool if provided.
+     *
+     *  \param expr      expression string
+     *  \param target    expression evaluation target
+     *  \param jobid     jobid optionally specified in expression
+     *  \param agfilter  bool optionally specified in expression
+     *                   of expr_eval_target_base_t type
+     *  \return          0 on success; -1 on error
+     */
+    virtual int extract (const std::string &p,
+                         const std::string &x,
+                         std::vector<std::pair<std::string, std::string>> &predicates) const = 0;
 };
 
 }  // namespace resource_model

--- a/resource/evaluators/expr_eval_vtx_target.cpp
+++ b/resource/evaluators/expr_eval_vtx_target.cpp
@@ -130,6 +130,25 @@ done:
     return rc;
 }
 
+int expr_eval_vtx_target_t::extract (
+    const std::string &p,
+    const std::string &x,
+    std::vector<std::pair<std::string, std::string>> &predicates) const
+{
+    int rc = 0;
+    std::string lcx = x;
+
+    if (!m_initialized) {
+        errno = EINVAL;
+        rc = -1;
+        goto done;
+    }
+    std::transform (x.begin (), x.end (), lcx.begin (), ::tolower);
+    predicates.push_back ({p, lcx});
+done:
+    return rc;
+}
+
 void expr_eval_vtx_target_t::initialize (const vtx_predicates_override_t &p,
                                          const resource_graph_t *g,
                                          vtx_t u)

--- a/resource/evaluators/expr_eval_vtx_target.hpp
+++ b/resource/evaluators/expr_eval_vtx_target.hpp
@@ -13,6 +13,7 @@
 
 #include <string>
 #include <memory>
+#include <vector>
 #include "resource/schema/resource_graph.hpp"
 #include "resource/evaluators/expr_eval_target.hpp"
 
@@ -70,6 +71,20 @@ class expr_eval_vtx_target_t : public expr_eval_target_base_t {
      *  \return          0 on success; -1 on error
      */
     virtual int evaluate (const std::string &p, const std::string &x, bool &result) const;
+
+    /*! Extract jobid and agfilter bool if provided.
+     *
+     *  \param expr      expression string
+     *  \param target    expression evaluation target
+     *  \param jobid     jobid optionally specified in expression
+     *  \param agfilter  bool optionally specified in expression
+     *                   of expr_eval_target_base_t type
+     *  \return          0 on success; -1 on error
+     */
+    virtual int extract (
+        const std::string &p,
+        const std::string &x,
+        std::vector<std::pair<std::string, std::string>> &predicates) const override;
 
     /*! Initialize the object of this class with a resource vertex.
      *  This must be called before the validate and evaluate interfaces

--- a/resource/evaluators/test/expr_eval_test01.cpp
+++ b/resource/evaluators/test/expr_eval_test01.cpp
@@ -16,6 +16,7 @@ extern "C" {
 
 #include <vector>
 #include <iostream>
+#include <algorithm>
 #include "resource/evaluators/expr_eval_api.hpp"
 #include "resource/evaluators/expr_eval_target.hpp"
 #include "src/common/libtap/tap.h"
@@ -25,19 +26,34 @@ using namespace Flux::resource_model;
 
 class expr_eval_test_target_t : public expr_eval_target_base_t {
    public:
-    virtual int validate (const std::string &p, const std::string &x) const;
+    virtual int validate (const std::string &p, const std::string &x) const override;
 
-    virtual int evaluate (const std::string &p, const std::string &x, bool &result) const;
+    virtual int evaluate (const std::string &p, const std::string &x, bool &result) const override;
+
+    virtual int extract (
+        const std::string &p,
+        const std::string &x,
+        std::vector<std::pair<std::string, std::string>> &predicates) const override;
 };
 
 int expr_eval_test_target_t::validate (const std::string &p, const std::string &x) const
 {
-    if (p != "status" && p != "sched-now")
+    if (p != "status" && p != "sched-now" && p != "jobid-alloc" && p != "agfilter")
         return -1;
     if (p == "status" && (x != "up" && x != "down"))
         return -1;
     if (p == "sched-now" && (x != "allocated" && x != "free"))
         return -1;
+    if (p == "jobid-alloc") {
+        try {
+            std::stoul (x);
+        } catch (std::out_of_range) {
+            return -1;
+        }
+    }
+    if (p == "agfilter" && (x != "true")) {
+        return -1;
+    }
     return 0;
 }
 
@@ -50,6 +66,19 @@ int expr_eval_test_target_t::evaluate (const std::string &p,
         return rc;
     result = true;
     return rc;
+}
+
+int expr_eval_test_target_t::extract (
+    const std::string &p,
+    const std::string &x,
+    std::vector<std::pair<std::string, std::string>> &predicates) const
+{
+    std::string lcx = x;
+    if (validate (p, x) < 0)
+        return -1;
+    std::transform (x.begin (), x.end (), lcx.begin (), ::tolower);
+    predicates.push_back ({p, lcx});
+    return 0;
 }
 
 void build_simple_expr (std::vector<std::string> &expr_vector)
@@ -79,6 +108,9 @@ void build_simple_expr (std::vector<std::string> &expr_vector)
     expr_vector.push_back ("sched-now=free status=down");
     expr_vector.push_back ("sched-now=free and status=down");
     expr_vector.push_back ("sched-now=free  or          status=down");
+    expr_vector.push_back ("agfilter=true");
+    expr_vector.push_back ("jobid-alloc=1");
+    expr_vector.push_back ("jobid-alloc=1 and agfilter=true");
 }
 
 void build_paren_expr (std::vector<std::string> &expr_vector)
@@ -121,6 +153,15 @@ void build_invalid_expr (std::vector<std::string> &expr_vector)
         "(sched-now=free)(status=down)");
     expr_vector.push_back ("(status=up and sched-now=allocated))");
     expr_vector.push_back ("(status=up and sched-now=allocated)))");
+    expr_vector.push_back ("jobid-alloc=18446744073709551616");
+}
+
+void build_extract_expr (std::vector<std::string> &expr_vector)
+{
+    expr_vector.push_back ("jobid-alloc=1");
+    expr_vector.push_back ("jobid-alloc=10");
+    expr_vector.push_back ("jobid-alloc=10 and agfilter=true");
+    expr_vector.push_back ("agfilter=true");
 }
 
 void test_validation (std::vector<std::string> &expr_vector,
@@ -159,12 +200,58 @@ void test_evaluation (std::vector<std::string> &expr_vector,
     }
 }
 
+void test_extraction (std::vector<std::string> &expr_vector,
+                      std::vector<unsigned long> &jobids,
+                      std::vector<bool> &agfilters,
+                      const std::string &label,
+                      bool must_success)
+{
+    int rc = 0;
+    int i = 0;
+    bool expected = false;
+    bool expected_jobid = false;
+    bool expected_agfilter = false;
+    bool agfilter = false;
+    unsigned long jobid = 0;
+    Flux::resource_model::expr_eval_api_t evaluator;
+    expr_eval_test_target_t expr_eval_test_target;
+
+    for (i = 0; i < expr_vector.size (); ++i) {
+        agfilter = false;
+        jobid = 0;
+        std::vector<std::pair<std::string, std::string>> predicates;
+        rc = evaluator.extract (expr_vector.at (i), expr_eval_test_target, predicates);
+        for (auto const &p : predicates) {
+            if (p.first == "jobid-alloc") {
+                jobid = std::stoul (p.second);
+            } else if (p.first == "agfilter") {
+                if (p.second == "true" || p.second == "t") {
+                    agfilter = true;
+                } else {
+                    agfilter = false;
+                }
+            }
+        }
+        expected = must_success ? rc == 0 : rc < 0;
+        expected_jobid = (jobids.at (i) == jobid);
+        expected_agfilter = (agfilters.at (i) == agfilter);
+
+        ok (expected && expected_jobid && expected_agfilter,
+            "%s: ^%s$",
+            label.c_str (),
+            expr_vector.at (i).c_str ());
+    }
+}
+
 int main (int argc, char *argv[])
 {
     size_t ntests = 0;
     std::vector<std::string> expr_vector1;
     std::vector<std::string> expr_vector2;
     std::vector<std::string> expr_vector3;
+    std::vector<std::string> expr_vector4;
+    std::vector<unsigned long> extr_vector_jobids{1, 10, 10, 0};
+    std::vector<bool> extr_vector_ag{false, false, true, true};
 
     build_simple_expr (expr_vector1);
 
@@ -172,10 +259,11 @@ int main (int argc, char *argv[])
 
     build_invalid_expr (expr_vector3);
 
-    ntests = expr_vector1.size () + expr_vector2.size () + expr_vector3.size ();
-    ;
+    build_extract_expr (expr_vector4);
 
-    plan (2 * ntests);
+    ntests = expr_vector1.size () + expr_vector2.size () + expr_vector3.size ();
+
+    plan (2 * ntests + expr_vector4.size ());
 
     test_validation (expr_vector1, "validates simple expr", true);
 
@@ -188,6 +276,12 @@ int main (int argc, char *argv[])
     test_validation (expr_vector3, "invalidates malformed expr", false);
 
     test_evaluation (expr_vector3, "expectedly evaluates malformed", false);
+
+    test_extraction (expr_vector4,
+                     extr_vector_jobids,
+                     extr_vector_ag,
+                     "extracts as expected",
+                     true);
 
     done_testing ();
 

--- a/resource/planner/c/planner_c_interface.cpp
+++ b/resource/planner/c/planner_c_interface.cpp
@@ -628,9 +628,8 @@ extern "C" int planner_reduce_span (planner_t *ctx,
         update_mintime_resource_tree (ctx, list);
         rc = 0;
     } else {
-        // Error
+        // Error; rc already -1
         errno = EINVAL;
-        rc - 1;
     }
 
     return rc;

--- a/resource/planner/c/planner_multi.h
+++ b/resource/planner/c/planner_multi.h
@@ -317,6 +317,16 @@ int planner_multi_reduce_span (planner_multi_t *ctx,
                                size_t len,
                                bool &removed);
 
+/*! Get the number of used resources of resource index i corresponding
+ *  to the provided span id.
+ *
+ *  \param ctx          opaque multi-planner context returned
+ *                      from planner_multi_new.
+ *  \param span_id      span_id returned from planner_add_span.
+ *  \param i            index of the resource type to queried
+ */
+int64_t planner_multi_span_planned_at (planner_multi_t *ctx, int64_t span_id, unsigned int i);
+
 //! Span iterators -- there is no specific iteration order
 //  return -1 when you no longer can iterate: EINVAL when ctx is NULL.
 //  ENOENT when you reached the end of the spans

--- a/resource/planner/c/planner_multi_c_interface.cpp
+++ b/resource/planner/c/planner_multi_c_interface.cpp
@@ -547,7 +547,24 @@ error:
     return rc;
 }
 
-int64_t planner_multi_span_first (planner_multi_t *ctx)
+extern "C" int64_t planner_multi_span_planned_at (planner_multi_t *ctx,
+                                                  int64_t span_id,
+                                                  unsigned int i)
+{
+    if (!ctx || span_id < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    auto span_it = ctx->plan_multi->get_span_lookup ().find (span_id);
+    if (span_it == ctx->plan_multi->get_span_lookup ().end ()) {
+        errno = ENOENT;
+        return -1;
+    }
+    return planner_span_resource_count (ctx->plan_multi->get_planner_at (i),
+                                        span_it->second.at (i));
+}
+
+extern "C" int64_t planner_multi_span_first (planner_multi_t *ctx)
 {
     int64_t rc = -1;
     std::map<uint64_t, std::vector<int64_t>>::iterator tmp_it =

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -800,6 +800,8 @@ int dfu_impl_t::dom_find_dfv (std::shared_ptr<match_writers_t> &w,
     bool reserved = !(*m_graph)[u].schedule.reservations.empty ();
     Flux::resource_model::vtx_predicates_override_t p_overridden = p;
     p_overridden.set (down, allocated, reserved);
+    std::map<std::string, std::string> agfilter_data;
+    planner_multi_t *filter_plan = NULL;
 
     (*m_graph)[u].idata.colors[dom] = m_color.gray ();
     m_trav_level++;
@@ -833,15 +835,44 @@ int dfu_impl_t::dom_find_dfv (std::shared_ptr<match_writers_t> &w,
     }
     if (agfilter) {
         // Check if there's a pruning (aggregate) filter initialized
-        if ((*m_graph)[u].idata.subplans[dom] == NULL)
+        if ((filter_plan = (*m_graph)[u].idata.subplans[dom]) == NULL)
             goto done;
+        if (jobid == 0) {  // jobid not specified; get totals
+            for (size_t i = 0; i < planner_multi_resources_len (filter_plan); ++i) {
+                int64_t total_resources = planner_multi_resource_total_at (filter_plan, i);
+                int64_t diff =
+                    total_resources - planner_multi_avail_resources_at (filter_plan, 0, i);
+                std::string rtype = std::string (planner_multi_resource_type_at (filter_plan, i));
+                std::string fcounts =
+                    "used:" + std::to_string (diff) + ", total:" + std::to_string (total_resources);
+                agfilter_data.insert ({rtype, fcounts});
+            }
+        } else {  // get agfilter utilization for specified jobid
+            auto &job2span = (*m_graph)[u].idata.job2span;
+            auto span_it = job2span.find (jobid);
+            if (span_it == (*m_graph)[u].idata.job2span.end ()) {
+                m_err_msg += __FUNCTION__;
+                m_err_msg += ": span missing in job2span ";
+                m_err_msg += " for vertex: " + (*m_graph)[u].name + "\n";
+                goto done;
+            }
+            for (size_t i = 0; i < planner_multi_resources_len (filter_plan); ++i) {
+                int64_t total_resources = planner_multi_resource_total_at (filter_plan, i);
+                int64_t planned_resources =
+                    planner_multi_span_planned_at (filter_plan, span_it->second, i);
+                std::string rtype = std::string (planner_multi_resource_type_at (filter_plan, i));
+                std::string fcounts = "used:" + std::to_string (planned_resources)
+                                      + ", total:" + std::to_string (total_resources);
+                agfilter_data.insert ({rtype, fcounts});
+            }
+        }
     }
 
     // Need to clear out any stale data from the ephemeral object before
     // emitting the vertex, since data could be leftover from previous
     // traversals where the vertex was matched but not emitted
     (*m_graph)[u].idata.ephemeral.check_and_clear_if_stale (m_best_k_cnt);
-    if ((rc = w->emit_vtx (level (), *m_graph, u, (*m_graph)[u].size, true)) < 0) {
+    if ((rc = w->emit_vtx (level (), *m_graph, u, (*m_graph)[u].size, agfilter_data, true)) < 0) {
         m_err_msg += __FUNCTION__;
         m_err_msg += std::string (": error from emit_vtx: ") + strerror (errno);
         goto done;
@@ -1198,6 +1229,7 @@ int dfu_impl_t::find (std::shared_ptr<match_writers_t> &writers, const std::stri
     vtx_predicates_override_t p_overridden;
     bool agfilter = false;
     uint64_t jobid = 0;
+    std::vector<std::pair<std::string, std::string>> predicates;
 
     if (!m_match || !m_graph || !m_graph_db || !writers) {
         errno = EINVAL;
@@ -1215,10 +1247,23 @@ int dfu_impl_t::find (std::shared_ptr<match_writers_t> &writers, const std::stri
         m_err_msg += ": invalid criteria: " + criteria + ".\n";
         goto done;
     }
-    if ((rc = m_expr_eval.extract (criteria, target, jobid, agfilter)) < 0) {
+    if ((rc = m_expr_eval.extract (criteria, target, predicates)) < 0) {
         m_err_msg += __FUNCTION__;
         m_err_msg += ": failed extraction.\n";
         goto done;
+    }
+    for (auto const &p : predicates) {
+        if (p.first == "jobid-alloc" || p.first == "jobid-span" || p.first == "jobid-tag"
+            || p.first == "jobid-reserved") {
+            // Don't need try; catch here since validate () succeeded
+            jobid = std::stoul (p.second);
+        } else if (p.first == "agfilter") {
+            if (p.second == "true" || p.second == "t") {
+                agfilter = true;
+            } else {
+                agfilter = false;
+            }
+        }
     }
 
     tick ();

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -465,7 +465,9 @@ class dfu_impl_t {
     int dom_find_dfv (std::shared_ptr<match_writers_t> &writers,
                       const std::string &criteria,
                       vtx_t u,
-                      const vtx_predicates_override_t &p);
+                      const vtx_predicates_override_t &p,
+                      const uint64_t jobid,
+                      const bool agfilter);
     int aux_find_upv (std::shared_ptr<match_writers_t> &writers,
                       const std::string &criteria,
                       vtx_t u,

--- a/resource/traversers/dfu_impl_update.cpp
+++ b/resource/traversers/dfu_impl_update.cpp
@@ -29,7 +29,8 @@ int dfu_impl_t::emit_vtx (vtx_t u,
                           unsigned int needs,
                           bool exclusive)
 {
-    return w->emit_vtx (level (), (*m_graph), u, needs, exclusive);
+    const std::map<std::string, std::string> agfilter_data;
+    return w->emit_vtx (level (), (*m_graph), u, needs, agfilter_data, exclusive);
 }
 
 int dfu_impl_t::emit_edg (edg_t e, std::shared_ptr<match_writers_t> &w)

--- a/resource/utilities/command.cpp
+++ b/resource/utilities/command.cpp
@@ -65,7 +65,9 @@ command_t commands[] =
       "f",
       cmd_find,
       "Find resources matched with criteria "
-      "(predicates: status={up|down} sched-now={allocated|free} sched-future={reserved|free}): "
+      "(predicates: status={up|down} sched-now={allocated|free} sched-future={reserved|free} "
+      "agfilter={true|false} jobid-alloc=jobid jobid-span=jobid jobid-tag=jobid "
+      "jobid-reserved=jobid): "
       "resource-query> find status=down and sched-now=allocated"},
      {"cancel",
       "c",

--- a/resource/writers/match_writers.cpp
+++ b/resource/writers/match_writers.cpp
@@ -140,6 +140,7 @@ int sim_match_writers_t::emit_vtx (const std::string &prefix,
                                    const resource_graph_t &g,
                                    const vtx_t &u,
                                    unsigned int needs,
+                                   const std::map<std::string, std::string> &agfilter_data,
                                    bool exclusive)
 {
     std::string mode = (exclusive) ? "x" : "s";
@@ -251,6 +252,7 @@ int jgf_match_writers_t::emit_vtx (const std::string &prefix,
                                    const resource_graph_t &g,
                                    const vtx_t &u,
                                    unsigned int needs,
+                                   const std::map<std::string, std::string> &agfilter_data,
                                    bool exclusive)
 {
     int rc = 0;
@@ -279,6 +281,12 @@ int jgf_match_writers_t::emit_vtx (const std::string &prefix,
     if ((rc = map2json (b, eph_map, "ephemeral") < 0)) {
         json_decref (b);
         goto out;
+    }
+    if (!agfilter_data.empty ()) {
+        if ((rc = map2json (b, agfilter_data, "agfilter") < 0)) {
+            json_decref (b);
+            goto out;
+        }
     }
     if ((o = json_pack ("{s:s s:o}", "id", std::to_string (g[u].uniq_id).c_str (), "metadata", b))
         == NULL) {
@@ -611,6 +619,7 @@ int rlite_match_writers_t::emit_vtx (const std::string &prefix,
                                      const resource_graph_t &g,
                                      const vtx_t &u,
                                      unsigned int needs,
+                                     const std::map<std::string, std::string> &agfilter_data,
                                      bool exclusive)
 {
     int rc = 0;
@@ -1009,11 +1018,12 @@ int rv1_match_writers_t::emit_vtx (const std::string &prefix,
                                    const resource_graph_t &g,
                                    const vtx_t &u,
                                    unsigned int needs,
+                                   const std::map<std::string, std::string> &agfilter_data,
                                    bool exclusive)
 {
     int rc = 0;
-    if ((rc = rlite.emit_vtx (prefix, g, u, needs, exclusive)) == 0)
-        rc = jgf.emit_vtx (prefix, g, u, needs, exclusive);
+    if ((rc = rlite.emit_vtx (prefix, g, u, needs, agfilter_data, exclusive)) == 0)
+        rc = jgf.emit_vtx (prefix, g, u, needs, agfilter_data, exclusive);
     return rc;
 }
 
@@ -1136,9 +1146,10 @@ int rv1_nosched_match_writers_t::emit_vtx (const std::string &prefix,
                                            const resource_graph_t &g,
                                            const vtx_t &u,
                                            unsigned int needs,
+                                           const std::map<std::string, std::string> &agfilter_data,
                                            bool exclusive)
 {
-    return rlite.emit_vtx (prefix, g, u, needs, exclusive);
+    return rlite.emit_vtx (prefix, g, u, needs, agfilter_data, exclusive);
 }
 
 int rv1_nosched_match_writers_t::emit_tm (uint64_t start_tm, uint64_t end_tm)
@@ -1194,6 +1205,7 @@ int pretty_sim_match_writers_t::emit_vtx (const std::string &prefix,
                                           const resource_graph_t &g,
                                           const vtx_t &u,
                                           unsigned int needs,
+                                          const std::map<std::string, std::string> &agfilter_data,
                                           bool exclusive)
 {
     std::stringstream out;

--- a/resource/writers/match_writers.hpp
+++ b/resource/writers/match_writers.hpp
@@ -39,6 +39,7 @@ class match_writers_t {
                           const resource_graph_t &g,
                           const vtx_t &u,
                           unsigned int needs,
+                          const std::map<std::string, std::string> &agfilter_data,
                           bool exclusive) = 0;
     virtual int emit_edg (const std::string &prefix, const resource_graph_t &g, const edg_t &e)
     {
@@ -72,7 +73,8 @@ class sim_match_writers_t : public match_writers_t {
                           const resource_graph_t &g,
                           const vtx_t &u,
                           unsigned int needs,
-                          bool exclusive);
+                          const std::map<std::string, std::string> &agfilter_data,
+                          bool exclusive) override;
 
    private:
     std::stringstream m_out;
@@ -102,7 +104,8 @@ class jgf_match_writers_t : public match_writers_t {
                           const resource_graph_t &g,
                           const vtx_t &u,
                           unsigned int needs,
-                          bool exclusive);
+                          const std::map<std::string, std::string> &agfilter_data,
+                          bool exclusive) override;
     virtual int emit_edg (const std::string &prefix, const resource_graph_t &g, const edg_t &e);
 
    private:
@@ -180,7 +183,8 @@ class rlite_match_writers_t : public match_writers_t {
                           const resource_graph_t &g,
                           const vtx_t &u,
                           unsigned int needs,
-                          bool exclusive);
+                          const std::map<std::string, std::string> &agfilter_data,
+                          bool exclusive) override;
 
    private:
     class rank_host_t {
@@ -211,7 +215,8 @@ class rv1_match_writers_t : public match_writers_t {
                           const resource_graph_t &g,
                           const vtx_t &u,
                           unsigned int needs,
-                          bool exclusive);
+                          const std::map<std::string, std::string> &agfilter_data,
+                          bool exclusive) override;
     virtual int emit_edg (const std::string &prefix, const resource_graph_t &g, const edg_t &e);
     virtual int emit_tm (uint64_t start_tm, uint64_t end_tm);
     virtual int emit_attrs (const std::string &k, const std::string &v);
@@ -237,7 +242,8 @@ class rv1_nosched_match_writers_t : public match_writers_t {
                           const resource_graph_t &g,
                           const vtx_t &u,
                           unsigned int needs,
-                          bool exclusive);
+                          const std::map<std::string, std::string> &agfilter_data,
+                          bool exclusive) override;
     virtual int emit_tm (uint64_t start_tm, uint64_t end_tm);
 
    private:
@@ -257,7 +263,8 @@ class pretty_sim_match_writers_t : public match_writers_t {
                           const resource_graph_t &g,
                           const vtx_t &u,
                           unsigned int needs,
-                          bool exclusive);
+                          const std::map<std::string, std::string> &agfilter_data,
+                          bool exclusive) override;
 
    private:
     std::list<std::string> m_out;

--- a/t/data/resource/expected/find-format/jgf.expected.agfilter.json
+++ b/t/data/resource/expected/find-format/jgf.expected.agfilter.json
@@ -1,0 +1,41 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "1",
+        "metadata": {
+          "type": "node",
+          "basename": "cab",
+          "id": 1234,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234"
+          },
+          "agfilter": {
+            "core": "used:0, total:16"
+          }
+        }
+      },
+      {
+        "id": "0",
+        "metadata": {
+          "type": "cluster",
+          "id": 0,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0"
+          },
+          "agfilter": {
+            "core": "used:0, total:16"
+          }
+        }
+      }
+    ],
+    "edges": [
+      {
+        "source": "0",
+        "target": "1"
+      }
+    ]
+  }
+}

--- a/t/data/resource/expected/find-format/jgf.expected.jobid.alloc.agfilter.json
+++ b/t/data/resource/expected/find-format/jgf.expected.jobid.alloc.agfilter.json
@@ -1,0 +1,41 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "1",
+        "metadata": {
+          "type": "node",
+          "basename": "cab",
+          "id": 1234,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234"
+          },
+          "agfilter": {
+            "core": "used:16, total:16"
+          }
+        }
+      },
+      {
+        "id": "0",
+        "metadata": {
+          "type": "cluster",
+          "id": 0,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0"
+          },
+          "agfilter": {
+            "core": "used:16, total:16"
+          }
+        }
+      }
+    ],
+    "edges": [
+      {
+        "source": "0",
+        "target": "1"
+      }
+    ]
+  }
+}

--- a/t/data/resource/expected/find-format/jgf.expected.jobid.alloc.json
+++ b/t/data/resource/expected/find-format/jgf.expected.jobid.alloc.json
@@ -1,0 +1,275 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "2",
+        "metadata": {
+          "type": "core",
+          "id": 0,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core0"
+          }
+        }
+      },
+      {
+        "id": "3",
+        "metadata": {
+          "type": "core",
+          "id": 1,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core1"
+          }
+        }
+      },
+      {
+        "id": "4",
+        "metadata": {
+          "type": "core",
+          "id": 2,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core2"
+          }
+        }
+      },
+      {
+        "id": "5",
+        "metadata": {
+          "type": "core",
+          "id": 3,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core3"
+          }
+        }
+      },
+      {
+        "id": "6",
+        "metadata": {
+          "type": "core",
+          "id": 4,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core4"
+          }
+        }
+      },
+      {
+        "id": "7",
+        "metadata": {
+          "type": "core",
+          "id": 5,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core5"
+          }
+        }
+      },
+      {
+        "id": "8",
+        "metadata": {
+          "type": "core",
+          "id": 6,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core6"
+          }
+        }
+      },
+      {
+        "id": "9",
+        "metadata": {
+          "type": "core",
+          "id": 7,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core7"
+          }
+        }
+      },
+      {
+        "id": "10",
+        "metadata": {
+          "type": "core",
+          "id": 8,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core8"
+          }
+        }
+      },
+      {
+        "id": "11",
+        "metadata": {
+          "type": "core",
+          "id": 9,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core9"
+          }
+        }
+      },
+      {
+        "id": "12",
+        "metadata": {
+          "type": "core",
+          "id": 10,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core10"
+          }
+        }
+      },
+      {
+        "id": "13",
+        "metadata": {
+          "type": "core",
+          "id": 11,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core11"
+          }
+        }
+      },
+      {
+        "id": "14",
+        "metadata": {
+          "type": "core",
+          "id": 12,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core12"
+          }
+        }
+      },
+      {
+        "id": "15",
+        "metadata": {
+          "type": "core",
+          "id": 13,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core13"
+          }
+        }
+      },
+      {
+        "id": "16",
+        "metadata": {
+          "type": "core",
+          "id": 14,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core14"
+          }
+        }
+      },
+      {
+        "id": "17",
+        "metadata": {
+          "type": "core",
+          "id": 15,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core15"
+          }
+        }
+      },
+      {
+        "id": "1",
+        "metadata": {
+          "type": "node",
+          "basename": "cab",
+          "id": 1234,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234"
+          }
+        }
+      },
+      {
+        "id": "0",
+        "metadata": {
+          "type": "cluster",
+          "id": 0,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0"
+          }
+        }
+      }
+    ],
+    "edges": [
+      {
+        "source": "1",
+        "target": "2"
+      },
+      {
+        "source": "1",
+        "target": "3"
+      },
+      {
+        "source": "1",
+        "target": "4"
+      },
+      {
+        "source": "1",
+        "target": "5"
+      },
+      {
+        "source": "1",
+        "target": "6"
+      },
+      {
+        "source": "1",
+        "target": "7"
+      },
+      {
+        "source": "1",
+        "target": "8"
+      },
+      {
+        "source": "1",
+        "target": "9"
+      },
+      {
+        "source": "1",
+        "target": "10"
+      },
+      {
+        "source": "1",
+        "target": "11"
+      },
+      {
+        "source": "1",
+        "target": "12"
+      },
+      {
+        "source": "1",
+        "target": "13"
+      },
+      {
+        "source": "1",
+        "target": "14"
+      },
+      {
+        "source": "1",
+        "target": "15"
+      },
+      {
+        "source": "1",
+        "target": "16"
+      },
+      {
+        "source": "1",
+        "target": "17"
+      },
+      {
+        "source": "0",
+        "target": "1"
+      }
+    ]
+  }
+}

--- a/t/data/resource/expected/find-format/jgf.expected.jobid.rsv.json
+++ b/t/data/resource/expected/find-format/jgf.expected.jobid.rsv.json
@@ -1,0 +1,275 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "2",
+        "metadata": {
+          "type": "core",
+          "id": 0,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core0"
+          }
+        }
+      },
+      {
+        "id": "3",
+        "metadata": {
+          "type": "core",
+          "id": 1,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core1"
+          }
+        }
+      },
+      {
+        "id": "4",
+        "metadata": {
+          "type": "core",
+          "id": 2,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core2"
+          }
+        }
+      },
+      {
+        "id": "5",
+        "metadata": {
+          "type": "core",
+          "id": 3,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core3"
+          }
+        }
+      },
+      {
+        "id": "6",
+        "metadata": {
+          "type": "core",
+          "id": 4,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core4"
+          }
+        }
+      },
+      {
+        "id": "7",
+        "metadata": {
+          "type": "core",
+          "id": 5,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core5"
+          }
+        }
+      },
+      {
+        "id": "8",
+        "metadata": {
+          "type": "core",
+          "id": 6,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core6"
+          }
+        }
+      },
+      {
+        "id": "9",
+        "metadata": {
+          "type": "core",
+          "id": 7,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core7"
+          }
+        }
+      },
+      {
+        "id": "10",
+        "metadata": {
+          "type": "core",
+          "id": 8,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core8"
+          }
+        }
+      },
+      {
+        "id": "11",
+        "metadata": {
+          "type": "core",
+          "id": 9,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core9"
+          }
+        }
+      },
+      {
+        "id": "12",
+        "metadata": {
+          "type": "core",
+          "id": 10,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core10"
+          }
+        }
+      },
+      {
+        "id": "13",
+        "metadata": {
+          "type": "core",
+          "id": 11,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core11"
+          }
+        }
+      },
+      {
+        "id": "14",
+        "metadata": {
+          "type": "core",
+          "id": 12,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core12"
+          }
+        }
+      },
+      {
+        "id": "15",
+        "metadata": {
+          "type": "core",
+          "id": 13,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core13"
+          }
+        }
+      },
+      {
+        "id": "16",
+        "metadata": {
+          "type": "core",
+          "id": 14,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core14"
+          }
+        }
+      },
+      {
+        "id": "17",
+        "metadata": {
+          "type": "core",
+          "id": 15,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core15"
+          }
+        }
+      },
+      {
+        "id": "1",
+        "metadata": {
+          "type": "node",
+          "basename": "cab",
+          "id": 1234,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234"
+          }
+        }
+      },
+      {
+        "id": "0",
+        "metadata": {
+          "type": "cluster",
+          "id": 0,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0"
+          }
+        }
+      }
+    ],
+    "edges": [
+      {
+        "source": "1",
+        "target": "2"
+      },
+      {
+        "source": "1",
+        "target": "3"
+      },
+      {
+        "source": "1",
+        "target": "4"
+      },
+      {
+        "source": "1",
+        "target": "5"
+      },
+      {
+        "source": "1",
+        "target": "6"
+      },
+      {
+        "source": "1",
+        "target": "7"
+      },
+      {
+        "source": "1",
+        "target": "8"
+      },
+      {
+        "source": "1",
+        "target": "9"
+      },
+      {
+        "source": "1",
+        "target": "10"
+      },
+      {
+        "source": "1",
+        "target": "11"
+      },
+      {
+        "source": "1",
+        "target": "12"
+      },
+      {
+        "source": "1",
+        "target": "13"
+      },
+      {
+        "source": "1",
+        "target": "14"
+      },
+      {
+        "source": "1",
+        "target": "15"
+      },
+      {
+        "source": "1",
+        "target": "16"
+      },
+      {
+        "source": "1",
+        "target": "17"
+      },
+      {
+        "source": "0",
+        "target": "1"
+      }
+    ]
+  }
+}

--- a/t/data/resource/expected/find-format/jgf.expected.jobid.span.agfilter.json
+++ b/t/data/resource/expected/find-format/jgf.expected.jobid.span.agfilter.json
@@ -1,0 +1,41 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "1",
+        "metadata": {
+          "type": "node",
+          "basename": "cab",
+          "id": 1234,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234"
+          },
+          "agfilter": {
+            "core": "used:16, total:16"
+          }
+        }
+      },
+      {
+        "id": "0",
+        "metadata": {
+          "type": "cluster",
+          "id": 0,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0"
+          },
+          "agfilter": {
+            "core": "used:16, total:16"
+          }
+        }
+      }
+    ],
+    "edges": [
+      {
+        "source": "0",
+        "target": "1"
+      }
+    ]
+  }
+}

--- a/t/data/resource/expected/find-format/jgf.expected.jobid.span.json
+++ b/t/data/resource/expected/find-format/jgf.expected.jobid.span.json
@@ -1,0 +1,35 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "1",
+        "metadata": {
+          "type": "node",
+          "basename": "cab",
+          "id": 1234,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234"
+          }
+        }
+      },
+      {
+        "id": "0",
+        "metadata": {
+          "type": "cluster",
+          "id": 0,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0"
+          }
+        }
+      }
+    ],
+    "edges": [
+      {
+        "source": "0",
+        "target": "1"
+      }
+    ]
+  }
+}

--- a/t/data/resource/expected/find-format/jgf.expected.jobid.tag.agfilter.json
+++ b/t/data/resource/expected/find-format/jgf.expected.jobid.tag.agfilter.json
@@ -1,0 +1,41 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "1",
+        "metadata": {
+          "type": "node",
+          "basename": "cab",
+          "id": 1234,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234"
+          },
+          "agfilter": {
+            "core": "used:16, total:16"
+          }
+        }
+      },
+      {
+        "id": "0",
+        "metadata": {
+          "type": "cluster",
+          "id": 0,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0"
+          },
+          "agfilter": {
+            "core": "used:16, total:16"
+          }
+        }
+      }
+    ],
+    "edges": [
+      {
+        "source": "0",
+        "target": "1"
+      }
+    ]
+  }
+}

--- a/t/data/resource/expected/find-format/jgf.expected.jobid.tag.json
+++ b/t/data/resource/expected/find-format/jgf.expected.jobid.tag.json
@@ -1,0 +1,275 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "2",
+        "metadata": {
+          "type": "core",
+          "id": 0,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core0"
+          }
+        }
+      },
+      {
+        "id": "3",
+        "metadata": {
+          "type": "core",
+          "id": 1,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core1"
+          }
+        }
+      },
+      {
+        "id": "4",
+        "metadata": {
+          "type": "core",
+          "id": 2,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core2"
+          }
+        }
+      },
+      {
+        "id": "5",
+        "metadata": {
+          "type": "core",
+          "id": 3,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core3"
+          }
+        }
+      },
+      {
+        "id": "6",
+        "metadata": {
+          "type": "core",
+          "id": 4,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core4"
+          }
+        }
+      },
+      {
+        "id": "7",
+        "metadata": {
+          "type": "core",
+          "id": 5,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core5"
+          }
+        }
+      },
+      {
+        "id": "8",
+        "metadata": {
+          "type": "core",
+          "id": 6,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core6"
+          }
+        }
+      },
+      {
+        "id": "9",
+        "metadata": {
+          "type": "core",
+          "id": 7,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core7"
+          }
+        }
+      },
+      {
+        "id": "10",
+        "metadata": {
+          "type": "core",
+          "id": 8,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core8"
+          }
+        }
+      },
+      {
+        "id": "11",
+        "metadata": {
+          "type": "core",
+          "id": 9,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core9"
+          }
+        }
+      },
+      {
+        "id": "12",
+        "metadata": {
+          "type": "core",
+          "id": 10,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core10"
+          }
+        }
+      },
+      {
+        "id": "13",
+        "metadata": {
+          "type": "core",
+          "id": 11,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core11"
+          }
+        }
+      },
+      {
+        "id": "14",
+        "metadata": {
+          "type": "core",
+          "id": 12,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core12"
+          }
+        }
+      },
+      {
+        "id": "15",
+        "metadata": {
+          "type": "core",
+          "id": 13,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core13"
+          }
+        }
+      },
+      {
+        "id": "16",
+        "metadata": {
+          "type": "core",
+          "id": 14,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core14"
+          }
+        }
+      },
+      {
+        "id": "17",
+        "metadata": {
+          "type": "core",
+          "id": 15,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234/core15"
+          }
+        }
+      },
+      {
+        "id": "1",
+        "metadata": {
+          "type": "node",
+          "basename": "cab",
+          "id": 1234,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0/cab1234"
+          }
+        }
+      },
+      {
+        "id": "0",
+        "metadata": {
+          "type": "cluster",
+          "id": 0,
+          "exclusive": true,
+          "paths": {
+            "containment": "/cluster0"
+          }
+        }
+      }
+    ],
+    "edges": [
+      {
+        "source": "1",
+        "target": "2"
+      },
+      {
+        "source": "1",
+        "target": "3"
+      },
+      {
+        "source": "1",
+        "target": "4"
+      },
+      {
+        "source": "1",
+        "target": "5"
+      },
+      {
+        "source": "1",
+        "target": "6"
+      },
+      {
+        "source": "1",
+        "target": "7"
+      },
+      {
+        "source": "1",
+        "target": "8"
+      },
+      {
+        "source": "1",
+        "target": "9"
+      },
+      {
+        "source": "1",
+        "target": "10"
+      },
+      {
+        "source": "1",
+        "target": "11"
+      },
+      {
+        "source": "1",
+        "target": "12"
+      },
+      {
+        "source": "1",
+        "target": "13"
+      },
+      {
+        "source": "1",
+        "target": "14"
+      },
+      {
+        "source": "1",
+        "target": "15"
+      },
+      {
+        "source": "1",
+        "target": "16"
+      },
+      {
+        "source": "1",
+        "target": "17"
+      },
+      {
+        "source": "0",
+        "target": "1"
+      }
+    ]
+  }
+}

--- a/t/t1015-find-format.t
+++ b/t/t1015-find-format.t
@@ -93,6 +93,113 @@ test_expect_success 'find/status: find status=up format=jgf works' '
     test_cmp jgf.query.json jgf.json
 '
 
+test_expect_success 'find/agfilter: find agfilter=true format=jgf works' '
+    flux ion-resource find --format=jgf agfilter=true \
+         | tail -1 > jgf.agfilter.raw.json &&
+    normalize_json < jgf.agfilter.raw.json > jgf.agfilter.json &&
+    test_cmp ${expected_basepath}/jgf.expected.agfilter.json jgf.agfilter.json
+'
+
+test_expect_success 'find/agfilter: find agfilter=false format=jgf works' '
+    out=$( flux ion-resource find --format=jgf agfilter=false \
+         | tail -1 ) &&
+    test -n ${out}
+'
+
+test_expect_success 'find/jobid: submit test job' '
+    flux run --dry-run -N 1 --exclusive -t 1h sleep 3600 > testjob.json &&
+    jobid=$(flux job submit testjob.json) &&
+    jobid1=$(flux job id ${jobid}) &&
+    flux job wait-event -t 10 ${jobid} start &&
+    jobid=$(flux job submit testjob.json) &&
+    jobid2=$(flux job id ${jobid})
+'
+
+test_expect_success 'find/jobid: find jobid-alloc format=jgf works' '
+    flux ion-resource find --format=jgf jobid-alloc=${jobid1} \
+         | tail -1 > jgf.jobid.alloc.raw.json &&
+    normalize_json < jgf.jobid.alloc.raw.json > jgf.jobid.alloc.json &&
+    test_cmp ${expected_basepath}/jgf.expected.jobid.alloc.json jgf.jobid.alloc.json
+'
+
+test_expect_success 'find/jobid: find jobid-alloc format=jgf output null for nonexistent jobid' '
+    out=$( flux ion-resource find --format=jgf jobid-alloc=10 \
+         | tail -1 ) &&
+    test -n ${out}
+'
+
+test_expect_success 'find/jobid: find jobid-alloc format=jgf EINVAL for invalid jobid' '
+    out=$( flux ion-resource find --format=jgf "jobid-alloc=18446744073709551616" \
+         | tail -1 ) &&
+    test "${out}" = "OSError: error(22): Invalid argument"
+'
+
+test_expect_success 'find/jobid: find jobid-reserved format=jgf output null for nonexistent jobid' '
+    out=$( flux ion-resource find --format=jgf jobid-reserved=10 \
+         | tail -1 ) &&
+    test -n ${out}
+'
+
+test_expect_success 'find/jobid: find jobid-span format=jgf output null for nonexistent jobid' '
+    out=$( flux ion-resource find --format=jgf jobid-span=10 \
+         | tail -1 ) &&
+    test -n ${out}
+'
+
+test_expect_success 'find/jobid: find jobid-tag format=jgf output null for nonexistent jobid' '
+    out=$( flux ion-resource find --format=jgf jobid-tag=10 \
+         | tail -1 ) &&
+    test -n ${out}
+'
+
+test_expect_success 'find/jobid: find jobid-alloc,agfilter=t format=jgf works' '
+    flux ion-resource find --format=jgf "jobid-alloc=${jobid1} and agfilter=t" \
+         | tail -1 > jgf.jobid.alloc.agfilter.raw.json &&
+    normalize_json < jgf.jobid.alloc.agfilter.raw.json > jgf.jobid.alloc.agfilter.json &&
+    test_cmp ${expected_basepath}/jgf.expected.jobid.alloc.agfilter.json jgf.jobid.alloc.agfilter.json
+'
+
+test_expect_success 'find/jobid: find jobid-span format=jgf works' '
+    flux ion-resource find --format=jgf jobid-span=${jobid1} \
+         | tail -1 > jgf.jobid.span.raw.json &&
+    normalize_json < jgf.jobid.span.raw.json > jgf.jobid.span.json &&
+    test_cmp ${expected_basepath}/jgf.expected.jobid.span.json jgf.jobid.span.json
+'
+
+test_expect_success 'find/jobid: find jobid-span,agfilter=t format=jgf works' '
+    flux ion-resource find --format=jgf "jobid-span=${jobid1} and agfilter=t" \
+         | tail -1 > jgf.jobid.span.agfilter.raw.json &&
+    normalize_json < jgf.jobid.span.agfilter.raw.json > jgf.jobid.span.agfilter.json &&
+    test_cmp ${expected_basepath}/jgf.expected.jobid.span.agfilter.json jgf.jobid.span.agfilter.json
+'
+
+test_expect_success 'find/jobid: find jobid-tag format=jgf works' '
+    flux ion-resource find --format=jgf jobid-tag=${jobid1} \
+         | tail -1 > jgf.jobid.tag.raw.json &&
+    normalize_json < jgf.jobid.tag.raw.json > jgf.jobid.tag.json &&
+    test_cmp ${expected_basepath}/jgf.expected.jobid.tag.json jgf.jobid.tag.json
+'
+
+test_expect_success 'find/jobid: find jobid-tag,agfilter=t format=jgf works' '
+    flux ion-resource find --format=jgf "jobid-tag=${jobid1} and agfilter=t" \
+         | tail -1 > jgf.jobid.tag.agfilter.raw.json &&
+    normalize_json < jgf.jobid.tag.agfilter.raw.json > jgf.jobid.tag.agfilter.json &&
+    test_cmp ${expected_basepath}/jgf.expected.jobid.tag.agfilter.json jgf.jobid.tag.agfilter.json
+'
+
+test_expect_success 'find/jobid: find jobid-reserved format=jgf works' '
+    flux ion-resource find --format=jgf jobid-reserved=${jobid2} \
+         | tail -1 > jgf.jobid.rsv.raw.json &&
+    normalize_json < jgf.jobid.rsv.raw.json > jgf.jobid.rsv.json &&
+    test_cmp ${expected_basepath}/jgf.expected.jobid.rsv.json jgf.jobid.rsv.json
+'
+
+test_expect_success 'find/status: cancel jobs' '
+    flux cancel ${jobid1} &&
+    flux cancel ${jobid2} &&
+    flux job wait-event -t 10 ${jobid2} clean
+'
+
 test_expect_success 'find/status: removing fluxion modules' '
     remove_qmanager &&
     remove_resource


### PR DESCRIPTION
Errors in partial cancel are causing inability to schedule resources in production. While evidence points to orphaned (i.e., not cleared) vertex data such as aggregate filters, it is difficult to investigate and debug without being able to inspect the state of the vertices.

The PR adds capability to print vertex-specific data by `jobid` and an `agfilter` boolean. The state can be printed based on whether the jobid is in the `allocations`, `reservations`, `job2span`, and `tags` maps.

This PR is WIP because I need to add support for all writers.