### PR TITLE
testsuite: set log-stderr-level on command line

### DIFF
--- a/t/t1007-recovery-full.t
+++ b/t/t1007-recovery-full.t
@@ -14,9 +14,7 @@ hwloc_basepath=`readlink -e ${SHARNESS_TEST_SRCDIR}/data/hwloc-data`
 excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers"
 
 export FLUX_SCHED_MODULE=none
-test_under_flux 1
-
-flux setattr log-stderr-level 6
+test_under_flux 1 full -Slog-stderr-level=6
 
 
 test_expect_success 'recovery: generate a test jobspec' '

--- a/t/t4011-match-duration.t
+++ b/t/t4011-match-duration.t
@@ -7,9 +7,7 @@ test_description='Test that parent duration is inherited according to RFC14'
 #
 # test_under_flux is under sharness.d/
 #
-test_under_flux 2
-
-flux setattr log-stderr-level 1
+test_under_flux 2 full -Slog-stderr-level=1
 export FLUX_URI_RESOLVE_LOCAL=t
 unset FLUX_MODPROBE_DISABLE
 


### PR DESCRIPTION
Problem: the log-stderr-level attribute is adjusted with flux-setattr(1) in several tests, but that interface may change as proposed in flux-framework/flux-core#7370.

Set it on the broker command line instead, by adding -Slog-stderr-level=N to test_under_flux.