### PR TITLE
libjobspec: ensure task count has exactly one key

### DIFF
--- a/resource/libjobspec/jobspec.cpp
+++ b/resource/libjobspec/jobspec.cpp
@@ -226,6 +226,9 @@ Task::Task (const YAML::Node &tasknode)
         if (!count_node.IsMap ()) {
             throw parse_error (count_node, "\"count\" in task is not a mapping");
         }
+        if (count_node.size () != 1) {
+            throw parse_error (count_node, "\"count\" in task must have exactly one entry");
+        }
         for (auto &&entry : count_node) {
             count[entry.first.as<std::string> ()] = entry.second.as<std::string> ();
         }

--- a/t/data/resource/jobspecs/validation/invalid/task_count_multiple_keys.yaml
+++ b/t/data/resource/jobspecs/validation/invalid/task_count_multiple_keys.yaml
@@ -1,0 +1,15 @@
+version: 9999
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: [ "app" ]
+    slot: foo
+    count:
+      per_slot: 1
+      total: 1
+attributes:


### PR DESCRIPTION
Problem: the desired number of tasks is ambiguous if more than one key is set in tasks.count

Fail with an error message if multiple keys are found in the jobspec

This is based on the proposed amendment to RFC 14 in flux-framework/rfc#441