### PR TITLE
cmake: Bump required flux-core version

### DIFF
--- a/cmake/FindFluxCore.cmake
+++ b/cmake/FindFluxCore.cmake
@@ -10,7 +10,7 @@ else()
     endif()
 endif()
 
-pkg_check_modules(FLUX_CORE REQUIRED IMPORTED_TARGET flux-core)
+pkg_check_modules(FLUX_CORE REQUIRED IMPORTED_TARGET flux-core>=0.77)
 set(FLUX_PREFIX ${FLUX_CORE_PREFIX})
 set(LIBFLUX_VERSION ${FLUX_CORE_VERSION})
 


### PR DESCRIPTION
problem: recent PRs have added things that require more recent flux versions and not added any check for the version being found

solution: add the required version into the pkg_check_modules call in cmake/FindFluxCore.cmake

Related to #1390 