### PR TITLE
WIP: support `shrink` key in resource acquisition protocol response

### DIFF
--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -1234,12 +1234,37 @@ static int mark (std::shared_ptr<resource_ctx_t> &ctx,
                                                : mark_lazy (ctx, ids, status);
 }
 
+// Subtract the idset string in b from the idset string in a.
+// Return result if non-empty in resultp (*resultp=NULL if no ids in result)
+// Returns 0 on success, -1 on failure.
+static int subtract_ids (const char *a, const char *b, char **resultp)
+{
+    int rc = -1;
+    char *result = NULL;
+    struct idset *idset = idset_decode (a);
+
+    *resultp = NULL;
+    if (!idset || idset_decode_subtract (idset, b, -1, NULL) < 0)
+        goto out;
+
+    // Success if idset is empty (result will be NULL) or non-empty
+    // idset successfully encoded:
+    if (idset_count (idset) == 0 || (*resultp = idset_encode (idset, IDSET_FLAG_RANGE)))
+        rc = 0;
+out:
+    idset_destroy (idset);
+    return rc;
+}
+
 static int update_resource_db (std::shared_ptr<resource_ctx_t> &ctx,
                                json_t *resources,
                                const char *up,
-                               const char *down)
+                               const char *down,
+                               const char *lost)
 {
     int rc = 0;
+    char *down_not_lost = NULL;
+
     // Will need to get duration update and set graph metadata when
     // resource.acquire duration update is supported in the future.
     if (resources && (rc = grow_resource_db (ctx, resources)) < 0) {
@@ -1250,11 +1275,29 @@ static int update_resource_db (std::shared_ptr<resource_ctx_t> &ctx,
         flux_log_error (ctx->h, "%s: mark (up)", __FUNCTION__);
         goto done;
     }
-    if (down && (rc = mark (ctx, down, resource_pool_t::status_t::DOWN)) < 0) {
+
+    // RFC 28 specifies that ranks in shrink (lost) will also appear
+    // in down, and that lost takes precedence. So subtract lost from
+    // down before marking resources.
+    if (lost && down) {
+        if (subtract_ids (down, lost, &down_not_lost) < 0) {
+            flux_log_error (ctx->h, "%s: failed to subtract shrink ranks from down", __FUNCTION__);
+            goto done;
+        }
+        down = down_not_lost;
+    }
+    if (down
+        && (rc = mark (ctx, down_not_lost ? down_not_lost : down, resource_pool_t::status_t::DOWN))
+               < 0) {
         flux_log_error (ctx->h, "%s: mark (down)", __FUNCTION__);
         goto done;
     }
+    if (lost && (rc = mark (ctx, lost, resource_pool_t::status_t::LOST)) < 0) {
+        flux_log_error (ctx->h, "%s: mark (lost)", __FUNCTION__);
+        goto done;
+    }
 done:
+    free (down_not_lost);
     return rc;
 }
 
@@ -1263,18 +1306,21 @@ static void update_resource (flux_future_t *f, void *arg)
     int rc = -1;
     const char *up = NULL;
     const char *down = NULL;
+    const char *lost = NULL;
     double expiration = -1.;
     json_t *resources = NULL;
     std::shared_ptr<resource_ctx_t> ctx = getctx ((flux_t *)arg);
 
     if ((rc = flux_rpc_get_unpack (f,
-                                   "{s?:o s?:s s?:s s?:F}",
+                                   "{s?:o s?:s s?:s s?s s?:F}",
                                    "resources",
                                    &resources,
                                    "up",
                                    &up,
                                    "down",
                                    &down,
+                                   "shrink",
+                                   &lost,
                                    "expiration",
                                    &expiration))
         < 0) {
@@ -1282,7 +1328,7 @@ static void update_resource (flux_future_t *f, void *arg)
         flux_reactor_stop (flux_get_reactor (ctx->h));
         goto done;
     }
-    if ((rc = update_resource_db (ctx, resources, up, down)) < 0) {
+    if ((rc = update_resource_db (ctx, resources, up, down, lost)) < 0) {
         flux_log_error (ctx->h, "%s: update_resource_db", __FUNCTION__);
         goto done;
     }

--- a/resource/schema/resource_data.cpp
+++ b/resource/schema/resource_data.cpp
@@ -42,7 +42,9 @@ resource_relation_t &resource_relation_t::operator= (resource_relation_t &&o) = 
 resource_relation_t::~resource_relation_t () = default;
 
 const resource_pool_t::string_to_status resource_pool_t::str_to_status =
-    {{"up", resource_pool_t::status_t::UP}, {"down", resource_pool_t::status_t::DOWN}};
+    {{"up", resource_pool_t::status_t::UP},
+     {"down", resource_pool_t::status_t::DOWN},
+     {"lost", resource_pool_t::status_t::LOST}};
 
 const std::string resource_pool_t::status_to_str (status_t s)
 {
@@ -53,6 +55,9 @@ const std::string resource_pool_t::status_to_str (status_t s)
             break;
         case status_t::DOWN:
             str = "DOWN";
+            break;
+        case status_t::LOST:
+            str = "LOST";
             break;
         default:
             str = "";

--- a/resource/schema/resource_data.hpp
+++ b/resource/schema/resource_data.hpp
@@ -36,7 +36,7 @@ struct resource_pool_t : public resource_t {
     resource_pool_t &operator= (resource_pool_t &&o);
     ~resource_pool_t ();
 
-    enum class status_t : int { UP = 0, DOWN = 1 };
+    enum class status_t : int { UP = 0, DOWN = 1, LOST = 2 };
 
     typedef std::unordered_map<std::string, status_t> string_to_status;
     static const string_to_status str_to_status;

--- a/resource/traversers/dfu.cpp
+++ b/resource/traversers/dfu.cpp
@@ -105,6 +105,8 @@ int dfu_traverser_t::request_feasible (detail::jobmeta_t const &meta,
         auto const &node = g[node_vtx];
         // if it matches the constraints
         if ((!meta.constraint || meta.constraint->match (node))
+            // if it's not lost
+            && !(node.status == resource_pool_t::status_t::LOST)
             // if it's up and not drained
             && (checking_satisfiability || node.status == resource_pool_t::status_t::UP)
             // if it's available

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -213,6 +213,12 @@ int dfu_impl_t::prune (const jobmeta_t &meta,
                        const std::vector<Jobspec::Resource> &resources)
 {
     int rc = 0;
+
+    // Prune LOST resources
+    if ((*m_graph)[u].status == resource_pool_t::status_t::LOST) {
+        rc = -1;
+        goto done;
+    }
     // Prune by the visiting resource vertex's availability
     // If resource is not UP, no reason to descend further.
     if (meta.alloc_type != jobmeta_t::alloc_type_t::AT_SATISFIABILITY
@@ -795,7 +801,8 @@ int dfu_impl_t::dom_find_dfv (std::shared_ptr<match_writers_t> &w,
     expr_eval_vtx_target_t vtx_target;
     subsystem_t dom = m_match->dom_subsystem ();
     bool result = false;
-    bool down = (*m_graph)[u].status == resource_pool_t::status_t::DOWN;
+    bool down = (*m_graph)[u].status == resource_pool_t::status_t::DOWN
+                || (*m_graph)[u].status == resource_pool_t::status_t::LOST;
     bool allocated = !(*m_graph)[u].schedule.allocations.empty ();
     bool reserved = !(*m_graph)[u].schedule.reservations.empty ();
     Flux::resource_model::vtx_predicates_override_t p_overridden = p;

--- a/t/t3024-resource-status.t
+++ b/t/t3024-resource-status.t
@@ -160,6 +160,14 @@ test_expect_success "${test031_desc}" '
     test_cmp 031.R.out ${exp_dir}/031.R.out
 '
 
+test031_desc_lost="allocate basic job w/ node exclusivity when node1 is lost"
+test_expect_success "${test031_desc_lost}" '
+    sed s/down/lost/ cmds031 > cmds031.lost &&
+    ${query} -L ${grugs} -F simple -S CA -P hinodex -t 031.R.lost \
+      < cmds031.lost &&
+    test_cmp 031.R.lost ${exp_dir}/031.R.out
+'
+
 cmds032="${cmd_dir}/cmds12.in"
 test032_desc="allocate w/ node exclusivity when node1 is set down then up"
 test_expect_success "${test032_desc}" '
@@ -198,6 +206,13 @@ test_expect_success "${test036_desc}" '
     sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds036} > cmds036 &&
     ${query} -L ${grugs} -F simple -S CA -P hinodex -t 036.R.out < cmds036 &&
     test_cmp 036.R.out ${exp_dir}/036.R.out
+'
+test036_desc_lost="submit unsatisfiable request to cluster with one node lost"
+test_expect_success "${test036_desc_lost}" '
+    sed s/down/lost/ cmds036 > cmds036.lost &&
+    ${query} -L ${grugs} -F simple -S CA -P hinodex -t 036.R.lost \
+      < cmds036.lost &&
+    test_cmp 036.R.lost ${exp_dir}/036.R.out
 '
 
 test_done


### PR DESCRIPTION
This PR adds initial support for the `shrink` key in the RFC 28 resource acquisition protocol response.

As discussed in the most recent Fluxion meeting, a new resource status is added in addition to `UP` and `DOWN`, which indicates the resource is not expected to ever be available again. I've called this state `LOST`.

The `LOST` state is treated the same as `DOWN`, except in the case of pruning and `request_feasible()`, where `LOST` resources are never considered.

This seems to address the use case and the spirit of the `shrink` idset, which is sent to a scheduler when nodes in a non-configuration based instance are lost.

This is a WIP until we can get some true system tests for this feature, which will require support from flux-core (pending in flux-framework/flux-core#6652)

Feel free to review the code as-is here though, in case I've missed something in the existing changes.