### PR TITLE
ci: add debug tmate action and use `docker-manifest.py` in generate-manifest step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,6 +111,10 @@ jobs:
       env: ${{matrix.env}}
       run: ${{matrix.command}}
 
+    - name: tmate debug
+      if: ${{ !cancelled() && runner.debug }}
+      uses: mxschmitt/action-tmate@v3
+
     - name: Upload test results
       if: always()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,18 +156,15 @@ jobs:
     name: Generate docker manifest
     runs-on: ubuntu-latest
     needs: [ci-checks]
+    if: (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')
     env:
       DOCKER_REPO: fluxrm/flux-sched
       DOCKER_USERNAME: travisflux
       DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_TRAVISFLUX_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+    - uses: actions/checkout@v4
     - name: make and push manifest as fluxrm/flux-sched
-      if: >
-        (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')
       run: |
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        for d in el9 noble bookworm ; do
-          docker manifest create fluxrm/flux-sched:$d fluxrm/flux-sched:$d-amd64 fluxrm/flux-sched:$d-arm64
-          docker manifest push fluxrm/flux-sched:$d
-        done
+        src/test/docker-manifest.py

--- a/src/test/docker-manifest.py
+++ b/src/test/docker-manifest.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+#
+#  Generate docker manifests when necessary based on set of docker tags
+#  provided by src/test/generate-matrix.py
+
+import json
+import subprocess
+from collections import defaultdict
+
+matrix = json.loads(
+    subprocess.run(
+        ["src/test/generate-matrix.py"], capture_output=True, text=True
+    ).stdout
+)
+
+tags = defaultdict(list)
+for entry in matrix["include"]:
+    if "DOCKER_TAG" in entry["env"]:
+        tags[entry["image"]].append(entry["env"]["DOCKER_TAG"])
+
+# Collect only those images with multiple tags:
+tags = {k: v for k, v in tags.items() if len(v) > 1}
+
+for image in tags.keys():
+    tag = f"fluxrm/flux-core:{image}"
+    print(f"docker manifest create {tag} ", *tags[image])
+    subprocess.run(["docker", "manifest", "create", tag, *tags[image]])
+    print(f"docker manifest push {tag} ")
+    subprocess.run(["docker", "manifest", "push", tag])


### PR DESCRIPTION
This PR pulls a couple recent ci updates from flux-core:

 - switch the `generate-manfest` step to use `src/test/docker-manifest.py` (I don't think there was a problem here, but this does automatically keep manifest generation in sync with `generate-matrix.py`)
 - add the tmate action which is conditionally run when restarting builds with the "debug" box checked