### PR TITLE
resource: add `rv1exec_force` load format

### DIFF
--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -971,7 +971,7 @@ static int grow_resource_db (std::shared_ptr<resource_ctx_t> &ctx, json_t *resou
         flux_log_error (ctx->h, "%s: unpack_resources", __FUNCTION__);
         goto done;
     }
-    if (jgf) {
+    if (jgf && ctx->opts.get_opt ().get_load_format () != "rv1exec_force") {
         if (ctx->reader == nullptr && (rc = create_reader (ctx, "jgf")) < 0) {
             flux_log (ctx->h, LOG_ERR, "%s: can't create jgf reader", __FUNCTION__);
             goto done;
@@ -984,7 +984,8 @@ static int grow_resource_db (std::shared_ptr<resource_ctx_t> &ctx, json_t *resou
                 goto done;
             }
             rc = grow_resource_db_hwloc (ctx, grow_set, r_lite);
-        } else if (ctx->opts.get_opt ().get_load_format () == "rv1exec") {
+        } else if (ctx->opts.get_opt ().get_load_format () == "rv1exec"
+                   || ctx->opts.get_opt ().get_load_format () == "rv1exec_force") {
             if (!ctx->reader && (rc = create_reader (ctx, "rv1exec")) < 0) {
                 flux_log (ctx->h, LOG_ERR, "%s: can't create rv1exec reader", __FUNCTION__);
                 goto done;

--- a/resource/readers/resource_reader_factory.cpp
+++ b/resource/readers/resource_reader_factory.cpp
@@ -26,7 +26,8 @@ namespace resource_model {
 bool known_resource_reader (const std::string &name)
 {
     bool rc = false;
-    if (name == "grug" || name == "hwloc" || name == "jgf" || name == "rv1exec")
+    if (name == "grug" || name == "hwloc" || name == "jgf" || name == "rv1exec"
+        || name == "rv1exec_force")
         rc = true;
     return rc;
 }
@@ -42,7 +43,7 @@ std::shared_ptr<resource_reader_base_t> create_resource_reader (const std::strin
             reader = std::make_shared<resource_reader_hwloc_t> ();
         } else if (name == "jgf") {
             reader = std::make_shared<resource_reader_jgf_t> ();
-        } else if (name == "rv1exec") {
+        } else if (name == "rv1exec" || name == "rv1exec_force") {
             reader = std::make_shared<resource_reader_rv1exec_t> ();
         } else {
             errno = EINVAL;

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -102,7 +102,7 @@ OPTIONS:
             Input file from which to load the resource graph data store
             (default=conf/default)
 
-    -f, --load-format=<grug|hwloc|jgf|rv1exec>
+    -f, --load-format=<grug|hwloc|jgf|rv1exec|rv1exec_force>
             Format of the load file (default=grug)
 
     -W, --load-allowlist=<resource1[,resource2[,resource3...]]>

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -70,6 +70,7 @@ set(ALL_TESTS
   t3035-resource-remove.t
   t3037-resource-custom-policy.t
   t3038-resource-flexible.t
+  t3039-resource-force-load-format.t
   t3300-system-dontblock.t
   t3301-system-latestart.t
   t4000-match-params.t

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -31,6 +31,7 @@ set(ALL_TESTS
   t1026-rv1-partial-release.t
   t1027-rv1-partial-release-brokerless-resources.t
   t1028-rv1-partial-release-across-racks.t
+  t1029-resource-force-load-format.t
   t2317-resource-shrink.t
   t3000-jobspec.t
   t3001-resource-basic.t

--- a/t/data/resource/jobspecs/load_format/t3039.yaml
+++ b/t/data/resource/jobspecs/load_format/t3039.yaml
@@ -1,0 +1,22 @@
+version: 9999
+resources:
+  - type: node
+    count: 10
+    with:
+      - type: slot
+        count: 1
+        label: default
+        with:
+          - type: core
+            count: 8
+          - type: gpu
+            count: 2
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: [ \"app\" ]
+    slot: default
+    count:
+      per_slot: 1

--- a/t/t1029-resource-force-load-format.t
+++ b/t/t1029-resource-force-load-format.t
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+test_description='Test the rv1exec_force load format'
+
+. $(dirname $0)/sharness.sh
+
+echo \
+'#!/bin/sh
+
+flux module remove -f sched-simple &&
+flux module remove -f sched-fluxion-qmanager &&
+flux module remove -f sched-fluxion-resource &&
+flux kvs get resource.R | jq ".scheduling = \"nonsense\"" > local_R &&
+flux kvs put resource.R="$(cat local_R)" &&
+flux module reload resource &&
+flux module load sched-fluxion-resource load-format="${1}" &&
+flux module load sched-fluxion-qmanager
+' > load_nonsense_scheduling_key.sh
+
+chmod +x load_nonsense_scheduling_key.sh
+
+test_under_flux 2
+
+test_expect_success 'load resource with load-format-rv1exec_force' '
+    flux module remove -f sched-simple &&
+    reload_resource load-format=rv1exec_force &&
+    reload_qmanager
+'
+
+test_expect_success 'init Fluxion with nonsense in R .scheduling key' '
+    ./load_nonsense_scheduling_key.sh rv1exec_force
+'
+
+test_expect_success 'job can run' '
+    jobid=$(flux submit -n1 true) &&
+    flux job wait-event -vt 5 ${jobid} clean &&
+    flux module list | grep sched-fluxion-resource
+'
+
+test_expect_success 'without rv1exec_force, job fails' '
+    test_must_fail flux alloc -t5s -N1 -n1 ./load_nonsense_scheduling_key.sh rv1exec &&
+    flux job attach $(flux job last) 2>&1 | grep -e grow_resource_db_jgf -e "Invalid argument" &&
+    flux job attach $(flux job last) 2>&1 | grep "module exiting abnormally"
+'
+
+test_expect_success 'remove manually loaded modules' '
+    remove_qmanager && remove_resource
+'
+
+test_done

--- a/t/t3039-resource-force-load-format.t
+++ b/t/t3039-resource-force-load-format.t
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+test_description='Test the rv1exec_force load format'
+
+. $(dirname $0)/sharness.sh
+
+query="../../resource/utilities/resource-query"
+jobspec="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/load_format/t3039.yaml"
+
+
+test_expect_success 'Generate rv1 with .scheduling key' '
+    flux R encode --hosts=compute[1-10] --cores=0-7 --gpu=0-1 | jq . > R.json &&
+    cat R.json | flux ion-R encode > R_JGF.json &&
+    jq -S "del(.execution.starttime, .execution.expiration)" R.json > R.norm.json
+'
+
+test_expect_success 'resource_query can be loaded with rv1exec_force' '
+    cat > match_jobspec_cmd <<-EOF &&
+    match allocate ${jobspec}
+    quit
+EOF
+    ${query} -L R_JGF.json -f rv1exec_force -F rv1_nosched -t R1.out -P high < match_jobspec_cmd &&
+    head -n1 R1.out | jq -S "del(.execution.starttime, .execution.expiration)" > match1.json &&
+    jq -S "del(.execution.starttime, .execution.expiration)" R.json > R.norm.json &&
+    test_cmp match1.json R.norm.json
+'
+
+test_expect_success 'resource_query can be loaded with rv1exec' '
+    ${query} -L R_JGF.json -f rv1exec -F rv1_nosched -t R2.out -P high < match_jobspec_cmd &&
+    head -n1 R2.out | jq -S "del(.execution.starttime, .execution.expiration)" > match2.json &&
+    test_cmp match2.json R.norm.json
+'
+
+test_expect_success 'resource_query can be loaded with jgf' '
+    jq .scheduling R_JGF.json > JGF.json &&
+    ${query} -L JGF.json -f jgf -F rv1_nosched -t R3.out -P high < match_jobspec_cmd &&
+    head -n1 R3.out | jq -S "del(.execution.starttime, .execution.expiration)" > match3.json &&
+    test_cmp match3.json R.norm.json
+'
+
+test_done


### PR DESCRIPTION
Problem: in some cases it can be useful to make the Fluxion resource module
initialize itself from rv1exec rather than JGF, even when the `scheduling`
key of R is present. Currently however, if the `scheduling` key is populated,
the resource module initializes itself with JGF.

Add a load-format, `rv1exec_force`, that tells the module to ignore the
`scheduling` key.

Checks the first box in #1414. There would need to be some configuration done in the system instance so that all its subinstances load `sched-fluxion-resource` with the `load-format=rv1exec_force` option. After chatting with @grondo, it sounds like:

> The best way to do this might be to have ansible drop an extension in to /etc/flux/modprobe/rc1.d/ that forces the option via:
> ```
> def setup(context):
>     context.setopt("sched-fluxion-resource", "OPT=VAL")
> ```

Using `context.attr_get("instance-level", 0) > 0` to check whether or not the script was running against the system instance.