### PR TITLE
testsuite: set broker.module-nopanic=1

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -10,7 +10,7 @@ fi
 
 PM=""
 case "$ID" in
-	ubuntu|debian)
+	ubuntu|debian|pop)
 		PM=apt
 		DEV_SUFFIX="-dev"
 		DEV_SUFFIX_APT="-dev"

--- a/t/issues/t1035-fluxion-reload.sh
+++ b/t/issues/t1035-fluxion-reload.sh
@@ -11,7 +11,7 @@ run_timeout() {
 if test -z "$ISSUE_1035_TEST_ACTIVE"; then
     export ISSUE_1035_TEST_ACTIVE=t
     log "relaunching under test instance of size 4..."
-    exec flux start -s 4 $0 "$@"
+    exec flux start -Sbroker.module-nopanic=1 -s 4 $0 "$@"
 fi
 test $(flux resource list -no {nnodes}) -eq 4 || die "test requires 4 nodes"
 

--- a/t/issues/t1182-exclude-with-down-ranks.sh
+++ b/t/issues/t1182-exclude-with-down-ranks.sh
@@ -9,7 +9,7 @@ log() { printf "issue#1182: $@\n" >&2; }
 if test "$ISSUE_1182_ACTIVE" != "t"; then
     export ISSUE_1182_ACTIVE=t
     log "Re-launching test script under flux-start"
-    exec flux start -s 4 $0
+    exec flux start -Sbroker.module-nopanic=1 -s 4 $0
 fi
 
 cat <<'EOF' >rcheck.py

--- a/t/t1010-sync-modules.t
+++ b/t/t1010-sync-modules.t
@@ -5,7 +5,7 @@ test_description='Test Synchronization Requirements for Fluxion modules'
 . `dirname $0`/sharness.sh
 
 export FLUX_SCHED_MODULE=none
-test_under_flux 1
+test_under_flux 1 full -Sbroker.module-nopanic=1
 
 # sched-simple acquires "exclusive" access to resource.
 

--- a/t/t2317-resource-shrink.t
+++ b/t/t2317-resource-shrink.t
@@ -33,7 +33,7 @@ test_expect_success 'load fluxion' '
 	flux module load sched-fluxion-feasibility
 '
 test_expect_success 'submit a resilient job using all ranks' '
-	jobid=$(flux alloc --bg -xN4 -o exit-timeout=none --conf=tbon.topo=kary:0) &&
+	jobid=$(flux alloc --broker-opts=-Sbroker.module-nopanic=1 --bg -xN4 -o exit-timeout=none --conf=tbon.topo=kary:0) &&
 	flux proxy $jobid flux overlay status
 '
 test_expect_success 'a job on all ranks is satisfiable' '

--- a/t/t3300-system-dontblock.t
+++ b/t/t3300-system-dontblock.t
@@ -20,6 +20,7 @@ if test -n "$FLUX_RC_USE_MODPROBE"; then
     # below.
     test_expect_success 'fluxion immediately fails to be loaded with hwloc (modprobe)' '
 	test_must_fail flux start -Slog-stderr-level=7 \
+		-Sbroker.module-nopanic=1 \
 		flux module stats sched-fluxion-resource \
 		>modprobe.out 2>&1 &&
 	test_debug "cat modprobe.out" &&
@@ -30,7 +31,7 @@ else
     # Comment in the following to generated scheduling key to R
     # TEST_UNDER_FLUX_AUGMENT_R=t
 
-    test_under_flux 2 system
+    test_under_flux 2 system -Sbroker.module-nopanic=1
 
     SCHED_MODULE=$(flux module list | awk '$NF == "sched" {print $1}')
 

--- a/t/t4000-match-params.t
+++ b/t/t4000-match-params.t
@@ -13,7 +13,7 @@ ne_xml="${SHARNESS_TEST_SRCDIR}/data/hwloc-data/001N/exclusive/ne/0.xml"
 # test_under_flux is under sharness.d/
 #
 export FLUX_SCHED_MODULE=none
-test_under_flux 1
+test_under_flux 1 full -Sbroker.module-nopanic=1
 
 #
 # print only with --debug

--- a/t/t4014-match-feasibility.t
+++ b/t/t4014-match-feasibility.t
@@ -15,7 +15,7 @@ jobspec1="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/basics/test001.yaml"
 export FLUX_URI_RESOLVE_LOCAL=t
 export FLUX_SCHED_MODULE=sched-simple
 
-test_under_flux 1
+test_under_flux 1 full -Sbroker.module-nopanic=1
 
 test_debug '
     echo ${grug} &&

--- a/t/t5100-issues-test-driver.t
+++ b/t/t5100-issues-test-driver.t
@@ -19,7 +19,7 @@ fi
 flux bulksubmit -n1 -o pty --job-name={./%} -t 10m \
 	--flags=waitable \
 	--quiet --watch  \
-	flux start {} \
+	flux start -Sbroker.module-nopanic=1 {} \
 	::: ${SHARNESS_TEST_SRCDIR}/issues/${T5100_ISSUES_GLOB}
 
 for id in $(flux jobs -ano {id}); do


### PR DESCRIPTION
Problem: some tests rely on flux-core <= 0.77 broker module runtime error handling, where a module spuriously exiting with error is not fatal to the Flux instance.
    
flux-framework/flux-core#6969 added a check so that if a module exits with error on its own, the instance shuts down with an error so that this condition can be more easily detected.
    
Temporarily set the broker attribute `broker.module-nopanic=1` in failing fluxion tests to get the old behavior.  At some point,  perhaps after flux-core-0.78.0 is released, tests should be updated to expect the new behavior and this commit may be reverted.

p.s. unrelated: also added pop!OS to `install-deps.sh` in this PR since that's what I'm using for development.