### PR TITLE
yggdrasil: fix invalid template calls

### DIFF
--- a/src/common/yggdrasil/rbtree.cpp
+++ b/src/common/yggdrasil/rbtree.cpp
@@ -513,12 +513,12 @@ RBTree<Node, NodeTraits, Options, Tag, Compare>::insert(
 		Node * parent = this->root;
 
 		if (parent == nullptr) {
-			this->insert_leaf_base<false>(node, parent);
+			this->insert_leaf_base(node, parent);
 		} else {
 			while (parent->NB::get_right() != nullptr) {
 				parent = parent->NB::get_right();
 			}
-			this->insert_leaf_base<false>(node, parent);
+			this->insert_leaf_base(node, parent);
 		}
 	} else {
 		this->insert(node, *hint);


### PR DESCRIPTION
problem: yggdrasil will not compile with clang++ 19+ because it adds an
invalid template parameter to a pair of calls to `insert_leaf_base`.
I'm not sure how this ever worked.

solution: remove the template parameter

I ran into this trying to test the recent issues on my Tumbleweed VM, all tests pass with the change locally and they are the only pair of calls that have this.