### PR TITLE
NEWS.md: add release notes for v0.42.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,12 @@
-flux-sched version 0.42.1 - 2025-02-10
+flux-sched version 0.42.2 - 2025-02-10
+--------------------------------------
+
+### New Features
+ * Break visitation cycle in mod_dfv to correct cancellation behavior
+   (#1335)
+
+
+flux-sched version 0.42.1 - 2025-02-08
 --------------------------------------
 
 ### New Features


### PR DESCRIPTION
Problem: there are no release notes for v0.42.2.

Add them.

Also fix release date for 0.42.1.