### PR TITLE
bindings: flux-sched python

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,40 @@ jobs:
     - name: format and linting checks
       run: pre-commit run --all-files --show-diff-on-failure
 
+  flux-sched-python:
+    name: flux-sched python
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+    - uses: devcontainers/ci@v0.3
+      with:
+        runCmd: |
+          set -e
+          sudo apt-get install -y python3-pip
+          sudo python3 -m pip install IPython Cython pytest --break-system-packages
+          sudo python3 -m pip install black pyflakes build --break-system-packages
+          for path in ./resource/reapi/bindings/python ./resource/reapi/bindings/python/tests
+          do          
+              black $path/*.py
+              pyflakes $path/*.py
+          done
+          export WITH_PYTHON_BINDINGS=yes
+          export LD_LIBRARY_PATH=$(pwd)/resource/reapi/bindings
+          ./configure
+          make -j
+          # Test relative to flux_sched (local module)
+          FLUXSCHED_PYTHON_ROOT=$(pwd)/resource/reapi/bindings/python
+          export PYTHONPATH=FLUXSCHED_PYTHON_ROOT
+          cd $FLUXSCHED_PYTHON_ROOT
+          pytest -xs ./tests/test_*.py
+          echo $?
+          # Test full build and install
+          # python3 -m build  --sdist --wheel
+          python3 -m build --sdist --wheel --no-isolation 
+          
   generate-matrix:
     # https://stackoverflow.com/questions/59977364
     name: Generate build matrix

--- a/resource/reapi/bindings/CMakeLists.txt
+++ b/resource/reapi/bindings/CMakeLists.txt
@@ -27,3 +27,8 @@ if(DEFINED ENV{WITH_GO})
     message(STATUS "WITH_GO is set to build go bindings")
     add_subdirectory( go )
 endif()
+
+if(DEFINED ENV{WITH_PYTHON_BINDINGS})
+  message(STATUS "WITH_PYTHON_BINDINGS detected to build python bindings")
+  add_subdirectory( python )
+endif()

--- a/resource/reapi/bindings/python/.gitignore
+++ b/resource/reapi/bindings/python/.gitignore
@@ -1,0 +1,5 @@
+*.cpp
+__pycache__
+build
+dist
+flux_sched.egg-info

--- a/resource/reapi/bindings/python/CMakeLists.txt
+++ b/resource/reapi/bindings/python/CMakeLists.txt
@@ -1,0 +1,108 @@
+# Find Python 3
+find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+
+# Find Cython  with python -m cython
+execute_process(
+    COMMAND ${Python3_EXECUTABLE} -m cython --version
+    RESULT_VARIABLE CYTHON_CHECK_RESULT
+    OUTPUT_QUIET
+    ERROR_QUIET
+)
+
+if(NOT CYTHON_CHECK_RESULT EQUAL 0)
+    message(FATAL_ERROR "Cython not found. Please install it: ${Python3_EXECUTABLE} -m pip install Cython")
+endif()
+
+set(CYTHON_COMMAND ${Python3_EXECUTABLE} -m cython)
+
+# Set up Include Directories
+# We need the top level for config.h and the bindings directory for headers
+include_directories(
+    ${CMAKE_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/resource/reapi/bindings
+)
+
+# ==============================================================================
+# Build flux_sched.reapi_cli
+# ==============================================================================
+
+# Step A: Generate C++ from Cython
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/reapi_cli.cpp
+    COMMAND ${CYTHON_COMMAND} --cplus -3
+            -I ${CMAKE_CURRENT_SOURCE_DIR}
+            -o ${CMAKE_CURRENT_BINARY_DIR}/reapi_cli.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/flux_sched/reapi_cli.pyx
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/flux_sched/reapi_cli.pyx
+            ${CMAKE_CURRENT_SOURCE_DIR}/flux_sched/c_reapi.pxd
+    COMMENT "Cythonizing flux_sched/reapi_cli.pyx"
+)
+
+# Create the Python Extension Module
+add_library(python_reapi_cli MODULE ${CMAKE_CURRENT_BINARY_DIR}/reapi_cli.cpp)
+
+# Link against the existing C++ library 'reapi_cli'
+# This pulls in 'resource', 'jobspec_conv', and 'flux::core' automatically
+target_link_libraries(python_reapi_cli PRIVATE
+    reapi_cli
+    Python3::Python
+)
+
+# Set output name to 'flux_sched/reapi_cli.so'
+set_target_properties(python_reapi_cli PROPERTIES
+    PREFIX ""
+    SUFFIX ".so"  # Force .so extension for Python consistency
+    OUTPUT_NAME "flux_sched/reapi_cli"
+)
+
+# ==============================================================================
+# Build flux_sched.reapi_module
+# ==============================================================================
+
+# Generate C++ from Cython
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/reapi_module.cpp
+    COMMAND ${CYTHON_COMMAND} --cplus -3
+            -I ${CMAKE_CURRENT_SOURCE_DIR}
+            -o ${CMAKE_CURRENT_BINARY_DIR}/reapi_module.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/flux_sched/reapi_module.pyx
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/flux_sched/reapi_module.pyx
+            ${CMAKE_CURRENT_SOURCE_DIR}/flux_sched/c_reapi.pxd
+    COMMENT "Cythonizing flux_sched/reapi_module.pyx"
+)
+
+# Create the Python Extension Module
+add_library(python_reapi_module MODULE ${CMAKE_CURRENT_BINARY_DIR}/reapi_module.cpp)
+
+# Link against the static library 'reapi_module'
+target_link_libraries(python_reapi_module PRIVATE
+    reapi_module
+    Python3::Python
+)
+
+# Step D: Set output name to 'flux_sched/reapi_module.so'
+set_target_properties(python_reapi_module PROPERTIES
+    PREFIX ""
+    SUFFIX ".so"
+    OUTPUT_NAME "flux_sched/reapi_module"
+)
+
+# ==============================================================================
+# Installation
+# ==============================================================================
+
+# Determine the install path for site-packages
+if(NOT DEFINED PYTHON_SITE_PACKAGES)
+    set(PYTHON_SITE_PACKAGES lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages)
+endif()
+
+# Install the python source files (__init__.py, etc)
+install(DIRECTORY flux_sched
+    DESTINATION ${PYTHON_SITE_PACKAGES}
+    FILES_MATCHING PATTERN "*.py" PATTERN "*.pxd"
+)
+
+# Install the compiled extensions (.so files)
+install(TARGETS python_reapi_cli python_reapi_module
+    DESTINATION ${PYTHON_SITE_PACKAGES}/flux_sched
+)

--- a/resource/reapi/bindings/python/MANIFEST.in
+++ b/resource/reapi/bindings/python/MANIFEST.in
@@ -1,0 +1,6 @@
+recursive-include flux_sched *
+prune env*
+global-exclude .env
+global-exclude *.py[co]
+recursive-exclude .git *
+global-exclude __pycache__

--- a/resource/reapi/bindings/python/README.md
+++ b/resource/reapi/bindings/python/README.md
@@ -1,0 +1,233 @@
+# flux-sched Python Bindings
+
+> Need a scheduler? I got you covered, in Python! 📅
+
+![PyPI - Version](https://img.shields.io/pypi/v/flux-sched)
+
+Python bindings for the **Flux Framework** scheduler (`flux-sched` or `fluxion`). These bindings provide a high-performance interface to Flux's graph-based resource model, allowing users to simulate scheduling decisions offline or interact with a live Flux instance.
+
+## Installation
+
+### From Source
+
+To build and install from within the `flux-sched` source tree:
+
+```bash
+cd resource/reapi/bindings/python
+
+# Build the "old school" way
+python3 setup.py sdist bdist_wheel
+
+# Install build...
+sudo python3 -m pip install build --break-system-packages
+
+# Try for isolated environment
+pyproject-build
+
+# This is more robust to work (detect libs, etc.)
+python3 -m build --sdist --wheel --no-isolation
+sudo pip install ./dist/flux_sched-0.0.0*.whl --break-system-packages
+```
+
+### Requirements
+
+*   Python 3.8+
+*   `flux-python` (recommended, make sure to match your Flux install version)
+*   Flux Framework core libraries (`libflux-core`, `libflux-sched`) installed in system paths.
+
+---
+
+## Testing
+
+To build or test Python, you will additionally need Cython installed and `pytest`. Then you can build flux-sched as normal.
+Ensuring that the `flux_sched` module is on the `PYTHONPATH` (or installed) you can then do:
+
+```bash
+pytest -xs ./resource/reapi/bindings/python/tests/test*.py
+```
+
+To incrementally make changes and test, just cd to the Python directory and run `make`.
+
+```bash
+cd ./resource/reapi/bindings/python
+make
+pytest -xs ./tests/test_basic.py
+```
+
+## Usage ReapiCli
+
+The `ReapiCli` class mimics the behavior of the internal scheduler logic in a standalone C++ object.
+
+### 1. Initialization (Loading JGF)
+
+To use the scheduler, you must initialize it with a Resource Graph. The following example uses **JGF (JSON Graph Format)** with the required metadata fields (`uniq_id`, `paths`, `basename`, etc.) derived from a standard Flux resource discovery.
+
+```python
+import json
+from flux_sched.reapi_cli import ReapiCli, ReapiError
+
+# 1. Create the Client
+cli = ReapiCli()
+
+# 2. Define the Resource Graph (JGF)
+# This represents a minimal 1-Node system (Cluster -> Rack -> Node -> Socket -> Core)
+# Note: Metadata fields like 'paths', 'uniq_id', and 'basename' are critical.
+rgraph = json.dumps({
+    "graph": {
+        "nodes": [
+            {
+                "id": "0",
+                "metadata": {
+                    "type": "cluster", "basename": "tiny", "name": "tiny0", "id": 0,
+                    "uniq_id": 0, "rank": -1, "exclusive": False, "size": 1,
+                    "paths": {"containment": "/tiny0"}
+                }
+            },
+            {
+                "id": "1",
+                "metadata": {
+                    "type": "rack", "basename": "rack", "name": "rack0", "id": 0,
+                    "uniq_id": 1, "rank": -1, "exclusive": False, "size": 1,
+                    "paths": {"containment": "/tiny0/rack0"}
+                }
+            },
+            {
+                "id": "2",
+                "metadata": {
+                    "type": "node", "basename": "node", "name": "node0", "id": 0,
+                    "uniq_id": 2, "rank": -1, "exclusive": False, "size": 1,
+                    "paths": {"containment": "/tiny0/rack0/node0"}
+                }
+            },
+            {
+                "id": "3",
+                "metadata": {
+                    "type": "core", "basename": "core", "name": "core0", "id": 0,
+                    "uniq_id": 3, "rank": -1, "exclusive": False, "size": 1,
+                    "paths": {"containment": "/tiny0/rack0/node0/core0"}
+                }
+            }
+        ],
+        "edges": [
+            {"source": "0", "target": "1", "metadata": {"subsystem": "containment"}},
+            {"source": "1", "target": "2", "metadata": {"subsystem": "containment"}},
+            {"source": "2", "target": "3", "metadata": {"subsystem": "containment"}}
+        ]
+    }
+})
+
+# 3. Define Loader Options
+# "load-format": "json" tells the C++ reader to use the JGF parser.
+# "prune-filters": "ALL:core" ensures we track resources down to the core level.
+options = json.dumps({
+    "load_format": "jgf",
+    "prune_filters": "ALL:core",
+    "subsystems": "containment",
+    "policy": "high"
+})
+
+# 4. Initialize
+cli.initialize(rgraph, options)
+```
+
+### 2. Matching & Allocation
+
+Submit a Jobspec (resource request) to be matched against the loaded graph.
+
+```python
+# Request 1 Node
+jobspec = json.dumps({
+  "version": 9999,
+  "resources": [
+    {
+      "type": "slot",
+      "count": 1,
+      "label": "default",
+      "with": [
+        {
+          "type": "core",
+          "count": 1
+        }
+     ]
+    }
+  ],
+  "attributes": {
+    "system": {
+      "duration": 3600
+    }
+  },
+  "tasks": [
+    {
+      "command": [
+        "app"
+      ],
+      "slot": "default",
+      "count": {
+        "per_slot": 1
+      }
+    }
+  ]
+})
+
+try:
+    # match() returns:
+    #   jobid (int):    The ID assigned to the job (0 if failure)
+    #   reserved (bool): True if future reservation, False if immediate allocation
+    #   R (str):        The assigned resources (R-spec string)
+    #   at (int):       Time of assignment
+    #   ov (float):     Performance overhead (seconds)
+    jobid, reserved, R, at, ov = cli.match(jobspec, orelse_reserve=False)
+    print(R)
+```
+
+### 3. Querying Job Info
+
+Check the status of an allocated job.
+
+```python
+mode, is_reserved, at, ov = cli.info(jobid)    
+print(f"Job {jobid} is currently: {mode}") 
+```
+
+### 4. Cancellation
+
+Free resources associated with a job ID, making them available for new matches.
+
+```python
+cli.cancel(jobid)
+print(f"Job {jobid} canceled. Resources released.")    
+info = cli.info(jobid)
+print(info)
+```
+
+### 5. Partial Cancellation
+
+Release a *subset* of resources from an active allocation (e.g., for dynamic workflows or shrinking jobs).
+
+```python
+# 'R_subset' is a string (R-spec or RV1) defining the specific resources to drop.
+# In this example, we assume we have an R string representing specific cores/nodes.
+R_subset = '{"rank": 0, "children": ...}' 
+is_fully_removed = cli.partial_cancel(jobid, R_subset)    
+if is_fully_removed:
+    print(f"Job {jobid} is now empty and fully removed.")
+else:
+    print(f"Job {jobid} was shrunk but remains active.")
+```
+
+## ReapiModule
+
+The `ReapiModule` wraps a live Flux handle. It requires the `flux` python package.
+
+```python
+import flux
+from flux_sched.reapi_module import ReapiModule
+
+# 1. Connect to local Flux instance
+# Make sure you flux start before running this example!
+h = flux.Flux()
+
+# 2. Initialize Wrapper
+mod = ReapiModule()
+mod.set_handle(h)
+```

--- a/resource/reapi/bindings/python/flux_sched/c_reapi.pxd
+++ b/resource/reapi/bindings/python/flux_sched/c_reapi.pxd
@@ -1,0 +1,54 @@
+from libc.stdint cimport int64_t, uint64_t, uintptr_t
+from libcpp cimport bool
+
+cdef extern from "flux/core.h":
+    pass
+
+
+cdef extern from "resource/policies/base/match_op.h":
+    ctypedef enum match_op_t:
+        MATCH_ALLOCATE
+        MATCH_ALLOCATE_ORELSE_RESERVE
+        MATCH_SATISFIABILITY
+        MATCH_ALLOCATE_W_SATISFIABILITY
+
+cdef extern from "c/reapi_cli.h":
+    ctypedef struct reapi_cli_ctx_t:
+        pass
+
+    reapi_cli_ctx_t *reapi_cli_new()
+    void reapi_cli_destroy(reapi_cli_ctx_t *ctx)
+    int reapi_cli_initialize(reapi_cli_ctx_t *ctx, const char *rgraph, const char *options)
+
+    int reapi_cli_match(reapi_cli_ctx_t *ctx, match_op_t match_op, const char *jobspec,
+                        uint64_t *jobid, bool *reserved, char **R, int64_t *at, double *ov)
+
+    int reapi_cli_update_allocate(reapi_cli_ctx_t *ctx, uint64_t jobid, const char *R,
+                                  int64_t *at, double *ov, const char **R_out)
+
+    int reapi_cli_cancel(reapi_cli_ctx_t *ctx, uint64_t jobid, bool noent_ok)
+    int reapi_cli_partial_cancel(reapi_cli_ctx_t *ctx,
+                                 uint64_t jobid,
+                                 const char *R,
+                                 bool noent_ok,
+                                 bool *full_removal)
+
+    int reapi_cli_info(reapi_cli_ctx_t *ctx, uint64_t jobid, char **mode,
+                       bool *reserved, int64_t *at, double *ov)
+
+    int reapi_cli_stat(reapi_cli_ctx_t *ctx, int64_t *V, int64_t *E, int64_t *J,
+                       double *load, double *min, double *max, double *avg)
+
+    const char *reapi_cli_get_err_msg(reapi_cli_ctx_t *ctx)
+    void reapi_cli_clear_err_msg(reapi_cli_ctx_t *ctx)
+
+cdef extern from "c/reapi_module.h":
+    ctypedef struct reapi_module_ctx_t:
+        pass
+
+    reapi_module_ctx_t *reapi_module_new()
+    void reapi_module_destroy(reapi_module_ctx_t *ctx)
+    int reapi_module_set_handle(reapi_module_ctx_t *ctx, void *handle)
+
+    int reapi_module_match(reapi_module_ctx_t *ctx, match_op_t match_op, const char *jobspec,
+                           uint64_t jobid, bool *reserved, char **R, int64_t *at, double *ov)

--- a/resource/reapi/bindings/python/flux_sched/reapi_cli.pyx
+++ b/resource/reapi/bindings/python/flux_sched/reapi_cli.pyx
@@ -1,0 +1,134 @@
+# resource/reapi/bindings/python/flux_sched/reapi_cli.pyx
+
+from libc.stdlib cimport free
+from libc.stdint cimport int64_t, uint64_t
+from libcpp cimport bool
+
+# FIX: Use absolute import
+from flux_sched.c_reapi cimport *
+
+class ReapiError(Exception):
+    pass
+
+cdef class ReapiCli:
+    cdef reapi_cli_ctx_t *_ctx
+
+    def __cinit__(self):
+        self._ctx = reapi_cli_new()
+        if self._ctx is NULL:
+            raise MemoryError("Failed to allocate reapi_cli context")
+
+    def __dealloc__(self):
+        if self._ctx is not NULL:
+            reapi_cli_destroy(self._ctx)
+
+    def initialize(self, str rgraph, str options="{}"):
+        cdef bytes rgraph_b = rgraph.encode('utf-8')
+        cdef bytes options_b = options.encode('utf-8')
+
+        # 2. Create C pointers to the bytes' internal buffers
+        cdef const char *rgraph_c = rgraph_b
+        cdef const char *options_c = options_b
+
+        rc = reapi_cli_initialize(self._ctx, rgraph_c, options_c)
+        if rc != 0:
+            self._raise_error()
+
+    def match(self, str jobspec, bint orelse_reserve=False):
+        """
+        Returns: (jobid, reserved, R, at, overhead)
+        """
+        cdef:
+            match_op_t op = MATCH_ALLOCATE_ORELSE_RESERVE if orelse_reserve else MATCH_ALLOCATE
+            bytes jobspec_b = jobspec.encode('utf-8')
+            uint64_t jobid = 0
+            bool reserved = False
+            char *R = NULL
+            int64_t at = 0
+            double ov = 0.0
+            int rc
+
+        rc = reapi_cli_match(self._ctx, op, jobspec_b, &jobid, &reserved, &R, &at, &ov)
+
+        if rc != 0:
+            self._raise_error()
+
+        try:
+            # Convert C string to Python string
+            R_str = R.decode('utf-8') if R is not NULL else ""
+            return (jobid, reserved, R_str, at, ov)
+        finally:
+            # Important: Free the memory allocated by strdup in C++
+            if R is not NULL:
+                free(R)
+
+    def info(self, uint64_t jobid):
+        cdef:
+            char *mode = NULL
+            bool reserved = False
+            int64_t at = 0
+            double ov = 0.0
+            int rc
+
+        rc = reapi_cli_info(self._ctx, jobid, &mode, &reserved, &at, &ov)
+        if rc != 0:
+            self._raise_error()
+
+        try:
+            mode_str = mode.decode('utf-8') if mode is not NULL else ""
+            return (mode_str, reserved, at, ov)
+        finally:
+            if mode is not NULL:
+                free(mode)
+
+    cdef _raise_error(self):
+        cdef const char *msg_c = reapi_cli_get_err_msg(self._ctx)
+        cdef str msg = "Unknown Error"
+
+        # Check msg_c, copy to python str, then free msg_c
+        if msg_c is not NULL:
+            try:
+                msg = msg_c.decode('utf-8')
+            finally:
+                # The C interface returns a strdup'd string that we own
+                # We cast away const to free it
+                free(<void*>msg_c)
+
+        reapi_cli_clear_err_msg(self._ctx)
+        raise ReapiError(msg)
+
+# ... (inside class ReapiCli) ...
+
+    def cancel(self, uint64_t jobid, bool noent_ok=False):
+        """
+        Cancel the allocation or reservation for the given jobid.
+        """
+        cdef int rc
+        rc = reapi_cli_cancel(self._ctx, jobid, noent_ok)
+        if rc != 0:
+            self._raise_error()
+
+    def partial_cancel(self, uint64_t jobid, str R, bool noent_ok=False):
+        """
+        Partially cancel resources for the given jobid.
+
+        Args:
+            jobid: The job ID.
+            R: The resource set (string/json) to release.
+            noent_ok: If True, ignore error if jobid doesn't exist.
+
+        Returns:
+            bool: True if the job was fully removed (became empty), False otherwise.
+        """
+        cdef:
+            bytes R_b = R.encode('utf-8')
+            const char *R_c = R_b
+            bool full_removal = False
+            int rc
+
+        rc = reapi_cli_partial_cancel(self._ctx, jobid, R_c, noent_ok, &full_removal)
+
+        if rc != 0:
+            self._raise_error()
+
+        return full_removal

--- a/resource/reapi/bindings/python/flux_sched/reapi_module.pyx
+++ b/resource/reapi/bindings/python/flux_sched/reapi_module.pyx
@@ -1,0 +1,79 @@
+# resource/reapi/bindings/python/flux_sched/reapi_module.pyx
+
+from libc.stdlib cimport free
+from libc.stdint cimport int64_t, uint64_t, uintptr_t
+from libcpp cimport bool
+from flux_sched.c_reapi cimport *
+
+cdef class ReapiModule:
+    cdef reapi_module_ctx_t *_ctx
+
+    def __cinit__(self):
+        self._ctx = reapi_module_new()
+        if self._ctx is NULL:
+            raise MemoryError("Failed to allocate reapi_module context")
+
+    def __dealloc__(self):
+        if self._ctx is not NULL:
+            reapi_module_destroy(self._ctx)
+
+    def set_handle(self, flux_handle):
+        """
+        Accepts a python flux handle (flux.Flux) OR a raw integer address.
+        """
+        cdef void *ptr
+        cdef uintptr_t val
+        cdef object ffi = None
+
+        # 1. Fast Path: Integer (Does not require flux-python)
+        if isinstance(flux_handle, int):
+            val = <uintptr_t>flux_handle
+            ptr = <void *>val
+            reapi_module_set_handle(self._ctx, ptr)
+            return
+
+        # 2. Check for flux-python availability
+        try:
+            import flux
+        except ImportError:
+            raise ImportError(
+                "The 'flux' package is required to use set_handle() with a Flux object. "
+                "Please install with: pip install flux-sched[reapi-module]"
+            )
+
+        # 3. Locate CFFI 'ffi' instance (Logic from previous step)
+        # Attempt A: flux.core.inner
+        if ffi is None:
+            try:
+                from flux.core.inner import ffi as _f
+                if hasattr(_f, 'cast'): ffi = _f
+            except ImportError: pass
+
+        # Attempt B: flux._core
+        if ffi is None:
+            try:
+                from flux._core import ffi as _f
+                if hasattr(_f, 'cast'): ffi = _f
+            except ImportError: pass
+
+        # Attempt C: Handle's own FFI
+        if ffi is None and hasattr(flux_handle, "_ffi"):
+            if hasattr(flux_handle._ffi, 'cast'): ffi = flux_handle._ffi
+
+        # 4. Perform Cast
+        if ffi is not None:
+            try:
+                if hasattr(flux_handle, "_handle"):
+                    val = <uintptr_t>int(ffi.cast("uintptr_t", flux_handle._handle))
+                else:
+                    val = <uintptr_t>int(ffi.cast("uintptr_t", flux_handle))
+
+                ptr = <void *>val
+                reapi_module_set_handle(self._ctx, ptr)
+                return
+            except Exception as e:
+                raise ValueError(f"Failed to cast handle: {e}")
+
+        raise ValueError("Could not locate valid 'ffi' object. Try passing int(handle) directly.")
+
+    # ... match/cancel methods remain the same ...

--- a/resource/reapi/bindings/python/pyproject.toml
+++ b/resource/reapi/bindings/python/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython"]
+build-backend = "setuptools.build_meta"
+
+[tool.black]
+exclude = "^env/"
+line-length = 100
+
+[tool.isort]
+profile = "black" # needed for black/isort compatibility
+line_length = 100

--- a/resource/reapi/bindings/python/setup.py
+++ b/resource/reapi/bindings/python/setup.py
@@ -1,0 +1,88 @@
+import os
+from setuptools import setup, Extension, find_packages
+from Cython.Build import cythonize
+
+base_dir = os.path.abspath(os.path.dirname(__file__))
+
+# We need headers for the Cython compilation
+bindings_dir = os.path.abspath(os.path.join(base_dir, "../"))
+reapi_c_dir = os.path.abspath(os.path.join(base_dir, "../../c"))
+here = os.path.dirname(os.path.abspath(__file__))
+root_dir = here
+for _ in range(4):
+    root_dir = os.path.dirname(root_dir)
+
+readme = os.path.join(here, "README.md")
+try:
+    with open("README.md", "r", encoding="utf-8") as fh:
+        long_description = fh.read()
+except FileNotFoundError:
+    long_description = "Python bindings for the Flux Scheduler (flux-sched)."
+
+extensions = [
+    Extension(
+        "flux_sched.reapi_cli",
+        sources=["flux_sched/reapi_cli.pyx"],
+        library_dirs=[bindings_dir],
+        include_dirs=[reapi_c_dir, bindings_dir, root_dir],
+        libraries=["reapi_cli", "flux-core"],
+        language="c++",
+        extra_compile_args=["-std=c++11"],
+    ),
+    Extension(
+        "flux_sched.reapi_module",
+        sources=["flux_sched/reapi_module.pyx"],
+        library_dirs=[bindings_dir],
+        include_dirs=[reapi_c_dir, bindings_dir, root_dir],
+        libraries=["reapi_module", "flux-core"],
+        language="c++",
+        extra_compile_args=["-std=c++11"],
+    ),
+]
+
+setup(
+    name="flux-sched",
+    version="0.0.0",
+    packages=find_packages(),
+    ext_modules=cythonize(extensions),
+    install_requires=[],
+    extras_require={
+        "reapi-module": ["flux-python"],
+    },
+    description="Python bindings for the Flux resource manager framework scheduler",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    author="Flux Framework Developers",
+    author_email="flux-discuss@llnl.gov",
+    maintainer="Vanessa Sochat",
+    url="https://github.com/flux-framework/flux-sched",
+    project_urls={
+        "Documentation": "https://flux-framework.readthedocs.io/",
+        "Source": "https://github.com/flux-framework/flux-sched",
+        "Tracker": "https://github.com/flux-framework/flux-sched/issues",
+    },
+    zip_safe=False,
+    classifiers=[
+        "Intended Audience :: Science/Research",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
+        "Programming Language :: C++",
+        "Programming Language :: Python",
+        "Topic :: Software Development",
+        "Topic :: Scientific/Engineering",
+        "Operating System :: Unix",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+    ],
+    keywords=[
+        "hpc",
+        "flux",
+        "fluxion",
+        "scheduler",
+        "resource-manager",
+        "distributed-computing",
+        "graph-scheduling",
+    ],
+)

--- a/resource/reapi/bindings/python/tests/paths.py
+++ b/resource/reapi/bindings/python/tests/paths.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+ROOT_DIR = HERE
+for _ in range(5):
+    ROOT_DIR = os.path.dirname(ROOT_DIR)
+
+DATA_DIR = os.path.join(ROOT_DIR, "t", "data", "resource")
+JGF_PATH = os.path.join(DATA_DIR, "jgfs", "tiny.json")
+GRUG_PATH = os.path.join(DATA_DIR, "grugs", "tiny.graphml")
+JOBSPEC_ROOT = os.path.join(DATA_DIR, "jobspecs")
+JOBSPEC_DIR = os.path.join(JOBSPEC_ROOT, "basics")
+JOBSPEC_DURATION = os.path.join(DATA_DIR, "jobspecs", "duration")

--- a/resource/reapi/bindings/python/tests/test_basic.py
+++ b/resource/reapi/bindings/python/tests/test_basic.py
@@ -1,0 +1,86 @@
+import pytest
+import os
+import json
+import sys
+
+# Assuming this file is in: resource/reapi/bindings/python/tests
+# And data is in:           resource/data/
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+for path in [ROOT, HERE]:
+    sys.path.insert(0, path)
+import utils  # noqa
+import paths  # noqa
+from flux_sched.reapi_cli import ReapiCli  # noqa
+
+
+@pytest.fixture(scope="module")
+def cli():
+    """
+    Initialize the ReapiCli once with tiny.json for all tests in this module.
+    """
+    if not os.path.exists(paths.JGF_PATH):
+        pytest.fail(f"Cannot find tiny.json at: {paths.JGF_PATH}")
+
+    c = ReapiCli()
+    rgraph = utils.read_file(paths.JGF_PATH)
+    options = json.dumps({"load_format": "jgf"})
+
+    try:
+        c.initialize(rgraph, options)
+    except Exception as e:
+        pytest.fail(f"Failed to initialize ReapiCli: {e}")
+
+    return c
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "test001.yaml",
+        "test002.yaml",
+        "test003.yaml",
+        "test004.yaml",
+        "test005.yaml",
+        "test006.yaml",
+        "test007.yaml",
+        "test008.yaml",
+        "test009.yaml",
+        "test010.yaml",
+        "test011.yaml",
+        "test012.yaml",
+        "test013.yaml",
+        "test014.yaml",
+        "test015.yaml",
+    ],
+)
+def test_all_basics_success(cli, filename):
+    """
+    Generalizes the manual python loop provided in your prompt.
+    Ensures all testXXX.yaml files in 'basics' result in a successful match.
+    """
+    jobspec = utils.load_jobspec(filename)
+
+    jobid, reserved, R, at, ov = cli.match(jobspec, orelse_reserve=False)
+
+    assert jobid > 0, f"Failed to match {filename}"
+    assert R is not None
+
+
+@pytest.mark.parametrize("filename", ["bad.yaml", "bad_res_type.yaml"])
+def test_basics_failure(cli, filename):
+    """
+    Ensures invalid jobspecs raise errors or return valid failures.
+    """
+    try:
+        jobspec = utils.load_jobspec(filename)
+        jobid, _, _, _, _ = cli.match(jobspec, orelse_reserve=False)
+
+        # If it returns 0 on failure - this is "success" because it failed to match as expected
+        if jobid == 0:
+            return  # Success (it failed to match as expected)
+
+    except Exception:
+        # If it raised an exception (parsing error), that is also a pass for a "bad" file
+        return

--- a/resource/reapi/bindings/python/tests/test_info_cancel.py
+++ b/resource/reapi/bindings/python/tests/test_info_cancel.py
@@ -1,0 +1,199 @@
+import pytest
+import os
+import json
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+for path in [ROOT, HERE]:
+    sys.path.insert(0, path)
+import utils  # noqa
+import paths  # noqa
+from flux_sched.reapi_cli import ReapiCli, ReapiError  # noqa
+
+
+class TestInfoCancelGrug:
+    """
+    Loading GRUG and testing standard cancel/info operations.
+    """
+
+    @pytest.fixture
+    def cli(self):
+        """
+        Initializes ReapiCli with 'tiny.graphml' and specific shell options.
+        """
+        cli_obj = ReapiCli()
+        grug_content = utils.read_file(paths.GRUG_PATH)
+
+        # Shell: load-file=${grug} prune-filters=ALL:core load-format=grug subsystems=containment policy=high
+        options = json.dumps(
+            {
+                "load_format": "grug",
+                "prune_filters": "ALL:core",
+                "subsystems": "containment",
+                "policy": "high",
+            }
+        )
+
+        cli_obj.initialize(grug_content, options)
+        return cli_obj
+
+    def test_resource_cancel_loop(self, cli):
+        """
+        Mimics: 'resource-cancel works'
+        Allocates and cancels a job 4 times in a row.
+        """
+        jobspec_path = os.path.join(paths.JOBSPEC_DIR, "test001.yaml")
+        jobspec_str = utils.load_jobspec(jobspec_path)
+
+        print("\n--- Testing Allocate/Cancel Loop ---")
+        for i in range(4):
+            # 1. Allocate
+            jobid, _, _, _, _ = cli.match(jobspec_str, orelse_reserve=False)
+            assert jobid > 0
+            print(f"  Iter {i}: Allocated Job {jobid}")
+
+            # 2. Cancel
+            # Note: Shell script hardcodes '0', but ReapiCli generates sequential IDs (1, 2...).
+            # We must cancel the actual ID returned by match.
+            try:
+                cli.cancel(jobid)
+                print(f"  Iter {i}: Canceled Job {jobid}")
+            except Exception as e:
+                pytest.fail(f"Failed to cancel job {jobid}: {e}")
+
+    def test_info_on_cancelled_failure(self, cli):
+        """
+        Mimics: 'resource-info will not report for canceled jobs'
+        """
+        jobspec_path = os.path.join(paths.JOBSPEC_DIR, "test001.yaml")
+        jobspec_str = utils.load_jobspec(jobspec_path)
+
+        # Allocate then cancel
+        jobid, _, _, _, _ = cli.match(jobspec_str)
+
+        # Info should report allocated then cancelled
+        info = cli.info(jobid)
+        assert info[0] == "ALLOCATED"
+        cli.cancel(jobid)
+        info = cli.info(jobid)
+        assert info[0] == "CANCELED"
+
+    def test_info_on_allocated_jobs(self, cli):
+        """
+        Mimics:
+        1. 'allocate works with 1-node/1-socket after cancels'
+        2. 'resource-info on allocated jobs works'
+        """
+        jobspec_path = os.path.join(paths.JOBSPEC_DIR, "test001.yaml")
+        jobspec_str = utils.load_jobspec(jobspec_path)
+
+        # 1. Fill up the system (4 slots on tiny.graphml)
+        active_jobids = []
+        print("\n--- Filling System ---")
+        for i in range(4):
+            jobid, _, _, _, _ = cli.match(jobspec_str)
+            assert jobid > 0
+            active_jobids.append(jobid)
+            print(f"  Allocated {jobid}")
+
+        # 2. Check Info
+        print("\n--- Checking Info ---")
+        for jobid in active_jobids:
+            # info returns: (mode, reserved, at, ov)
+            mode, reserved, _, _ = cli.info(jobid)
+
+            print(f"  Job {jobid} mode: {mode}")
+
+            # Shell script does: grep ALLOCATED info.N
+            assert "ALLOCATED" in mode
+            assert not reserved
+
+    def test_cancel_nonexistent(self, cli):
+        """
+        Mimics: 'cancel on nonexistent jobid is handled gracefully'
+        Shell expects code 3. ReapiCli should raise ReapiError (or similar).
+        """
+        bad_id = 100000
+        with pytest.raises(ReapiError):
+            # By default, noent_ok is False in standard python bindings logic
+            # unless explicitly exposed as an arg.
+            cli.cancel(bad_id)
+
+
+class TestPartialCancelRV1:
+    """
+    Represents the second half of the shell script:
+    Loading RV1 and testing partial cancellation.
+    """
+
+    @pytest.fixture
+    def cli(self):
+        """
+        Initializes ReapiCli with 'tiny_rv1exec.json'.
+        """
+        cli_obj = ReapiCli()
+
+        # Locate rv1exec file
+        # path: data/resource/rv1exec/tiny_rv1exec.json
+        rv1_path = os.path.join(paths.DATA_DIR, "rv1exec", "tiny_rv1exec.json")
+        rv1_content = utils.read_file(rv1_path)
+
+        # Shell: load-file=${rv1} prune-filters=ALL:core load-format=rv1exec subsystems=containment policy=low
+        options = json.dumps(
+            {
+                "load_format": "rv1exec",
+                "prune_filters": "ALL:core",
+                "subsystems": "containment",
+                "policy": "low",
+            }
+        )
+
+        cli_obj.initialize(rv1_content, options)
+        return cli_obj
+
+    def test_partial_cancel_workflow(self, cli):
+        """
+        Mimics: 'resource-cancel works' (in the RV1 context)
+        1. Match test018.yaml
+        2. Partial cancel using rank1_cancel.json
+        3. Match test019.yaml
+        """
+        # 1. Match test018
+        js1_path = os.path.join(paths.JOBSPEC_ROOT, "cancel", "test018.yaml")
+        js1_str = utils.load_jobspec(js1_path)
+
+        jobid1, _, _, _, _ = cli.match(js1_str)
+        print(f"\nAllocated Job 1 (test018): {jobid1}")
+        assert jobid1 > 0
+
+        # 2. Partial Cancel
+        # We need the content of rank1_cancel.json to pass as the 'R' string/json
+        cancel_file_path = os.path.join(
+            paths.DATA_DIR, "rv1exec", "cancel", "rank1_cancel.json"
+        )
+        cancel_r_content = utils.read_file(cancel_file_path)
+
+        print(
+            f"Partial Canceling Job {jobid1} with resources from {os.path.basename(cancel_file_path)}"
+        )
+
+        try:
+            # reapi_cli_partial_cancel returns: (int ret)
+            # It might also return full_removal bool via reference, depending on binding implementation
+            cli.partial_cancel(jobid1, cancel_r_content)
+        except AttributeError:
+            pytest.fail(
+                "ReapiCli.partial_cancel method not found. Please update reapi_cli.pyx."
+            )
+        except Exception as e:
+            pytest.fail(f"Partial cancel failed: {e}")
+
+        # 3. Match test019
+        # This job presumably fits only because resources were freed by the partial cancel
+        js2_path = os.path.join(paths.JOBSPEC_ROOT, "cancel", "test019.yaml")
+        js2_str = utils.load_jobspec(js2_path)
+
+        jobid2, _, _, _, _ = cli.match(js2_str)
+        print(f"Allocated Job 2 (test019): {jobid2}")
+        assert jobid2 > 0

--- a/resource/reapi/bindings/python/tests/test_match_allocate.py
+++ b/resource/reapi/bindings/python/tests/test_match_allocate.py
@@ -1,0 +1,115 @@
+import pytest
+import os
+import json
+import yaml
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+for path in [ROOT, HERE]:
+    sys.path.insert(0, path)
+import utils  # noqa
+import paths  # noqa
+from flux_sched.reapi_cli import ReapiCli, ReapiError  # noqa
+
+
+class TestMatchAllocate:
+    @pytest.fixture
+    def cli(self):
+        """
+        Initializes ReapiCli with the 'tiny.graphml' GRUG file
+        and the options specified in the shell script.
+        """
+        cli_obj = ReapiCli()
+
+        # 1. Read the GRUG file content
+        grug_content = utils.read_file(paths.GRUG_PATH)
+
+        # 2. Mimic shell options:
+        # load-file=${grug} (handled via first arg)
+        # prune-filters=ALL:core
+        # load-format=grug
+        # subsystems=containment
+        # policy=high
+        options = json.dumps(
+            {
+                "load_format": "grug",
+                "prune_filters": "ALL:core",
+                "subsystems": "containment",
+                "policy": "high",
+            }
+        )
+
+        cli_obj.initialize(grug_content, options)
+        return cli_obj
+
+    def test_allocation_saturation(self, cli):
+        """
+        Mimics:
+        1. 'match-allocate works with a 1-node, 1-socket jobspec' (4 times)
+        2. 'match-allocate fails when all resources are allocated' (4 times)
+        """
+        jobspec_path = os.path.join(paths.JOBSPEC_DIR, "test001.yaml")
+        jobspec_str = utils.load_jobspec(jobspec_path)
+
+        print("\n--- Phase 1: Allocating 4 jobs (Success expected) ---")
+        for i in range(1, 5):
+            # Should succeed
+            jobid, reserved, R, _, _ = cli.match(jobspec_str, orelse_reserve=False)
+            print(f"  Job {i}: Allocated JobID {jobid}")
+            assert jobid > 0
+            assert reserved is False
+
+        print("\n--- Phase 2: Allocating 4 more jobs (Failure expected) ---")
+        # The machine is tiny; 4 jobs should not go in after the first 4
+        for i in range(5, 9):
+            _, reserved, allocated, _, _ = cli.match(jobspec_str, orelse_reserve=False)
+            assert not allocated and not reserved
+            print(f"  Job {i}: Match Allocate failed as expected")
+
+    def test_malformed_jobspec(self, cli):
+        """
+        Mimics: 'handling of a malformed jobspec works'
+        Input: bad.yaml
+        """
+        path = os.path.join(paths.JOBSPEC_DIR, "bad.yaml")
+
+        # We pass the raw content because yaml.safe_load might fail if it's truly malformed YAML,
+        # but here we want to test how the C++ binding handles the bad input.
+        content = utils.read_file(path)
+
+        # If valid YAML but bad schema, pass as JSON. If invalid YAML, pass raw.
+        try:
+            js = yaml.safe_load(content)
+            content = json.dumps(js)
+        except Exception:
+            pass  # Pass raw content if it's not valid YAML
+
+        with pytest.raises(ReapiError):
+            cli.match(content)
+
+    def test_invalid_resource_type(self, cli):
+        """
+        Mimics: 'handling of an invalid resource type works'
+        Input: bad_res_type.yaml
+        """
+        path = os.path.join(paths.JOBSPEC_DIR, "bad_res_type.yaml")
+        jobspec_str = utils.load_jobspec(path)
+
+        with pytest.raises(ReapiError) as excinfo:
+            cli.match(jobspec_str)
+        print(f"Caught expected error: {excinfo.value}")
+
+    def test_non_existent_jobspec_equivalent(self, cli):
+        """
+        Mimics: 'detecting of a non-existent jobspec file works'
+
+        Note: The C++ binding accepts a string content, not a filename.
+        So we can't test 'file not found'. Instead, we test passing
+        garbage non-JSON content, which is effectively what happens if
+        one were to pass a filename string instead of file content.
+        """
+        garbage_input = "this is not a json string"
+
+        with pytest.raises(ReapiError):
+            cli.match(garbage_input)

--- a/resource/reapi/bindings/python/tests/utils.py
+++ b/resource/reapi/bindings/python/tests/utils.py
@@ -1,0 +1,30 @@
+import os
+import yaml
+import sys
+import json
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+
+def read_file(path):
+    """
+    Read path from filename
+    """
+    with open(path, "r") as f:
+        return f.read()
+
+
+def load_jobspec(filename):
+    """
+    Load a YAML jobspec from file, jump as json.
+
+    We don't technically need to json load, but this
+    helps to ensure it is valid json first.
+    """
+    import paths
+
+    path = os.path.join(paths.JOBSPEC_DIR, filename)
+    with open(path, "r") as f:
+        data = yaml.safe_load(f)
+    return json.dumps(data)


### PR DESCRIPTION
This pull request will add flux-sched Python bindings for the resource API. We want to do this so we can use flux-sched in agentic contexts. I've reproduced the reapi cli, and added the start of the reapi module, but without complete tests, etc., because it's not of interest or priority now (can be worked on when needed). For this PR, I've added:

- Python bindings that are based on Cython
- A modern setup (e.g., pyproject.toml with python3 -m build over setup.py
- Tests with pytest that do match allocate, cancel, and info (and mimic what we test for the Golang bindings)
- Documentation in the README.md
- An entire metadata / package that uploads to pypi.

I am not building / testing across matrices because it's annoying to install Cython in each one. Instead I am using the .devcontainer as a CI environment. I will update the title to remove the WIP when that is working fully.