### PR TITLE
evaluators: find by name and by property

### DIFF
--- a/resource/evaluators/expr_eval_vtx_target.cpp
+++ b/resource/evaluators/expr_eval_vtx_target.cpp
@@ -68,6 +68,8 @@ int expr_eval_vtx_target_t::validate (const std::string &p, const std::string &x
             rc = 0;
             hostlist_destroy (hlist);
         }
+    } else if (p == "property") {
+        rc = (lcx.length () > 0) ? 0 : -1;
     } else
         errno = EINVAL;
 done:
@@ -144,6 +146,8 @@ int expr_eval_vtx_target_t::evaluate (const std::string &p,
             result = false;
         }
         hostlist_destroy (hlist);
+    } else if (p == "property") {
+        result = (*m_g)[m_u].properties.contains (lcx);
     } else {
         rc = -1;
         errno = EINVAL;

--- a/resource/evaluators/expr_eval_vtx_target.cpp
+++ b/resource/evaluators/expr_eval_vtx_target.cpp
@@ -16,6 +16,7 @@ extern "C" {
 
 #include <algorithm>
 #include <cctype>
+#include <flux/hostlist.h>
 #include "resource/evaluators/expr_eval_vtx_target.hpp"
 
 namespace Flux {
@@ -35,6 +36,7 @@ int expr_eval_vtx_target_t::validate (const std::string &p, const std::string &x
 {
     int rc = -1;
     std::string lcx = x;
+    struct hostlist *hlist;
 
     if (!m_initialized) {
         errno = EINVAL;
@@ -58,6 +60,14 @@ int expr_eval_vtx_target_t::validate (const std::string &p, const std::string &x
         }
     } else if (p == "agfilter") {
         rc = (lcx == "true" || lcx == "t" || lcx == "false" || lcx == "f") ? 0 : -1;
+    } else if (p == "names") {
+        hlist = hostlist_decode (lcx.c_str ());
+        if (!hlist) {
+            rc = -1;
+        } else {
+            rc = 0;
+            hostlist_destroy (hlist);
+        }
     } else
         errno = EINVAL;
 done:
@@ -71,6 +81,7 @@ int expr_eval_vtx_target_t::evaluate (const std::string &p,
     int rc = 0;
     std::string lcx = x;
     unsigned long jobid = 0;
+    struct hostlist *hlist;
 
     result = false;
     if ((rc = validate (p, x)) < 0)
@@ -122,6 +133,17 @@ int expr_eval_vtx_target_t::evaluate (const std::string &p,
         } else {
             result = false;
         }
+    } else if (p == "names") {
+        if (!(hlist = hostlist_decode (lcx.c_str ()))) {
+            rc = -1;
+            goto done;
+        }
+        if (hostlist_find (hlist, (*m_g)[m_u].name.c_str ()) >= 0) {
+            result = true;
+        } else {
+            result = false;
+        }
+        hostlist_destroy (hlist);
     } else {
         rc = -1;
         errno = EINVAL;

--- a/resource/utilities/command.cpp
+++ b/resource/utilities/command.cpp
@@ -68,7 +68,7 @@ command_t commands[] =
       cmd_find,
       "Find resources matched with criteria "
       "(predicates: status={up|down} sched-now={allocated|free} sched-future={reserved|free} "
-      "agfilter={true|false} jobid-alloc=jobid jobid-span=jobid jobid-tag=jobid "
+      "agfilter={true|false} names=hostlist jobid-alloc=jobid jobid-span=jobid jobid-tag=jobid "
       "jobid-reserved=jobid): "
       "resource-query> find status=down and sched-now=allocated"},
      {"cancel",

--- a/resource/utilities/command.cpp
+++ b/resource/utilities/command.cpp
@@ -69,7 +69,7 @@ command_t commands[] =
       "Find resources matched with criteria "
       "(predicates: status={up|down} sched-now={allocated|free} sched-future={reserved|free} "
       "agfilter={true|false} names=hostlist jobid-alloc=jobid jobid-span=jobid jobid-tag=jobid "
-      "jobid-reserved=jobid): "
+      "jobid-reserved=jobid property=name): "
       "resource-query> find status=down and sched-now=allocated"},
      {"cancel",
       "c",

--- a/resource/utilities/command.cpp
+++ b/resource/utilities/command.cpp
@@ -60,7 +60,7 @@ command_t commands[] =
      {"remove",
       "j",
       cmd_remove,
-      "Remove a subgraph from the resource graph, specifying whether the target is"
+      "Remove a subgraph from the resource graph, specifying whether the target is "
       "a path (true) or idset (false): resource-query> remove (/path/to/node/ | idset) "
       "(true|false)"},
      {"find",

--- a/src/cmd/flux-ion-resource.py
+++ b/src/cmd/flux-ion-resource.py
@@ -365,10 +365,11 @@ def find_action(args):
 
     rmod = ResourceModuleInterface()
     resp = rmod.rpc_find(args.criteria, find_format=args.format)
-    print("CRITERIA")
-    print("'" + args.criteria + "'")
-    print("=" * width())
-    print("MATCHED RESOURCES:")
+    if not args.quiet:
+        print("CRITERIA")
+        print("'" + args.criteria + "'")
+        print("=" * width())
+        print("MATCHED RESOURCES:")
     print(json.dumps(resp["R"]))
 
 
@@ -491,6 +492,7 @@ def parse_find(parser_f: argparse.ArgumentParser):
     parser_f.add_argument(
         "--format", type=str, default=None, help="Writer format for find query"
     )
+    parser_f.add_argument("-q", "--quiet", action="store_true", help="be quiet")
     parser_f.set_defaults(func=find_action)
 
 

--- a/t/t3025-resource-find.t
+++ b/t/t3025-resource-find.t
@@ -324,4 +324,75 @@ EOF
     test_cmp down21.out down22.out
 '
 
+test_expect_success 'find names=node[0-1] works' "
+    cat > cmds023 <<-EOF &&
+    find names=node[0-1]
+    quit
+EOF
+    ${query} -L ${grugs} -F jgf -S CA -P high -t nodes.out < cmds023 &&
+    cat nodes.out | grep -v INFO > nodes.json &&
+    jq '.graph.nodes[].metadata | select(.type==\"node\")' nodes.json > nodes_selected.json &&
+    grep node0 nodes_selected.json &&
+    grep node1 nodes_selected.json
+"
+
+test_expect_success 'find names=node[0] works' "
+    cat > cmds024 <<-EOF &&
+    find names=node[0]
+    quit
+EOF
+    ${query} -L ${grugs} -F jgf -S CA -P high -t nodes.out < cmds024 &&
+    cat nodes.out | grep -v INFO > nodes2.json &&
+    jq '.graph.nodes[].metadata | select(.type==\"node\")' nodes2.json > nodes_selected2.json &&
+    grep node0 nodes_selected2.json &&
+    test_must_fail grep node1 nodes_selected2.json
+"
+
+test_expect_success 'find names=node1 works' "
+    cat > cmds025 <<-EOF &&
+    find names=node1
+    quit
+EOF
+    ${query} -L ${grugs} -F jgf -S CA -P high -t nodes.out < cmds025 &&
+    cat nodes.out | grep -v INFO > nodes3.json &&
+    jq '.graph.nodes[].metadata | select(.type==\"node\")' nodes3.json > nodes_selected3.json &&
+    grep node1 nodes_selected3.json &&
+    test_must_fail grep node0 nodes_selected3.json
+"
+
+test_expect_success 'find names=core[0-72] works' "
+    cat > cmds026 <<-EOF &&
+    find names=core[0-72]
+    quit
+EOF
+    ${query} -L ${grugs} -F jgf -S CA -P high -t cores.out < cmds026 &&
+    cat cores.out | grep -v INFO > cores.json &&
+    jq '.graph.nodes[].metadata | select(.type==\"core\")' cores.json > cores_selected.json &&
+    grep core1 cores_selected.json &&
+    grep core0 cores_selected.json &&
+    grep core19 cores_selected.json &&
+    test_must_fail grep core71 cores_selected.json
+"
+
+test_expect_success 'find names=core[0-18] works' "
+    cat > cmds027 <<-EOF &&
+    find names=core[0-18]
+    quit
+EOF
+    ${query} -L ${grugs} -F jgf -S CA -P high -t cores2.out < cmds027 &&
+    cat cores2.out | grep -v INFO > cores2.json &&
+    jq '.graph.nodes[].metadata | select(.type==\"core\")' cores2.json > cores_selected2.json &&
+    grep core1 cores_selected2.json &&
+    grep core18 cores_selected2.json &&
+    test_must_fail grep core19 cores_selected2.json
+"
+
+test_expect_success 'find names=socket[af[] fails' "
+    cat > cmds028 <<-EOF &&
+    find names=socket[af[]
+    quit
+EOF
+    ${query} -L ${grugs} -F jgf -S CA -P high < cmds028 2>&1 | grep 'invalid criteria'
+"
+
 test_done


### PR DESCRIPTION
Problem: there is no way to find resources by name and by property.

Add `names=HOSTLIST` and `property=PROP` operators to the evaluators and document them in resource-query.

Example usage:
```
resource-query> find hostlist=tuolumne[1,1001-1019] and sched-now=free
      ------tuolumne1[1:x]
      ------tuolumne1001[1:x]
      ------tuolumne1002[1:x]
      ------tuolumne1003[1:x]
      ------tuolumne1004[1:x]
      ------tuolumne1005[1:x]
      ------tuolumne1006[1:x]
      ------tuolumne1007[1:x]
      ------tuolumne1008[1:x]
      ------tuolumne1009[1:x]
      ------tuolumne1010[1:x]
      ------tuolumne1011[1:x]
      ------tuolumne1012[1:x]
      ------tuolumne1013[1:x]
      ------tuolumne1014[1:x]
      ------tuolumne1015[1:x]
      ------tuolumne1016[1:x]
      ------tuolumne1017[1:x]
      ------tuolumne1018[1:x]
      ------tuolumne1019[1:x]
      ---cluster0[1:x]
INFO: =============================
INFO: EXPRESSION="hostlist=tuolumne[1,1001-1019] and sched-now=free"
INFO: =============================
resource-query> f property=pdebug
      ------tuolumne1005[1:x]
      ------tuolumne1006[1:x]
      ------tuolumne1007[1:x]
      ------tuolumne1008[1:x]
      ---cluster0[1:x]
INFO: =============================
INFO: EXPRESSION="property=pdebug"
INFO: =============================
```

I haven't yet been able to figure out how to make the children of nodes show up in the output, but I don't think that's a blocker. That could always be added later if it's needed. However, until that's added, only the `--simple` and `jgf` output formats work, because the others expect cores or other vertices to be present in the output (at least this is my hypothesis as to why they fail).
