### PR TITLE
resource: fix leak in `status_request_cb()`

### DIFF
--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -2805,7 +2805,7 @@ static void status_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_
         || ctx->m_resources_updated) {
         if (run_find (ctx, "sched-now=allocated", "rv1_nosched", &R_alloc) < 0)
             goto error;
-        ctx->m_r_alloc = json_deep_copy (R_alloc);
+        ctx->m_r_alloc = json::value::take (json_deep_copy (R_alloc));
         ctx->m_resources_alloc_updated = std::chrono::system_clock::now ();
     } else
         R_alloc = json_deep_copy (ctx->m_r_alloc.get ());


### PR DESCRIPTION
Problem: A lead in the sched-fluxion-resource module is reported when running t2317-resource-shrink.t with FLUX_TEST_VAlGRIND=t set.

The leak is from the line

    ctx->m_r_alloc = json_deep_copy (R_alloc);

Other cached R representations in the module ctx object are saved with `json::value::take()`. Use this for `ctx->m_r_alloc` as well, which seems to fix the leak.

I have no idea if this is the right fix :shrug: 