### PR TITLE
ci: update typo checker version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Check Spelling
-      uses: crate-ci/typos@v1.35.5
+      uses: crate-ci/typos@v1.39.0
 
   python-format:
     name: code formatting


### PR DESCRIPTION
Problem: The typo checker has more typos in their dictionary that we are missing.

Update the typo checker version to v1.39.0.