### PR TITLE
etc: add missing "needs" to modprobe config

### DIFF
--- a/etc/modprobe/modprobe.d/fluxion.toml
+++ b/etc/modprobe/modprobe.d/fluxion.toml
@@ -13,6 +13,7 @@ priority = 500
 ranks = "0"
 after = ["sched-fluxion-resource"]
 requires = ["sched-fluxion-resource"]
+needs = ["sched-fluxion-resource"]
 
 [[modules]]
 name = "sched-fluxion-qmanager"
@@ -21,3 +22,4 @@ priority = 500
 ranks = "0"
 after = ["job-manager", "sched-fluxion-resource"]
 requires = ["sched-fluxion-resource", "job-manager"]
+needs = ["sched-fluxion-resource"]


### PR DESCRIPTION
Problem: sched-fluxion-qmanager and sched-fluxion-feasibility need sched-fluxion-resource in order to be loaded, but this is not reflected in the fluxion modprobe config.

Add

```
 needs = ["sched-fluxion-resource"]
```

to the config for sched-fluxion-qmanager and sched-fluxion-resource so that if sched-fluxion-qmanager is disabled, these modules are disabled as well.