### PR TITLE
ci: update ubuntu version for spelling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: flux-framework/pr-validator@master
 
   spelling:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Check Spelling


### PR DESCRIPTION
Problem: the ubuntu-20.04 was removed on April 15th.

Update to ubuntu 24.