### PR TITLE
Make macos build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,8 +199,12 @@ function(flux_add_plugin TargetName PluginType)
     ${__argsQuoted}
     )"
     )
-  target_link_options(${TargetName} PRIVATE
-    "LINKER:--version-script=${CMAKE_SOURCE_DIR}/flux-plugin.map" ${LinkerOpts})
+
+  if (${CMAKE_SYSTEM_NAME} MATCHES "LINUX")
+    target_link_options(${TargetName} PRIVATE
+      "LINKER:--version-script=${CMAKE_SOURCE_DIR}/flux-plugin.map" ${LinkerOpts})
+  endif()
+
   add_sanitizers(${TargetName})
   target_link_libraries(${TargetName} PRIVATE flux::core)
   if (NOT ARG_NOINSTALL)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -21,6 +21,18 @@
       "vendor": {}
     },
     {
+      "name": "mac",
+      "displayName": "MacOS Config",
+      "description": "MacOS build using Ninja generator",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build-mac",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      },
+      "environment": {},
+      "vendor": {}
+    },
+    {
       "name": "asan",
       "displayName": "Debug with address sanitizer",
       "description": "ASAN build using Ninja generator",

--- a/qmanager/modules/CMakeLists.txt
+++ b/qmanager/modules/CMakeLists.txt
@@ -11,4 +11,5 @@ target_link_libraries(sched-fluxion-qmanager PRIVATE
     flux::schedutil
     PkgConfig::JANSSON
     cppwrappers
+    fluxion-data
     )

--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -271,7 +271,7 @@ void qmanager_cb_t::jobmanager_stats_get_cb (flux_t *h,
         json::value qv;
         queue->to_json_value (qv);
         if (json_object_set (queues.get (), qname.c_str (), qv.get ()) < 0)
-            throw std::system_error ();
+            throw std::system_error (errno, std::generic_category ());
     }
     char *resp = json_dumps (stats.get (), 0);
     if (flux_respond (h, msg, resp) < 0) {

--- a/resource/CMakeLists.txt
+++ b/resource/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(fluxion-data SHARED schema/data_std.cpp)
-target_link_libraries(fluxion-data PRIVATE
+target_link_libraries(fluxion-data PUBLIC
     intern
     )
 set_target_properties(fluxion-data PROPERTIES

--- a/resource/libjobspec/CMakeLists.txt
+++ b/resource/libjobspec/CMakeLists.txt
@@ -1,19 +1,26 @@
 add_library ( jobspec_conv STATIC
-    ${CMAKE_CURRENT_SOURCE_DIR}/constraint.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/constraint.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/hostlist_constraint.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/hostlist_constraint.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/jobspec.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/jobspec.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/parse_error.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/rank_constraint.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/rank_constraint.hpp
+    constraint.cpp
+    constraint.hpp
+    hostlist_constraint.cpp
+    hostlist_constraint.hpp
+    jobspec.cpp
+    jobspec.hpp
+    parse_error.hpp
+    rank_constraint.cpp
+    rank_constraint.hpp
     )
 add_sanitizers(jobspec_conv)
-target_link_libraries(jobspec_conv PUBLIC flux::hostlist flux::idset
-    flux::core yaml-cpp PkgConfig::JANSSON 
-    PkgConfig::UUID
+target_link_libraries(jobspec_conv PUBLIC
+    flux::hostlist
+    flux::idset
+    flux::core
+    PkgConfig::JANSSON
+    PkgConfig::yaml-cpp
+    )
+target_link_libraries(jobspec_conv PRIVATE
     fluxion-data
+    PkgConfig::UUID
+    intern
     )
 
 add_executable(flux-jobspec-validate
@@ -21,9 +28,12 @@ add_executable(flux-jobspec-validate
     )
 add_sanitizers(flux-jobspec-validate)
 
-target_link_libraries(flux-jobspec-validate PRIVATE jobspec_conv)
+target_link_libraries(flux-jobspec-validate PRIVATE
+    jobspec_conv
+    intern
+    )
 
 add_executable(test_constraint.t test/constraint.cpp)
 add_sanitizers(test_constraint.t)
-target_link_libraries(test_constraint.t jobspec_conv libtap)
+target_link_libraries(test_constraint.t jobspec_conv libtap intern)
 flux_add_test(NAME test_constraint COMMAND test_constraint.t)

--- a/resource/planner/c++/CMakeLists.txt
+++ b/resource/planner/c++/CMakeLists.txt
@@ -9,6 +9,6 @@ add_library(planner_cxx STATIC
 	./scheduled_point_tree.hpp
  )
 add_sanitizers(planner_cxx) 
-target_link_libraries(planner_cxx yggdrasil)
+target_link_libraries(planner_cxx yggdrasil intern)
 
 

--- a/resource/schema/ephemeral.cpp
+++ b/resource/schema/ephemeral.cpp
@@ -16,6 +16,8 @@ extern "C" {
 
 #include "resource/schema/ephemeral.hpp"
 
+#include <errno.h>
+
 namespace Flux {
 namespace resource_model {
 

--- a/resource/writers/match_writers.hpp
+++ b/resource/writers/match_writers.hpp
@@ -256,7 +256,7 @@ class rv1_nosched_match_writers_t : public match_writers_t {
  */
 class pretty_sim_match_writers_t : public match_writers_t {
    public:
-    virtual bool empty ();
+    bool empty () override;
     virtual int emit_json (json_t **o, json_t **aux = nullptr);
     virtual int emit (std::stringstream &out);
     virtual int emit_vtx (const std::string &prefix,

--- a/src/common/c++wrappers/CMakeLists.txt
+++ b/src/common/c++wrappers/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(cppwrappers INTERFACE
         eh_wrapper.hpp
-        jansson.hpp)
+        jansson.hpp
+        chrono.hpp)
 target_include_directories(cppwrappers INTERFACE .)
 add_subdirectory(test)

--- a/src/common/c++wrappers/chrono.hpp
+++ b/src/common/c++wrappers/chrono.hpp
@@ -1,0 +1,16 @@
+#ifndef WRAPPERS_CHRONO_HPP
+#define WRAPPERS_CHRONO_HPP
+#include <chrono>
+
+namespace Flux {
+namespace chrono {
+template<typename clock = std::chrono::system_clock>
+double seconds_since_epoch ()
+{
+    auto duration_since_epoch = clock::now ().time_since_epoch ();
+    return std::chrono::duration<double> (duration_since_epoch).count ();
+}
+}  // namespace chrono
+}  // namespace Flux
+
+#endif

--- a/src/common/c++wrappers/jansson.hpp
+++ b/src/common/c++wrappers/jansson.hpp
@@ -4,7 +4,6 @@
 
 #ifndef JANSONN_HPP
 #define JANSONN_HPP
-#include <boost/icl/detail/map_algo.hpp>
 
 extern "C" {
 #include <jansson.h>

--- a/src/common/libintern/CMakeLists.txt
+++ b/src/common/libintern/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(intern STATIC
         interner.cpp)
+target_link_libraries(intern PUBLIC Boost::boost)
 
 add_executable(interned_string_test test/interned_string_test.cpp)
 add_sanitizers(interned_string_test)

--- a/src/common/libintern/interner.cpp
+++ b/src/common/libintern/interner.cpp
@@ -22,7 +22,12 @@
 
 namespace intern {
 namespace detail {
-std::shared_mutex group_mtx;
+
+static std::shared_mutex &get_group_mtx ()
+{
+    static std::shared_mutex group_mtx;
+    return group_mtx;
+}
 
 struct string_hash {
     using hash_type = std::hash<std::string_view>;
@@ -57,7 +62,7 @@ struct dense_inner_storage {
 dense_inner_storage &get_dense_inner_storage (size_t unique_id)
 {
     static std::unordered_map<size_t, dense_inner_storage> groups;
-    auto guard = std::unique_lock (group_mtx);
+    auto guard = std::unique_lock (get_group_mtx ());
     return groups[unique_id];
 }
 
@@ -96,7 +101,7 @@ struct sparse_inner_storage : std::enable_shared_from_this<sparse_inner_storage>
 sparse_inner_storage *get_sparse_inner_storage (size_t unique_id)
 {
     static std::unordered_map<size_t, std::shared_ptr<sparse_inner_storage>> groups;
-    auto guard = std::unique_lock (group_mtx);
+    auto guard = std::unique_lock (get_group_mtx ());
     auto &ret = groups[unique_id];
     if (!ret)
         ret = std::make_shared<sparse_inner_storage> ();

--- a/t/t0000-sharness.t
+++ b/t/t0000-sharness.t
@@ -448,7 +448,6 @@ test_expect_success 'empty sharness.d directory does not cause failure' '
 	mkdir nil-extensions &&
 	(
 		unset debug &&
-		unset verbose &&
 		cd nil-extensions &&
 		mkdir sharness.d  &&
 		ln -sf $SHARNESS_TEST_SRCDIR/sharness.sh . &&
@@ -456,7 +455,7 @@ test_expect_success 'empty sharness.d directory does not cause failure' '
 		test_description="sharness works"
 		. ./sharness.sh
 		test_expect_success "test success" "
-			/bin/true
+			true
 		"
 		test_done
 		EOF

--- a/t/t1001-qmanager-basic.t
+++ b/t/t1001-qmanager-basic.t
@@ -4,7 +4,7 @@ test_description='Test qmanager service in simulated mode'
 
 . `dirname $0`/sharness.sh
 
-hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+hwloc_basepath=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 1 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
 excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers"
 

--- a/t/t1002-qmanager-reload.t
+++ b/t/t1002-qmanager-reload.t
@@ -4,7 +4,7 @@ test_description='Test qmanager service reloading'
 
 . `dirname $0`/sharness.sh
 
-hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+hwloc_basepath=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 1 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
 excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers"
 

--- a/t/t1003-qmanager-policy.t
+++ b/t/t1003-qmanager-policy.t
@@ -4,7 +4,7 @@ test_description='Test the correctness of different queuing policies'
 
 . `dirname $0`/sharness.sh
 
-hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+hwloc_basepath=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 1 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
 excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers"
 

--- a/t/t1004-qmanager-optimize.t
+++ b/t/t1004-qmanager-optimize.t
@@ -4,7 +4,7 @@ test_description='Test the correctness of various queuing optimization'
 
 . `dirname $0`/sharness.sh
 
-hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+hwloc_basepath=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 1 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
 excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers"
 

--- a/t/t1006-qmanager-multiqueue.t
+++ b/t/t1006-qmanager-multiqueue.t
@@ -130,7 +130,7 @@ test_expect_success 'unload qmanager and deconfigure queues' '
 	flux config reload
 '
 test_expect_success 'submit job with no queue' '
-	flux submit /bin/true >noqueue.jobid
+	flux submit true >noqueue.jobid
 '
 test_expect_success 'reconfigure with one queue and load qmanager' '
 	cat >config/queues.toml <<-EOT &&
@@ -148,7 +148,7 @@ test_expect_success 'unload qmanager' '
 	remove_qmanager
 '
 test_expect_success 'submit job with queue' '
-	flux submit --queue=foo /bin/true >withqueue.jobid
+	flux submit --queue=foo true >withqueue.jobid
 '
 test_expect_success 'deconfigure queues and load qmanager' '
 	cp /dev/null config/queues.toml &&

--- a/t/t1007-recovery-full.t
+++ b/t/t1007-recovery-full.t
@@ -9,7 +9,7 @@ Full recovery case --
 
 . `dirname $0`/sharness.sh
 
-hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+hwloc_basepath=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 1 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
 excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers"
 

--- a/t/t1009-recovery-multiqueue.t
+++ b/t/t1009-recovery-multiqueue.t
@@ -6,7 +6,7 @@ test_description='Test the full state recovery of qmanager for multiple queues'
 
 mkdir -p config
 
-hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+hwloc_basepath=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 1 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
 excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers"
 

--- a/t/t1011-dynstate-change.t
+++ b/t/t1011-dynstate-change.t
@@ -6,7 +6,7 @@ test_description='Test Fluxion on Dynamic Resource State Changes'
 
 mkdir -p config
 
-hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+hwloc_basepath=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 4 brokers, each (exclusively) have:
 # 1 node, 2 sockets, 44 cores (22 per socket), 4 gpus (2 per socket)
 excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers-sierra2"

--- a/t/t1012-find-status.t
+++ b/t/t1012-find-status.t
@@ -4,7 +4,7 @@ test_description='Test Resource Find and Status with Fluxion Modules'
 
 . `dirname $0`/sharness.sh
 
-hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+hwloc_basepath=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 4 brokers, each (exclusively) have:
 # 1 node, 2 sockets, 44 cores (22 per socket), 4 gpus (2 per socket)
 excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers-sierra2"

--- a/t/t1013-qmanager-priority.t
+++ b/t/t1013-qmanager-priority.t
@@ -7,7 +7,7 @@ test_description='Fluxion takes into account urgency and t_submit'
 export TEST_UNDER_FLUX_QUORUM=1
 export TEST_UNDER_FLUX_START_MODE=leader
 
-hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+hwloc_basepath=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 1 node, 2 sockets, 44 cores (22 per socket), 4 gpus (2 per socket)
 excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers-sierra2"
 

--- a/t/t1014-annotation.t
+++ b/t/t1014-annotation.t
@@ -20,7 +20,7 @@ See RFC 27 for more details on alloc response and annotations.
 
 . `dirname $0`/sharness.sh
 
-hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+hwloc_basepath=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 1 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
 excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers"
 

--- a/t/t1015-find-format.t
+++ b/t/t1015-find-format.t
@@ -4,8 +4,8 @@ test_description='Test Resource Find and Status with Fluxion Modules'
 
 . `dirname $0`/sharness.sh
 
-hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
-expected_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/resource/expected/find-format`
+hwloc_basepath=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+expected_basepath=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/resource/expected/find-format`
 excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers/"
 query="../../resource/utilities/resource-query"
 

--- a/t/t1016-nest-namespace.t
+++ b/t/t1016-nest-namespace.t
@@ -4,7 +4,7 @@ test_description='Test Id Namespace Remapping for Nested Instances'
 
 . `dirname $0`/sharness.sh
 
-hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+hwloc_basepath=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 1 brokers: 1 node, 2 sockets, 44 cores 4 gpus
 excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers-sierra2"
 

--- a/t/t1017-rv1-bootstrap.t
+++ b/t/t1017-rv1-bootstrap.t
@@ -4,7 +4,7 @@ test_description='Test Bootstrapping from RV1 Object'
 
 . `dirname $0`/sharness.sh
 
-hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+hwloc_basepath=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 4 brokers: 1 node, 2 sockets, 44 cores 4 gpus
 excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers-sierra2"
 export WAITFILE="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"

--- a/t/t1019-qmanager-async.t
+++ b/t/t1019-qmanager-async.t
@@ -4,7 +4,7 @@ test_description='Coverage for async RPC between fluxion modules'
 
 . `dirname $0`/sharness.sh
 
-hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+hwloc_basepath=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 1 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
 excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers"
 

--- a/t/t1020-qmanager-feasibility.t
+++ b/t/t1020-qmanager-feasibility.t
@@ -4,7 +4,7 @@ test_description='Test fluxion with feasibility validator of job-validator'
 
 . `dirname $0`/sharness.sh
 
-hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+hwloc_basepath=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 1 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
 excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers"
 

--- a/t/t1021-qmanager-nodex.t
+++ b/t/t1021-qmanager-nodex.t
@@ -4,7 +4,7 @@ test_description='Test Node Exclusive Scheduling w/ qmanager'
 
 . `dirname $0`/sharness.sh
 
-hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+hwloc_basepath=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 4 brokers: 1 node, 2 sockets, 44 cores 4 gpus
 excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers-sierra2"
 

--- a/t/t1023-multiqueue-constraints.t
+++ b/t/t1023-multiqueue-constraints.t
@@ -43,20 +43,20 @@ test_expect_success 'load fluxion modules' '
 	load_qmanager
 '
 test_expect_success 'run a job in each queue' '
-	flux run --queue=debug /bin/true &&
-	flux run --queue=batch /bin/true
+	flux run --queue=debug true &&
+	flux run --queue=batch true
 '
 test_expect_success 'occupy resources in first queue' '
 	flux submit --queue=debug sleep 300 >job1.out
 '
 test_expect_success 'run a job in second queue' '
-	flux run --queue=batch /bin/true
+	flux run --queue=batch true
 '
 test_expect_success 'create a backlog in first queue' '
-	flux submit --queue=debug /bin/true
+	flux submit --queue=debug true
 '
 test_expect_success 'run a job in second queue' '
-	flux run --queue=batch /bin/true
+	flux run --queue=batch true
 '
 test_expect_success 'occupy resources in second queue' '
 	flux submit --queue=batch -N3 sleep 300 >job2.out
@@ -65,36 +65,36 @@ test_expect_success 'cancel job occupying first queue' '
 	flux cancel $(cat job1.out)
 '
 test_expect_success 'run a job in first queue' '
-	flux run --queue=debug /bin/true
+	flux run --queue=debug true
 '
 test_expect_success 'create a backlog in second queue' '
-	flux submit --queue=batch /bin/true
+	flux submit --queue=batch true
 '
 test_expect_success 'run a job in first queue' '
-	flux run --queue=debug /bin/true
+	flux run --queue=debug true
 '
 test_expect_success 'cancel job occupying second queue' '
 	flux cancel $(cat job2.out)
 '
 test_expect_success 'run a job in each queue' '
-	flux run --queue=debug /bin/true &&
-	flux run --queue=batch /bin/true
+	flux run --queue=debug true &&
+	flux run --queue=batch true
 '
 test_expect_success 'a job with redundant constraint works' '
-	flux run --queue=debug --requires=debug /bin/true
+	flux run --queue=debug --requires=debug true
 '
 test_expect_success 'a job with unsatisfiable constraint fails' '
-	test_must_fail flux run --queue=debug --requires=tinymem /bin/true
+	test_must_fail flux run --queue=debug --requires=tinymem true
 '
 test_expect_success 'a job with unsatisfiable node count fails' '
-	test_must_fail flux run --queue=debug -N2 /bin/true
+	test_must_fail flux run --queue=debug -N2 true
 '
 test_expect_success 'a job with satisfiable constraint works' '
-	flux run --queue=batch --requires=tinymem /bin/true
+	flux run --queue=batch --requires=tinymem true
 '
 test_expect_success 'a job with multiple constraints works in both queues' '
-	flux run --queue=debug --requires=bigmem /bin/true &&
-	flux run --queue=batch --requires=bigmem /bin/true
+	flux run --queue=debug --requires=bigmem true &&
+	flux run --queue=batch --requires=bigmem true
 '
 test_expect_success 'stop queues' '
 	flux queue stop --all
@@ -104,23 +104,23 @@ test_expect_success 'consume wait status so far' '
 '
 test_expect_success 'submit a held job to the first queue' '
 	flux submit --flags=waitable \
-	    --queue=debug --urgency=hold /bin/true >job3.out
+	    --queue=debug --urgency=hold true >job3.out
 '
 test_expect_success 'submit a diverse set of jobs to both queues' '
 	flux submit --flags=waitable \
-	    --queue=debug --requires=bigmem /bin/true &&
+	    --queue=debug --requires=bigmem true &&
 	flux submit --flags=waitable --cc=1-10 -N2 \
-	    --queue=batch /bin/true &&
+	    --queue=batch true &&
 	flux submit --flags=waitable \
-	    --queue=debug --requires=bigmem --urgency=31 /bin/true &&
+	    --queue=debug --requires=bigmem --urgency=31 true &&
 	flux submit --flags=waitable \
-	    --queue=batch --requires=bigmem /bin/true &&
+	    --queue=batch --requires=bigmem true &&
 	flux submit --flags=waitable --cc=1-10 \
-	    --queue=debug /bin/true &&
+	    --queue=debug true &&
 	flux submit --flags=waitable \
-	    --queue=debug --requires=bigmem --urgency=1 /bin/true &&
+	    --queue=debug --requires=bigmem --urgency=1 true &&
 	flux submit --flags=waitable \
-	    --queue=debug /bin/true
+	    --queue=debug true
 '
 test_expect_success 'drain a node' '
 	flux resource drain 1 testing...
@@ -130,9 +130,9 @@ test_expect_success 'start queues - bunch of alloc requests arrive at once' '
 '
 test_expect_success 'submit some additional work on top of that' '
 	flux submit --flags=waitable --cc=1-10 \
-	    --queue=batch /bin/true &&
+	    --queue=batch true &&
 	flux submit --flags=waitable --cc=1-10 \
-	    --queue=debug /bin/true
+	    --queue=debug true
 '
 test_expect_success 'undrain the node' '
 	flux resource undrain 1

--- a/t/t1024-alloc-check.t
+++ b/t/t1024-alloc-check.t
@@ -4,7 +4,7 @@ test_description='Check that fluxion never double books resources'
 
 . `dirname $0`/sharness.sh
 
-hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+hwloc_basepath=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 1 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
 excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers"
 

--- a/t/t1026-rv1-partial-release.t
+++ b/t/t1026-rv1-partial-release.t
@@ -65,17 +65,17 @@ if flux dmesg | grep +partial-ok; then
 fi
 
 test_expect_success 'run a normal job, resources are free' '
-	flux run -vvv -xN4 /bin/true &&
+	flux run -vvv -xN4 true &&
 	test_debug "echo free=\$(fluxion_free ncores)" &&
 	test $(fluxion_free ncores) -eq $TOTAL_NCORES
 '
 test_expect_success 'run 4 single node jobs, resources are free' '
-	flux submit -v --cc=1-4 -xN1 --wait /bin/true &&
+	flux submit -v --cc=1-4 -xN1 --wait true &&
 	flux resource list -s free -no "total={ncores}" &&
 	test $(flux resource list -s free -no {ncores}) -eq $TOTAL_NCORES
 '
 test_expect_success 'run 16 single core jobs, resources are free' '
-	flux submit -v --cc=1-16 -n1 --wait /bin/true &&
+	flux submit -v --cc=1-16 -n1 --wait true &&
 	test_debug "echo free=\$(fluxion_free ncores)" &&
 	test $(fluxion_free ncores) -eq $TOTAL_NCORES
 '
@@ -108,7 +108,7 @@ test_expect_success 'enable housekeeping with immediate partial release' '
 	EOF
 '
 test_expect_success 'run a job across all nodes, wait for housekeeping' '
-	flux run -N4 -n4 /bin/true &&
+	flux run -N4 -n4 true &&
 	hk_wait_for_running 0
 '
 test_expect_success 'attempt to ensure dmesg buffer synchronized' '

--- a/t/t2317-resource-shrink.t
+++ b/t/t2317-resource-shrink.t
@@ -4,7 +4,7 @@ test_description='Test resource shrink when not using resource configuration'
 
 . `dirname $0`/sharness.sh
 
-notify_base=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/satisfiability`
+notify_base=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/satisfiability`
 
 SIZE=4
 test_under_flux $SIZE full --test-exit-mode=leader

--- a/t/t3301-system-latestart.t
+++ b/t/t3301-system-latestart.t
@@ -55,12 +55,12 @@ test_expect_success 'resource status shows no drained nodes' '
 '
 
 test_expect_success 'flux exec -r 1 fails with EHOSTUNREACH' '
-	test_must_fail run_timeout 30 flux exec -r 1 /bin/true 2>unreach.err &&
+	test_must_fail run_timeout 30 flux exec -r 1 true 2>unreach.err &&
 	grep "$(strerror_symbol EHOSTUNREACH)" unreach.err
 '
 
 test_expect_success 'single node job can run with only rank 0 up' '
-	run_timeout 30 flux run -n1 /bin/true
+	run_timeout 30 flux run -n1 true
 '
 
 test_expect_success 'two node job is accepted although it cannot run yet' '

--- a/t/t4004-match-hwloc.t
+++ b/t/t4004-match-hwloc.t
@@ -8,7 +8,7 @@ Ensure that the match (allocate) handler within the resource module works
 
 . `dirname $0`/sharness.sh
 
-jobspec_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/`
+jobspec_basepath=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/`
 # slot[1]->core[1]
 jobspec_1core="${jobspec_basepath}/basics/test008.yaml"
 # node[1]->slot[2]->socket[1]
@@ -18,7 +18,7 @@ jobspec_2socket="${jobspec_basepath}/basics/test009.yaml"
 #                 ->gpu[2]
 jobspec_1socket_2gpu="${jobspec_basepath}/basics/test013.yaml"
 
-hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+hwloc_basepath=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 1 broker: 1 node, 1 socket, 4 cores
 hwloc_4core="${hwloc_basepath}/001N/exclusive/04-brokers/0.xml"
 # 4 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)

--- a/t/t4008-match-jgf.t
+++ b/t/t4008-match-jgf.t
@@ -8,7 +8,7 @@ Ensure that the match (allocate) handler within the resource module works
 
 . `dirname $0`/sharness.sh
 
-jobspec_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/`
+jobspec_basepath=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/`
 # slot[1]->core[1]
 jobspec_1core="${jobspec_basepath}/basics/test008.yaml"
 jgf_4core="${SHARNESS_TEST_SRCDIR}/data/resource/jgfs/hwloc_4core.json"

--- a/t/t4009-match-update.t
+++ b/t/t4009-match-update.t
@@ -8,7 +8,7 @@ Ensure that the resource.update handler within the resource module works
 
 . `dirname $0`/sharness.sh
 
-hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+hwloc_basepath=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 1 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
 excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers"
 

--- a/t/t4014-match-feasibility.t
+++ b/t/t4014-match-feasibility.t
@@ -8,7 +8,7 @@ test_description='Test the basic functionality of match satisfiability'
 . `dirname $0`/sharness.sh
 
 conf_base=${SHARNESS_TEST_SRCDIR}/conf.d
-notify_base=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/shrink`
+notify_base=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/shrink`
 grug="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/tiny.graphml"
 jobspec1="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/basics/test001.yaml"
 

--- a/t/t4015-notify-feasibility.t
+++ b/t/t4015-notify-feasibility.t
@@ -8,7 +8,7 @@ test_description='Test the functionality of match satisfiability after module re
 . `dirname $0`/sharness.sh
 
 conf_base=${SHARNESS_TEST_SRCDIR}/conf.d
-notify_base=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/satisfiability`
+notify_base=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/satisfiability`
 
 SIZE=4
 export FLUX_URI_RESOLVE_LOCAL=t

--- a/t/t6002-graph-hwloc.t
+++ b/t/t6002-graph-hwloc.t
@@ -4,7 +4,7 @@ test_description='Test Graph Data Store under the Fluxion Resource Module'
 
 . `dirname $0`/sharness.sh
 
-hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
+hwloc_basepath=`readlink -f ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 # 4 brokers, each (exclusively) have: 1 node, 2 sockets, 16 cores (8 per socket)
 excl_4N4B="${hwloc_basepath}/004N/exclusive/04-brokers"
 

--- a/t/valgrind/workload.d/00-job
+++ b/t/valgrind/workload.d/00-job
@@ -7,7 +7,7 @@ NJOBS=${NJOBS:-10}
 
 echo Submitting $NJOBS jobs
 for i in `seq 1 $NJOBS`; do
-    flux submit /bin/true
+    flux submit true
 done
 echo Waiting jobs to complete
 flux queue drain


### PR DESCRIPTION
Note that this requires flux-framework/flux-core#6929 and likely will not pass CI until that becomes part of HEAD in flux-core.  At present many of the tests do not pass, and I need to work out how best to determine the ones that do, but it does build and some of the tests run correctly on macos.  Interestingly, using an alternate c++ runtime and alternate linker exposed things that are potential problems on linux as well, this has been surprisingly useful as a way to find nondeterminism.