### PR TITLE
CMake: match hwloc version requirement to README

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 pkg_check_modules(yaml-cpp REQUIRED IMPORTED_TARGET yaml-cpp)
 pkg_check_modules(LIBEDIT REQUIRED IMPORTED_TARGET libedit)
-pkg_check_modules(HWLOC REQUIRED IMPORTED_TARGET hwloc>=1.11.1)
+pkg_check_modules(HWLOC REQUIRED IMPORTED_TARGET hwloc>=2)
 pkg_check_modules(JANSSON REQUIRED IMPORTED_TARGET jansson>=2.10)
 pkg_check_modules(UUID REQUIRED IMPORTED_TARGET uuid)
 


### PR DESCRIPTION
Problem: #1272 changed hwloc min version in README in but not CMakeLists.txt (Specifically commit https://github.com/flux-framework/flux-sched/commit/15c3c910972ab752b843908707fc39ef0143dc8f)

Solution: update CMakeLists.txt to match

This is partly a question of whether this was **intended** to be left as a _soft_ requirement? Or was it just a moot point since `hwloc` 2.0 came out in 2018?

The follow up question would be whether this requirement would apply across other Flux projects? I had asked an earlier question about dependency version mismatches here: https://github.com/flux-framework/flux-core/issues/7295