### PR TITLE
readers: add jgf reader that can skip exclusive subtrees

### DIFF
--- a/resource/CMakeLists.txt
+++ b/resource/CMakeLists.txt
@@ -39,6 +39,7 @@ set(RESOURCE_HEADERS
     readers/resource_reader_grug.hpp
     readers/resource_reader_hwloc.hpp
     readers/resource_reader_jgf.hpp
+    readers/resource_reader_jgf_shorthand.hpp
     readers/resource_reader_rv1exec.hpp
     readers/resource_reader_factory.hpp
     evaluators/scoring_api.hpp
@@ -75,6 +76,7 @@ add_library(resource STATIC
     readers/resource_reader_grug.cpp
     readers/resource_reader_hwloc.cpp
     readers/resource_reader_jgf.cpp
+    readers/resource_reader_jgf_shorthand.cpp
     readers/resource_reader_rv1exec.cpp
     readers/resource_reader_factory.cpp
     writers/match_writers.cpp

--- a/resource/readers/resource_reader_factory.cpp
+++ b/resource/readers/resource_reader_factory.cpp
@@ -18,6 +18,7 @@ extern "C" {
 #include "resource/readers/resource_reader_grug.hpp"
 #include "resource/readers/resource_reader_hwloc.hpp"
 #include "resource/readers/resource_reader_jgf.hpp"
+#include "resource/readers/resource_reader_jgf_shorthand.hpp"
 #include "resource/readers/resource_reader_rv1exec.hpp"
 
 namespace Flux {
@@ -26,8 +27,8 @@ namespace resource_model {
 bool known_resource_reader (const std::string &name)
 {
     bool rc = false;
-    if (name == "grug" || name == "hwloc" || name == "jgf" || name == "rv1exec"
-        || name == "rv1exec_force")
+    if (name == "grug" || name == "hwloc" || name == "jgf" || name == "jgf_shorthand"
+        || name == "rv1exec" || name == "rv1exec_force")
         rc = true;
     return rc;
 }
@@ -43,6 +44,8 @@ std::shared_ptr<resource_reader_base_t> create_resource_reader (const std::strin
             reader = std::make_shared<resource_reader_hwloc_t> ();
         } else if (name == "jgf") {
             reader = std::make_shared<resource_reader_jgf_t> ();
+        } else if (name == "jgf_shorthand") {
+            reader = std::make_shared<resource_reader_jgf_shorthand_t> ();
         } else if (name == "rv1exec" || name == "rv1exec_force") {
             reader = std::make_shared<resource_reader_rv1exec_t> ();
         } else {

--- a/resource/readers/resource_reader_jgf.cpp
+++ b/resource/readers/resource_reader_jgf.cpp
@@ -967,18 +967,40 @@ int resource_reader_jgf_t::update_vertices (resource_graph_t &g,
     int rc = -1;
     unsigned int i = 0;
     fetch_helper_t fetcher;
+    std::vector<fetch_helper_t> additional_vertices;
+    std::map<std::string, vmap_val_t> empty_vmap{};
 
     for (i = 0; i < json_array_size (nodes); i++) {
         fetcher.scrub ();
+        additional_vertices.clear ();
         if ((rc = unpack_vtx (json_array_get (nodes, i), fetcher)) != 0)
             goto done;
         if ((rc = update_vtx (g, m, vmap, fetcher, update_data)) != 0)
             goto done;
+        if (fetch_additional_vertices (g, m, empty_vmap, fetcher, additional_vertices) != 0)
+            goto done;
+        for (auto &fetcher : additional_vertices) {
+            std::string vertex_id = std::to_string (fetcher.uniq_id);
+            fetcher.vertex_id = vertex_id.c_str ();
+            if ((rc = update_vtx (g, m, vmap, fetcher, update_data)) != 0) {
+                goto done;
+            }
+        }
     }
     rc = 0;
 
 done:
     return rc;
+}
+
+int resource_reader_jgf_t::fetch_additional_vertices (
+    resource_graph_t &g,
+    resource_graph_metadata_t &m,
+    std::map<std::string, vmap_val_t> &vmap,
+    fetch_helper_t &fetcher,
+    std::vector<fetch_helper_t> &additional_vertices)
+{
+    return 0;
 }
 
 int resource_reader_jgf_t::unpack_edge (json_t *element,

--- a/resource/readers/resource_reader_jgf.cpp
+++ b/resource/readers/resource_reader_jgf.cpp
@@ -27,46 +27,6 @@ extern "C" {
 using namespace Flux;
 using namespace Flux::resource_model;
 
-class fetch_remap_support_t {
-   public:
-    int64_t get_remapped_id () const;
-    int64_t get_remapped_rank () const;
-    const std::string &get_remapped_name () const;
-    void set_remapped_id (int64_t i);
-    void set_remapped_rank (int64_t r);
-    void set_remapped_name (const std::string &n);
-    bool is_name_remapped () const;
-    bool is_id_remapped () const;
-    bool is_rank_remapped () const;
-    void clear ();
-
-   private:
-    int64_t m_remapped_id = -1;
-    int64_t m_remapped_rank = -1;
-    std::string m_remapped_name = "";
-};
-
-struct fetch_helper_t : public fetch_remap_support_t {
-    const char *get_proper_name () const;
-    int64_t get_proper_id () const;
-    int64_t get_proper_rank () const;
-    void scrub ();
-
-    int64_t id = -2;
-    int64_t rank = -1;
-    int64_t size = -1;
-    int64_t uniq_id = -1;
-    int exclusive = -1;
-    resource_pool_t::status_t status = resource_pool_t::status_t::UP;
-    const char *type = NULL;
-    std::string name;
-    const char *unit = NULL;
-    const char *basename = NULL;
-    const char *vertex_id = NULL;
-    std::map<std::string, std::string> properties;
-    std::map<subsystem_t, std::string> paths;
-};
-
 int64_t fetch_remap_support_t::get_remapped_id () const
 {
     return m_remapped_id;

--- a/resource/readers/resource_reader_jgf.hpp
+++ b/resource/readers/resource_reader_jgf.hpp
@@ -242,6 +242,11 @@ class resource_reader_jgf_t : public resource_reader_base_t {
                          std::map<std::string, vmap_val_t> &vmap,
                          json_t *nodes,
                          jgf_updater_data &updater_data);
+    virtual int fetch_additional_vertices (resource_graph_t &g,
+                                           resource_graph_metadata_t &m,
+                                           std::map<std::string, vmap_val_t> &vmap,
+                                           fetch_helper_t &fetcher,
+                                           std::vector<fetch_helper_t> &additional_vertices);
     int unpack_edge (json_t *element,
                      std::map<std::string, vmap_val_t> &vmap,
                      std::string &source,

--- a/resource/readers/resource_reader_jgf.hpp
+++ b/resource/readers/resource_reader_jgf.hpp
@@ -17,11 +17,50 @@
 #include "resource/schema/resource_graph.hpp"
 #include "resource/readers/resource_reader_base.hpp"
 
-struct fetch_helper_t;
 struct vmap_val_t;
 
 namespace Flux {
 namespace resource_model {
+
+class fetch_remap_support_t {
+   public:
+    int64_t get_remapped_id () const;
+    int64_t get_remapped_rank () const;
+    const std::string &get_remapped_name () const;
+    void set_remapped_id (int64_t i);
+    void set_remapped_rank (int64_t r);
+    void set_remapped_name (const std::string &n);
+    bool is_name_remapped () const;
+    bool is_id_remapped () const;
+    bool is_rank_remapped () const;
+    void clear ();
+
+   private:
+    int64_t m_remapped_id = -1;
+    int64_t m_remapped_rank = -1;
+    std::string m_remapped_name = "";
+};
+
+struct fetch_helper_t : public fetch_remap_support_t {
+    const char *get_proper_name () const;
+    int64_t get_proper_id () const;
+    int64_t get_proper_rank () const;
+    void scrub ();
+
+    int64_t id = -2;
+    int64_t rank = -1;
+    int64_t size = -1;
+    int64_t uniq_id = -1;
+    int exclusive = -1;
+    resource_pool_t::status_t status = resource_pool_t::status_t::UP;
+    const char *type = NULL;
+    std::string name;
+    const char *unit = NULL;
+    const char *basename = NULL;
+    const char *vertex_id = NULL;
+    std::map<std::string, std::string> properties;
+    std::map<subsystem_t, std::string> paths;
+};
 
 struct rank_data {
     // store counts of resources to be cancelled

--- a/resource/readers/resource_reader_jgf.hpp
+++ b/resource/readers/resource_reader_jgf.hpp
@@ -131,6 +131,14 @@ class resource_reader_jgf_t : public resource_reader_base_t {
      */
     virtual bool is_allowlist_supported ();
 
+   protected:
+    int apply_defaults (fetch_helper_t &f, const char *name);
+    int find_vtx (resource_graph_t &g,
+                  resource_graph_metadata_t &m,
+                  std::map<std::string, vmap_val_t> &vmap,
+                  const fetch_helper_t &fetcher,
+                  vtx_t &ret_v);
+
    private:
     int fetch_jgf (const std::string &str,
                    json_t **jgf_p,
@@ -139,7 +147,6 @@ class resource_reader_jgf_t : public resource_reader_base_t {
                    jgf_updater_data &update_data);
     int unpack_and_remap_vtx (fetch_helper_t &f, json_t *paths, json_t *properties);
     int remap_aware_unpack_vtx (fetch_helper_t &f, json_t *paths, json_t *properties);
-    int apply_defaults (fetch_helper_t &f, const char *name);
     int fill_fetcher (json_t *element, fetch_helper_t &f, json_t **path, json_t **properties);
     int unpack_vtx (json_t *element, fetch_helper_t &f);
     vtx_t create_vtx (resource_graph_t &g, const fetch_helper_t &fetcher);
@@ -169,11 +176,6 @@ class resource_reader_jgf_t : public resource_reader_base_t {
                int rank,
                const std::string &vid,
                vtx_t &v);
-    int find_vtx (resource_graph_t &g,
-                  resource_graph_metadata_t &m,
-                  std::map<std::string, vmap_val_t> &vmap,
-                  const fetch_helper_t &fetcher,
-                  vtx_t &ret_v);
     int update_vtx_plan (vtx_t v,
                          resource_graph_t &g,
                          const fetch_helper_t &fetcher,

--- a/resource/readers/resource_reader_jgf_shorthand.cpp
+++ b/resource/readers/resource_reader_jgf_shorthand.cpp
@@ -1,0 +1,15 @@
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/idset.h>
+}
+
+#include "resource/readers/resource_reader_jgf_shorthand.hpp"
+
+using namespace Flux;
+using namespace Flux::resource_model;
+
+resource_reader_jgf_shorthand_t::~resource_reader_jgf_shorthand_t ()
+{
+}

--- a/resource/readers/resource_reader_jgf_shorthand.cpp
+++ b/resource/readers/resource_reader_jgf_shorthand.cpp
@@ -13,3 +13,62 @@ using namespace Flux::resource_model;
 resource_reader_jgf_shorthand_t::~resource_reader_jgf_shorthand_t ()
 {
 }
+
+int resource_reader_jgf_shorthand_t::fetch_additional_vertices (
+    resource_graph_t &g,
+    resource_graph_metadata_t &m,
+    std::map<std::string, vmap_val_t> &vmap,
+    fetch_helper_t &fetcher,
+    std::vector<fetch_helper_t> &additional_vertices)
+{
+    int rc = -1;
+    vtx_t v = boost::graph_traits<resource_graph_t>::null_vertex ();
+    if (!fetcher.exclusive)  // vertex isn't exclusive, nothing to do
+        return 0;
+
+    if ((rc = resource_reader_jgf_t::find_vtx (g, m, vmap, fetcher, v)) != 0)
+        return rc;
+
+    return recursively_collect_vertices (g, v, additional_vertices);
+}
+
+int resource_reader_jgf_shorthand_t::recursively_collect_vertices (
+    resource_graph_t &g,
+    vtx_t v,
+    std::vector<fetch_helper_t> &additional_vertices)
+{
+    static const subsystem_t containment_sub{"containment"};
+    f_out_edg_iterator_t ei, ei_end;
+    vtx_t target;
+
+    if (v == boost::graph_traits<resource_graph_t>::null_vertex ()) {
+        return -1;
+    }
+
+    for (boost::tie (ei, ei_end) = boost::out_edges (v, g); ei != ei_end; ++ei) {
+        if (g[*ei].subsystem != containment_sub)
+            continue;
+        target = boost::target (*ei, g);
+
+        fetch_helper_t vertex_copy;
+        vertex_copy.type = g[target].type.c_str ();
+        vertex_copy.basename = g[target].basename.c_str ();
+        vertex_copy.size = g[target].size;
+        vertex_copy.uniq_id = g[target].uniq_id;
+        vertex_copy.rank = g[target].rank;
+        vertex_copy.status = g[target].status;
+        vertex_copy.id = g[target].id;
+        vertex_copy.name = g[target].name;
+        vertex_copy.properties = g[target].properties;
+        vertex_copy.paths = g[target].paths;
+        vertex_copy.unit = g[target].unit.c_str ();
+        if (resource_reader_jgf_t::apply_defaults (vertex_copy, g[target].name.c_str ()) < 0)
+            return -1;
+
+        additional_vertices.push_back (vertex_copy);
+        if (recursively_collect_vertices (g, target, additional_vertices) < 0) {
+            return -1;
+        }
+    }
+    return 0;
+}

--- a/resource/readers/resource_reader_jgf_shorthand.hpp
+++ b/resource/readers/resource_reader_jgf_shorthand.hpp
@@ -21,6 +21,17 @@ namespace resource_model {
 class resource_reader_jgf_shorthand_t : public resource_reader_jgf_t {
    public:
     virtual ~resource_reader_jgf_shorthand_t ();
+
+   protected:
+    int fetch_additional_vertices (resource_graph_t &g,
+                                   resource_graph_metadata_t &m,
+                                   std::map<std::string, vmap_val_t> &vmap,
+                                   fetch_helper_t &fetcher,
+                                   std::vector<fetch_helper_t> &additional_vertices) override;
+
+    int recursively_collect_vertices (resource_graph_t &g,
+                                      vtx_t v,
+                                      std::vector<fetch_helper_t> &additional_vertices);
 };
 
 }  // namespace resource_model

--- a/resource/readers/resource_reader_jgf_shorthand.hpp
+++ b/resource/readers/resource_reader_jgf_shorthand.hpp
@@ -1,0 +1,33 @@
+/*****************************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+#ifndef RESOURCE_READER_JGF_SHORTHAND_HPP
+#define RESOURCE_READER_JGF_SHORTHAND_HPP
+
+#include "resource/readers/resource_reader_jgf.hpp"
+
+namespace Flux {
+namespace resource_model {
+
+/*! JGF shorthand resource reader class.
+ */
+class resource_reader_jgf_shorthand_t : public resource_reader_jgf_t {
+   public:
+    virtual ~resource_reader_jgf_shorthand_t ();
+};
+
+}  // namespace resource_model
+}  // namespace Flux
+
+#endif  // RESOURCE_READER_JGF_SHORTHAND_HPP
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/utilities/command.cpp
+++ b/resource/utilities/command.cpp
@@ -50,7 +50,7 @@ command_t commands[] =
       "u",
       cmd_update,
       "Update resources with a JGF subgraph (subcmd: "
-      "allocate | reserve), (reader: jgf | rv1exec): "
+      "allocate | reserve), (reader: jgf | jgf_shorthand | rv1exec): "
       "resource-query> update allocate jgf jgf_file jobid starttime duration"},
      {"attach",
       "j",
@@ -365,16 +365,9 @@ static int update_run (std::shared_ptr<detail::resource_query_t> &ctx,
     struct timeval st, et;
     std::shared_ptr<resource_reader_base_t> rd;
 
-    if (reader == "jgf") {
-        if ((rd = create_resource_reader ("jgf")) == nullptr) {
-            std::cerr << "ERROR: can't create JGF reader " << std::endl;
-            return -1;
-        }
-    } else {
-        if ((rd = create_resource_reader ("rv1exec")) == nullptr) {
-            std::cerr << "ERROR: can't create rv1exec reader " << std::endl;
-            return -1;
-        }
+    if ((rd = create_resource_reader (reader)) == nullptr) {
+        std::cerr << "ERROR: can't create '" << reader << "' reader " << std::endl;
+        return -1;
     }
 
     gettimeofday (&st, NULL);
@@ -417,7 +410,7 @@ static int update (std::shared_ptr<detail::resource_query_t> &ctx,
         std::cerr << "ERROR: unknown subcmd " << args[1] << std::endl;
         return -1;
     }
-    if (!(reader == "jgf" || reader == "rv1exec")) {
+    if (!(reader == "jgf" || reader == "rv1exec" || reader == "jgf_shorthand")) {
         std::cerr << "ERROR: unsupported reader " << args[2] << std::endl;
         return -1;
     }

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -73,6 +73,7 @@ set(ALL_TESTS
   t3038-resource-flexible.t
   t3039-resource-force-load-format.t
   t3040-jgf-shorthand-match-format.t
+  t3041-jgf-shorthand-load-format.t
   t3300-system-dontblock.t
   t3301-system-latestart.t
   t4000-match-params.t

--- a/t/data/resource/jobspecs/load_format/t3041.yaml
+++ b/t/data/resource/jobspecs/load_format/t3041.yaml
@@ -1,0 +1,21 @@
+version: 9999
+resources:
+  - type: node
+    count: 20
+    with:
+      - type: slot
+        count: 1
+        label: default
+        with:
+          - type: core
+            count: 16
+          - type: gpu
+            count: 4
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: [ \"app\" ]
+    slot: default
+    count:
+      per_slot: 1

--- a/t/t3041-jgf-shorthand-load-format.t
+++ b/t/t3041-jgf-shorthand-load-format.t
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+test_description='Test the jgf_shorthand load format'
+
+. $(dirname $0)/sharness.sh
+
+query="../../resource/utilities/resource-query"
+jobspec="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/load_format/t3041.yaml"
+
+test_expect_success 'Generate rv1 with .scheduling key' '
+    flux R encode --hosts=compute[1-20] --cores=0-15 --gpu=0-3 | jq . > R.json &&
+    cat R.json | flux ion-R encode > R_JGF.json &&
+    jq -S "del(.execution.starttime, .execution.expiration)" R.json > R.norm.json
+'
+
+test_expect_success 'resource_query can be loaded with jgf_shorthand reader' '
+    cat > match_jobspec_cmd <<-EOF &&
+    match allocate ${jobspec}
+    quit
+EOF
+    jq -S .scheduling R_JGF.json > JGF.json &&
+    ${query} -L JGF.json -f jgf_shorthand -F rv1_nosched -t R1.out -P high < match_jobspec_cmd &&
+    head -n1 R1.out | jq -S "del(.execution.starttime, .execution.expiration)" > r_match.json &&
+    test_cmp r_match.json R.norm.json
+'
+
+test_expect_success 'generate jgf_shorthand to use to update regular JGF' '
+    ${query} -L JGF.json -f jgf_shorthand -F jgf_shorthand -t jgf1.out -P lonodex < match_jobspec_cmd &&
+    head -n1 jgf1.out | jq -S . > shorthand.json &&
+    test_must_fail grep core shorthand.json > /dev/null &&
+    test_must_fail grep gpu shorthand.json > /dev/null &&
+    grep node shorthand.json > /dev/null &&
+    grep compute1 shorthand.json > /dev/null
+'
+
+test_expect_success 'update graph to allocate a job using jgf_shorthand' '
+    cat > update_allocate_cmd <<-EOF &&
+    update allocate jgf_shorthand shorthand.json 0 0 5
+    f sched-now=allocated
+    quit
+EOF
+    jq -S .scheduling R_JGF.json > JGF.json &&
+    ${query} -L JGF.json -f jgf_shorthand -F jgf -t jgf2.out -P high < update_allocate_cmd &&
+    tail -n4 jgf2.out | head -n1 > allocated.json
+'
+
+test_expect_success 'JGF output shows all cores and gpus allocated' '
+    grep core allocated.json > /dev/null &&
+    grep gpu allocated.json > /dev/null &&
+    grep node allocated.json > /dev/null &&
+    grep compute1 allocated.json > /dev/null &&
+    jq -e ".graph.nodes[] | select(.metadata.type == \"core\") | .id" allocated.json > cores.json &&
+    test 320 -eq $(cat cores.json | wc -l) &&
+    jq -e ".graph.nodes[] | select(.metadata.type == \"gpu\") | .id" allocated.json > gpus.json &&
+    test 80 -eq $(cat gpus.json | wc -l)
+'
+
+test_done


### PR DESCRIPTION
This PR addresses a bullet in #1414:

> Add an option to the JGF writer to only write out the root exclusive vertex of any exclusively allocated subtrees. Quick test on tuo's data showed this to reduce a full system job JGF from 21mb to 700k (uncompressed).

Stacked on top of #1419.