### PR TITLE
Qmanager: remove no-longer-supported schedutil_free_respond()

### DIFF
--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -367,10 +367,6 @@ void qmanager_cb_t::jobmanager_free_cb (flux_t *h, const flux_msg_t *msg, const 
                         static_cast<intmax_t> (id));
         goto done;
     }
-    if (schedutil_free_respond (ctx->schedutil, msg) < 0) {
-        flux_log_error (h, "%s: schedutil_free_respond", __FUNCTION__);
-        goto done;
-    }
 
 done:
     json_decref (Res);


### PR DESCRIPTION
The `.free` RPC no longer receives a response, and `schedutil_free_respond()` is a noop. `jobmanager_free_cb` currently contains a call to schedutil_free_respond, which misleadingly suggests that not sending the response could be an error condition in flux-core.

This short PR remove the call and associated error handling from the qmanager free callback.