### PR TITLE
comply with RFC 20 when parsing Rv1 `starttime` and `expiration`

### DIFF
--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -1293,12 +1293,18 @@ static void update_resource (flux_future_t *f, void *arg)
         flux_log_error (ctx->h, "%s: update_resource_db", __FUNCTION__);
         goto done;
     }
-    if (expiration >= 0.) {
+    if (expiration > 0.) {
         /*  Update graph duration:
          */
         ctx->db->metadata.graph_duration.graph_end =
             std::chrono::system_clock::from_time_t ((time_t)expiration);
         flux_log (ctx->h, LOG_INFO, "resource expiration updated to %.2f", expiration);
+    } else if (expiration == 0.) {
+        /*  An expiration of 0 should be treated as "no expiration":
+         */
+        ctx->db->metadata.graph_duration.graph_end =
+            std::chrono::system_clock::from_time_t (detail::SYSTEM_MAX_DURATION);
+        flux_log (ctx->h, LOG_INFO, "resource expiration updated to 0. (unlimited)");
     }
     for (auto &kv : ctx->notify_msgs) {
         if ((rc += flux_respond (ctx->h, kv.second->get_msg (), NULL)) < 0) {

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -647,7 +647,7 @@ static int unpack_resources (json_t *resobj,
             < 0)
             goto inval;
         // flux-core validates these numbers, but checking here
-        // in case Fluxin is plugged into another resource manager
+        // in case Fluxion is plugged into another resource manager
         if (version != 1)
             goto inval;
         if (start != 0 && (start == end))

--- a/t/data/resource/rv1exec/tiny_rv1exec.json
+++ b/t/data/resource/rv1exec/tiny_rv1exec.json
@@ -1,1 +1,1 @@
-{"version": 1, "execution": {"R_lite": [{"rank": "0-1", "children": {"core": "0-15", "gpu": "0-3"}}], "nodelist": ["node[0-1]"], "starttime": 0, "expiration": 1000000}}
+{"version": 1, "execution": {"R_lite": [{"rank": "0-1", "children": {"core": "0-15", "gpu": "0-3"}}], "nodelist": ["node[0-1]"], "starttime": 0, "expiration": 0}}


### PR DESCRIPTION
I noticed some errors in handling of Rv1 in Fluxion while testing #1345. Most notably, Fluxion does not support an expiration of `0.` as specified in [RFC 20](https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_20.html#expiration), either in the initial Rv1 object used to initialize the resource graph or as a result of `flux update JOBID duration=0`. Additionally, RFC 20 specifies both `starttime` and `expiration` are optional, but Fluxion requires both keys.

This PR makes the necessary simple changes to bring Fluxion into compliance. This came up when testing the launch of Fluxion scheduled subinstances under sched-simple, which uses an expiration of `0.` to indicate unlimited (sched-fluxion-resource aborted at this point) It also may also come up if the duration of a job is updated to `0.`, which should indicate "unlimited", but Fluxion currently just sets the graph end time to `0.` and subsequent job submissions all fail with a generic "match error"

