### PR TITLE
NEWS.md: add release notes for v0.45.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+flux-sched version 0.45.0 - 2025-05-08
+--------------------------------------
+
+### Fixes
+ * resource: send notify response on mark RPC (#1362)
+
+### Build/Testsuite
+ * ci: update ubuntu version for spelling (#1363)
+
+
 flux-sched version 0.44.0 - 2025-03-31
 --------------------------------------
 


### PR DESCRIPTION
Problem: there are no release notes for v0.45.0.

Add them.

Waiting on #1362 .