### PR TITLE
writers: add rv1_shorthand match format

### DIFF
--- a/resource/evaluators/expr_eval_vtx_target.cpp
+++ b/resource/evaluators/expr_eval_vtx_target.cpp
@@ -17,6 +17,7 @@ extern "C" {
 #include <algorithm>
 #include <cctype>
 #include <flux/hostlist.h>
+#include <flux/core/job.h>
 #include "resource/evaluators/expr_eval_vtx_target.hpp"
 
 namespace Flux {
@@ -37,6 +38,7 @@ int expr_eval_vtx_target_t::validate (const std::string &p, const std::string &x
     int rc = -1;
     std::string lcx = x;
     struct hostlist *hlist;
+    flux_jobid_t id;
 
     if (!m_initialized) {
         errno = EINVAL;
@@ -50,14 +52,7 @@ int expr_eval_vtx_target_t::validate (const std::string &p, const std::string &x
     else if (p == "sched-future")
         rc = (lcx == "reserved" || lcx == "free") ? 0 : -1;
     else if (p == "jobid-alloc" || p == "jobid-span" || p == "jobid-tag" || p == "jobid-reserved") {
-        try {
-            std::stoul (lcx);
-            rc = 0;
-        } catch (std::invalid_argument) {
-            errno = EINVAL;
-        } catch (std::out_of_range) {
-            errno = ERANGE;
-        }
+        rc = flux_job_id_parse (lcx.c_str (), &id);
     } else if (p == "agfilter") {
         rc = (lcx == "true" || lcx == "t" || lcx == "false" || lcx == "f") ? 0 : -1;
     } else if (p == "names") {
@@ -82,7 +77,7 @@ int expr_eval_vtx_target_t::evaluate (const std::string &p,
 {
     int rc = 0;
     std::string lcx = x;
-    unsigned long jobid = 0;
+    flux_jobid_t jobid = 0;
     struct hostlist *hlist;
 
     result = false;
@@ -112,20 +107,20 @@ int expr_eval_vtx_target_t::evaluate (const std::string &p,
                 !m_overridden.sched_future_reserved && (*m_g)[m_u].schedule.reservations.empty ();
         }
     } else if (p == "jobid-alloc") {
-        jobid = std::stoul (lcx);
-        result = (*m_g)[m_u].schedule.allocations.contains (jobid);
+        result = (flux_job_id_parse (lcx.c_str (), &jobid) == 0
+                  && (*m_g)[m_u].schedule.allocations.contains (jobid));
     } else if (p == "jobid-reserved") {
-        jobid = std::stoul (lcx);
-        result = (*m_g)[m_u].schedule.reservations.contains (jobid);
+        result = (flux_job_id_parse (lcx.c_str (), &jobid) == 0
+                  && (*m_g)[m_u].schedule.reservations.contains (jobid));
     } else if (p == "jobid-span") {
-        jobid = std::stoul (lcx);
-        if (!(*m_g)[m_u].idata.job2span.contains (jobid)) {
+        if ((flux_job_id_parse (lcx.c_str (), &jobid) != 0
+             || !(*m_g)[m_u].idata.job2span.contains (jobid))) {
             goto done;
         }
         result = true;
     } else if (p == "jobid-tag") {
-        jobid = std::stoul (lcx);
-        if (!(*m_g)[m_u].idata.tags.contains (jobid)) {
+        if ((flux_job_id_parse (lcx.c_str (), &jobid) != 0
+             || !(*m_g)[m_u].idata.tags.contains (jobid))) {
             goto done;
         }
         result = true;

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -965,13 +965,28 @@ static int grow_resource_db (std::shared_ptr<resource_ctx_t> &ctx, json_t *resou
     struct idset *grow_set = NULL;
     json_t *r_lite = NULL;
     json_t *jgf = NULL;
+    const char *writer_uri = NULL;
+    bool jgf_shorthand = false;
     auto guard = resource_type_t::storage_t::open_for_scope ();
 
     if ((rc = unpack_resources (resources, &grow_set, &r_lite, &jgf, duration)) < 0) {
         flux_log_error (ctx->h, "%s: unpack_resources", __FUNCTION__);
         goto done;
     }
-    if (jgf && ctx->opts.get_opt ().get_load_format () != "rv1exec_force") {
+    if (jgf) {
+        json_unpack (jgf, "{s?s}", "writer", &writer_uri);
+    }
+    // only complete JGF is useful here; for shorthand JGF we have to fall
+    // back to rv1exec. Assume JGF is complete by default
+    if (writer_uri) {
+        if (std::string (writer_uri) == "fluxion:jgf_shorthand")
+            jgf_shorthand = true;
+        else {
+            flux_log (ctx->h, LOG_ERR, "%s: unrecognized reader URI %s", __FUNCTION__, writer_uri);
+            goto done;
+        }
+    }
+    if (jgf && ctx->opts.get_opt ().get_load_format () != "rv1exec_force" && !jgf_shorthand) {
         if (ctx->reader == nullptr && (rc = create_reader (ctx, "jgf")) < 0) {
             flux_log (ctx->h, LOG_ERR, "%s: can't create jgf reader", __FUNCTION__);
             goto done;

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -1369,7 +1369,28 @@ static int parse_R (std::shared_ptr<resource_ctx_t> &ctx,
         }
         R_graph_fmt = jgf_str;
         free (jgf_str);
-        format = "jgf";
+        const char *writer_uri = NULL;
+        if (json_unpack (graph, "{s?s}", "writer", &writer_uri) < 0) {
+            errno = EINVAL;
+            flux_log (ctx->h, LOG_ERR, "%s: json_unpack", __FUNCTION__);
+            rc = -1;
+            goto freemem_out;
+        }
+        if (writer_uri) {
+            if (std::string (writer_uri) == "fluxion:jgf_shorthand")
+                format = "jgf_shorthand";
+            else {
+                flux_log (ctx->h,
+                          LOG_ERR,
+                          "%s: unrecognized reader URI '%s'",
+                          __FUNCTION__,
+                          writer_uri);
+                rc = -1;
+                goto freemem_out;
+            }
+        } else {  // if URI not present, assume JGF
+            format = "jgf";
+        }
     } else {
         // Use the rv1exec reader
         R_graph_fmt = R;
@@ -1477,6 +1498,16 @@ static int run (std::shared_ptr<resource_ctx_t> &ctx,
             flux_log (ctx->h,
                       LOG_ERR,
                       "%s: create JGF reader (id=%jd)",
+                      __FUNCTION__,
+                      static_cast<intmax_t> (jobid));
+            goto out;
+        }
+    } else if (format == "jgf_shorthand") {
+        if ((rd = create_resource_reader ("jgf_shorthand")) == nullptr) {
+            rc = -1;
+            flux_log (ctx->h,
+                      LOG_ERR,
+                      "%s: create jgf_shorthand reader (id=%jd)",
                       __FUNCTION__,
                       static_cast<intmax_t> (jobid));
             goto out;

--- a/resource/readers/resource_reader_base.hpp
+++ b/resource/readers/resource_reader_base.hpp
@@ -30,6 +30,7 @@ struct modify_data_t {
     std::unordered_map<int64_t, vtx_t> rank_to_root;
     std::unordered_map<int64_t, std::unordered_map<resource_type_t, int64_t>> rank_to_counts;
     std::unordered_map<resource_type_t, int64_t> type_to_count;
+    uint64_t token = 0;
 };
 
 /*!  Base resource reader class.

--- a/resource/readers/resource_reader_base.hpp
+++ b/resource/readers/resource_reader_base.hpp
@@ -30,7 +30,7 @@ struct modify_data_t {
     std::unordered_map<int64_t, vtx_t> rank_to_root;
     std::unordered_map<int64_t, std::unordered_map<resource_type_t, int64_t>> rank_to_counts;
     std::unordered_map<resource_type_t, int64_t> type_to_count;
-    uint64_t token = 0;
+    uint64_t sequence_number = 0;
 };
 
 /*!  Base resource reader class.
@@ -77,8 +77,8 @@ class resource_reader_base_t {
      * \param at     start time of this job
      * \param dur    duration of this job
      * \param rsv    true if this update is for a reservation.
-     * \param trav_token
-     *               token to be used by traverser
+     * \param sequence_number
+     *               traversal token (trav_token) to be used by traverser
      * \return       0 on success; non-zero integer on an error
      */
     virtual int update (resource_graph_t &g,
@@ -88,7 +88,7 @@ class resource_reader_base_t {
                         int64_t at,
                         uint64_t dur,
                         bool rsv,
-                        uint64_t trav_token) = 0;
+                        uint64_t sequence_number) = 0;
 
     /*! Partial cancellation of jobid based on R.
      *

--- a/resource/readers/resource_reader_grug.cpp
+++ b/resource/readers/resource_reader_grug.cpp
@@ -468,7 +468,7 @@ int resource_reader_grug_t::update (resource_graph_t &g,
                                     int64_t at,
                                     uint64_t dur,
                                     bool rsv,
-                                    uint64_t token)
+                                    uint64_t sequence_number)
 {
     errno = ENOTSUP;  // GRUG reader currently does not support update
     return -1;

--- a/resource/readers/resource_reader_grug.hpp
+++ b/resource/readers/resource_reader_grug.hpp
@@ -24,7 +24,7 @@ namespace resource_model {
  */
 class resource_reader_grug_t : public resource_reader_base_t {
    public:
-    virtual ~resource_reader_grug_t ();
+    virtual ~resource_reader_grug_t () override;
 
     /*! Unpack str into a resource graph.
      *
@@ -36,10 +36,10 @@ class resource_reader_grug_t : public resource_reader_base_t {
      *                   ENOMEM: out of memory
      *                   EINVAL: invalid input or operation
      */
-    virtual int unpack (resource_graph_t &g,
-                        resource_graph_metadata_t &m,
-                        const std::string &str,
-                        int rank = -1);
+    int unpack (resource_graph_t &g,
+                resource_graph_metadata_t &m,
+                const std::string &str,
+                int rank = -1) override;
 
     /*! Unpack str into a resource graph and graft
      *  the top-level vertices to vtx.
@@ -51,11 +51,11 @@ class resource_reader_grug_t : public resource_reader_base_t {
      * \param rank   assign this rank to all the newly created resource vertices
      * \return       -1 with errno=ENOTSUP (Not supported yet)
      */
-    virtual int unpack_at (resource_graph_t &g,
-                           resource_graph_metadata_t &m,
-                           vtx_t &vtx,
-                           const std::string &str,
-                           int rank = -1);
+    int unpack_at (resource_graph_t &g,
+                   resource_graph_metadata_t &m,
+                   vtx_t &vtx,
+                   const std::string &str,
+                   int rank = -1) override;
 
     /*! Update resource graph g with str.
      *
@@ -70,14 +70,14 @@ class resource_reader_grug_t : public resource_reader_base_t {
      *               traversal token (trav_token) to be used by traverser
      * \return       0 on success; non-zero integer on an error
      */
-    virtual int update (resource_graph_t &g,
-                        resource_graph_metadata_t &m,
-                        const std::string &str,
-                        int64_t jobid,
-                        int64_t at,
-                        uint64_t dur,
-                        bool rsv,
-                        uint64_t sequence_number);
+    int update (resource_graph_t &g,
+                resource_graph_metadata_t &m,
+                const std::string &str,
+                int64_t jobid,
+                int64_t at,
+                uint64_t dur,
+                bool rsv,
+                uint64_t sequence_number) override;
 
     /*! Partial cancellation of jobid based on R.
      *
@@ -89,17 +89,17 @@ class resource_reader_grug_t : public resource_reader_base_t {
      * \param jobid  jobid of str
      * \return       0 on success; non-zero integer on an error
      */
-    virtual int partial_cancel (resource_graph_t &g,
-                                resource_graph_metadata_t &m,
-                                modify_data_t &mod_data,
-                                const std::string &R,
-                                int64_t jobid);
+    int partial_cancel (resource_graph_t &g,
+                        resource_graph_metadata_t &m,
+                        modify_data_t &mod_data,
+                        const std::string &R,
+                        int64_t jobid) override;
 
     /*! Is the selected reader format support allowlist
      *
      * \return       false
      */
-    virtual bool is_allowlist_supported ();
+    bool is_allowlist_supported () override;
 
    private:
     resource_gen_spec_t m_gspec;

--- a/resource/readers/resource_reader_grug.hpp
+++ b/resource/readers/resource_reader_grug.hpp
@@ -67,7 +67,7 @@ class resource_reader_grug_t : public resource_reader_base_t {
      * \param dur    duration of this job
      * \param rsv    true if this update is for a reservation.
      * \param sequence_number
-     *               traversal token (trav_token) to be used by traverser
+     *               traversal token to be used by traverser
      * \return       0 on success; non-zero integer on an error
      */
     int update (resource_graph_t &g,

--- a/resource/readers/resource_reader_grug.hpp
+++ b/resource/readers/resource_reader_grug.hpp
@@ -66,8 +66,8 @@ class resource_reader_grug_t : public resource_reader_base_t {
      * \param at     start time of this job
      * \param dur    duration of this job
      * \param rsv    true if this update is for a reservation.
-     * \param trav_token
-     *               token to be used by traverser
+     * \param sequence_number
+     *               traversal token (trav_token) to be used by traverser
      * \return       0 on success; non-zero integer on an error
      */
     virtual int update (resource_graph_t &g,
@@ -77,7 +77,7 @@ class resource_reader_grug_t : public resource_reader_base_t {
                         int64_t at,
                         uint64_t dur,
                         bool rsv,
-                        uint64_t trav_token);
+                        uint64_t sequence_number);
 
     /*! Partial cancellation of jobid based on R.
      *

--- a/resource/readers/resource_reader_hwloc.cpp
+++ b/resource/readers/resource_reader_hwloc.cpp
@@ -511,7 +511,7 @@ int resource_reader_hwloc_t::update (resource_graph_t &g,
                                      int64_t at,
                                      uint64_t dur,
                                      bool rsv,
-                                     uint64_t token)
+                                     uint64_t sequence_number)
 {
     errno = ENOTSUP;  // GRUG reader currently does not support update
     return -1;

--- a/resource/readers/resource_reader_hwloc.hpp
+++ b/resource/readers/resource_reader_hwloc.hpp
@@ -36,10 +36,10 @@ class resource_reader_hwloc_t : public resource_reader_base_t {
      *                   EINVAL: invalid input or operation (e.g. malformed str,
      *                               hwloc version or operation error)
      */
-    virtual int unpack (resource_graph_t &g,
-                        resource_graph_metadata_t &m,
-                        const std::string &str,
-                        int rank = -1);
+    int unpack (resource_graph_t &g,
+                resource_graph_metadata_t &m,
+                const std::string &str,
+                int rank = -1) override;
 
     /*! Unpack str into a resource graph and graft
      *  the top-level vertices to vtx.
@@ -54,11 +54,11 @@ class resource_reader_hwloc_t : public resource_reader_base_t {
      *                   EINVAL: invalid input or operation (e.g. malformed str,
      *                               hwloc version or operation error)
      */
-    virtual int unpack_at (resource_graph_t &g,
-                           resource_graph_metadata_t &m,
-                           vtx_t &vtx,
-                           const std::string &str,
-                           int rank = -1);
+    int unpack_at (resource_graph_t &g,
+                   resource_graph_metadata_t &m,
+                   vtx_t &vtx,
+                   const std::string &str,
+                   int rank = -1) override;
 
     /*! Update resource graph g with str.
      *
@@ -73,14 +73,14 @@ class resource_reader_hwloc_t : public resource_reader_base_t {
      *               traversal token (trav_token) to be used by traverser
      * \return       0 on success; non-zero integer on an error
      */
-    virtual int update (resource_graph_t &g,
-                        resource_graph_metadata_t &m,
-                        const std::string &str,
-                        int64_t jobid,
-                        int64_t at,
-                        uint64_t dur,
-                        bool rsv,
-                        uint64_t sequence_number);
+    int update (resource_graph_t &g,
+                resource_graph_metadata_t &m,
+                const std::string &str,
+                int64_t jobid,
+                int64_t at,
+                uint64_t dur,
+                bool rsv,
+                uint64_t sequence_number) override;
 
     /*! Partial cancellation of jobid based on R.
      *
@@ -92,17 +92,17 @@ class resource_reader_hwloc_t : public resource_reader_base_t {
      * \param jobid  jobid of str
      * \return       0 on success; non-zero integer on an error
      */
-    virtual int partial_cancel (resource_graph_t &g,
-                                resource_graph_metadata_t &m,
-                                modify_data_t &mod_data,
-                                const std::string &R,
-                                int64_t jobid);
+    int partial_cancel (resource_graph_t &g,
+                        resource_graph_metadata_t &m,
+                        modify_data_t &mod_data,
+                        const std::string &R,
+                        int64_t jobid) override;
 
     /*! Is the hwloc reader format support allowlist
      *
      * \return       true
      */
-    virtual bool is_allowlist_supported ();
+    bool is_allowlist_supported () override;
 
    private:
     int check_hwloc_version (std::string &m_err_msg);

--- a/resource/readers/resource_reader_hwloc.hpp
+++ b/resource/readers/resource_reader_hwloc.hpp
@@ -69,8 +69,8 @@ class resource_reader_hwloc_t : public resource_reader_base_t {
      * \param at     start time of this job
      * \param dur    duration of this job
      * \param rsv    true if this update is for a reservation.
-     * \param trav_token
-     *               token to be used by traverser
+     * \param sequence_number
+     *               traversal token (trav_token) to be used by traverser
      * \return       0 on success; non-zero integer on an error
      */
     virtual int update (resource_graph_t &g,
@@ -80,7 +80,7 @@ class resource_reader_hwloc_t : public resource_reader_base_t {
                         int64_t at,
                         uint64_t dur,
                         bool rsv,
-                        uint64_t trav_token);
+                        uint64_t sequence_number);
 
     /*! Partial cancellation of jobid based on R.
      *

--- a/resource/readers/resource_reader_hwloc.hpp
+++ b/resource/readers/resource_reader_hwloc.hpp
@@ -70,7 +70,7 @@ class resource_reader_hwloc_t : public resource_reader_base_t {
      * \param dur    duration of this job
      * \param rsv    true if this update is for a reservation.
      * \param sequence_number
-     *               traversal token (trav_token) to be used by traverser
+     *               traversal token to be used by traverser
      * \return       0 on success; non-zero integer on an error
      */
     int update (resource_graph_t &g,

--- a/resource/readers/resource_reader_jgf.cpp
+++ b/resource/readers/resource_reader_jgf.cpp
@@ -1165,7 +1165,8 @@ int resource_reader_jgf_t::update_tgt_edge (resource_graph_t &g,
     if (!found) {
         errno = EINVAL;
         m_err_msg += __FUNCTION__;
-        m_err_msg += ": JGF edge not found in resource graph.\n";
+        m_err_msg += ": JGF edge from " + source + " to ";
+        m_err_msg += target + " not found in resource graph.\n";
         goto done;
     }
     g[e].idata.set_for_trav_update (vmap[target].needs, vmap[target].exclusive, token);

--- a/resource/readers/resource_reader_jgf.cpp
+++ b/resource/readers/resource_reader_jgf.cpp
@@ -978,7 +978,12 @@ int resource_reader_jgf_t::update_vertices (resource_graph_t &g,
                 goto done;
             }
         }
-        if (fetch_additional_edges (g, m, vmap, fetcher, additional_vertices, update_data.token)
+        if (fetch_additional_edges (g,
+                                    m,
+                                    vmap,
+                                    fetcher,
+                                    additional_vertices,
+                                    update_data.sequence_number)
             < 0) {
             goto done;
         }
@@ -1003,7 +1008,7 @@ int resource_reader_jgf_t::fetch_additional_edges (resource_graph_t &g,
                                                    std::map<std::string, vmap_val_t> &vmap,
                                                    fetch_helper_t &root,
                                                    std::vector<fetch_helper_t> &additional_vertices,
-                                                   uint64_t token)
+                                                   uint64_t sequence_number)
 {
     return 0;
 }
@@ -1126,7 +1131,7 @@ int resource_reader_jgf_t::update_src_edge (resource_graph_t &g,
                                             resource_graph_metadata_t &m,
                                             std::map<std::string, vmap_val_t> &vmap,
                                             std::string &source,
-                                            uint64_t token)
+                                            uint64_t sequence_number)
 {
     if (vmap[source].is_roots.empty ())
         return 0;
@@ -1134,7 +1139,7 @@ int resource_reader_jgf_t::update_src_edge (resource_graph_t &g,
     for (const auto &kv : vmap[source].is_roots)
         m.v_rt_edges[kv.first].set_for_trav_update (vmap[source].needs,
                                                     vmap[source].exclusive,
-                                                    token);
+                                                    sequence_number);
 
     // This way, when a root vertex appears in multiple JGF edges
     // we only update the virtual in-edge into the root only once.
@@ -1147,7 +1152,7 @@ int resource_reader_jgf_t::update_tgt_edge (resource_graph_t &g,
                                             std::map<std::string, vmap_val_t> &vmap,
                                             std::string &source,
                                             std::string &target,
-                                            uint64_t token)
+                                            uint64_t sequence_number)
 {
     edg_t e;
     int rc = -1;
@@ -1169,7 +1174,7 @@ int resource_reader_jgf_t::update_tgt_edge (resource_graph_t &g,
         m_err_msg += target + " not found in resource graph.\n";
         goto done;
     }
-    g[e].idata.set_for_trav_update (vmap[target].needs, vmap[target].exclusive, token);
+    g[e].idata.set_for_trav_update (vmap[target].needs, vmap[target].exclusive, sequence_number);
     rc = 0;
 
 done:
@@ -1180,7 +1185,7 @@ int resource_reader_jgf_t::update_edges (resource_graph_t &g,
                                          resource_graph_metadata_t &m,
                                          std::map<std::string, vmap_val_t> &vmap,
                                          json_t *edges,
-                                         uint64_t token,
+                                         uint64_t sequence_number,
                                          jgf_updater_data &update_data)
 {
     edg_t e;
@@ -1201,9 +1206,9 @@ int resource_reader_jgf_t::update_edges (resource_graph_t &g,
             update_data.skipped = false;
             continue;
         }
-        if ((rc = update_src_edge (g, m, vmap, source, token)) != 0)
+        if ((rc = update_src_edge (g, m, vmap, source, sequence_number)) != 0)
             goto done;
-        if ((rc = update_tgt_edge (g, m, vmap, source, target, token)) != 0)
+        if ((rc = update_tgt_edge (g, m, vmap, source, target, sequence_number)) != 0)
             goto done;
     }
 
@@ -1275,7 +1280,7 @@ int resource_reader_jgf_t::update (resource_graph_t &g,
                                    int64_t at,
                                    uint64_t dur,
                                    bool rsv,
-                                   uint64_t token)
+                                   uint64_t sequence_number)
 {
     int rc = -1;
     json_t *jgf = NULL;
@@ -1298,7 +1303,7 @@ int resource_reader_jgf_t::update (resource_graph_t &g,
     update_data.duration = dur;
     update_data.reserved = rsv;
     update_data.update = true;
-    update_data.token = token;
+    update_data.sequence_number = sequence_number;
 
     if ((rc = fetch_jgf (str, &jgf, &nodes, &edges, update_data)) != 0)
         goto done;
@@ -1306,7 +1311,7 @@ int resource_reader_jgf_t::update (resource_graph_t &g,
         undo_vertices (g, vmap, update_data);
         goto done;
     }
-    if ((rc = update_edges (g, m, vmap, edges, token, update_data)) != 0)
+    if ((rc = update_edges (g, m, vmap, edges, sequence_number, update_data)) != 0)
         goto done;
 
 done:
@@ -1337,7 +1342,7 @@ int resource_reader_jgf_t::partial_cancel (resource_graph_t &g,
     // Fill in updater data
     p_cancel_data.jobid = jobid;
     p_cancel_data.update = false;
-    p_cancel_data.token = mod_data.token;
+    p_cancel_data.sequence_number = mod_data.sequence_number;
     if ((rc = fetch_jgf (R, &jgf, &nodes, &edges, p_cancel_data)) != 0)
         goto done;
 

--- a/resource/readers/resource_reader_jgf.cpp
+++ b/resource/readers/resource_reader_jgf.cpp
@@ -112,13 +112,6 @@ void fetch_helper_t::scrub ()
     clear ();
 }
 
-struct vmap_val_t {
-    vtx_t v;
-    std::map<subsystem_t, bool> is_roots;
-    unsigned int needs;
-    unsigned int exclusive;
-};
-
 bool operator== (const resource_pool_t &r, const fetch_helper_t &f)
 {
     return (r.type.get () == f.type && r.basename == f.basename
@@ -968,7 +961,6 @@ int resource_reader_jgf_t::update_vertices (resource_graph_t &g,
     unsigned int i = 0;
     fetch_helper_t fetcher;
     std::vector<fetch_helper_t> additional_vertices;
-    std::map<std::string, vmap_val_t> empty_vmap{};
 
     for (i = 0; i < json_array_size (nodes); i++) {
         fetcher.scrub ();
@@ -977,7 +969,7 @@ int resource_reader_jgf_t::update_vertices (resource_graph_t &g,
             goto done;
         if ((rc = update_vtx (g, m, vmap, fetcher, update_data)) != 0)
             goto done;
-        if (fetch_additional_vertices (g, m, empty_vmap, fetcher, additional_vertices) != 0)
+        if (fetch_additional_vertices (g, m, fetcher, additional_vertices) != 0)
             goto done;
         for (auto &additional_fetcher : additional_vertices) {
             std::string vertex_id = std::to_string (additional_fetcher.uniq_id);
@@ -996,7 +988,6 @@ done:
 int resource_reader_jgf_t::fetch_additional_vertices (
     resource_graph_t &g,
     resource_graph_metadata_t &m,
-    std::map<std::string, vmap_val_t> &vmap,
     fetch_helper_t &fetcher,
     std::vector<fetch_helper_t> &additional_vertices)
 {

--- a/resource/readers/resource_reader_jgf.cpp
+++ b/resource/readers/resource_reader_jgf.cpp
@@ -978,6 +978,10 @@ int resource_reader_jgf_t::update_vertices (resource_graph_t &g,
                 goto done;
             }
         }
+        if (fetch_additional_edges (g, m, vmap, fetcher, additional_vertices, update_data.token)
+            < 0) {
+            goto done;
+        }
     }
     rc = 0;
 
@@ -990,6 +994,16 @@ int resource_reader_jgf_t::fetch_additional_vertices (
     resource_graph_metadata_t &m,
     fetch_helper_t &fetcher,
     std::vector<fetch_helper_t> &additional_vertices)
+{
+    return 0;
+}
+
+int resource_reader_jgf_t::fetch_additional_edges (resource_graph_t &g,
+                                                   resource_graph_metadata_t &m,
+                                                   std::map<std::string, vmap_val_t> &vmap,
+                                                   fetch_helper_t &root,
+                                                   std::vector<fetch_helper_t> &additional_vertices,
+                                                   uint64_t token)
 {
     return 0;
 }
@@ -1283,6 +1297,7 @@ int resource_reader_jgf_t::update (resource_graph_t &g,
     update_data.duration = dur;
     update_data.reserved = rsv;
     update_data.update = true;
+    update_data.token = token;
 
     if ((rc = fetch_jgf (str, &jgf, &nodes, &edges, update_data)) != 0)
         goto done;
@@ -1321,8 +1336,10 @@ int resource_reader_jgf_t::partial_cancel (resource_graph_t &g,
     // Fill in updater data
     p_cancel_data.jobid = jobid;
     p_cancel_data.update = false;
+    p_cancel_data.token = 0;
     if ((rc = fetch_jgf (R, &jgf, &nodes, &edges, p_cancel_data)) != 0)
         goto done;
+
     if ((rc = update_vertices (g, m, vmap, nodes, p_cancel_data)) != 0)
         goto done;
 

--- a/resource/readers/resource_reader_jgf.cpp
+++ b/resource/readers/resource_reader_jgf.cpp
@@ -979,10 +979,10 @@ int resource_reader_jgf_t::update_vertices (resource_graph_t &g,
             goto done;
         if (fetch_additional_vertices (g, m, empty_vmap, fetcher, additional_vertices) != 0)
             goto done;
-        for (auto &fetcher : additional_vertices) {
-            std::string vertex_id = std::to_string (fetcher.uniq_id);
-            fetcher.vertex_id = vertex_id.c_str ();
-            if ((rc = update_vtx (g, m, vmap, fetcher, update_data)) != 0) {
+        for (auto &additional_fetcher : additional_vertices) {
+            std::string vertex_id = std::to_string (additional_fetcher.uniq_id);
+            additional_fetcher.vertex_id = vertex_id.c_str ();
+            if ((rc = update_vtx (g, m, vmap, additional_fetcher, update_data)) != 0) {
                 goto done;
             }
         }

--- a/resource/readers/resource_reader_jgf.cpp
+++ b/resource/readers/resource_reader_jgf.cpp
@@ -1337,7 +1337,7 @@ int resource_reader_jgf_t::partial_cancel (resource_graph_t &g,
     // Fill in updater data
     p_cancel_data.jobid = jobid;
     p_cancel_data.update = false;
-    p_cancel_data.token = 0;
+    p_cancel_data.token = mod_data.token;
     if ((rc = fetch_jgf (R, &jgf, &nodes, &edges, p_cancel_data)) != 0)
         goto done;
 

--- a/resource/readers/resource_reader_jgf.hpp
+++ b/resource/readers/resource_reader_jgf.hpp
@@ -111,10 +111,10 @@ class resource_reader_jgf_t : public resource_reader_base_t {
      *                   ENOMEM: out of memory
      *                   EINVAL: invalid input or operation
      */
-    virtual int unpack (resource_graph_t &g,
-                        resource_graph_metadata_t &m,
-                        const std::string &str,
-                        int rank = -1);
+    int unpack (resource_graph_t &g,
+                resource_graph_metadata_t &m,
+                const std::string &str,
+                int rank = -1) override;
 
     /*! Unpack str into a resource graph and graft
      *  the top-level vertices to vtx.
@@ -126,11 +126,11 @@ class resource_reader_jgf_t : public resource_reader_base_t {
      * \param rank   assign this rank to all the newly created resource vertices
      * \return       -1 with errno=ENOTSUP (Not supported yet)
      */
-    virtual int unpack_at (resource_graph_t &g,
-                           resource_graph_metadata_t &m,
-                           vtx_t &vtx,
-                           const std::string &str,
-                           int rank = -1);
+    int unpack_at (resource_graph_t &g,
+                   resource_graph_metadata_t &m,
+                   vtx_t &vtx,
+                   const std::string &str,
+                   int rank = -1) override;
 
     /*! Update resource graph g with str.
      *
@@ -145,14 +145,14 @@ class resource_reader_jgf_t : public resource_reader_base_t {
      *               traversal token (trav_token) to be used by traverser
      * \return       0 on success; non-zero integer on an error
      */
-    virtual int update (resource_graph_t &g,
-                        resource_graph_metadata_t &m,
-                        const std::string &str,
-                        int64_t jobid,
-                        int64_t at,
-                        uint64_t dur,
-                        bool rsv,
-                        uint64_t sequence_number);
+    int update (resource_graph_t &g,
+                resource_graph_metadata_t &m,
+                const std::string &str,
+                int64_t jobid,
+                int64_t at,
+                uint64_t dur,
+                bool rsv,
+                uint64_t sequence_number) override;
 
     /*! Partial cancellation of jobid based on R.
      *
@@ -164,17 +164,17 @@ class resource_reader_jgf_t : public resource_reader_base_t {
      * \param jobid  jobid of str
      * \return       0 on success; non-zero integer on an error
      */
-    virtual int partial_cancel (resource_graph_t &g,
-                                resource_graph_metadata_t &m,
-                                modify_data_t &mod_data,
-                                const std::string &R,
-                                int64_t jobid);
+    int partial_cancel (resource_graph_t &g,
+                        resource_graph_metadata_t &m,
+                        modify_data_t &mod_data,
+                        const std::string &R,
+                        int64_t jobid) override;
 
     /*! Is the selected reader format support allowlist
      *
      * \return       false
      */
-    virtual bool is_allowlist_supported ();
+    bool is_allowlist_supported () override;
 
    protected:
     int apply_defaults (fetch_helper_t &f, const char *name);

--- a/resource/readers/resource_reader_jgf.hpp
+++ b/resource/readers/resource_reader_jgf.hpp
@@ -85,7 +85,7 @@ struct jgf_updater_data {
     bool update = true;        // Updating or partial cancel
     bool isect_ranks = false;  // Updating with partial_ok; intersecting with ranks key
     bool skipped = false;
-    uint64_t token = 0;
+    uint64_t sequence_number = 0;
 };
 
 struct vmap_val_t {
@@ -141,8 +141,8 @@ class resource_reader_jgf_t : public resource_reader_base_t {
      * \param at     start time of this job
      * \param dur    duration of this job
      * \param rsv    true if this update is for a reservation.
-     * \param trav_token
-     *               token to be used by traverser
+     * \param sequence_number
+     *               traversal token (trav_token) to be used by traverser
      * \return       0 on success; non-zero integer on an error
      */
     virtual int update (resource_graph_t &g,
@@ -152,7 +152,7 @@ class resource_reader_jgf_t : public resource_reader_base_t {
                         int64_t at,
                         uint64_t dur,
                         bool rsv,
-                        uint64_t trav_token);
+                        uint64_t sequence_number);
 
     /*! Partial cancellation of jobid based on R.
      *
@@ -187,13 +187,13 @@ class resource_reader_jgf_t : public resource_reader_base_t {
                          resource_graph_metadata_t &m,
                          std::map<std::string, vmap_val_t> &vmap,
                          std::string &source,
-                         uint64_t token);
+                         uint64_t sequence_number);
     int update_tgt_edge (resource_graph_t &g,
                          resource_graph_metadata_t &m,
                          std::map<std::string, vmap_val_t> &vmap,
                          std::string &source,
                          std::string &target,
-                         uint64_t token);
+                         uint64_t sequence_number);
 
    private:
     int fetch_jgf (const std::string &str,
@@ -268,7 +268,7 @@ class resource_reader_jgf_t : public resource_reader_base_t {
                                         std::map<std::string, vmap_val_t> &vmap,
                                         fetch_helper_t &root,
                                         std::vector<fetch_helper_t> &additional_vertices,
-                                        uint64_t token);
+                                        uint64_t sequence_number);
     int unpack_edge (json_t *element,
                      std::map<std::string, vmap_val_t> &vmap,
                      std::string &source,
@@ -284,7 +284,7 @@ class resource_reader_jgf_t : public resource_reader_base_t {
                       resource_graph_metadata_t &m,
                       std::map<std::string, vmap_val_t> &vmap,
                       json_t *edges,
-                      uint64_t token,
+                      uint64_t sequence_number,
                       jgf_updater_data &update_data);
     int get_subgraph_vertices (resource_graph_t &g, vtx_t node, std::vector<vtx_t> &node_list);
     int get_parent_vtx (resource_graph_t &g, vtx_t node, vtx_t &parent_node);

--- a/resource/readers/resource_reader_jgf.hpp
+++ b/resource/readers/resource_reader_jgf.hpp
@@ -183,6 +183,17 @@ class resource_reader_jgf_t : public resource_reader_base_t {
                   std::map<std::string, vmap_val_t> &vmap,
                   const fetch_helper_t &fetcher,
                   vtx_t &ret_v);
+    int update_src_edge (resource_graph_t &g,
+                         resource_graph_metadata_t &m,
+                         std::map<std::string, vmap_val_t> &vmap,
+                         std::string &source,
+                         uint64_t token);
+    int update_tgt_edge (resource_graph_t &g,
+                         resource_graph_metadata_t &m,
+                         std::map<std::string, vmap_val_t> &vmap,
+                         std::string &source,
+                         std::string &target,
+                         uint64_t token);
 
    private:
     int fetch_jgf (const std::string &str,
@@ -264,17 +275,6 @@ class resource_reader_jgf_t : public resource_reader_base_t {
                      std::string &target,
                      std::string &subsystem,
                      jgf_updater_data &update_data);
-    int update_src_edge (resource_graph_t &g,
-                         resource_graph_metadata_t &m,
-                         std::map<std::string, vmap_val_t> &vmap,
-                         std::string &source,
-                         uint64_t token);
-    int update_tgt_edge (resource_graph_t &g,
-                         resource_graph_metadata_t &m,
-                         std::map<std::string, vmap_val_t> &vmap,
-                         std::string &source,
-                         std::string &target,
-                         uint64_t token);
     int unpack_edges (resource_graph_t &g,
                       resource_graph_metadata_t &m,
                       std::map<std::string, vmap_val_t> &vmap,

--- a/resource/readers/resource_reader_jgf.hpp
+++ b/resource/readers/resource_reader_jgf.hpp
@@ -142,7 +142,7 @@ class resource_reader_jgf_t : public resource_reader_base_t {
      * \param dur    duration of this job
      * \param rsv    true if this update is for a reservation.
      * \param sequence_number
-     *               traversal token (trav_token) to be used by traverser
+     *               traversal token to be used by traverser
      * \return       0 on success; non-zero integer on an error
      */
     int update (resource_graph_t &g,

--- a/resource/readers/resource_reader_jgf.hpp
+++ b/resource/readers/resource_reader_jgf.hpp
@@ -17,8 +17,6 @@
 #include "resource/schema/resource_graph.hpp"
 #include "resource/readers/resource_reader_base.hpp"
 
-struct vmap_val_t;
-
 namespace Flux {
 namespace resource_model {
 
@@ -87,6 +85,13 @@ struct jgf_updater_data {
     bool update = true;        // Updating or partial cancel
     bool isect_ranks = false;  // Updating with partial_ok; intersecting with ranks key
     bool skipped = false;
+};
+
+struct vmap_val_t {
+    vtx_t v;
+    std::map<subsystem_t, bool> is_roots;
+    unsigned int needs;
+    unsigned int exclusive;
 };
 
 /*! JGF resource reader class.
@@ -244,7 +249,6 @@ class resource_reader_jgf_t : public resource_reader_base_t {
                          jgf_updater_data &updater_data);
     virtual int fetch_additional_vertices (resource_graph_t &g,
                                            resource_graph_metadata_t &m,
-                                           std::map<std::string, vmap_val_t> &vmap,
                                            fetch_helper_t &fetcher,
                                            std::vector<fetch_helper_t> &additional_vertices);
     int unpack_edge (json_t *element,

--- a/resource/readers/resource_reader_jgf.hpp
+++ b/resource/readers/resource_reader_jgf.hpp
@@ -85,6 +85,7 @@ struct jgf_updater_data {
     bool update = true;        // Updating or partial cancel
     bool isect_ranks = false;  // Updating with partial_ok; intersecting with ranks key
     bool skipped = false;
+    uint64_t token = 0;
 };
 
 struct vmap_val_t {
@@ -251,6 +252,12 @@ class resource_reader_jgf_t : public resource_reader_base_t {
                                            resource_graph_metadata_t &m,
                                            fetch_helper_t &fetcher,
                                            std::vector<fetch_helper_t> &additional_vertices);
+    virtual int fetch_additional_edges (resource_graph_t &g,
+                                        resource_graph_metadata_t &m,
+                                        std::map<std::string, vmap_val_t> &vmap,
+                                        fetch_helper_t &root,
+                                        std::vector<fetch_helper_t> &additional_vertices,
+                                        uint64_t token);
     int unpack_edge (json_t *element,
                      std::map<std::string, vmap_val_t> &vmap,
                      std::string &source,

--- a/resource/readers/resource_reader_jgf_shorthand.cpp
+++ b/resource/readers/resource_reader_jgf_shorthand.cpp
@@ -73,3 +73,14 @@ int resource_reader_jgf_shorthand_t::recursively_collect_vertices (
     }
     return 0;
 }
+
+int resource_reader_jgf_shorthand_t::fetch_additional_edges (
+    resource_graph_t &g,
+    resource_graph_metadata_t &m,
+    std::map<std::string, vmap_val_t> &vmap,
+    fetch_helper_t &root,
+    std::vector<fetch_helper_t> &additional_vertices,
+    uint64_t token)
+{
+    return 0;
+}

--- a/resource/readers/resource_reader_jgf_shorthand.cpp
+++ b/resource/readers/resource_reader_jgf_shorthand.cpp
@@ -82,5 +82,42 @@ int resource_reader_jgf_shorthand_t::fetch_additional_edges (
     std::vector<fetch_helper_t> &additional_vertices,
     uint64_t token)
 {
+    if (additional_vertices.size () > 0 && update_additional_edges (g, m, vmap, root, token) < 0) {
+        return -1;
+    }
+    // iterate through again to add edges
+    for (auto &fetcher : additional_vertices) {
+        if (update_additional_edges (g, m, vmap, fetcher, token) < 0) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+int resource_reader_jgf_shorthand_t::update_additional_edges (
+    resource_graph_t &g,
+    resource_graph_metadata_t &m,
+    std::map<std::string, vmap_val_t> &vmap,
+    fetch_helper_t &fetcher,
+    uint64_t token)
+{
+    vtx_t v;
+    std::map<std::string, vmap_val_t> empty_vmap{};  // so `find_vtx` doesn't error out
+    std::string vertex_id = std::to_string (fetcher.uniq_id);
+    fetcher.vertex_id = vertex_id.c_str ();
+    if (resource_reader_jgf_t::find_vtx (g, m, empty_vmap, fetcher, v) != 0
+        || v == boost::graph_traits<resource_graph_t>::null_vertex ())
+        return -1;
+    fetcher.vertex_id = nullptr;
+    f_out_edg_iterator_t ei, ei_end;
+    for (boost::tie (ei, ei_end) = boost::out_edges (v, g); ei != ei_end; ++ei) {
+        if (g[*ei].subsystem != containment_sub)
+            continue;
+        std::string target_str = std::to_string (boost::target (*ei, g));
+        if (update_src_edge (g, m, vmap, vertex_id, token) < 0
+            || update_tgt_edge (g, m, vmap, vertex_id, target_str, token) < 0) {
+            return -1;
+        }
+    }
     return 0;
 }

--- a/resource/readers/resource_reader_jgf_shorthand.cpp
+++ b/resource/readers/resource_reader_jgf_shorthand.cpp
@@ -62,6 +62,7 @@ int resource_reader_jgf_shorthand_t::recursively_collect_vertices (
         vertex_copy.properties = g[target].properties;
         vertex_copy.paths = g[target].paths;
         vertex_copy.unit = g[target].unit.c_str ();
+        vertex_copy.exclusive = 1;  // must be exclusive as part of exclusive sub-tree
         if (resource_reader_jgf_t::apply_defaults (vertex_copy, g[target].name.c_str ()) < 0)
             return -1;
 

--- a/resource/readers/resource_reader_jgf_shorthand.cpp
+++ b/resource/readers/resource_reader_jgf_shorthand.cpp
@@ -17,16 +17,16 @@ resource_reader_jgf_shorthand_t::~resource_reader_jgf_shorthand_t ()
 int resource_reader_jgf_shorthand_t::fetch_additional_vertices (
     resource_graph_t &g,
     resource_graph_metadata_t &m,
-    std::map<std::string, vmap_val_t> &vmap,
     fetch_helper_t &fetcher,
     std::vector<fetch_helper_t> &additional_vertices)
 {
     int rc = -1;
+    std::map<std::string, vmap_val_t> empty_vmap{};  // so `find_vtx` doesn't error out
     vtx_t v = boost::graph_traits<resource_graph_t>::null_vertex ();
     if (!fetcher.exclusive)  // vertex isn't exclusive, nothing to do
         return 0;
 
-    if ((rc = resource_reader_jgf_t::find_vtx (g, m, vmap, fetcher, v)) != 0)
+    if ((rc = resource_reader_jgf_t::find_vtx (g, m, empty_vmap, fetcher, v)) != 0)
         return rc;
 
     return recursively_collect_vertices (g, v, additional_vertices);

--- a/resource/readers/resource_reader_jgf_shorthand.cpp
+++ b/resource/readers/resource_reader_jgf_shorthand.cpp
@@ -80,14 +80,15 @@ int resource_reader_jgf_shorthand_t::fetch_additional_edges (
     std::map<std::string, vmap_val_t> &vmap,
     fetch_helper_t &root,
     std::vector<fetch_helper_t> &additional_vertices,
-    uint64_t token)
+    uint64_t sequence_number)
 {
-    if (additional_vertices.size () > 0 && update_additional_edges (g, m, vmap, root, token) < 0) {
+    if (additional_vertices.size () > 0
+        && update_additional_edges (g, m, vmap, root, sequence_number) < 0) {
         return -1;
     }
     // iterate through again to add edges
     for (auto &fetcher : additional_vertices) {
-        if (update_additional_edges (g, m, vmap, fetcher, token) < 0) {
+        if (update_additional_edges (g, m, vmap, fetcher, sequence_number) < 0) {
             return -1;
         }
     }
@@ -99,7 +100,7 @@ int resource_reader_jgf_shorthand_t::update_additional_edges (
     resource_graph_metadata_t &m,
     std::map<std::string, vmap_val_t> &vmap,
     fetch_helper_t &fetcher,
-    uint64_t token)
+    uint64_t sequence_number)
 {
     vtx_t v;
     std::map<std::string, vmap_val_t> empty_vmap{};  // so `find_vtx` doesn't error out
@@ -114,8 +115,8 @@ int resource_reader_jgf_shorthand_t::update_additional_edges (
         if (g[*ei].subsystem != containment_sub)
             continue;
         std::string target_str = std::to_string (boost::target (*ei, g));
-        if (update_src_edge (g, m, vmap, vertex_id, token) < 0
-            || update_tgt_edge (g, m, vmap, vertex_id, target_str, token) < 0) {
+        if (update_src_edge (g, m, vmap, vertex_id, sequence_number) < 0
+            || update_tgt_edge (g, m, vmap, vertex_id, target_str, sequence_number) < 0) {
             return -1;
         }
     }

--- a/resource/readers/resource_reader_jgf_shorthand.hpp
+++ b/resource/readers/resource_reader_jgf_shorthand.hpp
@@ -28,13 +28,13 @@ class resource_reader_jgf_shorthand_t : public resource_reader_jgf_t {
                                 std::map<std::string, vmap_val_t> &vmap,
                                 fetch_helper_t &root,
                                 std::vector<fetch_helper_t> &additional_vertices,
-                                uint64_t token) override;
+                                uint64_t sequence_number) override;
 
     int update_additional_edges (resource_graph_t &g,
                                  resource_graph_metadata_t &m,
                                  std::map<std::string, vmap_val_t> &vmap,
                                  fetch_helper_t &fetcher,
-                                 uint64_t token);
+                                 uint64_t sequence_number);
 
     int fetch_additional_vertices (resource_graph_t &g,
                                    resource_graph_metadata_t &m,

--- a/resource/readers/resource_reader_jgf_shorthand.hpp
+++ b/resource/readers/resource_reader_jgf_shorthand.hpp
@@ -25,7 +25,6 @@ class resource_reader_jgf_shorthand_t : public resource_reader_jgf_t {
    protected:
     int fetch_additional_vertices (resource_graph_t &g,
                                    resource_graph_metadata_t &m,
-                                   std::map<std::string, vmap_val_t> &vmap,
                                    fetch_helper_t &fetcher,
                                    std::vector<fetch_helper_t> &additional_vertices) override;
 

--- a/resource/readers/resource_reader_jgf_shorthand.hpp
+++ b/resource/readers/resource_reader_jgf_shorthand.hpp
@@ -30,6 +30,12 @@ class resource_reader_jgf_shorthand_t : public resource_reader_jgf_t {
                                 std::vector<fetch_helper_t> &additional_vertices,
                                 uint64_t token) override;
 
+    int update_additional_edges (resource_graph_t &g,
+                                 resource_graph_metadata_t &m,
+                                 std::map<std::string, vmap_val_t> &vmap,
+                                 fetch_helper_t &fetcher,
+                                 uint64_t token);
+
     int fetch_additional_vertices (resource_graph_t &g,
                                    resource_graph_metadata_t &m,
                                    fetch_helper_t &fetcher,

--- a/resource/readers/resource_reader_jgf_shorthand.hpp
+++ b/resource/readers/resource_reader_jgf_shorthand.hpp
@@ -23,6 +23,13 @@ class resource_reader_jgf_shorthand_t : public resource_reader_jgf_t {
     virtual ~resource_reader_jgf_shorthand_t ();
 
    protected:
+    int fetch_additional_edges (resource_graph_t &g,
+                                resource_graph_metadata_t &m,
+                                std::map<std::string, vmap_val_t> &vmap,
+                                fetch_helper_t &root,
+                                std::vector<fetch_helper_t> &additional_vertices,
+                                uint64_t token) override;
+
     int fetch_additional_vertices (resource_graph_t &g,
                                    resource_graph_metadata_t &m,
                                    fetch_helper_t &fetcher,

--- a/resource/readers/resource_reader_jgf_shorthand.hpp
+++ b/resource/readers/resource_reader_jgf_shorthand.hpp
@@ -22,7 +22,7 @@ class resource_reader_jgf_shorthand_t : public resource_reader_jgf_t {
    public:
     virtual ~resource_reader_jgf_shorthand_t ();
 
-   protected:
+   private:
     int fetch_additional_edges (resource_graph_t &g,
                                 resource_graph_metadata_t &m,
                                 std::map<std::string, vmap_val_t> &vmap,

--- a/resource/readers/resource_reader_rv1exec.cpp
+++ b/resource/readers/resource_reader_rv1exec.cpp
@@ -371,7 +371,7 @@ int resource_reader_rv1exec_t::update_edges (resource_graph_t &g,
         m_err_msg += ": rv1exec edge not found in resource graph.\n";
         goto error;
     }
-    g[e].idata.set_for_trav_update (g[dst].size, true, update_data.token);
+    g[e].idata.set_for_trav_update (g[dst].size, true, update_data.sequence_number);
 
     return 0;
 
@@ -852,7 +852,7 @@ int resource_reader_rv1exec_t::unpack_rlite (resource_graph_t &g,
     // Set the cluster "needs" and make the update shared access to the cluster
     m.v_rt_edges[containment_sub].set_for_trav_update (g[cluster_vtx].size,
                                                        false,
-                                                       update_data.token);
+                                                       update_data.sequence_number);
     json_array_foreach (rlite, index, entry) {
         if (unpack_rlite_entry (g, m, cluster_vtx, entry, hlist, rmap, pmap, update_data) < 0)
             goto error;
@@ -1037,7 +1037,7 @@ int resource_reader_rv1exec_t::update (resource_graph_t &g,
                                        int64_t at,
                                        uint64_t dur,
                                        bool rsv,
-                                       uint64_t token)
+                                       uint64_t sequence_number)
 {
     int rc = -1;
     json_error_t error;
@@ -1060,7 +1060,7 @@ int resource_reader_rv1exec_t::update (resource_graph_t &g,
     update_data.at = at;
     update_data.duration = dur;
     update_data.reserved = rsv;
-    update_data.token = token;
+    update_data.sequence_number = sequence_number;
 
     if ((rc = unpack_internal (g, m, rv1, update_data)) == -1) {
         undo_vertices (g, update_data);

--- a/resource/readers/resource_reader_rv1exec.hpp
+++ b/resource/readers/resource_reader_rv1exec.hpp
@@ -27,7 +27,7 @@ struct updater_data {
     int64_t at = 0;
     uint64_t duration = 0;
     bool reserved = false;
-    uint64_t token = 0;
+    uint64_t sequence_number = 0;
     // track updated vertices to undo upon error
     std::map<int64_t, std::vector<vtx_t>> updated_vertices;
     bool update = true;  // Updating or adding vertex
@@ -81,8 +81,8 @@ class resource_reader_rv1exec_t : public resource_reader_base_t {
      * \param at     start time of this job
      * \param dur    duration of this job
      * \param rsv    true if this update is for a reservation.
-     * \param trav_token
-     *               token to be used by traverser
+     * \param sequence_number
+     *               traversal token (trav_token) to be used by traverser
      * \return       -1 with ENOTSUP (Not supported yet)
      */
     virtual int update (resource_graph_t &g,
@@ -92,7 +92,7 @@ class resource_reader_rv1exec_t : public resource_reader_base_t {
                         int64_t at,
                         uint64_t dur,
                         bool rsv,
-                        uint64_t trav_token);
+                        uint64_t sequence_number);
 
     /*! Partial cancellation of jobid based on R.
      *

--- a/resource/readers/resource_reader_rv1exec.hpp
+++ b/resource/readers/resource_reader_rv1exec.hpp
@@ -51,10 +51,10 @@ class resource_reader_rv1exec_t : public resource_reader_base_t {
      *                   ENOMEM: out of memory
      *                   EINVAL: invalid input or operation
      */
-    virtual int unpack (resource_graph_t &g,
-                        resource_graph_metadata_t &m,
-                        const std::string &str,
-                        int rank = -1);
+    int unpack (resource_graph_t &g,
+                resource_graph_metadata_t &m,
+                const std::string &str,
+                int rank = -1) override;
 
     /*! Unpack str into a resource graph and graft
      *  the top-level vertices to vtx.
@@ -66,11 +66,11 @@ class resource_reader_rv1exec_t : public resource_reader_base_t {
      * \param rank   assign this rank to all the newly created resource vertices
      * \return       -1 with ENOTSUP (Not supported yet)
      */
-    virtual int unpack_at (resource_graph_t &g,
-                           resource_graph_metadata_t &m,
-                           vtx_t &vtx,
-                           const std::string &str,
-                           int rank = -1);
+    int unpack_at (resource_graph_t &g,
+                   resource_graph_metadata_t &m,
+                   vtx_t &vtx,
+                   const std::string &str,
+                   int rank = -1) override;
 
     /*! Update resource graph g with str.
      *
@@ -85,14 +85,14 @@ class resource_reader_rv1exec_t : public resource_reader_base_t {
      *               traversal token (trav_token) to be used by traverser
      * \return       -1 with ENOTSUP (Not supported yet)
      */
-    virtual int update (resource_graph_t &g,
-                        resource_graph_metadata_t &m,
-                        const std::string &str,
-                        int64_t jobid,
-                        int64_t at,
-                        uint64_t dur,
-                        bool rsv,
-                        uint64_t sequence_number);
+    int update (resource_graph_t &g,
+                resource_graph_metadata_t &m,
+                const std::string &str,
+                int64_t jobid,
+                int64_t at,
+                uint64_t dur,
+                bool rsv,
+                uint64_t sequence_number) override;
 
     /*! Partial cancellation of jobid based on R.
      *
@@ -104,17 +104,17 @@ class resource_reader_rv1exec_t : public resource_reader_base_t {
      * \param jobid  jobid of str
      * \return       0 on success; non-zero integer on an error
      */
-    virtual int partial_cancel (resource_graph_t &g,
-                                resource_graph_metadata_t &m,
-                                modify_data_t &mod_data,
-                                const std::string &R,
-                                int64_t jobid);
+    int partial_cancel (resource_graph_t &g,
+                        resource_graph_metadata_t &m,
+                        modify_data_t &mod_data,
+                        const std::string &R,
+                        int64_t jobid) override;
 
     /*! Is the selected reader format support allowlist
      *
      * \return       false
      */
-    virtual bool is_allowlist_supported ();
+    bool is_allowlist_supported () override;
 
    private:
     class properties_t {

--- a/resource/readers/resource_reader_rv1exec.hpp
+++ b/resource/readers/resource_reader_rv1exec.hpp
@@ -82,7 +82,7 @@ class resource_reader_rv1exec_t : public resource_reader_base_t {
      * \param dur    duration of this job
      * \param rsv    true if this update is for a reservation.
      * \param sequence_number
-     *               traversal token (trav_token) to be used by traverser
+     *               traversal token to be used by traverser
      * \return       -1 with ENOTSUP (Not supported yet)
      */
     int update (resource_graph_t &g,

--- a/resource/schema/infra_data.cpp
+++ b/resource/schema/infra_data.cpp
@@ -160,7 +160,7 @@ relation_infra_t::relation_infra_t () = default;
 relation_infra_t::relation_infra_t (const relation_infra_t &o) : infra_base_t (o)
 {
     m_needs = o.m_needs;
-    m_trav_token = o.m_trav_token;
+    m_sequence_number = o.m_sequence_number;
     m_exclusive = o.m_exclusive;
 }
 
@@ -168,7 +168,7 @@ relation_infra_t &relation_infra_t::operator= (const relation_infra_t &o)
 {
     infra_base_t::operator= (o);
     m_needs = o.m_needs;
-    m_trav_token = o.m_trav_token;
+    m_sequence_number = o.m_sequence_number;
     m_exclusive = o.m_exclusive;
     return *this;
 }
@@ -180,14 +180,14 @@ relation_infra_t::~relation_infra_t ()
 void relation_infra_t::scrub ()
 {
     m_needs = 0;
-    m_trav_token = 0;
+    m_sequence_number = 0;
     m_exclusive = 0;
 }
 
-void relation_infra_t::set_for_trav_update (uint64_t needs, int exclusive, uint64_t trav_token)
+void relation_infra_t::set_for_trav_update (uint64_t needs, int exclusive, uint64_t sequence_number)
 {
     m_needs = needs;
-    m_trav_token = trav_token;
+    m_sequence_number = sequence_number;
     m_exclusive = exclusive;
 }
 
@@ -201,9 +201,9 @@ int relation_infra_t::get_exclusive () const
     return m_exclusive;
 }
 
-uint64_t relation_infra_t::get_trav_token () const
+uint64_t relation_infra_t::get_sequence_number () const
 {
-    return m_trav_token;
+    return m_sequence_number;
 }
 
 uint64_t relation_infra_t::get_weight () const

--- a/resource/schema/infra_data.hpp
+++ b/resource/schema/infra_data.hpp
@@ -59,17 +59,17 @@ class relation_infra_t : public infra_base_t {
     virtual ~relation_infra_t ();
     virtual void scrub ();
 
-    void set_for_trav_update (uint64_t needs, int exclusive, uint64_t trav_token);
+    void set_for_trav_update (uint64_t needs, int exclusive, uint64_t sequence_number);
 
     uint64_t get_needs () const;
     int get_exclusive () const;
-    uint64_t get_trav_token () const;
+    uint64_t get_sequence_number () const;
     uint64_t get_weight () const;
     void set_weight (uint64_t);
 
    private:
     uint64_t m_needs = 0;
-    uint64_t m_trav_token = 0;
+    uint64_t m_sequence_number = 0;
     uint64_t m_weight = std::numeric_limits<uint64_t>::max ();
     int m_exclusive = 0;
 };

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -19,6 +19,8 @@ extern "C" {
 #include <boost/iterator/transform_iterator.hpp>
 #include <chrono>
 
+#include <flux/core/job.h>
+
 using namespace Flux::Jobspec;
 using namespace Flux::resource_model;
 using namespace Flux::resource_model::detail;
@@ -1292,7 +1294,7 @@ int dfu_impl_t::find (std::shared_ptr<match_writers_t> &writers, const std::stri
     expr_eval_vtx_target_t target;
     vtx_predicates_override_t p_overridden;
     bool agfilter = false;
-    uint64_t jobid = 0;
+    flux_jobid_t jobid = 0;
     std::vector<std::pair<std::string, std::string>> predicates;
 
     if (!m_match || !m_graph || !m_graph_db || !writers) {
@@ -1319,8 +1321,8 @@ int dfu_impl_t::find (std::shared_ptr<match_writers_t> &writers, const std::stri
     for (auto const &p : predicates) {
         if (p.first == "jobid-alloc" || p.first == "jobid-span" || p.first == "jobid-tag"
             || p.first == "jobid-reserved") {
-            // Don't need try; catch here since validate () succeeded
-            jobid = std::stoul (p.second);
+            // Don't need to check returncode since validate () succeeded
+            flux_job_id_parse (p.second.c_str (), &jobid);
         } else if (p.first == "agfilter") {
             if (p.second == "true" || p.second == "t") {
                 agfilter = true;

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -40,7 +40,7 @@ const std::string dfu_impl_t::level () const
 
 void dfu_impl_t::tick ()
 {
-    m_best_k_cnt++;
+    m_sequence_number++;
     m_color.reset ();
 }
 
@@ -799,7 +799,7 @@ int dfu_impl_t::dom_dfv (const jobmeta_t &meta,
 
     for (auto &resource : resources) {
         if ((resource.type == (*m_graph)[u].type) && (!resource.label.empty ())) {
-            rc = (*m_graph)[u].idata.ephemeral.insert (m_best_k_cnt, "label", resource.label);
+            rc = (*m_graph)[u].idata.ephemeral.insert (m_sequence_number, "label", resource.label);
             if (rc < 0) {
                 m_err_msg += "dom_dfv: inserting label into ephemeral failed.\n";
                 m_err_msg += strerror (errno);
@@ -928,7 +928,7 @@ int dfu_impl_t::dom_find_dfv (std::shared_ptr<match_writers_t> &w,
     // Need to clear out any stale data from the ephemeral object before
     // emitting the vertex, since data could be leftover from previous
     // traversals where the vertex was matched but not emitted
-    (*m_graph)[u].idata.ephemeral.check_and_clear_if_stale (m_best_k_cnt);
+    (*m_graph)[u].idata.ephemeral.check_and_clear_if_stale (m_sequence_number);
     // The last two booleans are for exclusivity (which we set to true) and for exclusive_parent
     // which we set to `false` for simplicity.
     if ((rc = w->emit_vtx (level (), *m_graph, u, (*m_graph)[u].size, agfilter_data, true, false))
@@ -1058,7 +1058,7 @@ int dfu_impl_t::enforce (subsystem_t subsystem, scoring_api_t &dfu, bool enforce
                 for (auto &e : egroup.edges) {
                     (*m_graph)[e.edge].idata.set_for_trav_update (e.needs,
                                                                   e.exclusive,
-                                                                  m_best_k_cnt);
+                                                                  m_sequence_number);
                     // we need to resolve unconstrained resources up to the root in the dominant
                     // subsystem
                     if (enforce_unconstrained && subsystem == dom) {
@@ -1068,7 +1068,8 @@ int dfu_impl_t::enforce (subsystem_t subsystem, scoring_api_t &dfu, bool enforce
                         // only the root doesn't have one, so natural stop
                         while ((parent_e = find_parent_edge (parent_v, *m_graph, subsystem))) {
                             // if this parent is already marked, all of its will be too
-                            if ((*m_graph)[*parent_e].idata.get_trav_token () == m_best_k_cnt) {
+                            if ((*m_graph)[*parent_e].idata.get_sequence_number ()
+                                == m_sequence_number) {
                                 break;
                             }
                             parent_v = source (*parent_e, *m_graph);
@@ -1083,7 +1084,7 @@ int dfu_impl_t::enforce (subsystem_t subsystem, scoring_api_t &dfu, bool enforce
                             }
                             (*m_graph)[*parent_e].idata.set_for_trav_update ((*m_graph)[tgt].size,
                                                                              false,
-                                                                             m_best_k_cnt);
+                                                                             m_sequence_number);
                         }
                     }
                 }
@@ -1282,7 +1283,7 @@ int dfu_impl_t::select (Jobspec::Jobspec &j, vtx_t root, jobmeta_t &meta, bool e
         egrp.edges.push_back (ev_edg);
         dfu.add (dom, (*m_graph)[root].type, egrp);
         rc = resolve_graph (root, j.resources, dfu, excl, &needs);
-        m_graph_db->metadata.v_rt_edges[dom].set_for_trav_update (needs, x_in, m_best_k_cnt);
+        m_graph_db->metadata.v_rt_edges[dom].set_for_trav_update (needs, x_in, m_sequence_number);
     }
     return rc;
 }

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -851,7 +851,7 @@ int dfu_impl_t::dom_find_dfv (std::shared_ptr<match_writers_t> &w,
             rc = (s == dom) ? dom_find_dfv (w, criteria, tgt, p_overridden, jobid, agfilter)
                             : aux_find_upv (w, criteria, tgt, s, p_overridden);
             if (rc > 0) {
-                if (w->emit_edg (level (), *m_graph, *ei) < 0) {
+                if (w->emit_edg (level (), *m_graph, *ei, false) < 0) {
                     m_err_msg += __FUNCTION__;
                     m_err_msg += ": emit_edg returned an error.\n";
                 }
@@ -927,7 +927,10 @@ int dfu_impl_t::dom_find_dfv (std::shared_ptr<match_writers_t> &w,
     // emitting the vertex, since data could be leftover from previous
     // traversals where the vertex was matched but not emitted
     (*m_graph)[u].idata.ephemeral.check_and_clear_if_stale (m_best_k_cnt);
-    if ((rc = w->emit_vtx (level (), *m_graph, u, (*m_graph)[u].size, agfilter_data, true)) < 0) {
+    // The last two booleans are for exclusivity (which we set to true) and for exclusive_parent
+    // which we set to `false` for simplicity.
+    if ((rc = w->emit_vtx (level (), *m_graph, u, (*m_graph)[u].size, agfilter_data, true, false))
+        < 0) {
         m_err_msg += __FUNCTION__;
         m_err_msg += std::string (": error from emit_vtx: ") + strerror (errno);
         goto done;

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -530,8 +530,12 @@ class dfu_impl_t {
      *                                                                      *
      ************************************************************************/
     // Emit matched resource set
-    int emit_vtx (vtx_t u, std::shared_ptr<match_writers_t> &w, unsigned int needs, bool exclusive);
-    int emit_edg (edg_t e, std::shared_ptr<match_writers_t> &w);
+    int emit_vtx (vtx_t u,
+                  std::shared_ptr<match_writers_t> &w,
+                  unsigned int needs,
+                  bool exclusive,
+                  bool excl_parent);
+    int emit_edg (edg_t e, std::shared_ptr<match_writers_t> &w, bool excl_parent);
 
     // Update resource graph data store
     int upd_txfilter (vtx_t u,

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -631,7 +631,7 @@ class dfu_impl_t {
      *                                                                      *
      ************************************************************************/
     color_t m_color;
-    uint64_t m_best_k_cnt = 0;
+    uint64_t m_sequence_number = 0;
     unsigned int m_trav_level = 0;
     unsigned int m_preorder = 0;
     unsigned int m_postorder = 0;

--- a/resource/traversers/dfu_impl_update.cpp
+++ b/resource/traversers/dfu_impl_update.cpp
@@ -261,9 +261,7 @@ int dfu_impl_t::upd_sched (vtx_t u,
     if ((rc = upd_meta (u, s, needs, excl, n, jobmeta, dfu, to_parent)) == -1) {
         goto done;
     }
-    // emit vertex if writer emits exclusive subtrees, or if the parent vertex is
-    // not exclusive
-    if (n > 0 && (writers->emit_exclusive_subtrees () || !excl_parent)) {
+    if (n > 0) {
         if ((rc = emit_vtx (u, writers, needs, excl, excl_parent)) == -1) {
             m_err_msg += __FUNCTION__;
             m_err_msg += ": emit_vtx returned -1.\n";
@@ -355,13 +353,9 @@ int dfu_impl_t::upd_dfv (vtx_t u,
                     m_err_msg += __FUNCTION__;
                     m_err_msg += ": upd_by_outedges returned -1.\n";
                 }
-                // emit the edge if writer emits exclusive subtrees, OR if the source
-                // vertex is not exclusive
-                if (writers->emit_exclusive_subtrees () || !excl) {
-                    if (emit_edg (*ei, writers, excl) == -1) {
-                        m_err_msg += __FUNCTION__;
-                        m_err_msg += ": emit_edg returned -1.\n";
-                    }
+                if (emit_edg (*ei, writers, excl) == -1) {
+                    m_err_msg += __FUNCTION__;
+                    m_err_msg += ": emit_edg returned -1.\n";
                 }
                 n_plans += n_plan_sub;
             }

--- a/resource/traversers/dfu_impl_update.cpp
+++ b/resource/traversers/dfu_impl_update.cpp
@@ -27,15 +27,16 @@ using namespace Flux::resource_model::detail;
 int dfu_impl_t::emit_vtx (vtx_t u,
                           std::shared_ptr<match_writers_t> &w,
                           unsigned int needs,
-                          bool exclusive)
+                          bool exclusive,
+                          bool excl_parent)
 {
     const std::map<std::string, std::string> agfilter_data;
-    return w->emit_vtx (level (), (*m_graph), u, needs, agfilter_data, exclusive);
+    return w->emit_vtx (level (), (*m_graph), u, needs, agfilter_data, exclusive, excl_parent);
 }
 
-int dfu_impl_t::emit_edg (edg_t e, std::shared_ptr<match_writers_t> &w)
+int dfu_impl_t::emit_edg (edg_t e, std::shared_ptr<match_writers_t> &w, bool excl_parent)
 {
-    return w->emit_edg (level (), (*m_graph), e);
+    return w->emit_edg (level (), (*m_graph), e, excl_parent);
 }
 
 int dfu_impl_t::upd_txfilter (vtx_t u,
@@ -263,7 +264,7 @@ int dfu_impl_t::upd_sched (vtx_t u,
     // emit vertex if writer emits exclusive subtrees, or if the parent vertex is
     // not exclusive
     if (n > 0 && (writers->emit_exclusive_subtrees () || !excl_parent)) {
-        if ((rc = emit_vtx (u, writers, needs, excl)) == -1) {
+        if ((rc = emit_vtx (u, writers, needs, excl, excl_parent)) == -1) {
             m_err_msg += __FUNCTION__;
             m_err_msg += ": emit_vtx returned -1.\n";
         }
@@ -357,7 +358,7 @@ int dfu_impl_t::upd_dfv (vtx_t u,
                 // emit the edge if writer emits exclusive subtrees, OR if the source
                 // vertex is not exclusive
                 if (writers->emit_exclusive_subtrees () || !excl) {
-                    if (emit_edg (*ei, writers) == -1) {
+                    if (emit_edg (*ei, writers, excl) == -1) {
                         m_err_msg += __FUNCTION__;
                         m_err_msg += ": emit_edg returned -1.\n";
                     }

--- a/resource/traversers/dfu_impl_update.cpp
+++ b/resource/traversers/dfu_impl_update.cpp
@@ -972,7 +972,7 @@ int dfu_impl_t::remove (vtx_t root,
     m_postorder = 0;
 
     tick ();
-    mod_data.token = m_best_k_cnt;
+    mod_data.sequence_number = m_best_k_cnt;
     if (reader->partial_cancel (g, m, mod_data, R_to_cancel, jobid) != 0) {
         m_err_msg += __FUNCTION__;
         m_err_msg += ": partial_cancel returned error.\n";

--- a/resource/traversers/dfu_impl_update.cpp
+++ b/resource/traversers/dfu_impl_update.cpp
@@ -971,6 +971,8 @@ int dfu_impl_t::remove (vtx_t root,
     m_preorder = 0;
     m_postorder = 0;
 
+    tick ();
+    mod_data.token = m_best_k_cnt;
     if (reader->partial_cancel (g, m, mod_data, R_to_cancel, jobid) != 0) {
         m_err_msg += __FUNCTION__;
         m_err_msg += ": partial_cancel returned error.\n";

--- a/resource/traversers/dfu_impl_update.cpp
+++ b/resource/traversers/dfu_impl_update.cpp
@@ -295,7 +295,7 @@ bool dfu_impl_t::modify_traversal (vtx_t u, bool emit_shadow_from_parent) const
 
 bool dfu_impl_t::stop_explore_best (edg_t e, bool mod_trav) const
 {
-    return (*m_graph)[e].idata.get_trav_token () != m_best_k_cnt && !mod_trav;
+    return (*m_graph)[e].idata.get_sequence_number () != m_sequence_number && !mod_trav;
 }
 
 bool dfu_impl_t::get_eff_exclusive (bool x, bool mod_trav) const
@@ -847,7 +847,7 @@ int dfu_impl_t::update (vtx_t root, std::shared_ptr<match_writers_t> &writers, j
     std::map<resource_type_t, int64_t> dfu;
     subsystem_t dom = m_match->dom_subsystem ();
 
-    if (m_graph_db->metadata.v_rt_edges[dom].get_trav_token () != m_best_k_cnt) {
+    if (m_graph_db->metadata.v_rt_edges[dom].get_sequence_number () != m_sequence_number) {
         m_err_msg += __FUNCTION__;
         m_err_msg += ": resource state wasn't properly set up for update.\n";
         return -1;
@@ -906,14 +906,14 @@ int dfu_impl_t::update (vtx_t root,
                               jobmeta.at,
                               jobmeta.duration,
                               rsv,
-                              m_best_k_cnt))
+                              m_sequence_number))
         != 0) {
         m_err_msg += reader->err_message ();
         reader->clear_err_message ();
         return rc;
     }
 
-    if (m_graph_db->metadata.v_rt_edges[dom].get_trav_token () != m_best_k_cnt) {
+    if (m_graph_db->metadata.v_rt_edges[dom].get_sequence_number () != m_sequence_number) {
         // This condition occurs when the subgraph came from a
         // traverser different from this traverser, for example,
         // a traverser whose dominant subsystem is different than this.
@@ -972,7 +972,7 @@ int dfu_impl_t::remove (vtx_t root,
     m_postorder = 0;
 
     tick ();
-    mod_data.sequence_number = m_best_k_cnt;
+    mod_data.sequence_number = m_sequence_number;
     if (reader->partial_cancel (g, m, mod_data, R_to_cancel, jobid) != 0) {
         m_err_msg += __FUNCTION__;
         m_err_msg += ": partial_cancel returned error.\n";

--- a/resource/traversers/dfu_impl_update.cpp
+++ b/resource/traversers/dfu_impl_update.cpp
@@ -915,7 +915,7 @@ int dfu_impl_t::update (vtx_t root,
 
     if (m_graph_db->metadata.v_rt_edges[dom].get_trav_token () != m_best_k_cnt) {
         // This condition occurs when the subgraph came from a
-        // traverver different from this traverser, for example,
+        // traverser different from this traverser, for example,
         // a traverser whose dominant subsystem is different than this.
         return 0;
     }

--- a/resource/writers/match_writers.cpp
+++ b/resource/writers/match_writers.cpp
@@ -205,7 +205,14 @@ int jgf_match_writers_t::emit_json (json_t **o, json_t **aux)
 
     if ((rc = check_array_sizes ()) <= 0)
         goto ret;
-    if (!(*o = json_pack ("{s:{s:o s:o}}", "graph", "nodes", m_vout, "edges", m_eout))) {
+    if (!(*o = json_pack ("{s:{s:o s:o} s:s*}",
+                          "graph",
+                          "nodes",
+                          m_vout,
+                          "edges",
+                          m_eout,
+                          "writer",
+                          get_uri ()))) {
         json_decref (m_vout);
         json_decref (m_eout);
         m_vout = NULL;
@@ -488,6 +495,11 @@ out:
     return rc;
 }
 
+const char *jgf_match_writers_t::get_uri ()
+{
+    return NULL;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // JGF_shorthand Writers Class Public Method Definitions
 ////////////////////////////////////////////////////////////////////////////////
@@ -509,6 +521,7 @@ int jgf_shorthand_match_writers_t::emit_vtx (
     bool excl_parent)
 {
     if (excl_parent) {
+        m_complete = false;
         return 0;
     }
     return jgf_match_writers_t::emit_vtx (prefix,
@@ -526,9 +539,18 @@ int jgf_shorthand_match_writers_t::emit_edg (const std::string &prefix,
                                              bool excl_parent)
 {
     if (excl_parent) {
+        m_complete = false;
         return 0;
     }
     return jgf_match_writers_t::emit_edg (prefix, g, e, excl_parent);
+}
+
+const char *jgf_shorthand_match_writers_t::get_uri ()
+{
+    if (m_complete) {
+        return jgf_match_writers_t::get_uri ();
+    }
+    return m_uri.c_str ();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/resource/writers/match_writers.cpp
+++ b/resource/writers/match_writers.cpp
@@ -878,7 +878,7 @@ ret:
 
 bool rv1_match_writers_t::empty ()
 {
-    return (rlite.empty () && jgf.empty ());
+    return (rlite.empty () && get_jgf ().empty ());
 }
 
 int rv1_match_writers_t::attrs_json (json_t **o)
@@ -923,11 +923,11 @@ int rv1_match_writers_t::emit_json (json_t **j_o, json_t **aux)
     json_t *jgf_o = NULL;
     json_t *attrs_o = NULL;
 
-    if (rlite.empty () || jgf.empty ())
+    if (rlite.empty () || get_jgf ().empty ())
         goto ret;
     if ((rc = rlite.emit_json (&rlite_o, &rlite_aux_o)) < 0)
         goto ret;
-    if ((rc = jgf.emit_json (&jgf_o)) < 0) {
+    if ((rc = get_jgf ().emit_json (&jgf_o)) < 0) {
         saved_errno = errno;
         json_decref (rlite_aux_o);
         errno = saved_errno;
@@ -1008,7 +1008,7 @@ int rv1_match_writers_t::emit (std::stringstream &out)
     json_t *o = NULL;
     char *json_str = NULL;
 
-    if (rlite.empty () || jgf.empty ())
+    if (rlite.empty () || get_jgf ().empty ())
         goto ret;
     if ((rc = emit_json (&o)) < 0)
         goto ret;
@@ -1036,7 +1036,7 @@ int rv1_match_writers_t::emit_vtx (const std::string &prefix,
 {
     int rc = 0;
     if ((rc = rlite.emit_vtx (prefix, g, u, needs, agfilter_data, exclusive)) == 0)
-        rc = jgf.emit_vtx (prefix, g, u, needs, agfilter_data, exclusive);
+        rc = get_jgf ().emit_vtx (prefix, g, u, needs, agfilter_data, exclusive);
     return rc;
 }
 
@@ -1046,7 +1046,7 @@ int rv1_match_writers_t::emit_edg (const std::string &prefix,
 {
     int rc = 0;
     if ((rc = rlite.emit_edg (prefix, g, e)) == 0)
-        rc = jgf.emit_edg (prefix, g, e);
+        rc = get_jgf ().emit_edg (prefix, g, e);
     return rc;
 }
 
@@ -1061,6 +1061,11 @@ int rv1_match_writers_t::emit_attrs (const std::string &k, const std::string &v)
 {
     m_attrs[k] = v;
     return 0;
+}
+
+jgf_match_writers_t &rv1_match_writers_t::get_jgf ()
+{
+    return jgf_writer;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/resource/writers/match_writers.cpp
+++ b/resource/writers/match_writers.cpp
@@ -140,7 +140,8 @@ int sim_match_writers_t::emit_vtx (const std::string &prefix,
                                    const vtx_t &u,
                                    unsigned int needs,
                                    const std::map<std::string, std::string> &agfilter_data,
-                                   bool exclusive)
+                                   bool exclusive,
+                                   bool)
 {
     std::string mode = (exclusive) ? "x" : "s";
     m_out << prefix << g[u].name << "[" << needs << ":" << mode << "]" << std::endl;
@@ -252,7 +253,8 @@ int jgf_match_writers_t::emit_vtx (const std::string &prefix,
                                    const vtx_t &u,
                                    unsigned int needs,
                                    const std::map<std::string, std::string> &agfilter_data,
-                                   bool exclusive)
+                                   bool exclusive,
+                                   bool)
 {
     int rc = 0;
     json_t *o = NULL;
@@ -305,7 +307,8 @@ out:
 
 int jgf_match_writers_t::emit_edg (const std::string &prefix,
                                    const resource_graph_t &g,
-                                   const edg_t &e)
+                                   const edg_t &e,
+                                   bool)
 {
     int rc = 0;
     json_t *o = NULL;
@@ -633,7 +636,8 @@ int rlite_match_writers_t::emit_vtx (const std::string &prefix,
                                      const vtx_t &u,
                                      unsigned int needs,
                                      const std::map<std::string, std::string> &agfilter_data,
-                                     bool exclusive)
+                                     bool exclusive,
+                                     bool)
 {
     int rc = 0;
 
@@ -1032,21 +1036,23 @@ int rv1_match_writers_t::emit_vtx (const std::string &prefix,
                                    const vtx_t &u,
                                    unsigned int needs,
                                    const std::map<std::string, std::string> &agfilter_data,
-                                   bool exclusive)
+                                   bool exclusive,
+                                   bool excl_parent)
 {
     int rc = 0;
-    if ((rc = rlite.emit_vtx (prefix, g, u, needs, agfilter_data, exclusive)) == 0)
-        rc = get_jgf ().emit_vtx (prefix, g, u, needs, agfilter_data, exclusive);
+    if ((rc = rlite.emit_vtx (prefix, g, u, needs, agfilter_data, exclusive, excl_parent)) == 0)
+        rc = get_jgf ().emit_vtx (prefix, g, u, needs, agfilter_data, exclusive, excl_parent);
     return rc;
 }
 
 int rv1_match_writers_t::emit_edg (const std::string &prefix,
                                    const resource_graph_t &g,
-                                   const edg_t &e)
+                                   const edg_t &e,
+                                   bool excl_parent)
 {
     int rc = 0;
-    if ((rc = rlite.emit_edg (prefix, g, e)) == 0)
-        rc = get_jgf ().emit_edg (prefix, g, e);
+    if ((rc = rlite.emit_edg (prefix, g, e, excl_parent)) == 0)
+        rc = get_jgf ().emit_edg (prefix, g, e, excl_parent);
     return rc;
 }
 
@@ -1165,9 +1171,10 @@ int rv1_nosched_match_writers_t::emit_vtx (const std::string &prefix,
                                            const vtx_t &u,
                                            unsigned int needs,
                                            const std::map<std::string, std::string> &agfilter_data,
-                                           bool exclusive)
+                                           bool exclusive,
+                                           bool excl_parent)
 {
-    return rlite.emit_vtx (prefix, g, u, needs, agfilter_data, exclusive);
+    return rlite.emit_vtx (prefix, g, u, needs, agfilter_data, exclusive, excl_parent);
 }
 
 int rv1_nosched_match_writers_t::emit_tm (uint64_t start_tm, uint64_t end_tm)
@@ -1224,7 +1231,8 @@ int pretty_sim_match_writers_t::emit_vtx (const std::string &prefix,
                                           const vtx_t &u,
                                           unsigned int needs,
                                           const std::map<std::string, std::string> &agfilter_data,
-                                          bool exclusive)
+                                          bool exclusive,
+                                          bool)
 {
     std::stringstream out;
     std::string mode = (exclusive) ? "exclusive" : "shared";

--- a/resource/writers/match_writers.cpp
+++ b/resource/writers/match_writers.cpp
@@ -499,6 +499,38 @@ jgf_shorthand_match_writers_t &jgf_shorthand_match_writers_t::operator= (
     return *this;
 }
 
+int jgf_shorthand_match_writers_t::emit_vtx (
+    const std::string &prefix,
+    const resource_graph_t &g,
+    const vtx_t &u,
+    unsigned int needs,
+    const std::map<std::string, std::string> &agfilter_data,
+    bool exclusive,
+    bool excl_parent)
+{
+    if (excl_parent) {
+        return 0;
+    }
+    return jgf_match_writers_t::emit_vtx (prefix,
+                                          g,
+                                          u,
+                                          needs,
+                                          agfilter_data,
+                                          exclusive,
+                                          excl_parent);
+}
+
+int jgf_shorthand_match_writers_t::emit_edg (const std::string &prefix,
+                                             const resource_graph_t &g,
+                                             const edg_t &e,
+                                             bool excl_parent)
+{
+    if (excl_parent) {
+        return 0;
+    }
+    return jgf_match_writers_t::emit_edg (prefix, g, e, excl_parent);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // RLITE Writers Class Public Method Definitions
 ////////////////////////////////////////////////////////////////////////////////

--- a/resource/writers/match_writers.cpp
+++ b/resource/writers/match_writers.cpp
@@ -1217,6 +1217,15 @@ int rv1_nosched_match_writers_t::emit_tm (uint64_t start_tm, uint64_t end_tm)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// RV1 Nosched Writers Class Method Definitions
+////////////////////////////////////////////////////////////////////////////////
+
+jgf_match_writers_t &rv1_shorthand_match_writers_t::get_jgf ()
+{
+    return jgf_writer;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // PRETTY Simple Writers Class Public Method Definitions
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -1298,6 +1307,9 @@ std::shared_ptr<match_writers_t> match_writers_factory_t::create (match_format_t
             case match_format_t::RV1_NOSCHED:
                 w = std::make_shared<rv1_nosched_match_writers_t> ();
                 break;
+            case match_format_t::RV1_SHORTHAND:
+                w = std::make_shared<rv1_shorthand_match_writers_t> ();
+                break;
             case match_format_t::PRETTY_SIMPLE:
                 w = std::make_shared<pretty_sim_match_writers_t> ();
                 break;
@@ -1327,6 +1339,8 @@ match_format_t match_writers_factory_t::get_writers_type (const std::string &n)
         format = match_format_t::RV1;
     else if (n == "rv1_nosched")
         format = match_format_t::RV1_NOSCHED;
+    else if (n == "rv1_shorthand")
+        format = match_format_t::RV1_SHORTHAND;
     else if (n == "pretty_simple")
         format = match_format_t::PRETTY_SIMPLE;
     return format;
@@ -1335,7 +1349,8 @@ match_format_t match_writers_factory_t::get_writers_type (const std::string &n)
 bool known_match_format (const std::string &format)
 {
     return (format == "simple" || format == "jgf" || format == "jgf_shorthand" || format == "rlite"
-            || format == "rv1" || format == "rv1_nosched" || format == "pretty_simple");
+            || format == "rv1" || format == "rv1_nosched" || format == "rv1_shorthand"
+            || format == "pretty_simple");
 }
 
 }  // namespace resource_model

--- a/resource/writers/match_writers.hpp
+++ b/resource/writers/match_writers.hpp
@@ -82,16 +82,16 @@ class sim_match_writers_t : public match_writers_t {
     virtual ~sim_match_writers_t ()
     {
     }
-    virtual bool empty ();
-    virtual int emit_json (json_t **o, json_t **aux = nullptr);
-    virtual int emit (std::stringstream &out);
-    virtual int emit_vtx (const std::string &prefix,
-                          const resource_graph_t &g,
-                          const vtx_t &u,
-                          unsigned int needs,
-                          const std::map<std::string, std::string> &agfilter_data,
-                          bool exclusive,
-                          bool) override;
+    bool empty () override;
+    int emit_json (json_t **o, json_t **aux = nullptr) override;
+    int emit (std::stringstream &out) override;
+    int emit_vtx (const std::string &prefix,
+                  const resource_graph_t &g,
+                  const vtx_t &u,
+                  unsigned int needs,
+                  const std::map<std::string, std::string> &agfilter_data,
+                  bool exclusive,
+                  bool) override;
 
    private:
     std::stringstream m_out;
@@ -114,20 +114,20 @@ class jgf_match_writers_t : public match_writers_t {
     jgf_match_writers_t &operator= (const jgf_match_writers_t &w);
     virtual ~jgf_match_writers_t ();
 
-    virtual bool empty ();
-    virtual int emit_json (json_t **o, json_t **aux = nullptr);
-    virtual int emit (std::stringstream &out);
-    virtual int emit_vtx (const std::string &prefix,
-                          const resource_graph_t &g,
-                          const vtx_t &u,
-                          unsigned int needs,
-                          const std::map<std::string, std::string> &agfilter_data,
-                          bool exclusive,
-                          bool excl_parent) override;
-    virtual int emit_edg (const std::string &prefix,
-                          const resource_graph_t &g,
-                          const edg_t &e,
-                          bool excl_parent);
+    bool empty () override;
+    int emit_json (json_t **o, json_t **aux = nullptr) override;
+    int emit (std::stringstream &out) override;
+    int emit_vtx (const std::string &prefix,
+                  const resource_graph_t &g,
+                  const vtx_t &u,
+                  unsigned int needs,
+                  const std::map<std::string, std::string> &agfilter_data,
+                  bool exclusive,
+                  bool excl_parent) override;
+    int emit_edg (const std::string &prefix,
+                  const resource_graph_t &g,
+                  const edg_t &e,
+                  bool excl_parent) override;
 
    protected:
     virtual const char *get_uri ();
@@ -226,17 +226,17 @@ class rlite_match_writers_t : public match_writers_t {
     rlite_match_writers_t &operator= (const rlite_match_writers_t &w);
     virtual ~rlite_match_writers_t ();
 
-    virtual bool empty ();
-    virtual int emit_json (json_t **o, json_t **aux = nullptr);
+    bool empty () override;
+    int emit_json (json_t **o, json_t **aux = nullptr) override;
     virtual int emit (std::stringstream &out, bool newline);
-    virtual int emit (std::stringstream &out);
-    virtual int emit_vtx (const std::string &prefix,
-                          const resource_graph_t &g,
-                          const vtx_t &u,
-                          unsigned int needs,
-                          const std::map<std::string, std::string> &agfilter_data,
-                          bool exclusive,
-                          bool excl_parent) override;
+    int emit (std::stringstream &out) override;
+    int emit_vtx (const std::string &prefix,
+                  const resource_graph_t &g,
+                  const vtx_t &u,
+                  unsigned int needs,
+                  const std::map<std::string, std::string> &agfilter_data,
+                  bool exclusive,
+                  bool excl_parent) override;
 
    private:
     class rank_host_t {
@@ -260,20 +260,20 @@ class rlite_match_writers_t : public match_writers_t {
  */
 class rv1_match_writers_t : public match_writers_t {
    public:
-    virtual bool empty ();
-    virtual int emit_json (json_t **o, json_t **aux = nullptr);
-    virtual int emit (std::stringstream &out);
-    virtual int emit_vtx (const std::string &prefix,
-                          const resource_graph_t &g,
-                          const vtx_t &u,
-                          unsigned int needs,
-                          const std::map<std::string, std::string> &agfilter_data,
-                          bool exclusive,
-                          bool excl_parent) override;
-    virtual int emit_edg (const std::string &prefix,
-                          const resource_graph_t &g,
-                          const edg_t &e,
-                          bool excl_parent);
+    bool empty () override;
+    int emit_json (json_t **o, json_t **aux = nullptr) override;
+    int emit (std::stringstream &out) override;
+    int emit_vtx (const std::string &prefix,
+                  const resource_graph_t &g,
+                  const vtx_t &u,
+                  unsigned int needs,
+                  const std::map<std::string, std::string> &agfilter_data,
+                  bool exclusive,
+                  bool excl_parent) override;
+    int emit_edg (const std::string &prefix,
+                  const resource_graph_t &g,
+                  const edg_t &e,
+                  bool excl_parent) override;
     virtual int emit_tm (uint64_t start_tm, uint64_t end_tm);
     virtual int emit_attrs (const std::string &k, const std::string &v);
 
@@ -294,16 +294,16 @@ class rv1_match_writers_t : public match_writers_t {
  */
 class rv1_nosched_match_writers_t : public match_writers_t {
    public:
-    virtual bool empty ();
-    virtual int emit_json (json_t **o, json_t **aux = nullptr);
-    virtual int emit (std::stringstream &out);
-    virtual int emit_vtx (const std::string &prefix,
-                          const resource_graph_t &g,
-                          const vtx_t &u,
-                          unsigned int needs,
-                          const std::map<std::string, std::string> &agfilter_data,
-                          bool exclusive,
-                          bool excl_parent) override;
+    bool empty () override;
+    int emit_json (json_t **o, json_t **aux = nullptr) override;
+    int emit (std::stringstream &out) override;
+    int emit_vtx (const std::string &prefix,
+                  const resource_graph_t &g,
+                  const vtx_t &u,
+                  unsigned int needs,
+                  const std::map<std::string, std::string> &agfilter_data,
+                  bool exclusive,
+                  bool excl_parent) override;
     virtual int emit_tm (uint64_t start_tm, uint64_t end_tm);
 
    private:
@@ -326,16 +326,16 @@ class rv1_shorthand_match_writers_t : public rv1_match_writers_t {
  */
 class pretty_sim_match_writers_t : public match_writers_t {
    public:
-    virtual bool empty ();
-    virtual int emit_json (json_t **o, json_t **aux = nullptr);
-    virtual int emit (std::stringstream &out);
-    virtual int emit_vtx (const std::string &prefix,
-                          const resource_graph_t &g,
-                          const vtx_t &u,
-                          unsigned int needs,
-                          const std::map<std::string, std::string> &agfilter_data,
-                          bool exclusive,
-                          bool excl_parent) override;
+    bool empty () override;
+    int emit_json (json_t **o, json_t **aux = nullptr) override;
+    int emit (std::stringstream &out) override;
+    int emit_vtx (const std::string &prefix,
+                  const resource_graph_t &g,
+                  const vtx_t &u,
+                  unsigned int needs,
+                  const std::map<std::string, std::string> &agfilter_data,
+                  bool exclusive,
+                  bool excl_parent) override;
 
    private:
     std::list<std::string> m_out;

--- a/resource/writers/match_writers.hpp
+++ b/resource/writers/match_writers.hpp
@@ -129,6 +129,9 @@ class jgf_match_writers_t : public match_writers_t {
                           const edg_t &e,
                           bool excl_parent);
 
+   protected:
+    virtual const char *get_uri ();
+
    private:
     json_t *emit_vtx_base (const resource_graph_t &g,
                            const vtx_t &u,
@@ -206,6 +209,12 @@ class jgf_shorthand_match_writers_t : public jgf_match_writers_t {
                   const resource_graph_t &g,
                   const edg_t &e,
                   bool excl_parent) override;
+
+   private:
+    const char *get_uri () override;
+
+    bool m_complete = true;
+    const std::string m_uri = "fluxion:jgf_shorthand";
 };
 
 /*! RLITE match writers class for a matched resource set

--- a/resource/writers/match_writers.hpp
+++ b/resource/writers/match_writers.hpp
@@ -43,8 +43,12 @@ class match_writers_t {
                           const vtx_t &u,
                           unsigned int needs,
                           const std::map<std::string, std::string> &agfilter_data,
-                          bool exclusive) = 0;
-    virtual int emit_edg (const std::string &prefix, const resource_graph_t &g, const edg_t &e)
+                          bool exclusive,
+                          bool excl_parent) = 0;
+    virtual int emit_edg (const std::string &prefix,
+                          const resource_graph_t &g,
+                          const edg_t &e,
+                          bool excl_parent)
     {
         return 0;
     }
@@ -85,7 +89,8 @@ class sim_match_writers_t : public match_writers_t {
                           const vtx_t &u,
                           unsigned int needs,
                           const std::map<std::string, std::string> &agfilter_data,
-                          bool exclusive) override;
+                          bool exclusive,
+                          bool) override;
 
    private:
     std::stringstream m_out;
@@ -116,8 +121,12 @@ class jgf_match_writers_t : public match_writers_t {
                           const vtx_t &u,
                           unsigned int needs,
                           const std::map<std::string, std::string> &agfilter_data,
-                          bool exclusive) override;
-    virtual int emit_edg (const std::string &prefix, const resource_graph_t &g, const edg_t &e);
+                          bool exclusive,
+                          bool excl_parent) override;
+    virtual int emit_edg (const std::string &prefix,
+                          const resource_graph_t &g,
+                          const edg_t &e,
+                          bool excl_parent);
 
    private:
     json_t *emit_vtx_base (const resource_graph_t &g,
@@ -209,7 +218,8 @@ class rlite_match_writers_t : public match_writers_t {
                           const vtx_t &u,
                           unsigned int needs,
                           const std::map<std::string, std::string> &agfilter_data,
-                          bool exclusive) override;
+                          bool exclusive,
+                          bool excl_parent) override;
 
    private:
     class rank_host_t {
@@ -241,8 +251,12 @@ class rv1_match_writers_t : public match_writers_t {
                           const vtx_t &u,
                           unsigned int needs,
                           const std::map<std::string, std::string> &agfilter_data,
-                          bool exclusive) override;
-    virtual int emit_edg (const std::string &prefix, const resource_graph_t &g, const edg_t &e);
+                          bool exclusive,
+                          bool excl_parent) override;
+    virtual int emit_edg (const std::string &prefix,
+                          const resource_graph_t &g,
+                          const edg_t &e,
+                          bool excl_parent);
     virtual int emit_tm (uint64_t start_tm, uint64_t end_tm);
     virtual int emit_attrs (const std::string &k, const std::string &v);
 
@@ -271,7 +285,8 @@ class rv1_nosched_match_writers_t : public match_writers_t {
                           const vtx_t &u,
                           unsigned int needs,
                           const std::map<std::string, std::string> &agfilter_data,
-                          bool exclusive) override;
+                          bool exclusive,
+                          bool excl_parent) override;
     virtual int emit_tm (uint64_t start_tm, uint64_t end_tm);
 
    private:
@@ -292,7 +307,8 @@ class pretty_sim_match_writers_t : public match_writers_t {
                           const vtx_t &u,
                           unsigned int needs,
                           const std::map<std::string, std::string> &agfilter_data,
-                          bool exclusive) override;
+                          bool exclusive,
+                          bool excl_parent) override;
 
    private:
     std::list<std::string> m_out;

--- a/resource/writers/match_writers.hpp
+++ b/resource/writers/match_writers.hpp
@@ -64,14 +64,6 @@ class match_writers_t {
     int compress_hosts (const std::vector<std::string> &hosts,
                         const char *hostlist_init,
                         char **hostlist);
-
-    /* Return a boolean indicating whether or not the writer should be invoked
-     * on vertices that form non-root parts of exclusive subtrees.
-     */
-    virtual bool emit_exclusive_subtrees ()
-    {
-        return true;
-    }
 };
 
 /*! Simple match writers class for a matched resource set
@@ -194,10 +186,17 @@ class jgf_shorthand_match_writers_t : public jgf_match_writers_t {
     jgf_shorthand_match_writers_t (const jgf_shorthand_match_writers_t &w) = default;
     jgf_shorthand_match_writers_t &operator= (const jgf_shorthand_match_writers_t &w);
 
-    virtual bool emit_exclusive_subtrees () override
-    {
-        return false;
-    }
+    int emit_vtx (const std::string &prefix,
+                  const resource_graph_t &g,
+                  const vtx_t &u,
+                  unsigned int needs,
+                  const std::map<std::string, std::string> &agfilter_data,
+                  bool exclusive,
+                  bool excl_parent) override;
+    int emit_edg (const std::string &prefix,
+                  const resource_graph_t &g,
+                  const edg_t &e,
+                  bool excl_parent) override;
 };
 
 /*! RLITE match writers class for a matched resource set

--- a/resource/writers/match_writers.hpp
+++ b/resource/writers/match_writers.hpp
@@ -26,7 +26,16 @@ extern "C" {
 namespace Flux {
 namespace resource_model {
 
-enum class match_format_t { SIMPLE, JGF, JGF_SHORTHAND, RLITE, RV1, RV1_NOSCHED, PRETTY_SIMPLE };
+enum class match_format_t {
+    SIMPLE,
+    JGF,
+    JGF_SHORTHAND,
+    RLITE,
+    RV1,
+    RV1_NOSCHED,
+    RV1_SHORTHAND,
+    PRETTY_SIMPLE
+};
 
 /*! Base match writers class for a matched resource set
  */
@@ -292,6 +301,16 @@ class rv1_nosched_match_writers_t : public match_writers_t {
     rlite_match_writers_t rlite;
     int64_t m_starttime = 0;
     int64_t m_expiration = 0;
+};
+
+/*! R Version 1 with JGF shorthand writer
+ */
+class rv1_shorthand_match_writers_t : public rv1_match_writers_t {
+   protected:
+    jgf_match_writers_t &get_jgf () override;
+
+   private:
+    jgf_shorthand_match_writers_t jgf_writer;
 };
 
 /*! Human-friendly simple match writers class for a matched resource set

--- a/resource/writers/match_writers.hpp
+++ b/resource/writers/match_writers.hpp
@@ -246,6 +246,9 @@ class rv1_match_writers_t : public match_writers_t {
     virtual int emit_tm (uint64_t start_tm, uint64_t end_tm);
     virtual int emit_attrs (const std::string &k, const std::string &v);
 
+   protected:
+    virtual jgf_match_writers_t &get_jgf ();
+
    private:
     int attrs_json (json_t **o);
 
@@ -253,7 +256,7 @@ class rv1_match_writers_t : public match_writers_t {
     int64_t m_starttime = 0;
     int64_t m_expiration = 0;
     std::map<std::string, std::string> m_attrs;
-    jgf_match_writers_t jgf;
+    jgf_match_writers_t jgf_writer;
 };
 
 /*! R Version 1 with no "scheduling" key match writers class

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -32,6 +32,7 @@ set(ALL_TESTS
   t1027-rv1-partial-release-brokerless-resources.t
   t1028-rv1-partial-release-across-racks.t
   t1029-resource-force-load-format.t
+  t1030-rv1-shorthand.t
   t2317-resource-shrink.t
   t3000-jobspec.t
   t3001-resource-basic.t

--- a/t/data/resource/expected/match_format/t3040_expected_match1.json
+++ b/t/data/resource/expected/match_format/t3040_expected_match1.json
@@ -185,5 +185,6 @@
         }
       }
     ]
-  }
+  },
+  "writer": "fluxion:jgf_shorthand"
 }

--- a/t/data/resource/jobspecs/advanced/rabbit.yaml
+++ b/t/data/resource/jobspecs/advanced/rabbit.yaml
@@ -1,4 +1,4 @@
-version: 9999
+version: 1
 resources:
   - type: chassis
     count: 1
@@ -28,7 +28,7 @@ attributes:
   system:
     duration: 3600
 tasks:
-  - command: [ "app" ]
+  - command: [ "true" ]
     slot: task
     count:
       per_slot: 1

--- a/t/t1029-resource-force-load-format.t
+++ b/t/t1029-resource-force-load-format.t
@@ -7,6 +7,8 @@ test_description='Test the rv1exec_force load format'
 echo \
 '#!/bin/sh
 
+set -e
+
 flux module remove -f sched-simple &&
 flux module remove -f sched-fluxion-qmanager &&
 flux module remove -f sched-fluxion-resource &&
@@ -17,11 +19,26 @@ flux module load sched-fluxion-resource load-format="${1}" &&
 flux module load sched-fluxion-qmanager
 ' > load_nonsense_scheduling_key.sh
 
-chmod +x load_nonsense_scheduling_key.sh
+echo \
+'#!/bin/sh
+
+set -e
+
+flux module remove -f sched-simple &&
+flux module remove -f sched-fluxion-qmanager &&
+flux module remove -f sched-fluxion-resource &&
+flux module reload resource &&
+flux module load sched-fluxion-resource &&
+flux module load sched-fluxion-qmanager &&
+flux module list
+$@
+' > load_fluxion.sh
+
+chmod +x load_nonsense_scheduling_key.sh load_fluxion.sh
 
 test_under_flux 2
 
-test_expect_success 'load resource with load-format-rv1exec_force' '
+test_expect_success 'load resource with load-format=rv1exec_force' '
     flux module remove -f sched-simple &&
     reload_resource load-format=rv1exec_force &&
     reload_qmanager
@@ -41,6 +58,55 @@ test_expect_success 'without rv1exec_force, job fails' '
     test_must_fail flux alloc -t5s -N1 -n1 ./load_nonsense_scheduling_key.sh rv1exec &&
     flux job attach $(flux job last) 2>&1 | grep -e grow_resource_db_jgf -e "Invalid argument" &&
     flux job attach $(flux job last) 2>&1 | grep "module exiting abnormally"
+'
+
+test_expect_success 'load resource with match-format=rv1_shorthand' '
+    reload_resource load-format=rv1exec_force match-format=rv1_shorthand &&
+    reload_qmanager
+'
+
+test_expect_success 'jobs run with shorthand jgf' '
+    jobid=$(flux submit -n1 true) &&
+    flux job wait-event -vt 5 ${jobid} alloc &&
+    flux job info ${jobid} R | jq -e ".scheduling.writer == null" &&
+    flux job attach ${jobid} &&
+    jobid=$(flux submit -N1 true) &&
+    flux job wait-event -vt 5 ${jobid} alloc &&
+    flux job info ${jobid} R | jq -e ".scheduling.writer == \"fluxion:jgf_shorthand\"" &&
+    flux job attach ${jobid}
+'
+
+test_expect_success 'flux instances started with shorthand jgf can run jobs' '
+    flux alloc -t5s -N1 ./load_fluxion.sh flux run -n1 -c1 echo hello &&
+    flux job attach $(flux job last) &&
+    flux job info $(flux job last) R | jq -e ".scheduling.writer == \"fluxion:jgf_shorthand\"" &&
+    flux job info $(flux job last) R | jq .scheduling.graph | test_must_fail grep core
+'
+
+test_expect_success 'scheduler can be reloaded with jgf_shorthand jobs' '
+    jobid=$(flux submit -t15s -N1 flux start ./load_fluxion.sh sleep 10) &&
+    flux job wait-event ${jobid} alloc &&
+    reload_resource load-format=rv1exec_force match-format=rv1_shorthand &&
+    reload_qmanager &&
+    flux cancel ${jobid} &&
+    flux job wait-event ${jobid} clean &&
+    flux job info ${jobid} R | jq -e ".scheduling.writer == \"fluxion:jgf_shorthand\"" &&
+    flux job info ${jobid} R | jq .scheduling.graph | test_must_fail grep core
+'
+
+test_expect_success 'agfilters are correct' '
+    flux ion-resource find -q --format=jgf agfilter=true \
+        | jq . > agfilter_output.json &&
+    jq -e ".graph.nodes[].metadata.agfilter.core | startswith(\"used:0\")" agfilter_output.json &&
+    jq -e ".graph.nodes[].metadata | select(.type == \"cluster\") | .agfilter.node
+        | startswith(\"used:0\")" agfilter_output.json
+'
+
+test_expect_success 'jobid span/tag/alloc output shows no vertices' '
+    test $(flux ion-resource find -q --format=jgf jobid-span=${jobid}) = null &&
+    test $(flux ion-resource find -q --format=jgf jobid-tag=${jobid}) = null &&
+    test $(flux ion-resource find -q --format=jgf jobid-alloc=${jobid}) = null &&
+    test $(flux ion-resource find -q --format=jgf sched-now=allocated) = null
 '
 
 test_expect_success 'remove manually loaded modules' '

--- a/t/t1030-rv1-shorthand.t
+++ b/t/t1030-rv1-shorthand.t
@@ -1,0 +1,215 @@
+#!/bin/sh
+
+test_description='Test a rabbit cluster with rv1_shorthand'
+
+. $(dirname $0)/sharness.sh
+
+cluster_jgf="${SHARNESS_TEST_SRCDIR}/data/resource/jgfs/rabbit.json"
+rabbit_jobspec="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/advanced/rabbit.yaml"
+HOSTLIST="hetchy[1,201-202,1001-1018]"
+SIZE="$(flux hostlist -c ${HOSTLIST})"
+
+test_under_flux ${SIZE}
+
+test_expect_success 'configure Flux' '
+    flux config load <<-EOF
+    [sched-fluxion-resource]
+    match-format = "rv1_shorthand"
+
+    [resource]
+    noverify = true
+    norestrict = true
+    scheduling = "${cluster_jgf}"
+
+    [[resource.config]]
+    hosts = "${HOSTLIST}"
+    cores = "0-1"
+EOF
+'
+
+test_expect_success 'load resource' '
+    flux module remove -f sched-simple &&
+    flux module remove -f sched-fluxion-qmanager &&
+    flux module remove -f sched-fluxion-resource &&
+    flux module reload resource &&
+    flux module load sched-fluxion-resource &&
+    flux module load sched-fluxion-qmanager &&
+    test_debug flux module list &&
+    flux resource list &&
+    FLUX_RESOURCE_LIST_RPC=sched.resource-status flux resource list
+
+'
+
+test_expect_success 'run a job' '
+    jobid=$(flux submit -N1 hostname) &&
+    flux job attach ${jobid} &&
+    flux job info ${jobid} R | jq -e ".scheduling.writer == \"fluxion:jgf_shorthand\"" &&
+    flux job info ${jobid} R | jq .scheduling.graph | test_must_fail grep core
+'
+
+test_expect_success 'run an alloc job' '
+    jobid=$(flux alloc -N1 flux resource list -no "{ncores}") &&
+    flux job info $(flux job last) R | jq -e ".scheduling.writer == \"fluxion:jgf_shorthand\"" &&
+    flux job info $(flux job last) R | jq .scheduling.graph | test_must_fail grep core &&
+    test $(flux job attach $(flux job last)) -eq 2
+'
+
+test_expect_success 'run a rabbit job' '
+    # take $rabbit_jobspec YAML, convert it to JSON, and make it node-exclusive
+    python3 -c "import sys, yaml, json; json.dump(yaml.safe_load(sys.stdin), sys.stdout, sort_keys=True, indent=4)" \
+        < ${rabbit_jobspec} | jq ".resources[0].with[0].exclusive = true" > rabbit_jobspec.json &&
+    jobid=$(flux job submit rabbit_jobspec.json) &&
+    flux job attach ${jobid} &&
+    flux job info ${jobid} R | jq -e ".scheduling.writer == \"fluxion:jgf_shorthand\"" &&
+    # there should only be one core vertex in the JGF, under the rabbit (either hetchy201 or 202)
+    # because the rabbit is not allocated exclusively
+    flux job info ${jobid} R | jq -e ".scheduling.graph.nodes |
+        [.[] | select (.metadata.type == \"core\")] | length" > corecount &&
+    test "$(cat corecount)" -eq 1 &&
+    flux job info ${jobid} R | jq -e ".scheduling.graph.nodes[].metadata |
+        select(.type == \"core\") | .paths.containment" | grep -E "hetchy201|hetchy202"
+'
+
+test_expect_success 'agfilters are correct: all have used:0' '
+    flux ion-resource find -q --format=jgf agfilter=true \
+        | jq . > agfilter_output.json &&
+    jq -e ".graph.nodes[].metadata.agfilter.core | startswith(\"used:0\")" agfilter_output.json &&
+    jq -e ".graph.nodes[].metadata | select(.type == \"cluster\") | .agfilter.ssd
+        | startswith(\"used:0\")" agfilter_output.json &&
+    jq -e ".graph.nodes[].metadata | select(.type == \"chassis\" or .type == \"cluster\")
+        | .agfilter.node | startswith(\"used:0\")" agfilter_output.json
+'
+
+test_expect_success 'start a rabbit job and leave it running' '
+    # take node-exclusive rabbit JSON jobspec and change it to execute `sleep 30`
+    # so the job is still running when we reload the scheduler
+    jq ".tasks[0].command = [\"sleep\", \"30\"]" rabbit_jobspec.json > rabbit_jobspec_sleep.json &&
+    jobid=$(flux job submit rabbit_jobspec_sleep.json) &&
+    flux job wait-event ${jobid} alloc
+'
+
+test_expect_success 'agfilters are correct for storage_node' '
+    flux ion-resource find -q --format=jgf agfilter=true \
+        | jq . > agfilter_active_jobs.json &&
+    # one rabbit should show that one core is allocated
+    rabbit_cores_used=$(jq ".graph.nodes[].metadata | select(.type == \"storage_node\") | .agfilter.core
+        | startswith(\"used:1\")" agfilter_active_jobs.json | grep true | wc -l) &&
+    echo "${rabbit_cores_used}" == 1 &&
+    test "${rabbit_cores_used}" -eq 1
+'
+
+test_expect_success 'agfilters are correct for cluster' '
+    # one ssd should be allocated, size 793
+    jq -e ".graph.nodes[].metadata | select(.type == \"cluster\") | .agfilter.ssd
+        | startswith(\"used:793\")" agfilter_active_jobs.json &&
+    jq -e ".graph.nodes[].metadata | select(.type == \"cluster\")
+        | .agfilter.node | startswith(\"used:1\")" agfilter_active_jobs.json &&
+    jq -e ".graph.nodes[].metadata | select(.type == \"cluster\")
+        | .agfilter.core | startswith(\"used:3\")" agfilter_active_jobs.json
+'
+
+test_expect_success 'agfilters are correct for chassis' '
+    # one of the two chassis should show one node and three cores used
+    # the "storage_node" does not count as a node, otherwise it would be two nodes used
+    chassis_nodes_used=$(jq ".graph.nodes[].metadata | select(.type == \"chassis\") | .agfilter.node
+        | startswith(\"used:1\")" agfilter_active_jobs.json | grep true | wc -l) &&
+    echo "${chassis_nodes_used}" == 1 &&
+    test "${chassis_nodes_used}" -eq 1 &&
+    chassis_with_three_cores_used=$(jq ".graph.nodes[].metadata | select(.type == \"chassis\") | .agfilter.core
+        | startswith(\"used:3\")" agfilter_active_jobs.json | grep true | wc -l) &&
+    echo "${chassis_with_three_cores_used}" == 1 &&
+    test "${chassis_with_three_cores_used}" -eq 1
+'
+
+test_expect_success 'agfilters are correct for node' '
+    # one node should show that both of its two cores are allocated
+    cores_used=$(jq ".graph.nodes[].metadata | select(.type == \"node\") | .agfilter.core
+        | startswith(\"used:2\")" agfilter_active_jobs.json | grep true | wc -l) &&
+    echo "${cores_used}" == 1 &&
+    test "${cores_used}" -eq 1
+'
+
+test_expect_success 'reload the scheduler' '
+    flux module remove -f sched-fluxion-qmanager &&
+    flux module remove -f sched-fluxion-resource &&
+    flux module load sched-fluxion-resource &&
+    flux module load sched-fluxion-qmanager
+'
+
+test_expect_success 'after reload, agfilters are correct for storage_node' '
+    flux ion-resource find -q --format=jgf agfilter=true \
+        | jq . > agfilter_after_reload.json &&
+    # one rabbit should show that one core is allocated
+    rabbit_cores_used=$(jq ".graph.nodes[].metadata | select(.type == \"storage_node\") | .agfilter.core
+        | startswith(\"used:1\")" agfilter_after_reload.json | grep true | wc -l) &&
+    echo "${rabbit_cores_used}" == 1 &&
+    test "${rabbit_cores_used}" -eq 1
+'
+
+test_expect_success 'after reload, agfilters are correct for cluster' '
+    # one ssd should be allocated, size 793
+    jq -e ".graph.nodes[].metadata | select(.type == \"cluster\") | .agfilter.ssd
+        | startswith(\"used:793\")" agfilter_after_reload.json &&
+    jq -e ".graph.nodes[].metadata | select(.type == \"cluster\")
+        | .agfilter.node | startswith(\"used:1\")" agfilter_after_reload.json &&
+    jq -e ".graph.nodes[].metadata | select(.type == \"cluster\")
+        | .agfilter.core | startswith(\"used:3\")" agfilter_after_reload.json
+'
+
+test_expect_success 'after reload, agfilters are correct for chassis' '
+    # one of the two chassis should show one node and three cores used
+    # the "storage_node" does not count as a node, otherwise it would be two nodes used
+    chassis_nodes_used=$(jq ".graph.nodes[].metadata | select(.type == \"chassis\") | .agfilter.node
+        | startswith(\"used:1\")" agfilter_after_reload.json | grep true | wc -l) &&
+    echo "${chassis_nodes_used}" == 1 &&
+    test "${chassis_nodes_used}" -eq 1 &&
+    chassis_with_three_cores_used=$(jq ".graph.nodes[].metadata | select(.type == \"chassis\") | .agfilter.core
+        | startswith(\"used:3\")" agfilter_after_reload.json | grep true | wc -l) &&
+    echo "${chassis_with_three_cores_used}" == 1 &&
+    test "${chassis_with_three_cores_used}" -eq 1
+'
+
+test_expect_success 'after reload, agfilters are correct for node' '
+    # one node should show that both of its two cores are allocated
+    cores_used=$(jq ".graph.nodes[].metadata | select(.type == \"node\") | .agfilter.core
+        | startswith(\"used:2\")" agfilter_after_reload.json | grep true | wc -l) &&
+    echo "${cores_used}" == 1 &&
+    test "${cores_used}" -eq 1
+'
+
+test_expect_success 'sched-now=allocated is correct' '
+    flux ion-resource find -q --format=jgf sched-now=allocated \
+        | jq . > sched_now_alloc.json &&
+    # three cores should be allocated: two from a node, one from a storage_node
+    jq -e ".graph.nodes | [.[] | select(.metadata.type == \"core\")] | length == 3" \
+        sched_now_alloc.json &&
+    jq -e ".graph.nodes | [.[] | select(.metadata.type == \"node\")] | length == 1" \
+        sched_now_alloc.json &&
+    jq -e ".graph.nodes | [.[] | select(.metadata.type == \"storage_node\")] | length == 1" \
+        sched_now_alloc.json
+'
+
+test_expect_success 'cancel job' '
+    flux cancel ${jobid} && flux job wait-event ${jobid} clean
+'
+
+test_expect_success 'agfilters are correct: all have used:0' '
+    flux ion-resource find -q --format=jgf agfilter=true \
+        | jq . > agfilter_jobs_complete.json &&
+    jq -e ".graph.nodes[].metadata.agfilter.core | startswith(\"used:0\")" agfilter_jobs_complete.json &&
+    jq -e ".graph.nodes[].metadata | select(.type == \"cluster\") | .agfilter.ssd
+        | startswith(\"used:0\")" agfilter_jobs_complete.json &&
+    jq -e ".graph.nodes[].metadata | select(.type == \"chassis\" or .type == \"cluster\")
+        | .agfilter.node | startswith(\"used:0\")" agfilter_jobs_complete.json
+'
+
+test_expect_success 'sched-now=allocated is null' '
+    flux ion-resource find -q --format=jgf sched-now=allocated &&
+    flux ion-resource find -q --format=jgf sched-now=allocated | jq -e ". == null"
+'
+
+test_expect_success 'remove manually loaded modules' '
+    remove_qmanager && remove_resource
+'
+
+test_done

--- a/t/t3040-jgf-shorthand-match-format.t
+++ b/t/t3040-jgf-shorthand-match-format.t
@@ -103,4 +103,36 @@ test_expect_success 'emitted jgf_shorthand resource graph can be loaded but has 
     grep cluster shorthand3-2.out && grep node shorthand3-2.out
 '
 
+test_expect_success 'rv1_shorthand does not emit cores or gpus with exclusive nodes' '
+    ${query} -L JGF.json -f jgf -F rv1_shorthand -t rv1_shorthand.out -P high < match_jobspec_exclusive_cmd &&
+    head -n1 rv1_shorthand.out | jq -S . > match4.json &&
+    grep core match4.json > /dev/null &&
+    grep gpu match4.json > /dev/null &&
+    jq .scheduling match4.json > match4_jgf.json &&
+    test_must_fail grep core match4_jgf.json > /dev/null &&
+    test_must_fail grep gpu match4_jgf.json > /dev/null &&
+    grep node match4_jgf.json > /dev/null &&
+    grep compute1 match4_jgf.json > /dev/null &&
+    grep cluster match4_jgf.json > /dev/null &&
+    jq -e ".graph.nodes[] | select(.id == \"23\") | .metadata.name == \"compute3\"" match4_jgf.json &&
+    # result should be the same as above when a non-exclusive jobspec was submitted with a
+    # node-exclusive match policy (i.e. match1)
+    test_cmp match4_jgf.json ${exp_dir}/t3040_expected_match1.json
+'
+
+test_expect_success 'rv1_shorthand does not emit cores or gpus with policy=hinodex' '
+    ${query} -L JGF.json -f jgf -F rv1_shorthand -t rv1_shorthand2.out -P hinodex < match_jobspec_cmd &&
+    head -n1 rv1_shorthand2.out | jq -S . > match5.json &&
+    grep core match5.json > /dev/null &&
+    grep gpu match5.json > /dev/null &&
+    jq .scheduling match5.json > match5_jgf.json &&
+    test_must_fail grep core match5_jgf.json > /dev/null &&
+    test_must_fail grep gpu match5_jgf.json > /dev/null &&
+    grep node match5_jgf.json > /dev/null &&
+    grep compute1 match5_jgf.json > /dev/null &&
+    grep cluster match5_jgf.json > /dev/null &&
+    jq -e ".graph.nodes[] | select(.id == \"23\") | .metadata.name == \"compute3\"" match5_jgf.json &&
+    test_cmp match5_jgf.json ${exp_dir}/t3040_expected_match1.json
+'
+
 test_done

--- a/t/t3040-jgf-shorthand-match-format.t
+++ b/t/t3040-jgf-shorthand-match-format.t
@@ -60,7 +60,9 @@ test_expect_success 'jgf_shorthand emits cores and gpus with policy=low' '
     grep compute1 match2.json > /dev/null &&
     grep cluster match2.json > /dev/null &&
     jq -e ".graph.nodes[] | select(.id == \"23\") | .metadata.name == \"compute3\"" match2.json &&
-    test_cmp match2.json ${exp_dir}/t3040_expected_match2.json
+    jq -e ".writer == null" match2.json &&
+    jq "del(.graph.metadata)" match2.json > match2_without_metadata.json &&
+    test_cmp match2_without_metadata.json ${exp_dir}/t3040_expected_match2.json
 '
 
 test_expect_success 'emitted jgf_shorthand resource graph can be loaded' '


### PR DESCRIPTION
Problem: there is no match writer that emits both R and JGF
shorthand.

Add one.

Also, there is no way to distinguish shorthand JGF from complete
JGF.

Add a metadata object with two fields: 'version' and 'complete.'
'Version' is currently always 1. 'complete' is always true for the
regular JGF writer and is false for the shorthand writer when it
omits vertices.