### PR TITLE
resource: consider matches again with `ENOMEM`

### DIFF
--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -2202,7 +2202,7 @@ static void match_multi_request_cb (flux_t *h,
             goto error;
         }
         if (run_match (ctx, jobid, cmd, js_str, &now, &at, &overhead, R, NULL) < 0) {
-            if (errno != EBUSY && errno != ENODEV)
+            if (errno != EBUSY && errno != ENODEV && errno != ENOMEM)
                 flux_log_error (ctx->h,
                                 "%s: match failed due to match error (id=%jd)",
                                 __FUNCTION__,


### PR DESCRIPTION
This would partially solve #1372, though we shouldn't close that until we identify the underlying race condition and improve our errno handling (I recognize the irony that #1330 is assigned to me _grimacing_, sorry!).

I'm putting this up because it fully passed the testsuite and I was thinking today we might discuss if this is a good idea or not. Some additional thoughts:

1. We could `fork()` on `ENOMEM` and dump a core and stack trace to catch when this happens again
2. If there's a legitimate `ENOMEM` caused by `run_match`, it won't be logged. Seems inadvisable. Maybe `ENOMEM` should be logged with `flux_log` and not `flux_log_error`?