### PR TITLE
NEWS.md: add release notes for v0.42.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+flux-sched version 0.42.1 - 2025-02-10
+--------------------------------------
+
+### New Features
+ * resource: remove property (#1332)
+
+
 flux-sched version 0.42.0 - 2025-02-05
 --------------------------------------
 


### PR DESCRIPTION
Problem: flux-coral2 depends on functionality in #1332 (see e.g. https://github.com/flux-framework/flux-coral2/pull/266 and https://github.com/flux-framework/flux-coral2/pull/265), and so a new flux-coral2 RPM will require that PR, but there isn't a release yet that includes it.