### PR TITLE
Typos corrections

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -680,7 +680,7 @@ flux-sched version 0.16.0 - 2021-05-05
 
 Note: Do you have a need to run high-throughput workloads
 at large scale? Check out this version. It combines
-our new first-match policy with asynchrous
+our new first-match policy with asynchronous
 communications to significantly improve scheduling scalability.
 
 ### Features

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -615,7 +615,7 @@ static int unpack_resobj (json_t *resobj,
                 < 0)
                 goto inval;
             // Split the rank idset in resobj, convert each entry into
-            // distict_range_t and use it as the key to std::map.
+            // distinct_range_t and use it as the key to std::map.
             // The value is the pointer to resobj_t.
             // The distinct_range_t class provides ordering logic such that
             // you will be able to iterate through ranges in strictly

--- a/resource/reapi/bindings/c++/reapi.hpp
+++ b/resource/reapi/bindings/c++/reapi.hpp
@@ -105,7 +105,7 @@ class reapi_t {
      *                   from 1 of 4 choices:
      *                   MATCH_ALLOCATE: try to allocate now and fail if resources
      *                   aren't available.
-     *                   MATCH_ALLOCATE_ORELSE_RESERVE : Try to allocate and reseve
+     *                   MATCH_ALLOCATE_ORELSE_RESERVE : Try to allocate and reserve
      *                   if resources aren't available now.
      *                   MATCH_SATISFIABILITY: Do a satisfiablity check and do not
      *                   allocate.
@@ -148,7 +148,7 @@ class reapi_t {
      *                   from 1 of 4 choices:
      *                   MATCH_ALLOCATE: try to allocate now and fail if resources
      *                   aren't available.
-     *                   MATCH_ALLOCATE_ORELSE_RESERVE : Try to allocate and reseve
+     *                   MATCH_ALLOCATE_ORELSE_RESERVE : Try to allocate and reserve
      *                   if resources aren't available now.
      *                   MATCH_SATISFIABILITY: Do a satisfiablity check and do not
      *                   allocate.

--- a/resource/utilities/README.md
+++ b/resource/utilities/README.md
@@ -524,7 +524,7 @@ The Scoring API classes and implementation are entirely located in
 
 ## Fully vs. Paritially Specified Resource Request
 
-The resource section of a job specification can be fully or partitially
+The resource section of a job specification can be fully or partially
 hierarchically specified. A fully specified request describes the resource
 shape fully from the root to the requested resources with respect
 to the resource graph data used by `resource-query`. A partially specified


### PR DESCRIPTION
These commits corrects typos for `distinct_range_t`, `partially`, `asynchronous` and `reserve`