### PR TITLE
ci: drop alpine

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,7 +167,7 @@ jobs:
         (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')
       run: |
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        for d in el9 noble alpine bookworm ; do
+        for d in el9 noble bookworm ; do
           docker manifest create fluxrm/flux-sched:$d fluxrm/flux-sched:$d-amd64 fluxrm/flux-sched:$d-arm64
           docker manifest push fluxrm/flux-sched:$d
         done

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -198,14 +198,16 @@ matrix.add_multiarch_build(
         CHECK_RUN_SOURCE_ENV="/opt/rh/gcc-toolset-13/enable",
     ),
 )
-matrix.add_multiarch_build(
-    name="alpine",
-    default_suffix=" - test-install",
-    args=common_args,
-    env=dict(
-        TEST_INSTALL="t",
-    ),
-)
+# Disabled because the arm64 build is failing and preventing the
+# generate-manifest step from running
+# matrix.add_multiarch_build(
+#     name="alpine",
+#     default_suffix=" - test-install",
+#     args=common_args,
+#     env=dict(
+#         TEST_INSTALL="t",
+#     ),
+# )
 # single arch builds that still produce a container
 matrix.add_build(
     name="fedora40 - test-install",


### PR DESCRIPTION
Problem: the alpine-arm64 build is failing and stopping the generate-manifests step from running.

Disable the alpine build, to be brought back once the arm64 build can be fixed.

See #1326 