### PR TITLE
resource: Add match --within option

### DIFF
--- a/resource/CMakeLists.txt
+++ b/resource/CMakeLists.txt
@@ -100,6 +100,7 @@ target_link_libraries(resource PUBLIC
     Boost::graph
     jobspec_conv
     match_op
+    dfu_match_attrs
     )
 add_sanitizers(resource)
 
@@ -109,7 +110,7 @@ add_subdirectory(evaluators)
 add_subdirectory(policies)
 add_subdirectory(schema)
 add_subdirectory(writers)
-add_subdirectory(traversers/test)
+add_subdirectory(traversers)
 
 # programs that depend on libresource
 add_subdirectory(utilities)

--- a/resource/modules/CMakeLists.txt
+++ b/resource/modules/CMakeLists.txt
@@ -21,7 +21,9 @@ flux_add_plugin ( sched-fluxion-feasibility MODULE
 
 target_link_libraries (sched-fluxion-resource PRIVATE
 	sched-fluxion-resource-module
+	dfu_match_attrs
     )
 target_link_libraries (sched-fluxion-feasibility PRIVATE
 	sched-fluxion-resource-module
+	dfu_match_attrs
     )

--- a/resource/modules/feasibility.cpp
+++ b/resource/modules/feasibility.cpp
@@ -204,12 +204,12 @@ static void feasibility_request_cb (flux_t *h,
 {
     int64_t at = 0;
     int64_t now = 0;
-    double overhead = 0.0f;
     int saved_errno = 0;
     std::stringstream R;
     json_t *jobspec = nullptr;
     const char *js_str = nullptr;
     std::string errmsg;
+    traverser_match_attrs attrs = default_match_attrs;
     flux_error_t error;
     std::shared_ptr<resource_ctx_t> ctx = getctx ((flux_t *)arg);
 
@@ -220,7 +220,7 @@ static void feasibility_request_cb (flux_t *h,
         goto error;
     }
     error.text[0] = '\0';
-    if (run_match (ctx, -1, "satisfiability", js_str, &now, &at, &overhead, R, &error) < 0) {
+    if (run_match (ctx, -1, "satisfiability", js_str, &now, &at, R, &attrs, &error) < 0) {
         if (errno == ENODEV)
             errmsg = "Unsatisfiable request";
         else {

--- a/resource/modules/resource.cpp
+++ b/resource/modules/resource.cpp
@@ -368,19 +368,22 @@ static void match_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_t
     const char *cmd = NULL;
     const char *js_str = NULL;
     const char *status = nullptr;
+    int64_t candidate_within = std::numeric_limits<int64_t>::min ();
     std::stringstream R;
     traverser_match_attrs attrs = default_match_attrs;
 
     std::shared_ptr<resource_ctx_t> ctx = getctx ((flux_t *)arg);
     if (flux_request_unpack (msg,
                              NULL,
-                             "{s:s s:I s:s}",
+                             "{s:s s:I s:s s?I}",
                              "cmd",
                              &cmd,
                              "jobid",
                              &jobid,
                              "jobspec",
-                             &js_str)
+                             &js_str,
+                             "within",
+                             &candidate_within)
         < 0)
         goto error;
     // Jobid -1 denotes that the matched resources do not belong to any particular job.
@@ -394,6 +397,8 @@ static void match_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_t
         flux_log_error (h, "%s: existent job (%jd).", __FUNCTION__, (intmax_t)jobid);
         goto error;
     }
+    if (candidate_within != std::numeric_limits<int64_t>::min ())
+        attrs.match_within = candidate_within;
     if (run_match (ctx, jobid, cmd, js_str, &now, &at, R, &attrs, NULL) < 0) {
         if (errno != EBUSY && errno != ENODEV)
             flux_log_error (ctx->h,

--- a/resource/modules/resource.cpp
+++ b/resource/modules/resource.cpp
@@ -287,10 +287,10 @@ static void update_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_
 {
     char *R = NULL;
     int64_t at = 0;
-    double overhead = 0.0f;
     int64_t jobid = 0;
     uint64_t duration = 0;
     const char *status = nullptr;
+    traverser_match_attrs attrs = default_match_attrs;
     std::stringstream o;
     std::chrono::time_point<std::chrono::system_clock> start;
     std::chrono::duration<double> elapsed;
@@ -317,7 +317,7 @@ static void update_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_
         }
         elapsed = std::chrono::system_clock::now () - start;
         // If a jobid with matching R exists, no need to update
-        overhead = elapsed.count ();
+        attrs.match_overhead = elapsed.count ();
         status = get_jobstate_str (ctx->jobs[jobid]->state);
         o << ctx->jobs[jobid]->R;
         at = ctx->jobs[jobid]->scheduled_at;
@@ -326,7 +326,7 @@ static void update_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_
                   "%s: jobid (%jd) with matching R exists",
                   __FUNCTION__,
                   static_cast<intmax_t> (jobid));
-    } else if (run_update (ctx, jobid, R, at, overhead, o) < 0) {
+    } else if (run_update (ctx, jobid, R, at, &attrs, o) < 0) {
         flux_log_error (ctx->h,
                         "%s: update failed (id=%jd)",
                         __FUNCTION__,
@@ -345,7 +345,7 @@ static void update_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_
                            "status",
                            status,
                            "overhead",
-                           overhead,
+                           attrs.match_overhead,
                            "R",
                            o.str ().c_str (),
                            "at",
@@ -365,11 +365,11 @@ static void match_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_t
     int64_t at = 0;
     int64_t now = 0;
     int64_t jobid = -1;
-    double overhead = 0.0f;
     const char *cmd = NULL;
     const char *js_str = NULL;
     const char *status = nullptr;
     std::stringstream R;
+    traverser_match_attrs attrs = default_match_attrs;
 
     std::shared_ptr<resource_ctx_t> ctx = getctx ((flux_t *)arg);
     if (flux_request_unpack (msg,
@@ -394,7 +394,7 @@ static void match_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_t
         flux_log_error (h, "%s: existent job (%jd).", __FUNCTION__, (intmax_t)jobid);
         goto error;
     }
-    if (run_match (ctx, jobid, cmd, js_str, &now, &at, &overhead, R, NULL) < 0) {
+    if (run_match (ctx, jobid, cmd, js_str, &now, &at, R, &attrs, NULL) < 0) {
         if (errno != EBUSY && errno != ENODEV)
             flux_log_error (ctx->h,
                             "%s: match failed due to match error (id=%jd)",
@@ -417,7 +417,7 @@ static void match_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_t
                            "status",
                            status,
                            "overhead",
-                           overhead,
+                           attrs.match_overhead,
                            "R",
                            R.str ().c_str (),
                            "at",
@@ -463,8 +463,8 @@ static void match_multi_request_cb (flux_t *h,
         char *jobspec_str = nullptr;
         int64_t at = 0;
         int64_t now = 0;
-        double overhead = 0.0f;
         std::stringstream R;
+        traverser_match_attrs attrs = default_match_attrs;
 
         if (json_unpack (value, "{s:I s:o}", "jobid", &jobid, "jobspec", &jobspec_obj) < 0)
             goto error;
@@ -481,7 +481,7 @@ static void match_multi_request_cb (flux_t *h,
             free (jobspec_str);
             goto error;
         }
-        if (run_match (ctx, jobid, cmd, jobspec_str, &now, &at, &overhead, R, NULL) < 0) {
+        if (run_match (ctx, jobid, cmd, jobspec_str, &now, &at, R, &attrs, NULL) < 0) {
             if (errno != EBUSY && errno != ENODEV)
                 flux_log_error (ctx->h,
                                 "%s: match failed due to match error (id=%jd)",
@@ -506,7 +506,7 @@ static void match_multi_request_cb (flux_t *h,
                                "status",
                                status,
                                "overhead",
-                               overhead,
+                               attrs.match_overhead,
                                "R",
                                R.str ().c_str (),
                                "at",

--- a/resource/modules/resource.cpp
+++ b/resource/modules/resource.cpp
@@ -369,18 +369,22 @@ static void match_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_t
     const char *cmd = NULL;
     const char *js_str = NULL;
     const char *status = nullptr;
+    boost::optional<int64_t> within = boost::none;
+    int64_t candidate_within = std::numeric_limits<int64_t>::min ();
     std::stringstream R;
 
     std::shared_ptr<resource_ctx_t> ctx = getctx ((flux_t *)arg);
     if (flux_request_unpack (msg,
                              NULL,
-                             "{s:s s:I s:s}",
+                             "{s:s s:I s:s s?I}",
                              "cmd",
                              &cmd,
                              "jobid",
                              &jobid,
                              "jobspec",
-                             &js_str)
+                             &js_str,
+                             "within",
+                             &candidate_within)
         < 0)
         goto error;
     // Jobid -1 denotes that the matched resources do not belong to any particular job.
@@ -394,7 +398,9 @@ static void match_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_t
         flux_log_error (h, "%s: existent job (%jd).", __FUNCTION__, (intmax_t)jobid);
         goto error;
     }
-    if (run_match (ctx, jobid, cmd, js_str, &now, &at, &overhead, R, NULL) < 0) {
+    if (candidate_within != std::numeric_limits<int64_t>::min ())
+        within = candidate_within;
+    if (run_match (ctx, jobid, cmd, js_str, &now, &at, &overhead, R, NULL, within) < 0) {
         if (errno != EBUSY && errno != ENODEV)
             flux_log_error (ctx->h,
                             "%s: match failed due to match error (id=%jd)",

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -1463,12 +1463,13 @@ static int run (std::shared_ptr<resource_ctx_t> &ctx,
                 match_op_t op,
                 const std::string &jstr,
                 int64_t *at,
+                traverser_match_attrs *attrs,
                 flux_error_t *errp)
 {
     int rc = -1;
     try {
         Flux::Jobspec::Jobspec j{jstr};
-        rc = ctx->traverser->run (j, ctx->writers, op, jobid, at);
+        rc = ctx->traverser->run (j, ctx->writers, op, jobid, at, attrs);
     } catch (const Flux::Jobspec::parse_error &e) {
         errno = EINVAL;
         if (errp && e.what ()) {
@@ -1550,14 +1551,15 @@ int run_match (std::shared_ptr<resource_ctx_t> &ctx,
                const std::string &jstr,
                int64_t *now,
                int64_t *at,
-               double *overhead,
                std::stringstream &o,
+               traverser_match_attrs *attrs,
                flux_error_t *errp)
 {
     int rc = 0;
     std::chrono::time_point<std::chrono::system_clock> start;
     std::chrono::duration<double> elapsed;
     std::chrono::duration<int64_t> epoch;
+    double overhead = 0.0f;
     bool rsv = false;
 
     start = std::chrono::system_clock::now ();
@@ -1571,10 +1573,12 @@ int run_match (std::shared_ptr<resource_ctx_t> &ctx,
 
     epoch = std::chrono::duration_cast<std::chrono::seconds> (start.time_since_epoch ());
     *at = *now = epoch.count ();
-    if ((rc = run (ctx, jobid, op, jstr, at, errp)) < 0) {
+    if ((rc = run (ctx, jobid, op, jstr, at, attrs, errp)) < 0) {
         elapsed = std::chrono::system_clock::now () - start;
-        *overhead = elapsed.count ();
-        update_match_perf (*overhead, jobid, false);
+        overhead = elapsed.count ();
+        update_match_perf (overhead, jobid, false);
+        if (attrs)
+            attrs->match_overhead = overhead;
         goto done;
     }
     if ((rc = ctx->writers->emit (o)) < 0) {
@@ -1584,12 +1588,14 @@ int run_match (std::shared_ptr<resource_ctx_t> &ctx,
 
     rsv = (*now != *at) ? true : false;
     elapsed = std::chrono::system_clock::now () - start;
-    *overhead = elapsed.count ();
-    update_match_perf (*overhead, jobid, true);
+    overhead = elapsed.count ();
+    update_match_perf (overhead, jobid, true);
+    if (attrs)
+        attrs->match_overhead = overhead;
 
     if (op != match_op_t::MATCH_SATISFIABILITY && op != match_op_t::MATCH_WITHOUT_ALLOCATING
         && op != match_op_t::MATCH_WITHOUT_ALLOCATING_FUTURE) {
-        if ((rc = track_schedule_info (ctx, jobid, rsv, *at, jstr, o, *overhead)) != 0) {
+        if ((rc = track_schedule_info (ctx, jobid, rsv, *at, jstr, o, overhead)) != 0) {
             flux_log_error (ctx->h,
                             "%s: can't add job info (id=%jd)",
                             __FUNCTION__,
@@ -1606,7 +1612,7 @@ int run_update (std::shared_ptr<resource_ctx_t> &ctx,
                 int64_t jobid,
                 const char *R,
                 int64_t &at,
-                double &overhead,
+                traverser_match_attrs *attrs,
                 std::stringstream &o)
 {
     int rc = 0;
@@ -1615,6 +1621,7 @@ int run_update (std::shared_ptr<resource_ctx_t> &ctx,
     std::chrono::duration<double> elapsed;
     std::string R_graph_fmt;
     std::string format;
+    double overhead = 0.0f;
 
     start = std::chrono::system_clock::now ();
     if ((rc = parse_R (ctx, R, R_graph_fmt, at, duration, format)) < 0) {
@@ -1625,6 +1632,8 @@ int run_update (std::shared_ptr<resource_ctx_t> &ctx,
         elapsed = std::chrono::system_clock::now () - start;
         overhead = elapsed.count ();
         update_match_perf (overhead, jobid, false);
+        if (attrs)
+            attrs->match_overhead = overhead;
         flux_log_error (ctx->h, "%s: run", __FUNCTION__);
         goto done;
     }
@@ -1635,6 +1644,8 @@ int run_update (std::shared_ptr<resource_ctx_t> &ctx,
     elapsed = std::chrono::system_clock::now () - start;
     overhead = elapsed.count ();
     update_match_perf (overhead, jobid, true);
+    if (attrs)
+        attrs->match_overhead = overhead;
     if ((rc = track_schedule_info (ctx, jobid, false, at, "", o, overhead)) != 0) {
         flux_log_error (ctx->h, "%s: can't add job info (id=%jd)", __FUNCTION__, (intmax_t)jobid);
         goto done;

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -1462,13 +1462,14 @@ static int run (std::shared_ptr<resource_ctx_t> &ctx,
                 int64_t jobid,
                 match_op_t op,
                 const std::string &jstr,
+                boost::optional<int64_t> within,
                 int64_t *at,
                 flux_error_t *errp)
 {
     int rc = -1;
     try {
         Flux::Jobspec::Jobspec j{jstr};
-        rc = ctx->traverser->run (j, ctx->writers, op, jobid, at);
+        rc = ctx->traverser->run (j, ctx->writers, op, jobid, at, within);
     } catch (const Flux::Jobspec::parse_error &e) {
         errno = EINVAL;
         if (errp && e.what ()) {
@@ -1552,14 +1553,15 @@ int run_match (std::shared_ptr<resource_ctx_t> &ctx,
                int64_t *at,
                double *overhead,
                std::stringstream &o,
-               flux_error_t *errp)
+               flux_error_t *errp,
+               boost::optional<int64_t> within)
 {
     int rc = 0;
     std::chrono::time_point<std::chrono::system_clock> start;
     std::chrono::duration<double> elapsed;
     std::chrono::duration<int64_t> epoch;
     bool rsv = false;
-
+    ;
     start = std::chrono::system_clock::now ();
     match_op_t op = match_op_from_string (cmd);
     if (!match_op_valid (op)) {
@@ -1571,7 +1573,8 @@ int run_match (std::shared_ptr<resource_ctx_t> &ctx,
 
     epoch = std::chrono::duration_cast<std::chrono::seconds> (start.time_since_epoch ());
     *at = *now = epoch.count ();
-    if ((rc = run (ctx, jobid, op, jstr, at, errp)) < 0) {
+
+    if ((rc = run (ctx, jobid, op, jstr, within, at, errp)) < 0) {
         elapsed = std::chrono::system_clock::now () - start;
         *overhead = elapsed.count ();
         update_match_perf (*overhead, jobid, false);

--- a/resource/modules/resource_match.hpp
+++ b/resource/modules/resource_match.hpp
@@ -144,15 +144,15 @@ int run_match (std::shared_ptr<resource_ctx_t> &ctx,
                const std::string &jstr,
                int64_t *now,
                int64_t *at,
-               double *overhead,
                std::stringstream &o,
+               traverser_match_attrs *attrs,
                flux_error_t *errp);
 
 int run_update (std::shared_ptr<resource_ctx_t> &ctx,
                 int64_t jobid,
                 const char *R,
                 int64_t &at,
-                double &overhead,
+                traverser_match_attrs *attrs,
                 std::stringstream &o);
 
 int run_remove (std::shared_ptr<resource_ctx_t> &ctx,

--- a/resource/modules/resource_match.hpp
+++ b/resource/modules/resource_match.hpp
@@ -26,6 +26,8 @@ extern "C" {
 #include <map>
 #include <cinttypes>
 #include <chrono>
+#include <boost/optional.hpp>
+#include <jansson.hpp>
 
 #include "resource_match.hpp"
 #include "resource/schema/resource_graph.hpp"
@@ -35,7 +37,6 @@ extern "C" {
 #include "resource/policies/dfu_match_policy_factory.hpp"
 #include "resource_match_opts.hpp"
 #include "resource/schema/perf_data.hpp"
-#include <jansson.hpp>
 
 using namespace Flux::resource_model;
 using namespace Flux::opts_manager;
@@ -146,7 +147,8 @@ int run_match (std::shared_ptr<resource_ctx_t> &ctx,
                int64_t *at,
                double *overhead,
                std::stringstream &o,
-               flux_error_t *errp);
+               flux_error_t *errp,
+               boost::optional<int64_t> within = boost::none);
 
 int run_update (std::shared_ptr<resource_ctx_t> &ctx,
                 int64_t jobid,

--- a/resource/reapi/bindings/CMakeLists.txt
+++ b/resource/reapi/bindings/CMakeLists.txt
@@ -13,6 +13,7 @@ target_link_libraries( reapi_cli PUBLIC
     flux::core
     flux::idset
     match_op
+    dfu_match_attrs
     )
 install(TARGETS reapi_cli LIBRARY DESTINATION "${FLUX_LIB_DIR}")
 
@@ -28,6 +29,7 @@ target_link_libraries( reapi_module PRIVATE
     )
 target_link_libraries( reapi_module PUBLIC
     match_op
+    dfu_match_attrs
     )
 
 if(BUILD_TESTING)

--- a/resource/reapi/bindings/c++/reapi.hpp
+++ b/resource/reapi/bindings/c++/reapi.hpp
@@ -131,6 +131,7 @@ class reapi_t {
      *                   at which the job is reserved.
      *  \param attrs     Optional traversal attributes:
      *    match_overhead    Double into which to return performance overhead.
+     *    match_within      Don't return matches starting after this duration.
      *  \return          0 on success; -1 on error.
      */
     static int match_allocate (void *h,

--- a/resource/reapi/bindings/c++/reapi.hpp
+++ b/resource/reapi/bindings/c++/reapi.hpp
@@ -25,6 +25,7 @@ extern "C" {
 #include <string>
 #include <optional>
 #include "resource/schema/resource_data.hpp"
+#include "resource/traversers/dfu.hpp"
 
 namespace Flux {
 namespace resource_model {
@@ -128,9 +129,8 @@ class reapi_t {
      *                   allocated or reserved.
      *  \param at        If allocated, 0 is returned; if reserved, actual time
      *                   at which the job is reserved.
-     *  \param ov        Double into which to return performance overhead
-     *                   in terms of elapse time needed to complete
-     *                   the match operation.
+     *  \param attrs     Optional traversal attributes:
+     *    match_overhead    Double into which to return performance overhead.
      *  \return          0 on success; -1 on error.
      */
     static int match_allocate (void *h,
@@ -140,7 +140,7 @@ class reapi_t {
                                bool &reserved,
                                std::string &R,
                                int64_t &at,
-                               double &ov)
+                               traverser_match_attrs *attrs)
     {
         return -1;
     }

--- a/resource/reapi/bindings/c++/reapi.hpp
+++ b/resource/reapi/bindings/c++/reapi.hpp
@@ -24,6 +24,7 @@ extern "C" {
 #include <cstdint>
 #include <string>
 #include <optional>
+#include <boost/optional.hpp>
 #include "resource/schema/resource_data.hpp"
 
 namespace Flux {
@@ -131,6 +132,11 @@ class reapi_t {
      *  \param ov        Double into which to return performance overhead
      *                   in terms of elapse time needed to complete
      *                   the match operation.
+     *  \param within    Only return matches that start between now and now+within.
+     *                   If within < 0, don't apply this filter.  However, if
+     *                   within == boost::none, also search for a 'within'
+     *                   value in the jobspec's user attributes dictionary.
+     *
      *  \return          0 on success; -1 on error.
      */
     static int match_allocate (void *h,
@@ -140,7 +146,8 @@ class reapi_t {
                                bool &reserved,
                                std::string &R,
                                int64_t &at,
-                               double &ov)
+                               double &ov,
+                               boost::optional<int64_t> within = boost::none)
     {
         return -1;
     }

--- a/resource/reapi/bindings/c++/reapi_cli.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli.hpp
@@ -97,7 +97,11 @@ class resource_query_t {
     void incr_job_counter ();
 
     /* Run the traverser to match the jobspec */
-    int traverser_run (Flux::Jobspec::Jobspec &job, match_op_t op, int64_t jobid, int64_t &at);
+    int traverser_run (Flux::Jobspec::Jobspec &job,
+                       match_op_t op,
+                       int64_t jobid,
+                       int64_t &at,
+                       traverser_match_attrs *attrs = nullptr);
     int traverser_find (std::string criteria);
 
     // must be public; results in a deleted stringstream if converted to
@@ -143,7 +147,7 @@ class reapi_cli_t : public reapi_t {
                                bool &reserved,
                                std::string &R,
                                int64_t &at,
-                               double &ov);
+                               traverser_match_attrs *attrs = nullptr);
     static int match_allocate_multi (void *h,
                                      bool orelse_reserve,
                                      const char *jobs,

--- a/resource/reapi/bindings/c++/reapi_cli.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli.hpp
@@ -23,6 +23,7 @@ extern "C" {
 
 #include <fstream>
 #include <memory>
+#include <boost/optional.hpp>
 #include "resource/reapi/bindings/c++/reapi.hpp"
 #include "resource/jobinfo/jobinfo.hpp"
 #include "resource/policies/dfu_match_policy_factory.hpp"
@@ -97,7 +98,11 @@ class resource_query_t {
     void incr_job_counter ();
 
     /* Run the traverser to match the jobspec */
-    int traverser_run (Flux::Jobspec::Jobspec &job, match_op_t op, int64_t jobid, int64_t &at);
+    int traverser_run (Flux::Jobspec::Jobspec &job,
+                       match_op_t op,
+                       int64_t jobid,
+                       int64_t &at,
+                       boost::optional<int64_t> within = boost::none);
     int traverser_find (std::string criteria);
 
     // must be public; results in a deleted stringstream if converted to
@@ -143,7 +148,8 @@ class reapi_cli_t : public reapi_t {
                                bool &reserved,
                                std::string &R,
                                int64_t &at,
-                               double &ov);
+                               double &ov,
+                               boost::optional<int64_t> within = boost::none);
     static int match_allocate_multi (void *h,
                                      bool orelse_reserve,
                                      const char *jobs,

--- a/resource/reapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli_impl.hpp
@@ -101,12 +101,12 @@ int reapi_cli_t::match_allocate (void *h,
                                  bool &reserved,
                                  std::string &R,
                                  int64_t &at,
-                                 double &ov)
+                                 traverser_match_attrs *attrs)
 {
     resource_query_t *rq = static_cast<resource_query_t *> (h);
     int traverser_rc;
     at = 0;
-    ov = 0.0f;
+    double ov = 0.0f;
     job_lifecycle_t st;
     std::shared_ptr<job_info_t> job_info = nullptr;
     struct timeval start_time, end_time;
@@ -149,7 +149,7 @@ int reapi_cli_t::match_allocate (void *h,
      * ENODEV - unsatisfiable
      * Otherwise, return immediately.
      */
-    if ((traverser_rc = rq->traverser_run (job, match_op, (int64_t)jobid, at)) < 0) {
+    if ((traverser_rc = rq->traverser_run (job, match_op, (int64_t)jobid, at, attrs)) < 0) {
         traverser_errno = errno;
         if (rq->get_traverser_err_msg () != "") {
             m_err_msg += __FUNCTION__;
@@ -180,6 +180,8 @@ int reapi_cli_t::match_allocate (void *h,
     }
 
     ov = get_elapsed_time (start_time, end_time);
+    if (attrs)
+        attrs->match_overhead = ov;
 
     if (matched) {
         if (match_op == match_op_t::MATCH_WITHOUT_ALLOCATING
@@ -1357,9 +1359,10 @@ void resource_query_t::incr_job_counter ()
 int resource_query_t::traverser_run (Flux::Jobspec::Jobspec &job,
                                      match_op_t op,
                                      int64_t jobid,
-                                     int64_t &at)
+                                     int64_t &at,
+                                     traverser_match_attrs *attrs)
 {
-    return traverser->run (job, writers, op, jobid, &at);
+    return traverser->run (job, writers, op, jobid, &at, attrs);
 }
 
 int resource_query_t::traverser_find (std::string criteria)

--- a/resource/reapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli_impl.hpp
@@ -23,6 +23,7 @@ extern "C" {
 #include <vector>
 #include <jansson.h>
 #include <boost/algorithm/string.hpp>
+#include <boost/optional.hpp>
 #include "resource/reapi/bindings/c++/reapi_cli.hpp"
 #include "resource/readers/resource_reader_factory.hpp"
 #include "resource/config/system_defaults.hpp"
@@ -101,7 +102,8 @@ int reapi_cli_t::match_allocate (void *h,
                                  bool &reserved,
                                  std::string &R,
                                  int64_t &at,
-                                 double &ov)
+                                 double &ov,
+                                 boost::optional<int64_t> within)
 {
     resource_query_t *rq = static_cast<resource_query_t *> (h);
     int traverser_rc;
@@ -149,7 +151,7 @@ int reapi_cli_t::match_allocate (void *h,
      * ENODEV - unsatisfiable
      * Otherwise, return immediately.
      */
-    if ((traverser_rc = rq->traverser_run (job, match_op, (int64_t)jobid, at)) < 0) {
+    if ((traverser_rc = rq->traverser_run (job, match_op, (int64_t)jobid, at, within)) < 0) {
         traverser_errno = errno;
         if (rq->get_traverser_err_msg () != "") {
             m_err_msg += __FUNCTION__;
@@ -1345,9 +1347,10 @@ void resource_query_t::incr_job_counter ()
 int resource_query_t::traverser_run (Flux::Jobspec::Jobspec &job,
                                      match_op_t op,
                                      int64_t jobid,
-                                     int64_t &at)
+                                     int64_t &at,
+                                     boost::optional<int64_t> within)
 {
-    return traverser->run (job, writers, op, jobid, &at);
+    return traverser->run (job, writers, op, jobid, &at, within);
 }
 
 int resource_query_t::traverser_find (std::string criteria)

--- a/resource/reapi/bindings/c++/reapi_module.hpp
+++ b/resource/reapi/bindings/c++/reapi_module.hpp
@@ -22,6 +22,7 @@ extern "C" {
 
 #include <cstdint>
 #include <string>
+#include <boost/optional.hpp>
 #include "resource/reapi/bindings/c++/reapi.hpp"
 #include "resource/policies/base/match_op.h"
 #include "resource/writers/match_writers.hpp"
@@ -39,7 +40,8 @@ class reapi_module_t : public reapi_t {
                                bool &reserved,
                                std::string &R,
                                int64_t &at,
-                               double &ov);
+                               double &ov,
+                               boost::optional<int64_t> within = boost::none);
     static int match_allocate (void *h,
                                bool orelse_reserve,
                                const std::string &jobspec,
@@ -47,7 +49,8 @@ class reapi_module_t : public reapi_t {
                                bool &reserved,
                                std::string &R,
                                int64_t &at,
-                               double &ov);
+                               double &ov,
+                               boost::optional<int64_t> within = boost::none);
     static int match_allocate_multi (void *h,
                                      bool orelse_reserve,
                                      json_t *jobs,

--- a/resource/reapi/bindings/c++/reapi_module.hpp
+++ b/resource/reapi/bindings/c++/reapi_module.hpp
@@ -39,7 +39,7 @@ class reapi_module_t : public reapi_t {
                                bool &reserved,
                                std::string &R,
                                int64_t &at,
-                               double &ov);
+                               traverser_match_attrs *attrs = nullptr);
     static int match_allocate (void *h,
                                bool orelse_reserve,
                                const std::string &jobspec,
@@ -47,7 +47,7 @@ class reapi_module_t : public reapi_t {
                                bool &reserved,
                                std::string &R,
                                int64_t &at,
-                               double &ov);
+                               traverser_match_attrs *attrs = nullptr);
     static int match_allocate_multi (void *h,
                                      bool orelse_reserve,
                                      json_t *jobs,

--- a/resource/reapi/bindings/c++/reapi_module_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_module_impl.hpp
@@ -32,12 +32,13 @@ int reapi_module_t::match_allocate (void *h,
                                     bool &reserved,
                                     std::string &R,
                                     int64_t &at,
-                                    double &ov)
+                                    traverser_match_attrs *attrs)
 {
     int rc = -1;
     int64_t rj = -1;
     flux_t *fh = (flux_t *)h;
     flux_future_t *f = NULL;
+    double ov = 0.0f;
     const char *rset = NULL;
     const char *status = NULL;
     const char *cmd = match_op_to_string (match_op);
@@ -78,6 +79,8 @@ int reapi_module_t::match_allocate (void *h,
     }
     reserved = (std::string ("RESERVED") == status) ? true : false;
     R = rset;
+    if (attrs)
+        attrs->match_overhead = ov;
     if (rj != (int64_t)jobid) {
         errno = EINVAL;
         goto out;
@@ -96,12 +99,12 @@ int reapi_module_t::match_allocate (void *h,
                                     bool &reserved,
                                     std::string &R,
                                     int64_t &at,
-                                    double &ov)
+                                    traverser_match_attrs *attrs)
 {
     match_op_t match_op = (orelse_reserve) ? match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE
                                            : match_op_t::MATCH_ALLOCATE_W_SATISFIABILITY;
 
-    return match_allocate (h, match_op, jobspec, jobid, reserved, R, at, ov);
+    return match_allocate (h, match_op, jobspec, jobid, reserved, R, at, attrs);
 }
 
 void match_allocate_multi_cont (flux_future_t *f, void *arg)
@@ -188,7 +191,7 @@ int reapi_module_t::update_allocate (void *h,
                                      const uint64_t jobid,
                                      const std::string &R,
                                      int64_t &at,
-                                     double &ov,
+                                     double &overhead,
                                      std::string &R_out)
 {
     int rc = -1;
@@ -196,7 +199,6 @@ int reapi_module_t::update_allocate (void *h,
     flux_t *fh = (flux_t *)h;
     flux_future_t *f = NULL;
     int64_t scheduled_at = -1;
-    double overhead = 0.0f;
     const char *rset = NULL;
     const char *status = NULL;
 
@@ -235,7 +237,6 @@ int reapi_module_t::update_allocate (void *h,
         goto out;
     }
     R_out = rset;
-    ov = overhead;
     at = scheduled_at;
 
 out:

--- a/resource/reapi/bindings/c++/reapi_module_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_module_impl.hpp
@@ -19,6 +19,8 @@ extern "C" {
 }
 
 #include <cerrno>
+#include <cstdint>
+#include <boost/optional.hpp>
 #include "resource/reapi/bindings/c++/reapi_module.hpp"
 
 namespace Flux {
@@ -32,7 +34,8 @@ int reapi_module_t::match_allocate (void *h,
                                     bool &reserved,
                                     std::string &R,
                                     int64_t &at,
-                                    double &ov)
+                                    double &ov,
+                                    boost::optional<int64_t> within)
 {
     int rc = -1;
     int64_t rj = -1;
@@ -51,13 +54,15 @@ int reapi_module_t::match_allocate (void *h,
                              "sched-fluxion-resource.match",
                              FLUX_NODEID_ANY,
                              0,
-                             "{s:s s:I s:s}",
+                             "{s:s s:I s:s s:I}",
                              "cmd",
                              cmd,
                              "jobid",
                              (const int64_t)jobid,
                              "jobspec",
-                             jobspec.c_str ()))) {
+                             jobspec.c_str (),
+                             "within",
+                             within ? *within : INT64_MIN))) {
         goto out;
     }
 
@@ -96,12 +101,13 @@ int reapi_module_t::match_allocate (void *h,
                                     bool &reserved,
                                     std::string &R,
                                     int64_t &at,
-                                    double &ov)
+                                    double &ov,
+                                    boost::optional<int64_t> within)
 {
     match_op_t match_op = (orelse_reserve) ? match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE
                                            : match_op_t::MATCH_ALLOCATE_W_SATISFIABILITY;
 
-    return match_allocate (h, match_op, jobspec, jobid, reserved, R, at, ov);
+    return match_allocate (h, match_op, jobspec, jobid, reserved, R, at, ov, within);
 }
 
 void match_allocate_multi_cont (flux_future_t *f, void *arg)

--- a/resource/reapi/bindings/c++/reapi_module_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_module_impl.hpp
@@ -19,6 +19,7 @@ extern "C" {
 }
 
 #include <cerrno>
+#include <cstdint>
 #include "resource/reapi/bindings/c++/reapi_module.hpp"
 
 namespace Flux {
@@ -52,13 +53,15 @@ int reapi_module_t::match_allocate (void *h,
                              "sched-fluxion-resource.match",
                              FLUX_NODEID_ANY,
                              0,
-                             "{s:s s:I s:s}",
+                             "{s:s s:I s:s s:I}",
                              "cmd",
                              cmd,
                              "jobid",
                              (const int64_t)jobid,
                              "jobspec",
-                             jobspec.c_str ()))) {
+                             jobspec.c_str (),
+                             "within",
+                             attrs ? attrs->match_within : INT64_MIN))) {
         goto out;
     }
 

--- a/resource/reapi/bindings/c++/test/reapi_cli_cancel_test.cpp
+++ b/resource/reapi/bindings/c++/test/reapi_cli_cancel_test.cpp
@@ -116,17 +116,10 @@ static int test_cancel_full ()
     bool reserved = false;
     std::string R;
     int64_t at = 0;
-    double ov = 0.0;
 
     // Allocate a job (precondition for the cancel under test)
-    int rc = reapi_cli_t::match_allocate (h,
-                                          MATCH_ALLOCATE,
-                                          two_core_jobspec,
-                                          jobid,
-                                          reserved,
-                                          R,
-                                          at,
-                                          ov);
+    int rc =
+        reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, two_core_jobspec, jobid, reserved, R, at);
 
     if (rc != 0)
         BAIL_OUT ("match_allocate failed to set up full cancel test");
@@ -167,17 +160,10 @@ static int test_cancel_with_r ()
     bool reserved = false;
     std::string R;
     int64_t at = 0;
-    double ov = 0.0;
 
     // Allocate a job (precondition for the cancel under test)
-    int rc = reapi_cli_t::match_allocate (h,
-                                          MATCH_ALLOCATE,
-                                          two_core_jobspec,
-                                          jobid,
-                                          reserved,
-                                          R,
-                                          at,
-                                          ov);
+    int rc =
+        reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, two_core_jobspec, jobid, reserved, R, at);
     if (rc != 0)
         BAIL_OUT ("match_allocate failed to set up full R cancel test");
 
@@ -232,17 +218,10 @@ static int test_cancel_partial ()
     bool reserved = false;
     std::string R;
     int64_t at = 0;
-    double ov = 0.0;
 
     // Allocate 2 nodes (precondition for the partial cancel under test)
-    int rc = reapi_cli_t::match_allocate (h,
-                                          MATCH_ALLOCATE,
-                                          two_node_jobspec,
-                                          jobid,
-                                          reserved,
-                                          R,
-                                          at,
-                                          ov);
+    int rc =
+        reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, two_node_jobspec, jobid, reserved, R, at);
     if (rc != 0)
         BAIL_OUT ("match_allocate failed to allocate 2 nodes");
     ok (rc == 0, "allocated 2 nodes");
@@ -396,20 +375,13 @@ static int test_cancel_bad_writer ()
     bool reserved = false;
     std::string R;
     int64_t at = 0;
-    double ov = 0.0;
 
     // Allocate a job so cancel reaches format detection in remove_job.
     // (cancel checks allocation_exists() first and returns ENOENT otherwise.)
     // This is a precondition for the test, not the behavior under test, so a
     // failure here means the test itself is broken -> bail out loudly.
-    int rc = reapi_cli_t::match_allocate (h,
-                                          MATCH_ALLOCATE,
-                                          two_core_jobspec,
-                                          jobid,
-                                          reserved,
-                                          R,
-                                          at,
-                                          ov);
+    int rc =
+        reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, two_core_jobspec, jobid, reserved, R, at);
     if (rc != 0)
         BAIL_OUT ("match_allocate failed to set up bad-writer test");
 

--- a/resource/reapi/bindings/c++/test/reapi_cli_clone_test.cpp
+++ b/resource/reapi/bindings/c++/test/reapi_cli_clone_test.cpp
@@ -175,7 +175,6 @@ static int test_clone_independence ()
     bool reserved = false;
     std::string R1;
     int64_t at = 0;
-    double ov = 0.0;
 
     int rc = reapi_cli_t::match_allocate (h_clone,
                                           MATCH_ALLOCATE,
@@ -183,8 +182,7 @@ static int test_clone_independence ()
                                           jobid1,
                                           reserved,
                                           R1,
-                                          at,
-                                          ov);
+                                          at);
     ok (rc == 0, "allocation on clone succeeded");
 
     // Test: allocate same resources on original - should succeed (clone is independent)
@@ -196,8 +194,7 @@ static int test_clone_independence ()
                                       jobid2,
                                       reserved,
                                       R2,
-                                      at,
-                                      ov);
+                                      at);
     ok (rc == 0, "allocation on original succeeded (clone is independent)");
 
     delete clone;
@@ -222,16 +219,9 @@ static int test_clone_copies_allocations ()
     bool reserved = false;
     std::string R1;
     int64_t at = 0;
-    double ov = 0.0;
 
-    int rc = reapi_cli_t::match_allocate (h,
-                                          MATCH_ALLOCATE,
-                                          simple_jobspec,
-                                          jobid1,
-                                          reserved,
-                                          R1,
-                                          at,
-                                          ov);
+    int rc =
+        reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, simple_jobspec, jobid1, reserved, R1, at);
     if (rc < 0) {
         delete rq;
         BAIL_OUT ("match_allocate failed");
@@ -258,8 +248,7 @@ static int test_clone_copies_allocations ()
                                       jobid2,
                                       reserved,
                                       R2,
-                                      at,
-                                      ov);
+                                      at);
     ok (rc == -1 && errno == EBUSY, "allocation on clone fails with EBUSY (allocation was copied)");
 
     // Test: cancel on clone shouldn't affect original
@@ -295,7 +284,6 @@ static int test_clone_copies_reservations ()
     bool reserved = false;
     std::string R1;
     int64_t at = 0;
-    double ov = 0.0;
 
     int rc = reapi_cli_t::match_allocate (h,
                                           MATCH_ALLOCATE_ORELSE_RESERVE,
@@ -303,8 +291,7 @@ static int test_clone_copies_reservations ()
                                           jobid1,
                                           reserved,
                                           R1,
-                                          at,
-                                          ov);
+                                          at);
     if (rc < 0) {
         delete rq;
         BAIL_OUT ("match_allocate failed");
@@ -397,16 +384,9 @@ static int test_clone_with_multiple_jobs ()
     bool reserved = false;
     std::string R1;
     int64_t at = 0;
-    double ov = 0.0;
 
-    int rc = reapi_cli_t::match_allocate (h,
-                                          MATCH_ALLOCATE,
-                                          simple_jobspec,
-                                          jobid1,
-                                          reserved,
-                                          R1,
-                                          at,
-                                          ov);
+    int rc =
+        reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, simple_jobspec, jobid1, reserved, R1, at);
     if (rc < 0) {
         delete rq;
         BAIL_OUT ("first allocation failed");
@@ -415,14 +395,7 @@ static int test_clone_with_multiple_jobs ()
     // Allocate second job on other node
     uint64_t jobid2 = 2;
     std::string R2;
-    rc = reapi_cli_t::match_allocate (h,
-                                      MATCH_ALLOCATE,
-                                      simple_jobspec,
-                                      jobid2,
-                                      reserved,
-                                      R2,
-                                      at,
-                                      ov);
+    rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, simple_jobspec, jobid2, reserved, R2, at);
     if (rc < 0) {
         delete rq;
         BAIL_OUT ("second allocation failed");
@@ -482,16 +455,9 @@ static int test_clone_of_clone ()
     bool reserved = false;
     std::string R1;
     int64_t at = 0;
-    double ov = 0.0;
 
-    int rc = reapi_cli_t::match_allocate (h,
-                                          MATCH_ALLOCATE,
-                                          simple_jobspec,
-                                          jobid1,
-                                          reserved,
-                                          R1,
-                                          at,
-                                          ov);
+    int rc =
+        reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, simple_jobspec, jobid1, reserved, R1, at);
     if (rc < 0) {
         delete rq;
         BAIL_OUT ("allocation failed");
@@ -641,7 +607,6 @@ static int test_clone_planner_state ()
     bool reserved = false;
     std::string R_alloc;
     int64_t at = 0;
-    double ov = 0.0;
 
     int rc = reapi_cli_t::match_allocate (h,
                                           MATCH_ALLOCATE,
@@ -649,8 +614,7 @@ static int test_clone_planner_state ()
                                           jobid_alloc1,
                                           reserved,
                                           R_alloc,
-                                          at,
-                                          ov);
+                                          at);
     if (rc < 0) {
         delete rq;
         BAIL_OUT ("first allocation failed");
@@ -662,8 +626,7 @@ static int test_clone_planner_state ()
                                       jobid_alloc2,
                                       reserved,
                                       R_alloc,
-                                      at,
-                                      ov);
+                                      at);
     if (rc < 0) {
         delete rq;
         BAIL_OUT ("second allocation failed");
@@ -679,8 +642,7 @@ static int test_clone_planner_state ()
                                       jobid1,
                                       reserved,
                                       R1,
-                                      at1,
-                                      ov);
+                                      at1);
     if (rc < 0 || !reserved) {
         delete rq;
         BAIL_OUT ("first reservation failed");
@@ -696,8 +658,7 @@ static int test_clone_planner_state ()
                                       jobid2,
                                       reserved,
                                       R2,
-                                      at2,
-                                      ov);
+                                      at2);
     if (rc < 0 || !reserved) {
         delete rq;
         BAIL_OUT ("second reservation failed");
@@ -754,16 +715,9 @@ static int test_clone_perf_stats_independence ()
     bool reserved = false;
     std::string R1;
     int64_t at = 0;
-    double ov = 0.0;
 
-    int rc = reapi_cli_t::match_allocate (h,
-                                          MATCH_ALLOCATE,
-                                          simple_jobspec,
-                                          jobid1,
-                                          reserved,
-                                          R1,
-                                          at,
-                                          ov);
+    int rc =
+        reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, simple_jobspec, jobid1, reserved, R1, at);
     if (rc < 0) {
         delete rq;
         BAIL_OUT ("allocation failed");
@@ -830,7 +784,6 @@ static int test_clone_traverser_independence ()
     bool reserved = false;
     std::string R1, R2;
     int64_t at = 0;
-    double ov = 0.0;
 
     int rc1 = reapi_cli_t::match_allocate (h_orig,
                                            MATCH_ALLOCATE,
@@ -838,16 +791,14 @@ static int test_clone_traverser_independence ()
                                            jobid1,
                                            reserved,
                                            R1,
-                                           at,
-                                           ov);
+                                           at);
     int rc2 = reapi_cli_t::match_allocate (h_clone,
                                            MATCH_ALLOCATE,
                                            simple_jobspec,
                                            jobid2,
                                            reserved,
                                            R2,
-                                           at,
-                                           ov);
+                                           at);
 
     ok (rc1 == 0 && rc2 == 0, "traverser works independently on both contexts");
 
@@ -862,16 +813,14 @@ static int test_clone_traverser_independence ()
                                        jobid3,
                                        reserved,
                                        R3,
-                                       at,
-                                       ov);
+                                       at);
     rc2 = reapi_cli_t::match_allocate (h_clone,
                                        MATCH_ALLOCATE,
                                        simple_jobspec,
                                        jobid4,
                                        reserved,
                                        R4,
-                                       at,
-                                       ov);
+                                       at);
 
     ok (rc1 == 0 && rc2 == 0, "multiple traverser operations work independently on both contexts");
 

--- a/resource/reapi/bindings/c++/test/reapi_cli_errno_test.cpp
+++ b/resource/reapi/bindings/c++/test/reapi_cli_errno_test.cpp
@@ -31,11 +31,10 @@ static int test_match_allocate_invalid_match_op ()
     std::string jobspec = "{}";
     std::string R;
     int64_t at = 0;
-    double ov = 0.0;
 
     // Test with invalid match_op (use out of range enum value)
     errno = 0;
-    int rc = reapi_cli_t::match_allocate (h, (match_op_t)999, jobspec, jobid, reserved, R, at, ov);
+    int rc = reapi_cli_t::match_allocate (h, (match_op_t)999, jobspec, jobid, reserved, R, at);
 
     ok (rc == -1 && errno == EINVAL,
         "match_allocate returns -1 with errno=EINVAL for invalid match_op");
@@ -61,13 +60,11 @@ static int test_match_allocate_invalid_jobspec_with_ctx ()
     bool reserved = false;
     std::string R;
     int64_t at = 0;
-    double ov = 0.0;
 
     // Test with invalid JSON
     errno = 0;
     std::string invalid_json = "not valid json";
-    int rc =
-        reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, invalid_json, jobid, reserved, R, at, ov);
+    int rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, invalid_json, jobid, reserved, R, at);
 
     ok (rc == -1 && errno == EINVAL,
         "match_allocate returns -1 with errno=EINVAL for invalid JSON");
@@ -78,14 +75,8 @@ static int test_match_allocate_invalid_jobspec_with_ctx ()
         "version": 1,
         "tasks": [{"command": ["app"], "slot": "task", "count": {"per_slot": 1}}]
     })";
-    rc = reapi_cli_t::match_allocate (h,
-                                      MATCH_ALLOCATE,
-                                      incomplete_jobspec,
-                                      jobid,
-                                      reserved,
-                                      R,
-                                      at,
-                                      ov);
+    rc =
+        reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, incomplete_jobspec, jobid, reserved, R, at);
 
     ok (rc == -1 && errno == EINVAL,
         "match_allocate returns -1 with errno=EINVAL for jobspec missing required fields");
@@ -129,7 +120,6 @@ static int test_match_allocate_ebusy ()
     bool reserved = false;
     std::string R;
     int64_t at = 0;
-    double ov = 0.0;
 
     // Clear any previous error messages
     reapi_cli_t::clear_err_message ();
@@ -167,14 +157,14 @@ static int test_match_allocate_ebusy ()
     })";
 
     errno = 0;
-    int rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec1, jobid1, reserved, R, at, ov);
+    int rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec1, jobid1, reserved, R, at);
     int saved_errno = errno;
 
     if (rc == 0) {
         // Now try to allocate again - should get EBUSY
         errno = 0;
         std::string jobspec2 = jobspec1;  // Same request
-        rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec2, jobid2, reserved, R, at, ov);
+        rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec2, jobid2, reserved, R, at);
 
         ok (rc == -1 && errno == EBUSY,
             "match_allocate returns -1 with errno=EBUSY when resources unavailable");
@@ -235,7 +225,6 @@ static int test_match_allocate_enodev ()
     bool reserved = false;
     std::string R;
     int64_t at = 0;
-    double ov = 0.0;
 
     // Clear any previous error messages
     reapi_cli_t::clear_err_message ();
@@ -255,8 +244,7 @@ static int test_match_allocate_enodev ()
                                           jobid,
                                           reserved,
                                           R,
-                                          at,
-                                          ov);
+                                          at);
 
     ok (rc == -1 && errno == ENODEV,
         "match_allocate (satisfiability mode) returns -1 with errno=ENODEV for infeasible request");
@@ -266,7 +254,7 @@ static int test_match_allocate_enodev ()
     // Before commit 38d34b75, resolve_graph() failure could leave errno=0
     errno = 0;
     jobid = 2;
-    rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec, jobid, reserved, R, at, ov);
+    rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec, jobid, reserved, R, at);
 
     ok (rc == -1 && errno == EBUSY,
         "match_allocate (regular mode) returns -1 with errno=EBUSY for infeasible request");
@@ -405,7 +393,6 @@ static int test_match_allocate_orelse_reserve ()
     bool reserved = false;
     std::string R;
     int64_t at = 0;
-    double ov = 0.0;
 
     // Request a resource type that doesn't exist (gpu) - infeasible
     // MATCH_ALLOCATE_ORELSE_RESERVE uses satisfiability checking, so returns ENODEV for infeasible
@@ -422,8 +409,7 @@ static int test_match_allocate_orelse_reserve ()
                                           jobid,
                                           reserved,
                                           R,
-                                          at,
-                                          ov);
+                                          at);
     ok (rc == -1 && errno == ENODEV,
         "match_allocate (orelse_reserve) returns -1 with errno=ENODEV for infeasible request");
 
@@ -462,7 +448,6 @@ static int test_allocate_then_cancel ()
     bool reserved = false;
     std::string R;
     int64_t at = 0;
-    double ov = 0.0;
 
     std::string jobspec = R"({
         "version": 1,
@@ -486,7 +471,7 @@ static int test_allocate_then_cancel ()
 
     // Allocate the job
     errno = 0;
-    int rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec, jobid, reserved, R, at, ov);
+    int rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec, jobid, reserved, R, at);
 
     if (rc != 0) {
         ok (1, "# SKIP: allocation failed, can't test cancel");

--- a/resource/reapi/bindings/c++/test/reapi_cli_find_test.cpp
+++ b/resource/reapi/bindings/c++/test/reapi_cli_find_test.cpp
@@ -57,7 +57,6 @@ static int test_find_allocated ()
     bool reserved = false;
     std::string R;
     int64_t at = 0;
-    double ov = 0.0;
 
     std::string jobspec = R"({
         "version": 1,
@@ -81,13 +80,13 @@ static int test_find_allocated ()
 
     // Allocate two jobs
     uint64_t jobid1 = 1;
-    int rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec, jobid1, reserved, R, at, ov);
+    int rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec, jobid1, reserved, R, at);
     if (rc != 0)
         BAIL_OUT ("match_allocate failed for jobid 1");
     ok (rc == 0, "allocated job 1");
 
     uint64_t jobid2 = 2;
-    rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec, jobid2, reserved, R, at, ov);
+    rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec, jobid2, reserved, R, at);
     if (rc != 0)
         BAIL_OUT ("match_allocate failed for jobid 2");
     ok (rc == 0, "allocated job 2");

--- a/resource/reapi/bindings/c++/test/reapi_cli_status_test.cpp
+++ b/resource/reapi/bindings/c++/test/reapi_cli_status_test.cpp
@@ -387,7 +387,6 @@ static void test_allocation_with_down_node ()
     std::string R;
     bool reserved = false;
     int64_t at = 0;
-    double ov = 0.0;
     errno = 0;
     rc = reapi_cli_t::match_allocate (ctx,
                                       match_op_t::MATCH_ALLOCATE,
@@ -395,8 +394,7 @@ static void test_allocation_with_down_node ()
                                       1,
                                       reserved,
                                       R,
-                                      at,
-                                      ov);
+                                      at);
 
     ok (rc == -1, "allocation_with_down_node: allocation fails when all nodes are down");
 
@@ -448,7 +446,6 @@ static void test_allocation_with_mixed_status ()
     std::string R;
     bool reserved = false;
     int64_t at = 0;
-    double ov = 0.0;
     errno = 0;
     rc = reapi_cli_t::match_allocate (ctx,
                                       match_op_t::MATCH_ALLOCATE,
@@ -456,8 +453,7 @@ static void test_allocation_with_mixed_status ()
                                       1,
                                       reserved,
                                       R,
-                                      at,
-                                      ov);
+                                      at);
 
     ok (rc == 0, "allocation_with_mixed_status: allocation succeeds with one node down");
 

--- a/resource/reapi/bindings/c++/test/reapi_cli_update_allocate_test.cpp
+++ b/resource/reapi/bindings/c++/test/reapi_cli_update_allocate_test.cpp
@@ -53,7 +53,6 @@ static int test_update_allocate_basic ()
     bool reserved = false;
     std::string R;
     int64_t at = 0;
-    double ov = 0.0;
 
     std::string jobspec = R"({
         "version": 1,
@@ -77,7 +76,7 @@ static int test_update_allocate_basic ()
 
     // Allocate a job to get an R string
     errno = 0;
-    int rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec, jobid, reserved, R, at, ov);
+    int rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec, jobid, reserved, R, at);
     if (rc != 0)
         BAIL_OUT ("match_allocate failed for jobid 1");
 
@@ -91,10 +90,10 @@ static int test_update_allocate_basic ()
     uint64_t jobid2 = 2;
     std::string R_out;
     int64_t at_out = 0;
-    double ov_out = 0.0;
+    double ov = 0.0f;
 
     errno = 0;
-    rc = reapi_cli_t::update_allocate (h, jobid2, R, at_out, ov_out, R_out);
+    rc = reapi_cli_t::update_allocate (h, jobid2, R, at_out, ov, R_out);
     ok (rc == 0, "update_allocate succeeded for jobid 2");
     ok (!R_out.empty (), "update_allocate returned non-empty R_out");
 
@@ -132,7 +131,6 @@ static int test_update_allocate_duplicate_jobid ()
     bool reserved = false;
     std::string R;
     int64_t at = 0;
-    double ov = 0.0;
 
     std::string jobspec = R"({
         "version": 1,
@@ -156,17 +154,17 @@ static int test_update_allocate_duplicate_jobid ()
 
     // Allocate a job
     errno = 0;
-    int rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec, jobid, reserved, R, at, ov);
+    int rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec, jobid, reserved, R, at);
     if (rc != 0)
         BAIL_OUT ("match_allocate failed for jobid 1");
 
     // Try update_allocate with the same jobid - should fail with EEXIST
     std::string R_out;
     int64_t at_out = 0;
-    double ov_out = 0.0;
+    double ov = 0.0f;
 
     errno = 0;
-    rc = reapi_cli_t::update_allocate (h, jobid, R, at_out, ov_out, R_out);
+    rc = reapi_cli_t::update_allocate (h, jobid, R, at_out, ov, R_out);
     ok (rc == -1 && errno == EEXIST,
         "update_allocate returns -1 with errno=EEXIST for duplicate jobid");
 
@@ -204,7 +202,6 @@ static int test_update_allocate_no_expiration ()
     bool reserved = false;
     std::string R;
     int64_t at = 0;
-    double ov = 0.0;
 
     std::string jobspec = R"({
         "version": 1,
@@ -228,7 +225,7 @@ static int test_update_allocate_no_expiration ()
 
     // Allocate a job to get an R string, then free the resources
     errno = 0;
-    int rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec, jobid, reserved, R, at, ov);
+    int rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec, jobid, reserved, R, at);
     if (rc != 0)
         BAIL_OUT ("match_allocate failed for jobid 1");
     rc = reapi_cli_t::cancel (h, jobid, false);
@@ -253,10 +250,10 @@ static int test_update_allocate_no_expiration ()
     uint64_t jobid2 = 2;
     std::string R_out;
     int64_t at_out = 0;
-    double ov_out = 0.0;
+    double ov = 0.0f;
 
     errno = 0;
-    rc = reapi_cli_t::update_allocate (h, jobid2, R_no_exp, at_out, ov_out, R_out);
+    rc = reapi_cli_t::update_allocate (h, jobid2, R_no_exp, at_out, ov, R_out);
     ok (rc == 0, "update_allocate succeeded for R with no expiration key");
     ok (!R_out.empty (), "update_allocate returned non-empty R_out");
 
@@ -271,7 +268,7 @@ static int test_update_allocate_null_ctx ()
     std::string R = "{}";
     std::string R_out;
     int64_t at = 0;
-    double ov = 0.0;
+    double ov = 0.0f;
 
     errno = 0;
     int rc = reapi_cli_t::update_allocate (h, jobid, R, at, ov, R_out);

--- a/resource/reapi/bindings/c/reapi_cli.cpp
+++ b/resource/reapi/bindings/c/reapi_cli.cpp
@@ -164,7 +164,7 @@ extern "C" int reapi_cli_match_with_jobid (reapi_cli_ctx_t *ctx,
                                            bool *reserved,
                                            char **R,
                                            int64_t *at,
-                                           double *ov)
+                                           struct traverser_match_attrs *attrs)
 {
     int rc = -1;
     std::string R_buf = "";
@@ -176,7 +176,7 @@ extern "C" int reapi_cli_match_with_jobid (reapi_cli_ctx_t *ctx,
     }
 
     if ((rc = reapi_cli_t::
-             match_allocate (ctx->rqt, match_op, jobspec, jobid, *reserved, R_buf, *at, *ov))
+             match_allocate (ctx->rqt, match_op, jobspec, jobid, *reserved, R_buf, *at, attrs))
         < 0) {
         goto out;
     }
@@ -201,7 +201,7 @@ extern "C" int reapi_cli_match (reapi_cli_ctx_t *ctx,
                                 bool *reserved,
                                 char **R,
                                 int64_t *at,
-                                double *ov)
+                                struct traverser_match_attrs *attrs)
 {
     int rc = -1;
 
@@ -217,7 +217,7 @@ extern "C" int reapi_cli_match (reapi_cli_ctx_t *ctx,
         || match_op == match_op_t::MATCH_WITHOUT_ALLOCATING_FUTURE)
         seq = -1;
 
-    if ((rc = reapi_cli_match_with_jobid (ctx, match_op, jobspec, seq, reserved, R, at, ov)) < 0)
+    if ((rc = reapi_cli_match_with_jobid (ctx, match_op, jobspec, seq, reserved, R, at, attrs)) < 0)
         goto done;
     *jobid = seq;
 
@@ -232,18 +232,18 @@ extern "C" int reapi_cli_match_allocate (reapi_cli_ctx_t *ctx,
                                          bool *reserved,
                                          char **R,
                                          int64_t *at,
-                                         double *ov)
+                                         struct traverser_match_attrs *attrs)
 {
     match_op_t match_op =
         orelse_reserve ? match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE : match_op_t::MATCH_ALLOCATE;
 
-    return reapi_cli_match (ctx, match_op, jobspec, jobid, reserved, R, at, ov);
+    return reapi_cli_match (ctx, match_op, jobspec, jobid, reserved, R, at, attrs);
 }
 
 extern "C" int reapi_cli_match_satisfy (reapi_cli_ctx_t *ctx,
                                         const char *jobspec,
                                         bool *sat,
-                                        double *ov)
+                                        struct traverser_match_attrs *attrs)
 {
     match_op_t match_op = match_op_t::MATCH_SATISFIABILITY;
     uint64_t jobid;
@@ -253,7 +253,7 @@ extern "C" int reapi_cli_match_satisfy (reapi_cli_ctx_t *ctx,
     int ret;
     *sat = true;
 
-    ret = reapi_cli_match (ctx, match_op, jobspec, &jobid, &reserved, &R, &at, ov);
+    ret = reapi_cli_match (ctx, match_op, jobspec, &jobid, &reserved, &R, &at, attrs);
 
     // Not satisfiable if the match reported unsatisfiable (ENODEV) or failed
     // for any other reason (e.g. a jobspec referencing an unknown resource
@@ -274,6 +274,7 @@ extern "C" int reapi_cli_update_allocate (reapi_cli_ctx_t *ctx,
     int rc = -1;
     std::string R_buf = "";
     const char *R_buf_c = NULL;
+
     if (!ctx || !ctx->rqt || !R) {
         errno = EINVAL;
         goto out;

--- a/resource/reapi/bindings/c/reapi_cli.cpp
+++ b/resource/reapi/bindings/c/reapi_cli.cpp
@@ -165,6 +165,28 @@ extern "C" int reapi_cli_match_with_jobid (reapi_cli_ctx_t *ctx,
                                            char **R,
                                            int64_t *at,
                                            double *ov)
+
+{
+    return reapi_cli_match_with_jobid_within (ctx,
+                                              match_op,
+                                              jobspec,
+                                              jobid,
+                                              reserved,
+                                              R,
+                                              at,
+                                              ov,
+                                              INT64_MIN);
+}
+
+extern "C" int reapi_cli_match_with_jobid_within (reapi_cli_ctx_t *ctx,
+                                                  match_op_t match_op,
+                                                  const char *jobspec,
+                                                  uint64_t jobid,
+                                                  bool *reserved,
+                                                  char **R,
+                                                  int64_t *at,
+                                                  double *ov,
+                                                  int64_t within)
 {
     int rc = -1;
     std::string R_buf = "";
@@ -175,8 +197,15 @@ extern "C" int reapi_cli_match_with_jobid (reapi_cli_ctx_t *ctx,
         goto out;
     }
 
-    if ((rc = reapi_cli_t::
-             match_allocate (ctx->rqt, match_op, jobspec, jobid, *reserved, R_buf, *at, *ov))
+    if ((rc = reapi_cli_t::match_allocate (ctx->rqt,
+                                           match_op,
+                                           jobspec,
+                                           jobid,
+                                           *reserved,
+                                           R_buf,
+                                           *at,
+                                           *ov,
+                                           within))
         < 0) {
         goto out;
     }

--- a/resource/reapi/bindings/c/reapi_cli.h
+++ b/resource/reapi/bindings/c/reapi_cli.h
@@ -142,6 +142,57 @@ int reapi_cli_match_with_jobid (reapi_cli_ctx_t *ctx,
 
 /*! Match a jobspec to the "best" resources and either allocate
  *  orelse reserve them. The best resources are determined by
+ *  the selected match policy.  This function is identical to
+ *  reapi_cli_match_with_jobid() in all respects except the
+ *  "within" parameter, which filters out late resource matches.
+ *  N.B. To avoid jobid collisions, this call should not be mixed
+ *  with the other match calls that allocate them internally.
+ *
+ *  \param ctx       reapi_cli_ctx_t context object
+ *  \param match_op  match_op_t: set to specify the specific match option
+ *                   from 1 of 4 choices:
+ *                   MATCH_ALLOCATE: try to allocate now and fail if resources
+ *                   aren't available.
+ *                   MATCH_ALLOCATE_ORELSE_RESERVE : Try to allocate and reserve
+ *                   if resources aren't available now.
+ *                   MATCH_SATISFIABILITY: Do a satisfiablity check and do not
+ *                   allocate.
+ *                   MATCH_ALLOCATE_W_SATISFIABILITY: try to allocate and run
+ *                   satisfiability check if resources are not available.
+ *                   MATCH_WITHOUT_ALLOCATING: match and return resources
+ *                   but do not allocate or reserve them.
+ *                   MATCH_WITHOUT_ALLOCATING_FUTURE: match and return resources
+ *                   but do not allocate or reserve them. Return the earliest
+ *                   match, which could be in the future.
+ *  \param jobspec   jobspec string.
+ *  \param jobid     jobid provided by caller
+ *  \param reserved  Boolean into which to return true if this job has been
+ *                   reserved instead of allocated.
+ *  \param R         String into which to return the resource set either
+ *                   allocated or reserved.
+ *  \param at        If allocated, 0 is returned; if reserved, actual time
+ *                   at which the job is reserved.
+ *  \param ov        Double into which to return performance overhead
+ *                   in terms of elapse time needed to complete
+ *                   the match operation.
+ *  \param within    Return only matches that start between now and now+within.
+ *                   If within < 0, don't apply this filter.
+ *                   If and only if within == INT64_MIN, also search for a
+ *                   'within' value in the jobspec's user attributes.
+ *  \return          0 on success; -1 on error.
+ */
+int reapi_cli_match_with_jobid_within (reapi_cli_ctx_t *ctx,
+                                       match_op_t match_op,
+                                       const char *jobspec,
+                                       uint64_t jobid,
+                                       bool *reserved,
+                                       char **R,
+                                       int64_t *at,
+                                       double *ov,
+                                       int64_t within);
+
+/*! Match a jobspec to the "best" resources and either allocate
+ *  orelse reserve them. The best resources are determined by
  *  the selected match policy.
  *
  *  \param ctx       reapi_cli_ctx_t context object

--- a/resource/reapi/bindings/c/reapi_cli.h
+++ b/resource/reapi/bindings/c/reapi_cli.h
@@ -83,6 +83,7 @@ int reapi_cli_initialize (reapi_cli_ctx_t *ctx, const char *rgraph, const char *
  *                   at which the job is reserved.
  *  \param attrs     Optional traversal attributes:
  *    match_overhead    Double into which to return performance overhead.
+ *    match_within      Don't return matches starting after this duration.
  *  \return          0 on success; -1 on error.
  */
 int reapi_cli_match (reapi_cli_ctx_t *ctx,
@@ -128,6 +129,7 @@ int reapi_cli_match (reapi_cli_ctx_t *ctx,
  *                   at which the job is reserved.
  *  \param attrs     Optional traversal attributes:
  *    match_overhead    Double into which to return performance overhead.
+ *    match_within      Don't return matches starting after this duration.
  *  \return          0 on success; -1 on error.
  */
 int reapi_cli_match_with_jobid (reapi_cli_ctx_t *ctx,
@@ -157,6 +159,7 @@ int reapi_cli_match_with_jobid (reapi_cli_ctx_t *ctx,
  *                   at which the job is reserved.
  *  \param attrs     Optional traversal attributes:
  *    match_overhead    Double into which to return performance overhead.
+ *    match_within      Don't return matches starting after this duration.
  *  \return          0 on success; -1 on error.
  */
 int reapi_cli_match_allocate (reapi_cli_ctx_t *ctx,
@@ -179,6 +182,7 @@ int reapi_cli_match_allocate (reapi_cli_ctx_t *ctx,
  *                   satisfiable.
  *  \param attrs     Optional traversal attributes:
  *    match_overhead    Double into which to return performance overhead.
+ *    match_within      Don't return matches starting after this duration.
  *  \return          0 on success; -1 on error.
  */
 int reapi_cli_match_satisfy (reapi_cli_ctx_t *ctx,

--- a/resource/reapi/bindings/c/reapi_cli.h
+++ b/resource/reapi/bindings/c/reapi_cli.h
@@ -20,6 +20,7 @@ extern "C" {
 #endif
 #include <flux/core.h>
 #include "resource/policies/base/match_op.h"
+#include "resource/traversers/dfu_match_attributes.h"
 #include "resource_status.h"
 
 typedef struct reapi_cli_ctx reapi_cli_ctx_t;
@@ -80,9 +81,8 @@ int reapi_cli_initialize (reapi_cli_ctx_t *ctx, const char *rgraph, const char *
  *                   allocated or reserved.
  *  \param at        If allocated, 0 is returned; if reserved, actual time
  *                   at which the job is reserved.
- *  \param ov        Double into which to return performance overhead
- *                   in terms of elapse time needed to complete
- *                   the match operation.
+ *  \param attrs     Optional traversal attributes:
+ *    match_overhead    Double into which to return performance overhead.
  *  \return          0 on success; -1 on error.
  */
 int reapi_cli_match (reapi_cli_ctx_t *ctx,
@@ -92,7 +92,7 @@ int reapi_cli_match (reapi_cli_ctx_t *ctx,
                      bool *reserved,
                      char **R,
                      int64_t *at,
-                     double *ov);
+                     struct traverser_match_attrs *attrs);
 
 /*! Match a jobspec to the "best" resources and either allocate
  *  orelse reserve them. The best resources are determined by
@@ -126,9 +126,8 @@ int reapi_cli_match (reapi_cli_ctx_t *ctx,
  *                   allocated or reserved.
  *  \param at        If allocated, 0 is returned; if reserved, actual time
  *                   at which the job is reserved.
- *  \param ov        Double into which to return performance overhead
- *                   in terms of elapse time needed to complete
- *                   the match operation.
+ *  \param attrs     Optional traversal attributes:
+ *    match_overhead    Double into which to return performance overhead.
  *  \return          0 on success; -1 on error.
  */
 int reapi_cli_match_with_jobid (reapi_cli_ctx_t *ctx,
@@ -138,7 +137,7 @@ int reapi_cli_match_with_jobid (reapi_cli_ctx_t *ctx,
                                 bool *reserved,
                                 char **R,
                                 int64_t *at,
-                                double *ov);
+                                struct traverser_match_attrs *attrs);
 
 /*! Match a jobspec to the "best" resources and either allocate
  *  orelse reserve them. The best resources are determined by
@@ -156,9 +155,8 @@ int reapi_cli_match_with_jobid (reapi_cli_ctx_t *ctx,
  *                   allocated or reserved.
  *  \param at        If allocated, 0 is returned; if reserved, actual time
  *                   at which the job is reserved.
- *  \param ov        Double into which to return performance overhead
- *                   in terms of elapse time needed to complete
- *                   the match operation.
+ *  \param attrs     Optional traversal attributes:
+ *    match_overhead    Double into which to return performance overhead.
  *  \return          0 on success; -1 on error.
  */
 int reapi_cli_match_allocate (reapi_cli_ctx_t *ctx,
@@ -168,7 +166,7 @@ int reapi_cli_match_allocate (reapi_cli_ctx_t *ctx,
                               bool *reserved,
                               char **R,
                               int64_t *at,
-                              double *ov);
+                              struct traverser_match_attrs *attrs);
 
 /*! Run Satisfiability check for jobspec.
  *  When sat is true, there is no error and the job is satisfiable.
@@ -179,12 +177,14 @@ int reapi_cli_match_allocate (reapi_cli_ctx_t *ctx,
  *  \param jobspec   jobspec string.
  *  \param sat       bool sat into which to return if jobspec is
  *                   satisfiable.
- *  \param ov        Double into which to return performance overhead
- *                   in terms of elapse time needed to complete
- *                   the match operation.
+ *  \param attrs     Optional traversal attributes:
+ *    match_overhead    Double into which to return performance overhead.
  *  \return          0 on success; -1 on error.
  */
-int reapi_cli_match_satisfy (reapi_cli_ctx_t *ctx, const char *jobspec, bool *sat, double *ov);
+int reapi_cli_match_satisfy (reapi_cli_ctx_t *ctx,
+                             const char *jobspec,
+                             bool *sat,
+                             struct traverser_match_attrs *attrs);
 
 /*! Update the resource state with R.
  *

--- a/resource/reapi/bindings/c/reapi_module.cpp
+++ b/resource/reapi/bindings/c/reapi_module.cpp
@@ -54,7 +54,7 @@ extern "C" int reapi_module_match (reapi_module_ctx_t *ctx,
                                    bool *reserved,
                                    char **R,
                                    int64_t *at,
-                                   double *ov)
+                                   struct traverser_match_attrs *attrs)
 {
     int rc = -1;
     std::string R_buf = "";
@@ -65,7 +65,7 @@ extern "C" int reapi_module_match (reapi_module_ctx_t *ctx,
         goto out;
     }
     if ((rc = reapi_module_t::
-             match_allocate (ctx->h, match_op, jobspec, jobid, *reserved, R_buf, *at, *ov))
+             match_allocate (ctx->h, match_op, jobspec, jobid, *reserved, R_buf, *at, attrs))
         < 0) {
         goto out;
     }
@@ -86,15 +86,17 @@ extern "C" int reapi_module_match_allocate (reapi_module_ctx_t *ctx,
                                             bool *reserved,
                                             char **R,
                                             int64_t *at,
-                                            double *ov)
+                                            struct traverser_match_attrs *attrs)
 {
     match_op_t match_op =
         orelse_reserve ? match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE : match_op_t::MATCH_ALLOCATE;
 
-    return reapi_module_match (ctx, match_op, jobspec, jobid, reserved, R, at, ov);
+    return reapi_module_match (ctx, match_op, jobspec, jobid, reserved, R, at, attrs);
 }
 
-extern "C" int reapi_module_match_satisfy (reapi_module_ctx_t *ctx, const char *jobspec, double *ov)
+extern "C" int reapi_module_match_satisfy (reapi_module_ctx_t *ctx,
+                                           const char *jobspec,
+                                           struct traverser_match_attrs *attrs)
 {
     match_op_t match_op = match_op_t::MATCH_SATISFIABILITY;
     const uint64_t jobid = 0;
@@ -102,7 +104,7 @@ extern "C" int reapi_module_match_satisfy (reapi_module_ctx_t *ctx, const char *
     char **R;
     int64_t *at;
 
-    return reapi_module_match (ctx, match_op, jobspec, jobid, reserved, R, at, ov);
+    return reapi_module_match (ctx, match_op, jobspec, jobid, reserved, R, at, attrs);
 }
 
 extern "C" int reapi_module_update_allocate (reapi_module_ctx_t *ctx,
@@ -115,6 +117,7 @@ extern "C" int reapi_module_update_allocate (reapi_module_ctx_t *ctx,
     int rc = -1;
     std::string R_buf = "";
     const char *R_buf_c = NULL;
+    traverser_match_attrs attrs = default_match_attrs;
 
     if (!ctx || !ctx->h || !R) {
         errno = EINVAL;
@@ -128,6 +131,7 @@ extern "C" int reapi_module_update_allocate (reapi_module_ctx_t *ctx,
         goto out;
     }
     *R_out = R_buf_c;
+    *ov = attrs.match_overhead;
 out:
     return rc;
 }

--- a/resource/reapi/bindings/c/reapi_module.cpp
+++ b/resource/reapi/bindings/c/reapi_module.cpp
@@ -56,6 +56,27 @@ extern "C" int reapi_module_match (reapi_module_ctx_t *ctx,
                                    int64_t *at,
                                    double *ov)
 {
+    return reapi_module_match_within (ctx,
+                                      match_op,
+                                      jobspec,
+                                      jobid,
+                                      reserved,
+                                      R,
+                                      at,
+                                      ov,
+                                      INT64_MIN);
+}
+
+extern "C" int reapi_module_match_within (reapi_module_ctx_t *ctx,
+                                          match_op_t match_op,
+                                          const char *jobspec,
+                                          const uint64_t jobid,
+                                          bool *reserved,
+                                          char **R,
+                                          int64_t *at,
+                                          double *ov,
+                                          int64_t within)
+{
     int rc = -1;
     std::string R_buf = "";
     char *R_buf_c = NULL;
@@ -65,7 +86,7 @@ extern "C" int reapi_module_match (reapi_module_ctx_t *ctx,
         goto out;
     }
     if ((rc = reapi_module_t::
-             match_allocate (ctx->h, match_op, jobspec, jobid, *reserved, R_buf, *at, *ov))
+             match_allocate (ctx->h, match_op, jobspec, jobid, *reserved, R_buf, *at, *ov, within))
         < 0) {
         goto out;
     }

--- a/resource/reapi/bindings/c/reapi_module.h
+++ b/resource/reapi/bindings/c/reapi_module.h
@@ -64,6 +64,7 @@ void reapi_module_destroy (reapi_module_ctx_t *ctx);
  *                   at which the job is reserved.
  *  \param attrs     Optional traversal attributes:
  *    match_overhead    Double into which to return performance overhead.
+ *    match_within      Don't return matches starting after this duration.
  *  \return          0 on success; -1 on error.
  */
 int reapi_module_match (reapi_module_ctx_t *ctx,
@@ -93,6 +94,7 @@ int reapi_module_match (reapi_module_ctx_t *ctx,
  *                   at which the job is reserved.
  *  \param attrs     Optional traversal attributes:
  *    match_overhead    Double into which to return performance overhead.
+ *    match_within      Don't return matches starting after this duration.
  *  \return          0 on success; -1 on error.
  */
 int reapi_module_match_allocate (reapi_module_ctx_t *ctx,
@@ -110,6 +112,7 @@ int reapi_module_match_allocate (reapi_module_ctx_t *ctx,
  *  \param jobspec   jobspec string.
  *  \param attrs     Optional traversal attributes:
  *    match_overhead    Double into which to return performance overhead.
+ *    match_within      Don't return matches starting after this duration.
  *  \return          0 on success; -1 on error.
  */
 int reapi_module_match_satisfy (reapi_module_ctx_t *ctx,

--- a/resource/reapi/bindings/c/reapi_module.h
+++ b/resource/reapi/bindings/c/reapi_module.h
@@ -62,9 +62,8 @@ void reapi_module_destroy (reapi_module_ctx_t *ctx);
  *                   allocated or reserved.
  *  \param at        If allocated, 0 is returned; if reserved, actual time
  *                   at which the job is reserved.
- *  \param ov        Double into which to return performance overhead
- *                   in terms of elapse time needed to complete
- *                   the match operation.
+ *  \param attrs     Optional traversal attributes:
+ *    match_overhead    Double into which to return performance overhead.
  *  \return          0 on success; -1 on error.
  */
 int reapi_module_match (reapi_module_ctx_t *ctx,
@@ -74,7 +73,7 @@ int reapi_module_match (reapi_module_ctx_t *ctx,
                         bool *reserved,
                         char **R,
                         int64_t *at,
-                        double *ov);
+                        struct traverser_match_attrs *attrs);
 
 /*! Match a jobspec to the "best" resources and either allocate
  *  orelse reserve them. The best resources are determined by
@@ -92,9 +91,8 @@ int reapi_module_match (reapi_module_ctx_t *ctx,
  *                   allocated or reserved.
  *  \param at        If allocated, 0 is returned; if reserved, actual time
  *                   at which the job is reserved.
- *  \param ov        Double into which to return performance overhead
- *                   in terms of elapse time needed to complete
- *                   the match operation.
+ *  \param attrs     Optional traversal attributes:
+ *    match_overhead    Double into which to return performance overhead.
  *  \return          0 on success; -1 on error.
  */
 int reapi_module_match_allocate (reapi_module_ctx_t *ctx,
@@ -104,18 +102,19 @@ int reapi_module_match_allocate (reapi_module_ctx_t *ctx,
                                  bool *reserved,
                                  char **R,
                                  int64_t *at,
-                                 double *ov);
+                                 struct traverser_match_attrs *attrs);
 
 /*! Run Satisfiability check for jobspec.
  *
  *  \param ctx       reapi_module_ctx_t context object
  *  \param jobspec   jobspec string.
- *  \param ov        Double into which to return performance overhead
- *                   in terms of elapse time needed to complete
- *                   the match operation.
+ *  \param attrs     Optional traversal attributes:
+ *    match_overhead    Double into which to return performance overhead.
  *  \return          0 on success; -1 on error.
  */
-int reapi_module_match_satisfy (reapi_module_ctx_t *ctx, const char *jobspec, double *ov);
+int reapi_module_match_satisfy (reapi_module_ctx_t *ctx,
+                                const char *jobspec,
+                                struct traverser_match_attrs *attrs);
 
 /*! Update the resource state with R.
  *

--- a/resource/reapi/bindings/c/reapi_module.h
+++ b/resource/reapi/bindings/c/reapi_module.h
@@ -81,6 +81,53 @@ int reapi_module_match (reapi_module_ctx_t *ctx,
  *  the selected match policy.
  *
  *  \param ctx       reapi_module_ctx_t context object
+ *  \param match_op  match_op_t: set to specify the specific match option
+ *                   from 1 of 4 choices:
+ *                   MATCH_ALLOCATE: try to allocate now and fail if resources
+ *                   aren't available.
+ *                   MATCH_ALLOCATE_ORELSE_RESERVE : Try to allocate and reserve
+ *                   if resources aren't available now.
+ *                   MATCH_SATISFIABILITY: Do a satisfiablity check and do not
+ *                   allocate.
+ *                   MATCH_ALLOCATE_W_SATISFIABILITY: try to allocate and run
+ *                   satisfiability check if resources are not available.
+ *                   MATCH_WITHOUT_ALLOCATING: match and return resources
+ *                   but do not allocate or reserve them.
+ *                   MATCH_WITHOUT_ALLOCATING_FUTURE: match and return resources
+ *                   but do not allocate or reserve them. Return the earliest
+ *                   match, which could be in the future.
+ *  \param jobspec   jobspec string.
+ *  \param jobid     jobid of the uint64_t type.
+ *  \param reserved  Boolean into which to return true if this job has been
+ *                   reserved instead of allocated.
+ *  \param R         String into which to return the resource set either
+ *                   allocated or reserved.
+ *  \param at        If allocated, 0 is returned; if reserved, actual time
+ *                   at which the job is reserved.
+ *  \param ov        Double into which to return performance overhead
+ *                   in terms of elapse time needed to complete
+ *                   the match operation.
+ *  \param within    Only return matches that start between now and now+within.
+ *                   If within < 0, don't apply this filter.
+ *                   If and only if within == INT64_MIN, also search for a
+ *                   'within' value in the jobspec's user attributes.
+ *  \return          0 on success; -1 on error.
+ */
+int reapi_module_match_within (reapi_module_ctx_t *ctx,
+                               match_op_t match_op,
+                               const char *jobspec,
+                               const uint64_t jobid,
+                               bool *reserved,
+                               char **R,
+                               int64_t *at,
+                               double *ov,
+                               int64_t within);
+
+/*! Match a jobspec to the "best" resources and either allocate
+ *  orelse reserve them. The best resources are determined by
+ *  the selected match policy.
+ *
+ *  \param ctx       reapi_module_ctx_t context object
  *  \param orelse_reserve
  *                   Boolean: if false, only allocate; otherwise, first try
  *                   to allocate and if that fails, reserve.

--- a/resource/reapi/bindings/c/test/reapi_cli_test.c
+++ b/resource/reapi/bindings/c/test/reapi_cli_test.c
@@ -110,7 +110,6 @@ static int test_match_with_jobid ()
     bool reserved = false;
     char *R = NULL;
     int64_t at = 0;
-    double ov = 0.0;
 
     // Test reapi_cli_match_with_jobid with explicit jobid
     errno = 0;
@@ -121,7 +120,7 @@ static int test_match_with_jobid ()
                                      &reserved,
                                      &R,
                                      &at,
-                                     &ov);
+                                     NULL);
     ok (rc == 0, "reapi_cli_match_with_jobid succeeded");
     ok (R != NULL, "reapi_cli_match_with_jobid returned R string");
     free (R);
@@ -147,7 +146,7 @@ static int test_match_with_jobid ()
                                      &reserved,
                                      &R,
                                      &at,
-                                     &ov);
+                                     NULL);
     ok (rc == -1 && errno == EINVAL,
         "reapi_cli_match_with_jobid returns -1 with errno=EINVAL for NULL context");
 
@@ -349,10 +348,9 @@ static int test_cancel_ex ()
     bool reserved = false;
     char *R = NULL;
     int64_t at = 0;
-    double ov = 0.0;
 
     // Allocate a job first
-    rc = reapi_cli_match_allocate (ctx, false, simple_jobspec, &jobid, &reserved, &R, &at, &ov);
+    rc = reapi_cli_match_allocate (ctx, false, simple_jobspec, &jobid, &reserved, &R, &at, NULL);
     if (rc < 0)
         BAIL_OUT ("reapi_cli_match_allocate failed: %s", reapi_cli_get_err_msg (ctx));
 
@@ -432,7 +430,6 @@ static int test_find ()
     bool reserved = false;
     char *R = NULL;
     int64_t at = 0;
-    double ov = 0.0;
 
     rc = reapi_cli_match_with_jobid (ctx,
                                      MATCH_ALLOCATE,
@@ -441,7 +438,7 @@ static int test_find ()
                                      &reserved,
                                      &R,
                                      &at,
-                                     &ov);
+                                     NULL);
     if (rc < 0)
         BAIL_OUT ("reapi_cli_match_with_jobid failed");
     ok (rc == 0, "allocated job for find test");
@@ -502,11 +499,10 @@ static int test_match_satisfy_absent_type ()
         BAIL_OUT ("reapi_cli_initialize failed: %s", reapi_cli_get_err_msg (ctx));
 
     bool sat = false;
-    double ov = 0.0;
 
     // Sanity: a satisfiable request is reported satisfiable.
     sat = false;
-    rc = reapi_cli_match_satisfy (ctx, simple_jobspec, &sat, &ov);
+    rc = reapi_cli_match_satisfy (ctx, simple_jobspec, &sat, NULL);
     ok (rc == 0 && sat, "reapi_cli_match_satisfy: satisfiable request -> satisfiable");
 
     // A request for a resource type absent from the graph must NOT be reported
@@ -515,7 +511,7 @@ static int test_match_satisfy_absent_type ()
     // with errno != ENODEV) was wrongly reported satisfiable.
     sat = true;
     errno = 0;
-    rc = reapi_cli_match_satisfy (ctx, jobspec_absent_type, &sat, &ov);
+    rc = reapi_cli_match_satisfy (ctx, jobspec_absent_type, &sat, NULL);
     ok (rc != 0 && !sat, "reapi_cli_match_satisfy: absent resource type -> unsatisfiable");
 
     reapi_cli_destroy (ctx);

--- a/resource/reapi/test/reapi_cli_test_c.cpp
+++ b/resource/reapi/test/reapi_cli_test_c.cpp
@@ -123,6 +123,110 @@ TEST_CASE ("Match basic jobspec", "[match C]")
         CHECK (jobid == -1);
         REQUIRE (rc == -1);
     }
+
+    SECTION ("Match only within some duration")
+    {
+        match_op_t match_op = match_op_t::MATCH_UNKNOWN;
+        bool reserved = false;
+        char *R;
+        uint64_t jobid = -1;
+        double ov = 0.0;
+        int64_t at = 0;
+        int64_t within = 0;
+
+        // Allocate all resources from 0 to 3600
+        match_op = match_op_t::MATCH_ALLOCATE;
+        for (int i = 1; i <= 4; i++) {
+            rc = reapi_cli_match_with_jobid_within (ctx,
+                                                    match_op,
+                                                    jobspec.c_str (),
+                                                    jobid,
+                                                    &reserved,
+                                                    &R,
+                                                    &at,
+                                                    &ov,
+                                                    within);
+            CAPTURE (i);
+            CHECK (reserved == false);
+            CHECK (at == 0);
+            REQUIRE (rc == 0);
+        }
+
+        // Fail to match within 3599 units (first avail at 3600)
+        within = 3599;
+        for (match_op_t match_op : {match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE,
+                                    match_op_t::MATCH_WITHOUT_ALLOCATING_FUTURE}) {
+            rc = reapi_cli_match_with_jobid_within (ctx,
+                                                    match_op,
+                                                    jobspec.c_str (),
+                                                    jobid,
+                                                    &reserved,
+                                                    &R,
+                                                    &at,
+                                                    &ov,
+                                                    within);
+            CAPTURE (match_op_to_string (match_op));
+            REQUIRE (rc != 0);
+        }
+
+        // Successfully match within 3600 units (first avail at 3600)
+        within = 3600;
+        match_op = match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE;
+        rc = reapi_cli_match_with_jobid_within (ctx,
+                                                match_op,
+                                                jobspec.c_str (),
+                                                jobid,
+                                                &reserved,
+                                                &R,
+                                                &at,
+                                                &ov,
+                                                within);
+        CHECK (reserved == true);
+        CHECK (at == 3600);
+        REQUIRE (rc == 0);
+        match_op = match_op_t::MATCH_WITHOUT_ALLOCATING_FUTURE;
+        rc = reapi_cli_match_with_jobid_within (ctx,
+                                                match_op,
+                                                jobspec.c_str (),
+                                                jobid,
+                                                &reserved,
+                                                &R,
+                                                &at,
+                                                &ov,
+                                                within);
+        CHECK (reserved == false);
+        CHECK (at == 3600);
+        REQUIRE (rc == 0);
+
+        // Successfully match within negative (infinite) units
+        within = -1;
+        match_op = match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE;
+        rc = reapi_cli_match_with_jobid_within (ctx,
+                                                match_op,
+                                                jobspec.c_str (),
+                                                jobid,
+                                                &reserved,
+                                                &R,
+                                                &at,
+                                                &ov,
+                                                within);
+        CHECK (reserved == true);
+        CHECK (at == 3600);
+        REQUIRE (rc == 0);
+        match_op = match_op_t::MATCH_WITHOUT_ALLOCATING_FUTURE;
+        rc = reapi_cli_match_with_jobid_within (ctx,
+                                                match_op,
+                                                jobspec.c_str (),
+                                                jobid,
+                                                &reserved,
+                                                &R,
+                                                &at,
+                                                &ov,
+                                                within);
+        CHECK (reserved == false);
+        CHECK (at == 3600);
+        REQUIRE (rc == 0);
+    }
 }
 
 TEST_CASE ("Initialize REAPI CLI and test match, satisfy, and cancel",

--- a/resource/reapi/test/reapi_cli_test_c.cpp
+++ b/resource/reapi/test/reapi_cli_test_c.cpp
@@ -3,6 +3,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <resource/reapi/bindings/c/reapi_cli.h>
 #include <resource/policies/base/match_op.h>
+#include <resource/traversers/dfu_match_attributes.h>
 #include <fstream>
 #include <iostream>
 
@@ -121,6 +122,104 @@ TEST_CASE ("Match basic jobspec", "[match C]")
         CHECK (at == 0);
         CHECK (jobid == -1);
         REQUIRE (rc == -1);
+    }
+
+    SECTION ("Match only within some duration")
+    {
+        match_op_t match_op = match_op_t::MATCH_UNKNOWN;
+        bool reserved = false;
+        char *R;
+        uint64_t jobid = -1;
+        int64_t at = 0;
+        traverser_match_attrs attrs = default_match_attrs;
+
+        // Allocate all resources from 0 to 3600
+        attrs.match_within = 0;
+        match_op = match_op_t::MATCH_ALLOCATE;
+        for (int i = 1; i <= 4; i++) {
+            rc = reapi_cli_match_with_jobid (ctx,
+                                             match_op,
+                                             jobspec.c_str (),
+                                             jobid,
+                                             &reserved,
+                                             &R,
+                                             &at,
+                                             &attrs);
+            CAPTURE (i);
+            CHECK (reserved == false);
+            CHECK (at == 0);
+            REQUIRE (rc == 0);
+        }
+
+        // Fail to match within 3599 units (first avail at 3600)
+        attrs.match_within = 3599;
+        for (match_op_t match_op : {match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE,
+                                    match_op_t::MATCH_WITHOUT_ALLOCATING_FUTURE}) {
+            rc = reapi_cli_match_with_jobid (ctx,
+                                             match_op,
+                                             jobspec.c_str (),
+                                             jobid,
+                                             &reserved,
+                                             &R,
+                                             &at,
+                                             &attrs);
+            CAPTURE (match_op_to_string (match_op));
+            REQUIRE (rc != 0);
+        }
+
+        // Successfully match within 3600 units (first avail at 3600)
+        attrs.match_within = 3600;
+        match_op = match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE;
+        rc = reapi_cli_match_with_jobid (ctx,
+                                         match_op,
+                                         jobspec.c_str (),
+                                         jobid,
+                                         &reserved,
+                                         &R,
+                                         &at,
+                                         &attrs);
+        CHECK (reserved == true);
+        CHECK (at == 3600);
+        REQUIRE (rc == 0);
+        match_op = match_op_t::MATCH_WITHOUT_ALLOCATING_FUTURE;
+        rc = reapi_cli_match_with_jobid (ctx,
+                                         match_op,
+                                         jobspec.c_str (),
+                                         jobid,
+                                         &reserved,
+                                         &R,
+                                         &at,
+                                         &attrs);
+        CHECK (reserved == false);
+        CHECK (at == 3600);
+        REQUIRE (rc == 0);
+
+        // Successfully match within negative (infinite) units
+        attrs.match_within = -1;
+        match_op = match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE;
+        rc = reapi_cli_match_with_jobid (ctx,
+                                         match_op,
+                                         jobspec.c_str (),
+                                         jobid,
+                                         &reserved,
+                                         &R,
+                                         &at,
+                                         &attrs);
+        CHECK (reserved == true);
+        CHECK (at == 3600);
+        REQUIRE (rc == 0);
+        match_op = match_op_t::MATCH_WITHOUT_ALLOCATING_FUTURE;
+        rc = reapi_cli_match_with_jobid (ctx,
+                                         match_op,
+                                         jobspec.c_str (),
+                                         jobid,
+                                         &reserved,
+                                         &R,
+                                         &at,
+                                         &attrs);
+        CHECK (reserved == false);
+        CHECK (at == 3600);
+        REQUIRE (rc == 0);
     }
 }
 

--- a/resource/reapi/test/reapi_cli_test_c.cpp
+++ b/resource/reapi/test/reapi_cli_test_c.cpp
@@ -60,10 +60,9 @@ TEST_CASE ("Match basic jobspec", "[match C]")
         bool reserved = false;
         char *R;
         uint64_t jobid = 1;
-        double ov = 0.0;
         int64_t at = 0;
 
-        rc = reapi_cli_match (ctx, match_op, jobspec.c_str (), &jobid, &reserved, &R, &at, &ov);
+        rc = reapi_cli_match (ctx, match_op, jobspec.c_str (), &jobid, &reserved, &R, &at, NULL);
         CHECK (rc == 0);
         CHECK (reserved == false);
         CHECK (at == 0);
@@ -74,12 +73,11 @@ TEST_CASE ("Match basic jobspec", "[match C]")
         bool reserved = false;
         char *R;
         uint64_t jobid = 1;
-        double ov = 0.0;
         int64_t at = 0;
 
         // MWOA should succeed on an empty graph
         match_op_t match_op = MATCH_WITHOUT_ALLOCATING;
-        rc = reapi_cli_match (ctx, match_op, jobspec.c_str (), &jobid, &reserved, &R, &at, &ov);
+        rc = reapi_cli_match (ctx, match_op, jobspec.c_str (), &jobid, &reserved, &R, &at, NULL);
         CHECK (reserved == false);
         CHECK (at == 0);
         CHECK (jobid == -1);
@@ -87,7 +85,7 @@ TEST_CASE ("Match basic jobspec", "[match C]")
 
         // MWOA_FUTURE should succeed on an empty graph
         match_op = MATCH_WITHOUT_ALLOCATING_FUTURE;
-        rc = reapi_cli_match (ctx, match_op, jobspec.c_str (), &jobid, &reserved, &R, &at, &ov);
+        rc = reapi_cli_match (ctx, match_op, jobspec.c_str (), &jobid, &reserved, &R, &at, NULL);
         CHECK (reserved == false);
         CHECK (at == 0);
         CHECK (jobid == -1);
@@ -96,7 +94,8 @@ TEST_CASE ("Match basic jobspec", "[match C]")
         // Allocate all resources
         match_op = MATCH_ALLOCATE;
         for (int i = 1; i <= 4; i++) {
-            rc = reapi_cli_match (ctx, match_op, jobspec.c_str (), &jobid, &reserved, &R, &at, &ov);
+            rc =
+                reapi_cli_match (ctx, match_op, jobspec.c_str (), &jobid, &reserved, &R, &at, NULL);
             CHECK (reserved == false);
             CHECK (at == 0);
             CHECK (jobid == i);
@@ -104,12 +103,12 @@ TEST_CASE ("Match basic jobspec", "[match C]")
         }
 
         // The tiny graph should be full
-        rc = reapi_cli_match (ctx, match_op, jobspec.c_str (), &jobid, &reserved, &R, &at, &ov);
+        rc = reapi_cli_match (ctx, match_op, jobspec.c_str (), &jobid, &reserved, &R, &at, NULL);
         REQUIRE (rc == -1);
 
         // MWOA_FUTURE should match the next available time, which is in the future
         match_op = MATCH_WITHOUT_ALLOCATING_FUTURE;
-        rc = reapi_cli_match (ctx, match_op, jobspec.c_str (), &jobid, &reserved, &R, &at, &ov);
+        rc = reapi_cli_match (ctx, match_op, jobspec.c_str (), &jobid, &reserved, &R, &at, NULL);
         CHECK (reserved == false);
         CHECK (at == 3600);
         CHECK (jobid == -1);
@@ -117,7 +116,7 @@ TEST_CASE ("Match basic jobspec", "[match C]")
 
         // MWOA should try to match at t=0 and fail because the graph is full
         match_op = MATCH_WITHOUT_ALLOCATING;
-        rc = reapi_cli_match (ctx, match_op, jobspec.c_str (), &jobid, &reserved, &R, &at, &ov);
+        rc = reapi_cli_match (ctx, match_op, jobspec.c_str (), &jobid, &reserved, &R, &at, NULL);
         CHECK (reserved == false);
         CHECK (at == 0);
         CHECK (jobid == -1);
@@ -144,7 +143,7 @@ TEST_CASE ("Initialize REAPI CLI and test match, satisfy, and cancel",
     bool reserved, satisfiable;
     char *R = nullptr, *mode = nullptr;
     int64_t at;
-    double ov;
+    double ov = 0.0f;
 
     REQUIRE (resource_file.is_open () == true);
     buffer << resource_file.rdbuf ();
@@ -165,7 +164,7 @@ TEST_CASE ("Initialize REAPI CLI and test match, satisfy, and cancel",
     INFO (reapi_cli_get_err_msg (ctx));
 
     // Test match with empty resource graph
-    REQUIRE (reapi_cli_match (ctx, match_op, jobspec.c_str (), &jobid, &reserved, &R, &at, &ov)
+    REQUIRE (reapi_cli_match (ctx, match_op, jobspec.c_str (), &jobid, &reserved, &R, &at, NULL)
              != 0);
 
     // Test initialization with valid params
@@ -173,22 +172,22 @@ TEST_CASE ("Initialize REAPI CLI and test match, satisfy, and cancel",
     INFO (reapi_cli_get_err_msg (ctx));
 
     // Test match with populated resource graph
-    CHECK (reapi_cli_match (ctx, match_op, jobspec.c_str (), &jobid2, &reserved, &R, &at, &ov)
+    CHECK (reapi_cli_match (ctx, match_op, jobspec.c_str (), &jobid2, &reserved, &R, &at, NULL)
            == 0);
     CHECK (reserved == false);
     INFO (reapi_cli_get_err_msg (ctx));
 
     // Test match_allocate with orelse_reserve = true
-    CHECK (reapi_cli_match_allocate (ctx, true, jobspec.c_str (), &jobid3, &reserved, &R, &at, &ov)
+    CHECK (reapi_cli_match_allocate (ctx, true, jobspec.c_str (), &jobid3, &reserved, &R, &at, NULL)
            == 0);
     INFO (reapi_cli_get_err_msg (ctx));
 
     // Test satisfy
-    CHECK (reapi_cli_match_satisfy (ctx, jobspec.c_str (), &satisfiable, &ov) == 0);
+    CHECK (reapi_cli_match_satisfy (ctx, jobspec.c_str (), &satisfiable, NULL) == 0);
     CHECK (satisfiable == true);
 
     // Test satisfy with unsatisfiable jobspec
-    CHECK (reapi_cli_match_satisfy (ctx, jobspec2.c_str (), &satisfiable, &ov) != 0);
+    CHECK (reapi_cli_match_satisfy (ctx, jobspec2.c_str (), &satisfiable, NULL) != 0);
     CHECK (satisfiable == false);
 
     // Test info with valid jobid

--- a/resource/reapi/test/reapi_cli_test_cxx.cpp
+++ b/resource/reapi/test/reapi_cli_test_cxx.cpp
@@ -4,6 +4,7 @@
 #include <catch2/generators/catch_generators.hpp>
 #include <resource/reapi/bindings/c++/reapi_cli.hpp>
 #include <resource/policies/base/match_op.h>
+#include <resource/traversers/dfu_match_attributes.h>
 #include <resource/schema/resource_graph.hpp>
 #include <fstream>
 #include <cstdlib>
@@ -208,6 +209,103 @@ TEST_CASE ("Match basic jobspec", "[match C++]")
         CHECK (reserved == false);
         CHECK (at == 0);
         CHECK (rc == -1);
+    }
+
+    SECTION ("Match only within some duration")
+    {
+        bool reserved = false;
+        std::string R = "";
+        uint64_t jobid = 1;
+        int64_t at = 0;
+        traverser_match_attrs attrs = default_match_attrs;
+
+        match_op_t match_op = match_op_t::MATCH_ALLOCATE;
+
+        for (int i = 0; i < 4; i++) {
+            rc =
+                reapi_cli_t::match_allocate (ctx.get (), match_op, jobspec, jobid, reserved, R, at);
+            CHECK (reserved == false);
+            CHECK (at == 0);
+            REQUIRE (rc == 0);
+            jobid++;
+        }
+
+        // Fail to match within 3599 units (first avail at 3600)
+        attrs.match_within = 3599;
+        match_op = match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE;
+        rc = reapi_cli_t::match_allocate (ctx.get (),
+                                          match_op,
+                                          jobspec,
+                                          jobid,
+                                          reserved,
+                                          R,
+                                          at,
+                                          &attrs);
+        REQUIRE (rc != 0);
+        match_op = match_op_t::MATCH_WITHOUT_ALLOCATING_FUTURE;
+        rc = reapi_cli_t::match_allocate (ctx.get (),
+                                          match_op,
+                                          jobspec,
+                                          jobid,
+                                          reserved,
+                                          R,
+                                          at,
+                                          &attrs);
+        REQUIRE (rc != 0);
+
+        // Successfully match within 3600 units (first avail at 3600)
+        attrs.match_within = 3600;
+        match_op = match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE;
+        rc = reapi_cli_t::match_allocate (ctx.get (),
+                                          match_op,
+                                          jobspec,
+                                          jobid,
+                                          reserved,
+                                          R,
+                                          at,
+                                          &attrs);
+        CHECK (reserved == true);
+        CHECK (at == 3600);
+        REQUIRE (rc == 0);
+        match_op = match_op_t::MATCH_WITHOUT_ALLOCATING_FUTURE;
+        rc = reapi_cli_t::match_allocate (ctx.get (),
+                                          match_op,
+                                          jobspec,
+                                          jobid,
+                                          reserved,
+                                          R,
+                                          at,
+                                          &attrs);
+        CHECK (reserved == false);
+        CHECK (at == 3600);
+        REQUIRE (rc == 0);
+
+        // Successfully match within negative (infinite) units
+        attrs.match_within = -1;
+        match_op = match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE;
+        rc = reapi_cli_t::match_allocate (ctx.get (),
+                                          match_op,
+                                          jobspec,
+                                          jobid,
+                                          reserved,
+                                          R,
+                                          at,
+                                          &attrs);
+        CHECK (reserved == true);
+        CHECK (at == 3600);
+        REQUIRE (rc == 0);
+        match_op = match_op_t::MATCH_WITHOUT_ALLOCATING_FUTURE;
+        rc = reapi_cli_t::match_allocate (ctx.get (),
+                                          match_op,
+                                          jobspec,
+                                          jobid,
+                                          reserved,
+                                          R,
+                                          at,
+                                          &attrs);
+        CHECK (reserved == false);
+        CHECK (at == 3600);
+        REQUIRE (rc == 0);
     }
 }
 

--- a/resource/reapi/test/reapi_cli_test_cxx.cpp
+++ b/resource/reapi/test/reapi_cli_test_cxx.cpp
@@ -1,6 +1,7 @@
 #define CATCH_CONFIG_MAIN
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 #include <resource/reapi/bindings/c++/reapi_cli.hpp>
 #include <resource/policies/base/match_op.h>
 #include <resource/schema/resource_graph.hpp>
@@ -128,17 +129,6 @@ TEST_CASE ("Match basic jobspec", "[match C++]")
 
     SECTION ("MATCH_WITHOUT_ALLOCATING[_FUTURE]")
     {
-        std::map<vtx_t, pool_infra_t> idata_map;
-        std::map<vtx_t, schedule_t> sched_map;
-        vtx_iterator_t u, end;
-        for (boost::tuples::tie (u, end) = boost::vertices (ctx->db->resource_graph); u != end;
-             u++) {
-            idata_map[*u] = ctx->db->resource_graph[*u].idata;
-            sched_map[*u] = ctx->db->resource_graph[*u].schedule;
-            REQUIRE (idata_map[*u] == ctx->db->resource_graph[*u].idata);
-            REQUIRE (sched_map[*u] == ctx->db->resource_graph[*u].schedule);
-        }
-
         bool reserved = false;
         std::string R = "";
         uint64_t jobid = 1;
@@ -173,13 +163,6 @@ TEST_CASE ("Match basic jobspec", "[match C++]")
         REQUIRE (reserved == false);
         REQUIRE (at == 0);
 
-        // Check that the post-MWOA graph state is the same as the initial state
-        for (boost::tuples::tie (u, end) = boost::vertices (ctx->db->resource_graph); u != end;
-             u++) {
-            CHECK (idata_map.at (*u).equal_except_color (ctx->db->resource_graph[*u].idata));
-            CHECK (sched_map.at (*u) == ctx->db->resource_graph[*u].schedule);
-        }
-
         // Allocate all resources
         match_op = MATCH_ALLOCATE;
         for (int i = 0; i < 4; i++) {
@@ -206,15 +189,6 @@ TEST_CASE ("Match basic jobspec", "[match C++]")
                                                   at,
                                                   ov);
         REQUIRE (rc == -1);
-
-        // The graph state should have changed
-        bool changed = false;
-        for (boost::tuples::tie (u, end) = boost::vertices (ctx->db->resource_graph); u != end;
-             u++) {
-            changed |= !(idata_map.at (*u).equal_except_color (ctx->db->resource_graph[*u].idata));
-            changed |= !(sched_map.at (*u) == ctx->db->resource_graph[*u].schedule);
-        }
-        REQUIRE (changed == true);
 
         // MWOA_FUTURE should match the next available time, which is in the future
         match_op = MATCH_WITHOUT_ALLOCATING_FUTURE;
@@ -322,9 +296,11 @@ TEST_CASE ("Test the graph idempotence of certain match operations", "[match C++
     double ov = 0.0;
     int64_t at = 0;
 
-    SECTION ("MATCH_SATISFIABILITY doesn't change the graph")
+    SECTION ("Non-mutating match options don't change the graph")
     {
-        match_op = MATCH_SATISFIABILITY;
+        match_op = GENERATE (MATCH_SATISFIABILITY,
+                             MATCH_WITHOUT_ALLOCATING,
+                             MATCH_WITHOUT_ALLOCATING_FUTURE);
         rc = detail::reapi_cli_t::match_allocate (ctx.get (),
                                                   match_op,
                                                   jobspec,
@@ -337,9 +313,10 @@ TEST_CASE ("Test the graph idempotence of certain match operations", "[match C++
         CHECK (at == 0);
         REQUIRE (rc == 0);
 
-        // Check that the post-MATCH_SATISFIABILITY graph state is the same as the initial state
+        // Check that the post-match graph state is the same as the initial state
         for (boost::tuples::tie (u, end) = boost::vertices (ctx->db->resource_graph); u != end;
              u++) {
+            INFO ("vertex at index " << *u << " mutated by " << match_op_to_string (match_op));
             CHECK (idata_map.at (*u).equal_except_color (ctx->db->resource_graph[*u].idata));
             CHECK (sched_map.at (*u) == ctx->db->resource_graph[*u].schedule);
         }
@@ -367,7 +344,7 @@ TEST_CASE ("Test the graph idempotence of certain match operations", "[match C++
             changed |= !(idata_map.at (*u).equal_except_color (ctx->db->resource_graph[*u].idata));
             changed |= !(sched_map.at (*u) == ctx->db->resource_graph[*u].schedule);
         }
-        REQUIRE (changed == true);
+        REQUIRE (changed);
     }
 }
 

--- a/resource/reapi/test/reapi_cli_test_cxx.cpp
+++ b/resource/reapi/test/reapi_cli_test_cxx.cpp
@@ -111,7 +111,6 @@ TEST_CASE ("Match basic jobspec", "[match C++]")
         bool reserved = false;
         std::string R = "";
         uint64_t jobid = 1;
-        double ov = 0.0;
         int64_t at = 0;
 
         rc = detail::reapi_cli_t::match_allocate (ctx.get (),
@@ -120,8 +119,7 @@ TEST_CASE ("Match basic jobspec", "[match C++]")
                                                   jobid,
                                                   reserved,
                                                   R,
-                                                  at,
-                                                  ov);
+                                                  at);
         CHECK (rc == 0);
         CHECK (reserved == false);
         CHECK (at == 0);
@@ -132,7 +130,6 @@ TEST_CASE ("Match basic jobspec", "[match C++]")
         bool reserved = false;
         std::string R = "";
         uint64_t jobid = 1;
-        double ov = 0.0;
         int64_t at = 0;
 
         // MWOA should succeed on an empty graph
@@ -143,8 +140,7 @@ TEST_CASE ("Match basic jobspec", "[match C++]")
                                                   jobid,
                                                   reserved,
                                                   R,
-                                                  at,
-                                                  ov);
+                                                  at);
         REQUIRE (rc == 0);
         REQUIRE (reserved == false);
         REQUIRE (at == 0);
@@ -157,8 +153,7 @@ TEST_CASE ("Match basic jobspec", "[match C++]")
                                                   jobid,
                                                   reserved,
                                                   R,
-                                                  at,
-                                                  ov);
+                                                  at);
         REQUIRE (rc == 0);
         REQUIRE (reserved == false);
         REQUIRE (at == 0);
@@ -172,8 +167,7 @@ TEST_CASE ("Match basic jobspec", "[match C++]")
                                                       jobid,
                                                       reserved,
                                                       R,
-                                                      at,
-                                                      ov);
+                                                      at);
             CHECK (reserved == false);
             CHECK (at == 0);
             REQUIRE (rc == 0);
@@ -186,8 +180,7 @@ TEST_CASE ("Match basic jobspec", "[match C++]")
                                                   jobid,
                                                   reserved,
                                                   R,
-                                                  at,
-                                                  ov);
+                                                  at);
         REQUIRE (rc == -1);
 
         // MWOA_FUTURE should match the next available time, which is in the future
@@ -198,8 +191,7 @@ TEST_CASE ("Match basic jobspec", "[match C++]")
                                                   jobid,
                                                   reserved,
                                                   R,
-                                                  at,
-                                                  ov);
+                                                  at);
         CHECK (reserved == false);
         CHECK (at == 3600);
         CHECK (rc == 0);
@@ -212,8 +204,7 @@ TEST_CASE ("Match basic jobspec", "[match C++]")
                                                   jobid,
                                                   reserved,
                                                   R,
-                                                  at,
-                                                  ov);
+                                                  at);
         CHECK (reserved == false);
         CHECK (at == 0);
         CHECK (rc == -1);
@@ -293,7 +284,6 @@ TEST_CASE ("Test the graph idempotence of certain match operations", "[match C++
     bool reserved = false;
     std::string R = "";
     uint64_t jobid = 1;
-    double ov = 0.0;
     int64_t at = 0;
 
     SECTION ("Non-mutating match options don't change the graph")
@@ -307,8 +297,7 @@ TEST_CASE ("Test the graph idempotence of certain match operations", "[match C++
                                                   jobid,
                                                   reserved,
                                                   R,
-                                                  at,
-                                                  ov);
+                                                  at);
         CHECK (reserved == false);
         CHECK (at == 0);
         REQUIRE (rc == 0);
@@ -331,8 +320,7 @@ TEST_CASE ("Test the graph idempotence of certain match operations", "[match C++
                                                   jobid,
                                                   reserved,
                                                   R,
-                                                  at,
-                                                  ov);
+                                                  at);
         CHECK (reserved == false);
         CHECK (at == 0);
         REQUIRE (rc == 0);

--- a/resource/reapi/test/reapi_cli_test_cxx.cpp
+++ b/resource/reapi/test/reapi_cli_test_cxx.cpp
@@ -244,6 +244,112 @@ TEST_CASE ("Match basic jobspec", "[match C++]")
         CHECK (at == 0);
         CHECK (rc == -1);
     }
+
+    SECTION ("Match only within some duration")
+    {
+        bool reserved = false;
+        std::string R = "";
+        uint64_t jobid = 1;
+        double ov = 0.0;
+        int64_t at = 0;
+
+        match_op_t match_op = match_op_t::MATCH_ALLOCATE;
+
+        for (int i = 0; i < 4; i++) {
+            rc = reapi_cli_t::match_allocate (ctx.get (),
+                                              match_op,
+                                              jobspec,
+                                              jobid,
+                                              reserved,
+                                              R,
+                                              at,
+                                              ov);
+            CHECK (reserved == false);
+            CHECK (at == 0);
+            REQUIRE (rc == 0);
+            jobid++;
+        }
+
+        // Fail to match within 3599 units (first avail at 3600)
+        match_op = match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE;
+        rc = reapi_cli_t::match_allocate (ctx.get (),
+                                          match_op,
+                                          jobspec,
+                                          jobid,
+                                          reserved,
+                                          R,
+                                          at,
+                                          ov,
+                                          3599);
+        REQUIRE (rc != 0);
+        match_op = match_op_t::MATCH_WITHOUT_ALLOCATING_FUTURE;
+        rc = reapi_cli_t::match_allocate (ctx.get (),
+                                          match_op,
+                                          jobspec,
+                                          jobid,
+                                          reserved,
+                                          R,
+                                          at,
+                                          ov,
+                                          3599);
+        REQUIRE (rc != 0);
+
+        // Successfully match within 3600 units (first avail at 3600)
+        match_op = match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE;
+        rc = reapi_cli_t::match_allocate (ctx.get (),
+                                          match_op,
+                                          jobspec,
+                                          jobid,
+                                          reserved,
+                                          R,
+                                          at,
+                                          ov,
+                                          3600);
+        CHECK (reserved == true);
+        CHECK (at == 3600);
+        REQUIRE (rc == 0);
+        match_op = match_op_t::MATCH_WITHOUT_ALLOCATING_FUTURE;
+        rc = reapi_cli_t::match_allocate (ctx.get (),
+                                          match_op,
+                                          jobspec,
+                                          jobid,
+                                          reserved,
+                                          R,
+                                          at,
+                                          ov,
+                                          3600);
+        CHECK (reserved == false);
+        CHECK (at == 3600);
+        REQUIRE (rc == 0);
+
+        // Successfully match within negative (infinite) units
+        match_op = match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE;
+        rc = reapi_cli_t::match_allocate (ctx.get (),
+                                          match_op,
+                                          jobspec,
+                                          jobid,
+                                          reserved,
+                                          R,
+                                          at,
+                                          ov,
+                                          -1);
+        CHECK (reserved == true);
+        CHECK (at == 3600);
+        REQUIRE (rc == 0);
+        match_op = match_op_t::MATCH_WITHOUT_ALLOCATING_FUTURE;
+        rc = reapi_cli_t::match_allocate (ctx.get (),
+                                          match_op,
+                                          jobspec,
+                                          jobid,
+                                          reserved,
+                                          R,
+                                          at,
+                                          ov,
+                                          -1);
+        CHECK (reserved == false);
+        CHECK (at == 3600);
+        REQUIRE (rc == 0);
+    }
 }
 
 TEST_CASE ("Initialize REAPI CLI and test add and remove", "[initialize-add-remove C++]")

--- a/resource/traversers/CMakeLists.txt
+++ b/resource/traversers/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_library(dfu_match_attrs INTERFACE
+    dfu_match_attributes.h
+    )
+
+add_subdirectory(test)

--- a/resource/traversers/dfu.cpp
+++ b/resource/traversers/dfu.cpp
@@ -371,7 +371,8 @@ int dfu_traverser_t::run (Jobspec::Jobspec &jobspec,
                           std::shared_ptr<match_writers_t> &writers,
                           match_op_t op,
                           int64_t jobid,
-                          int64_t *at)
+                          int64_t *at,
+                          traverser_match_attrs *attrs)
 {
     // Clear the error message to disambiguate errors
     clear_err_message ();

--- a/resource/traversers/dfu.cpp
+++ b/resource/traversers/dfu.cpp
@@ -371,7 +371,8 @@ int dfu_traverser_t::run (Jobspec::Jobspec &jobspec,
                           std::shared_ptr<match_writers_t> &writers,
                           match_op_t op,
                           int64_t jobid,
-                          int64_t *at)
+                          int64_t *at,
+                          boost::optional<int64_t> within)
 {
     // Clear the error message to disambiguate errors
     clear_err_message ();
@@ -389,6 +390,7 @@ int dfu_traverser_t::run (Jobspec::Jobspec &jobspec,
     int64_t graph_end = std::chrono::duration_cast<std::chrono::seconds> (
                             graph_duration.graph_end.time_since_epoch ())
                             .count ();
+    int64_t latest = std::numeric_limits<int64_t>::max ();
     detail::jobmeta_t meta;
     vtx_t root = get_graph_db ()->metadata.roots.at (dom);
     bool x = traverser->exclusivity (jobspec.resources, root);
@@ -399,6 +401,15 @@ int dfu_traverser_t::run (Jobspec::Jobspec &jobspec,
     if (meta.build (jobspec, detail::jobmeta_t::alloc_type_t::AT_ALLOC, jobid, *at, graph_duration)
         < 0)
         return -1;
+
+    // If within is not specified , read it from the jobspec's user attributes.
+    // Note *within == INT64_MIN when it comes from the REAPI CLI.
+    YAML::Node match_within_node = jobspec.attributes.user["match-within"];
+    if ((!within || *within == INT64_MIN) && match_within_node.IsDefined ())
+        within = match_within_node.as<int64_t> ();
+
+    if (within && *within >= 0 && within <= std::numeric_limits<int64_t>::max () - *at)
+        latest = *at + *within;
 
     // If matching without allocation, set alloc_type to prevent allocation in update
     if (op == match_op_t::MATCH_WITHOUT_ALLOCATING
@@ -412,7 +423,7 @@ int dfu_traverser_t::run (Jobspec::Jobspec &jobspec,
         }
     } else if ((rc = schedule (jobspec, meta, x, op, root, dfv)) == 0) {
         *at = meta.at;
-        if (*at == graph_end) {
+        if (*at == graph_end || *at > latest) {
             traverser->reset_exclusive_resource_types (exclusive_types);
             // no schedulable point found even at the end of the time, return EBUSY
             errno = EBUSY;

--- a/resource/traversers/dfu.cpp
+++ b/resource/traversers/dfu.cpp
@@ -390,6 +390,8 @@ int dfu_traverser_t::run (Jobspec::Jobspec &jobspec,
     int64_t graph_end = std::chrono::duration_cast<std::chrono::seconds> (
                             graph_duration.graph_end.time_since_epoch ())
                             .count ();
+    int64_t within = attrs ? attrs->match_within : INT64_MIN;
+    int64_t latest = std::numeric_limits<int64_t>::max ();
     detail::jobmeta_t meta;
     vtx_t root = get_graph_db ()->metadata.roots.at (dom);
     bool x = traverser->exclusivity (jobspec.resources, root);
@@ -400,6 +402,15 @@ int dfu_traverser_t::run (Jobspec::Jobspec &jobspec,
     if (meta.build (jobspec, detail::jobmeta_t::alloc_type_t::AT_ALLOC, jobid, *at, graph_duration)
         < 0)
         return -1;
+
+    // If within is not specified , read it from the jobspec's user attributes.
+    // Note within == INT64_MIN when it is unspecified.
+    YAML::Node match_within_node = jobspec.attributes.user["match-within"];
+    if ((within == INT64_MIN) && match_within_node.IsDefined ())
+        within = match_within_node.as<int64_t> ();
+
+    if (within >= 0 && within <= std::numeric_limits<int64_t>::max () - *at)
+        latest = *at + within;
 
     // If matching without allocation, set alloc_type to prevent allocation in update
     if (op == match_op_t::MATCH_WITHOUT_ALLOCATING
@@ -413,7 +424,7 @@ int dfu_traverser_t::run (Jobspec::Jobspec &jobspec,
         }
     } else if ((rc = schedule (jobspec, meta, x, op, root, dfv)) == 0) {
         *at = meta.at;
-        if (*at == graph_end) {
+        if (*at == graph_end || *at > latest) {
             traverser->reset_exclusive_resource_types (exclusive_types);
             // no schedulable point found even at the end of the time, return EBUSY
             errno = EBUSY;

--- a/resource/traversers/dfu.hpp
+++ b/resource/traversers/dfu.hpp
@@ -102,6 +102,7 @@ class dfu_traverser_t {
      *  \param at[out]   when the job is scheduled if reserved.
      *  \param attrs     optional attributes of the traversal:
      *    match_overhead     double into which to return performance overhead.
+     *    match_within       don't return matches starting after this duration.
      *  \return          0 on success; -1 on error.
      *                       EINVAL: graph, roots or match callback not set.
      *                       ENOTSUP: roots does not contain a subsystem the

--- a/resource/traversers/dfu.hpp
+++ b/resource/traversers/dfu.hpp
@@ -13,6 +13,7 @@
 
 #include <iostream>
 #include <cstdlib>
+#include <boost/optional.hpp>
 #include "resource/traversers/dfu_impl.hpp"
 #include "resource/traversers/dfu_traverser_policy_factory.hpp"
 
@@ -99,6 +100,7 @@ class dfu_traverser_t {
      *                       without_allocating, or without_allocating_future.
      *  \param id        job ID to use for the schedule operation.
      *  \param at[out]   when the job is scheduled if reserved.
+     *  \param within    don't return matches that start after this duration.
      *  \return          0 on success; -1 on error.
      *                       EINVAL: graph, roots or match callback not set.
      *                       ENOTSUP: roots does not contain a subsystem the
@@ -112,7 +114,8 @@ class dfu_traverser_t {
              std::shared_ptr<match_writers_t> &writers,
              match_op_t op,
              int64_t id,
-             int64_t *at);
+             int64_t *at,
+             boost::optional<int64_t> within = boost::none);
 
     /*! Read str which is a serialized allocation data (e.g., written in JGF)
      *  with rd, and traverse the resource graph to update it with this data.

--- a/resource/traversers/dfu.hpp
+++ b/resource/traversers/dfu.hpp
@@ -15,6 +15,7 @@
 #include <cstdlib>
 #include "resource/traversers/dfu_impl.hpp"
 #include "resource/traversers/dfu_traverser_policy_factory.hpp"
+#include "resource/traversers/dfu_match_attributes.h"
 
 namespace Flux {
 namespace resource_model {
@@ -99,6 +100,8 @@ class dfu_traverser_t {
      *                       without_allocating, or without_allocating_future.
      *  \param id        job ID to use for the schedule operation.
      *  \param at[out]   when the job is scheduled if reserved.
+     *  \param attrs     optional attributes of the traversal:
+     *    match_overhead     double into which to return performance overhead.
      *  \return          0 on success; -1 on error.
      *                       EINVAL: graph, roots or match callback not set.
      *                       ENOTSUP: roots does not contain a subsystem the
@@ -112,7 +115,8 @@ class dfu_traverser_t {
              std::shared_ptr<match_writers_t> &writers,
              match_op_t op,
              int64_t id,
-             int64_t *at);
+             int64_t *at,
+             traverser_match_attrs *attrs);
 
     /*! Read str which is a serialized allocation data (e.g., written in JGF)
      *  with rd, and traverse the resource graph to update it with this data.

--- a/resource/traversers/dfu_match_attributes.h
+++ b/resource/traversers/dfu_match_attributes.h
@@ -1,0 +1,37 @@
+/*****************************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+#ifndef DFU_MATCH_ATTRIBUTES_H
+#define DFU_MATCH_ATTRIBUTES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+/*! Wrapper for optional traversal attributes.
+ *  Passing around a pointer to traverser_match_attrs allows adding new attributes
+ *  without breaking ABI compatibility.
+ *    match_overhead     Double to store performance overhead in terms of
+ *                       elapsed time needed to complete the match operation.
+ *                       Not used by traverser.
+ */
+struct traverser_match_attrs {
+    double match_overhead;
+};
+
+const struct traverser_match_attrs default_match_attrs = {0.0f};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // DFU_MATCH_ATTRIBUTES_H

--- a/resource/traversers/dfu_match_attributes.h
+++ b/resource/traversers/dfu_match_attributes.h
@@ -23,12 +23,17 @@ extern "C" {
  *    match_overhead     Double to store performance overhead in terms of
  *                       elapsed time needed to complete the match operation.
  *                       Not used by traverser.
+ *    match_within       Only return matches that start between now and now+within.
+ *                       If within < 0, don't apply this filter.  However, if
+ *                       within == INT64_MIN, also search for a 'within'
+ *                       value in the jobspec's user attributes dictionary.
  */
 struct traverser_match_attrs {
     double match_overhead;
+    int64_t match_within;
 };
 
-const struct traverser_match_attrs default_match_attrs = {0.0f};
+const struct traverser_match_attrs default_match_attrs = {0.0f, INT64_MIN};
 
 #ifdef __cplusplus
 }

--- a/resource/utilities/command.cpp
+++ b/resource/utilities/command.cpp
@@ -243,7 +243,8 @@ static int run_match (std::shared_ptr<detail::resource_query_t> &ctx,
                       int64_t jobid,
                       const match_op_t match_op,
                       const std::string &jobspec_fn,
-                      std::ostream &out)
+                      std::ostream &out,
+                      int64_t within = std::numeric_limits<int64_t>::min ())
 {
     int rc = 0;
     int64_t at = 0;
@@ -270,7 +271,8 @@ static int run_match (std::shared_ptr<detail::resource_query_t> &ctx,
                                               reserved,
                                               R,
                                               at,
-                                              ov);
+                                              ov,
+                                              within);
 
     // check for match success - only check errno if match_allocate failed
     if (rc < 0) {
@@ -310,7 +312,7 @@ int cmd_match (std::shared_ptr<detail::resource_query_t> &ctx,
 {
     match_op_t match_op;
 
-    if (args.size () != 3) {
+    if (args.size () < 3 || args.size () > 4) {
         std::cerr << "ERROR: malformed command" << std::endl;
         return 0;
     }
@@ -323,7 +325,17 @@ int cmd_match (std::shared_ptr<detail::resource_query_t> &ctx,
     uint64_t jobid = ctx->get_job_counter ();
     std::string &jobspec_fn = args[2];
 
-    run_match (ctx, jobid, match_op, jobspec_fn, out);
+    int64_t within = std::numeric_limits<int64_t>::min ();
+    if (args.size () == 4) {
+        try {
+            within = std::stoi (args[3]);
+        } catch (...) {
+            std::cerr << "ERROR: invalid integer for 'within' param: " << args[3] << std::endl;
+            return 0;
+        }
+    }
+
+    run_match (ctx, jobid, match_op, jobspec_fn, out, within);
 
     return 0;
 }

--- a/resource/utilities/command.cpp
+++ b/resource/utilities/command.cpp
@@ -315,7 +315,7 @@ int cmd_match (std::shared_ptr<detail::resource_query_t> &ctx,
     match_op_t match_op;
     traverser_match_attrs attrs = default_match_attrs;
 
-    if (args.size () != 3) {
+    if (args.size () < 3 || args.size () > 4) {
         std::cerr << "ERROR: malformed command" << std::endl;
         return 0;
     }
@@ -327,6 +327,15 @@ int cmd_match (std::shared_ptr<detail::resource_query_t> &ctx,
 
     uint64_t jobid = ctx->get_job_counter ();
     std::string &jobspec_fn = args[2];
+
+    if (args.size () == 4) {
+        try {
+            attrs.match_within = std::stoi (args[3]);
+        } catch (...) {
+            std::cerr << "ERROR: invalid integer for 'within' param: " << args[3] << std::endl;
+            return 0;
+        }
+    }
 
     run_match (ctx, jobid, match_op, jobspec_fn, &attrs, out);
 

--- a/resource/utilities/command.cpp
+++ b/resource/utilities/command.cpp
@@ -243,6 +243,7 @@ static int run_match (std::shared_ptr<detail::resource_query_t> &ctx,
                       int64_t jobid,
                       const match_op_t match_op,
                       const std::string &jobspec_fn,
+                      traverser_match_attrs *attrs,
                       std::ostream &out)
 {
     int rc = 0;
@@ -250,9 +251,12 @@ static int run_match (std::shared_ptr<detail::resource_query_t> &ctx,
     bool reserved = false;
     bool sat = true;
     bool matched = true;
-    double ov = 0.0;
     std::string R = "";
 
+    if (!attrs) {
+        std::cerr << "ERROR: invalid match attributes" << std::endl;
+        return -1;
+    }
     std::ifstream jobspec_in (jobspec_fn);
     if (!jobspec_in) {
         std::cerr << "ERROR: can't open " << jobspec_fn << std::endl;
@@ -270,7 +274,7 @@ static int run_match (std::shared_ptr<detail::resource_query_t> &ctx,
                                               reserved,
                                               R,
                                               at,
-                                              ov);
+                                              attrs);
 
     // check for match success - only check errno if match_allocate failed
     if (rc < 0) {
@@ -288,7 +292,7 @@ static int run_match (std::shared_ptr<detail::resource_query_t> &ctx,
     out << R;
 
     if (match_op == match_op_t::MATCH_SATISFIABILITY)
-        print_sat_info (ctx, out, sat, ov);
+        print_sat_info (ctx, out, sat, attrs->match_overhead);
     else
         print_schedule_info (ctx,
                              out,
@@ -299,7 +303,7 @@ static int run_match (std::shared_ptr<detail::resource_query_t> &ctx,
                                  && match_op != match_op_t::MATCH_WITHOUT_ALLOCATING_FUTURE,
                              at,
                              sat,
-                             ov);
+                             attrs->match_overhead);
 
     return rc;
 }
@@ -309,6 +313,7 @@ int cmd_match (std::shared_ptr<detail::resource_query_t> &ctx,
                std::ostream &out)
 {
     match_op_t match_op;
+    traverser_match_attrs attrs = default_match_attrs;
 
     if (args.size () != 3) {
         std::cerr << "ERROR: malformed command" << std::endl;
@@ -323,7 +328,7 @@ int cmd_match (std::shared_ptr<detail::resource_query_t> &ctx,
     uint64_t jobid = ctx->get_job_counter ();
     std::string &jobspec_fn = args[2];
 
-    run_match (ctx, jobid, match_op, jobspec_fn, out);
+    run_match (ctx, jobid, match_op, jobspec_fn, &attrs, out);
 
     return 0;
 }
@@ -335,6 +340,7 @@ int cmd_match_multi (std::shared_ptr<detail::resource_query_t> &ctx,
     int rc = 0;
     size_t i;
     match_op_t match_op;
+    traverser_match_attrs attrs = default_match_attrs;
 
     if (args.size () <= 3) {
         std::cerr << "ERROR: malformed command" << std::endl;
@@ -349,7 +355,7 @@ int cmd_match_multi (std::shared_ptr<detail::resource_query_t> &ctx,
     for (i = 2; i < args.size (); i++) {
         int64_t jobid = ctx->jobid_counter;
         std::string &jobspec_fn = args[i];
-        rc = run_match (ctx, jobid, match_op, jobspec_fn, out);
+        rc = run_match (ctx, jobid, match_op, jobspec_fn, &attrs, out);
         if (rc != 0)
             break;
     }

--- a/src/cmd/flux-ion-resource.py
+++ b/src/cmd/flux-ion-resource.py
@@ -30,6 +30,16 @@ def width():
     return 20 + 20 + 20 + 20
 
 
+def parse_fsd_or_none(candidate_fsd):
+    if not candidate_fsd:
+        return None
+    try:
+        fsd = int(flux.util.parse_fsd(candidate_fsd))
+    except ValueError:
+        fsd = None
+    return fsd
+
+
 class ResourceModuleInterface:
     """Class to interface with the sched-fluxion-resource module with RPC"""
 
@@ -40,40 +50,58 @@ class ResourceModuleInterface:
         resp = self.handle.rpc("sched-fluxion-resource.next_jobid").get()
         return resp["jobid"]
 
-    def rpc_allocate(self, jobid, jobspec_str):
-        payload = {"cmd": "allocate", "jobid": jobid, "jobspec": jobspec_str}
+    def rpc_allocate(self, jobid, jobspec_str, within):
+        payload = {
+            "cmd": "allocate",
+            "jobid": jobid,
+            "jobspec": jobspec_str,
+        }
+        if within:
+            payload["within"] = within
         return self.handle.rpc("sched-fluxion-resource.match", payload).get()
 
     def rpc_update(self, jobid, Res):
         payload = {"jobid": jobid, "R": Res}
         return self.handle.rpc("sched-fluxion-resource.update", payload).get()
 
-    def rpc_allocate_with_sat(self, jobid, jobspec_str):
+    def rpc_allocate_with_sat(self, jobid, jobspec_str, within):
         payload = {
             "cmd": "allocate_with_satisfiability",
             "jobid": jobid,
             "jobspec": jobspec_str,
         }
+        if within:
+            payload["within"] = within
         return self.handle.rpc("sched-fluxion-resource.match", payload).get()
 
-    def rpc_reserve(self, jobid, jobspec_str):
+    def rpc_reserve(self, jobid, jobspec_str, within):
         payload = {
             "cmd": "allocate_orelse_reserve",
             "jobid": jobid,
             "jobspec": jobspec_str,
         }
+        if within:
+            payload["within"] = within
         return self.handle.rpc("sched-fluxion-resource.match", payload).get()
 
-    def rpc_wo_alloc(self, jobid, jobspec_str):
-        payload = {"cmd": "without_allocating", "jobid": jobid, "jobspec": jobspec_str}
+    def rpc_wo_alloc(self, jobid, jobspec_str, within):
+        payload = {
+            "cmd": "without_allocating",
+            "jobid": jobid,
+            "jobspec": jobspec_str,
+        }
+        if within:
+            payload["within"] = within
         return self.handle.rpc("sched-fluxion-resource.match", payload).get()
 
-    def rpc_wo_alloc_future(self, jobid, jobspec_str):
+    def rpc_wo_alloc_future(self, jobid, jobspec_str, within):
         payload = {
             "cmd": "without_allocating_future",
             "jobid": jobid,
             "jobspec": jobspec_str,
         }
+        if within:
+            payload["within"] = within
         return self.handle.rpc("sched-fluxion-resource.match", payload).get()
 
     def rpc_info(self, jobid):
@@ -146,8 +174,9 @@ def match_alloc_action(args):
 
     with open(args.jobspec, "r") as stream:
         jobspec_str = yaml.dump(yaml.safe_load(stream))
+        within = parse_fsd_or_none(args.within)
         rmormod = ResourceModuleInterface()
-        resp = rmormod.rpc_allocate(rmormod.rpc_next_jobid(), jobspec_str)
+        resp = rmormod.rpc_allocate(rmormod.rpc_next_jobid(), jobspec_str, within)
         print(heading())
         print(body(resp["jobid"], resp["status"], resp["at"], resp["overhead"]))
         print("=" * width())
@@ -162,8 +191,9 @@ def match_alloc_sat_action(args):
 
     with open(args.jobspec, "r") as stream:
         jobspec_str = yaml.dump(yaml.safe_load(stream))
+        within = parse_fsd_or_none(args.within)
         rmod = ResourceModuleInterface()
-        resp = rmod.rpc_allocate_with_sat(rmod.rpc_next_jobid(), jobspec_str)
+        resp = rmod.rpc_allocate_with_sat(rmod.rpc_next_jobid(), jobspec_str, within)
         print(heading())
         print(body(resp["jobid"], resp["status"], resp["at"], resp["overhead"]))
         print("=" * width())
@@ -178,8 +208,9 @@ def match_reserve_action(args):
 
     with open(args.jobspec, "r") as stream:
         jobspec_str = yaml.dump(yaml.safe_load(stream))
+        within = parse_fsd_or_none(args.within)
         rmod = ResourceModuleInterface()
-        resp = rmod.rpc_reserve(rmod.rpc_next_jobid(), jobspec_str)
+        resp = rmod.rpc_reserve(rmod.rpc_next_jobid(), jobspec_str, within)
         print(heading())
         print(body(resp["jobid"], resp["status"], resp["at"], resp["overhead"]))
         print("=" * width())
@@ -194,8 +225,9 @@ def match_wo_alloc_action(args):
 
     with open(args.jobspec, "r") as stream:
         jobspec_str = yaml.dump(yaml.safe_load(stream))
+        within = parse_fsd_or_none(args.within)
         rmod = ResourceModuleInterface()
-        resp = rmod.rpc_wo_alloc(rmod.rpc_next_jobid(), jobspec_str)
+        resp = rmod.rpc_wo_alloc(rmod.rpc_next_jobid(), jobspec_str, within)
         print(heading())
         print(body(resp["jobid"], resp["status"], resp["at"], resp["overhead"]))
         print("=" * width())
@@ -210,8 +242,9 @@ def match_wo_alloc_future_action(args):
 
     with open(args.jobspec, "r") as stream:
         jobspec_str = yaml.dump(yaml.safe_load(stream))
+        within = parse_fsd_or_none(args.within)
         rmod = ResourceModuleInterface()
-        resp = rmod.rpc_wo_alloc_future(rmod.rpc_next_jobid(), jobspec_str)
+        resp = rmod.rpc_wo_alloc_future(rmod.rpc_next_jobid(), jobspec_str, within)
         print(heading())
         print(body(resp["jobid"], resp["status"], resp["at"], resp["overhead"]))
         print("=" * width())
@@ -541,6 +574,14 @@ def parse_match(parser_m: argparse.ArgumentParser):
     for subparser in parser_ma, parser_ms, parser_mr, parser_mw, parser_mf, parser_fe:
         subparser.add_argument(
             "jobspec", metavar="Jobspec", type=str, help="Jobspec file name"
+        )
+        subparser.add_argument(
+            "-w",
+            "--within",
+            metavar="within",
+            type=str,
+            default=None,
+            help="Return only matches that start within this duration (FSD)",
         )
 
     parser_ma.set_defaults(func=match_alloc_action)

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -99,6 +99,7 @@ set(ALL_TESTS
   t4015-notify-feasibility.t
   t4016-match-flexible.t
   t4017-match-without-allocating.t
+  t4018-match-within.t
   t5000-valgrind.t
   t5100-issues-test-driver.t
   t5200-jgf-load-no-parent-jgf.t

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -100,6 +100,7 @@ set(ALL_TESTS
   t4015-notify-feasibility.t
   t4016-match-flexible.t
   t4017-match-without-allocating.t
+  t4018-match-within.t
   t5000-valgrind.t
   t5100-issues-test-driver.t
   t5200-jgf-load-no-parent-jgf.t

--- a/t/data/resource/jobspecs/user_attributes/within_duration.yaml
+++ b/t/data/resource/jobspecs/user_attributes/within_duration.yaml
@@ -1,0 +1,31 @@
+version: 9999
+resources:
+    - type: cluster
+      count: 1
+      with:
+        - type: rack
+          count: 1
+          with:
+            - type: node
+              count: 1
+              with:
+                  - type: slot
+                    count: 1
+                    label: default
+                    with:
+                      - type: socket
+                        count: 1
+                        with:
+                          - type: core
+                            count: 18
+# a comment
+attributes:
+  user:
+    match-within: 3579
+  system:
+    duration: 3600
+tasks:
+  - command: [ "app" ]
+    slot: default
+    count:
+      per_slot: 1

--- a/t/data/resource/jobspecs/user_attributes/within_infinity.yaml
+++ b/t/data/resource/jobspecs/user_attributes/within_infinity.yaml
@@ -1,0 +1,31 @@
+version: 9999
+resources:
+    - type: cluster
+      count: 1
+      with:
+        - type: rack
+          count: 1
+          with:
+            - type: node
+              count: 1
+              with:
+                  - type: slot
+                    count: 1
+                    label: default
+                    with:
+                      - type: socket
+                        count: 1
+                        with:
+                          - type: core
+                            count: 18
+# a comment
+attributes:
+  user:
+    match-within: -1
+  system:
+    duration: 3600
+tasks:
+  - command: [ "app" ]
+    slot: default
+    count:
+      per_slot: 1

--- a/t/t4018-match-within.t
+++ b/t/t4018-match-within.t
@@ -6,6 +6,8 @@ test_description='Test the functionality of match --within FSD'
 
 grug="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/tiny.graphml"
 jobspec="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/basics/test001.yaml"
+within_3579_js="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/user_attributes/within_duration.yaml"
+within_infinity_js="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/user_attributes/within_infinity.yaml"
 query="../../resource/utilities/resource-query"
 
 test_under_flux 1
@@ -25,7 +27,7 @@ test_expect_success 'ion-resource successfully matches within 0 units' '
 '
 
 # A negative value should be interpreted as infinity
-test_expect_success 'ion-resource successfully matches  within negative units' '
+test_expect_success 'ion-resource successfully matches within negative units' '
     flux ion-resource match without_allocating_future ${jobspec} --within -1 &&
     flux ion-resource match without_allocating_future ${jobspec} --within \"-1d\"
 '
@@ -42,9 +44,41 @@ test_expect_success 'ion-resource fails to match within 3579 units (first avail 
     test_expect_code 16 flux ion-resource match without_allocating_future ${jobspec} -w 3579
 '
 
+test_expect_success 'ion-resource fails to match when the match-within user attribute = 3579' '
+    # All slots are already allocated
+    test_expect_code 16 flux ion-resource match allocate ${within_3579_js} &&
+    test_expect_code 16 flux ion-resource match allocate_with_satisfiability ${within_3579_js} &&
+    test_expect_code 16 flux ion-resource match allocate_orelse_reserve ${within_3579_js} &&
+    test_expect_code 16 flux ion-resource match without_allocating_future ${within_3579_js}
+'
+
+test_expect_success 'ion-resource fails to match within 3579 units (overridden jobspec usrattr)' '
+    # All slots are already allocated
+    test_expect_code 16 \
+        flux ion-resource match allocate ${within_infinity_js} --within=3579 &&
+    test_expect_code 16 \
+        flux ion-resource match allocate_with_satisfiability ${within_infinity_js} -w=3579 &&
+    test_expect_code 16 \
+        flux ion-resource match allocate_orelse_reserve ${within_infinity_js} --within 3579 &&
+    test_expect_code 16 \
+        flux ion-resource match without_allocating_future ${within_infinity_js} -w 3579
+'
+
 test_expect_success 'ion-resource successfully matches within 3600 units (first avail at 3600)' '
     flux ion-resource match allocate_orelse_reserve ${jobspec} --within=3600 | grep RESERVED &&
     flux ion-resource match without_allocating_future ${jobspec} -w=3600 | grep MATCHED
+'
+
+test_expect_success 'ion-resource matches within 3600 units (overriding the jobspec user attr)' '
+    flux ion-resource match allocate_orelse_reserve ${within_3579_js} -w=3600 | grep RESERVED &&
+    flux ion-resource match without_allocating_future ${within_3579_js} -w=3600 | grep MATCHED
+'
+
+test_expect_success 'ion-resource matches eventually (w/wo jobspec user attr match_within=-1)' '
+    flux ion-resource match allocate_orelse_reserve ${jobspec} &&
+    flux ion-resource match without_allocating_future ${jobspec} &&
+    flux ion-resource match allocate_orelse_reserve ${within_infinity_js} &&
+    flux ion-resource match without_allocating_future ${within_infinity_js}
 '
 
 test_expect_success 'removing resource works' '

--- a/t/t4018-match-within.t
+++ b/t/t4018-match-within.t
@@ -1,0 +1,99 @@
+#!/bin/sh
+
+test_description='Test the functionality of match --within FSD'
+
+. `dirname $0`/sharness.sh
+
+grug="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/tiny.graphml"
+jobspec="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/basics/test001.yaml"
+query="../../resource/utilities/resource-query"
+
+test_under_flux 1
+
+
+test_expect_success 'loading resource module with a tiny machine config works' '
+    load_resource \
+load-file=${grug} prune-filters=ALL:core \
+load-format=grug subsystems=containment policy=high
+'
+
+test_expect_success 'ion-resource successfully matches within 0 units' '
+    flux ion-resource match allocate --within 0 ${jobspec} &&
+    flux ion-resource match allocate_with_satisfiability --within 0d ${jobspec} &&
+    flux ion-resource match allocate_orelse_reserve ${jobspec} --within 0 &&
+    flux ion-resource match without_allocating_future ${jobspec} --within 0d
+'
+
+# A negative value should be interpreted as infinity
+test_expect_success 'ion-resource successfully matches  within negative units' '
+    flux ion-resource match without_allocating_future ${jobspec} --within -1 &&
+    flux ion-resource match without_allocating_future ${jobspec} --within \"-1d\"
+'
+
+test_expect_success 'ion-resource fails to match within 3579 units (first avail at 3600)' '
+    # Allocate the last open slot
+    flux ion-resource match allocate ${jobspec} &&
+    # This can accidentally succeed if the execution is delayed, hence the 20 second buffer.
+    # resource-query covers this edge case more easily because it does not use real time;
+    # see reapi_cli_t::match_allocate to confirm.
+    test_expect_code 16 flux ion-resource match allocate --within 3579 ${jobspec} &&
+    test_expect_code 16 flux ion-resource match allocate_with_satisfiability -w 3579 ${jobspec} &&
+    test_expect_code 16 flux ion-resource match allocate_orelse_reserve ${jobspec} --within 3579 &&
+    test_expect_code 16 flux ion-resource match without_allocating_future ${jobspec} -w 3579
+'
+
+test_expect_success 'ion-resource successfully matches within 3600 units (first avail at 3600)' '
+    flux ion-resource match allocate_orelse_reserve ${jobspec} --within=3600 | grep RESERVED &&
+    flux ion-resource match without_allocating_future ${jobspec} -w=3600 | grep MATCHED
+'
+
+test_expect_success 'removing resource works' '
+    remove_resource
+'
+
+test_expect_success 'resource-query successfully matches within 0 units' '
+	${query} -L ${grug} -S CA -t rq.out <<-'EOF' &&
+	match allocate ${jobspec} 0
+	match allocate_with_satisfiability ${jobspec} 0
+	match allocate_orelse_reserve ${jobspec} 0
+	match without_allocating_future ${jobspec} 0
+    quit
+	EOF
+    cat rq.out &&
+    test $(grep MATCHED <rq.out | wc -l) -eq 1 &&
+    test $(grep ALLOCATED <rq.out | wc -l) -eq 3
+'
+
+test_expect_success 'resource-query fails to match within 3599 units (first avail at 3600)' '
+	${query} -L ${grug} -S CA -t rq.out <<-'EOF' &&
+	match allocate ${jobspec}
+	match allocate ${jobspec}
+	match allocate ${jobspec}
+	match allocate ${jobspec}
+	match allocate_orelse_reserve ${jobspec} 3599
+	match without_allocating_future ${jobspec} 3599
+    quit
+	EOF
+    cat rq.out &&
+    test $(grep MATCHED <rq.out | wc -l) -eq 0 &&
+    test $(grep RESERVED <rq.out | wc -l) -eq 0 &&
+    test $(grep ALLOCATED <rq.out | wc -l) -eq 4
+'
+
+test_expect_success 'resource-query successfully matches within 3600 units (first avail at 3600)' '
+	${query} -L ${grug} -S CA -t rq.out <<-'EOF' &&
+	match allocate ${jobspec}
+	match allocate ${jobspec}
+	match allocate ${jobspec}
+	match allocate ${jobspec}
+	match allocate_orelse_reserve ${jobspec} 3600
+	match without_allocating_future ${jobspec} 3600
+    quit
+	EOF
+    cat rq.out &&
+    test $(grep MATCHED <rq.out | wc -l) -eq 1 &&
+    test $(grep RESERVED <rq.out | wc -l) -eq 1 &&
+    test $(grep ALLOCATED <rq.out | wc -l) -eq 4
+'
+
+test_done


### PR DESCRIPTION
This PR adds a "within" parameter for the resource module, REAPI C/C++, resource-query, and test suite. The "within" parameter forces the traverser to return only matches that start within the given duration (i.e. start at $now + $within or earlier).

It only affects MATCH_ALLOCATE_ORELSE_RESERVE and MATCH_WITHOUT_ALLOCATING right now, since those are the only two match options that can return resource sets that begin in the future. However, I added the parameter to every match option so that future match options don't need to worry about adding it manually. Internally, it is implemented as a "latest" parameter to dfu_match_t::run(), which specifies the latest start time allowed for returned matches.

I am wondering if it would be simpler to add a "within" parameter as a jobspec attribute instead, since this would cut down on the amount of option-handling code spread across resource, REAPI, and rq. We may still want the option-handling code in any case, but the implementation may ultimately be cleaner based off a jobspec attribute, perhaps including on the flux-core side of things.

This PR depends on #1387.