### PR TITLE
ci: add el10 build

### DIFF
--- a/scripts/add_docker_user.sh
+++ b/scripts/add_docker_user.sh
@@ -1,14 +1,14 @@
 #!/bin/sh
 if test "$USER" != "flux"; then
-    sudo groupadd -g $UID $USER
-    sudo useradd -g $USER -u $UID -d /home/$USER -m $USER
-    sudo sh -c "printf \"$USER ALL= NOPASSWD: ALL\\n\" >> /etc/sudoers"
+    groupadd -g $UID $USER
+    useradd -g $USER -u $UID -d /home/$USER -m $USER
+    sh -c "printf \"$USER ALL= NOPASSWD: ALL\\n\" >> /etc/sudoers"
     case "$ID" in
         ubuntu|debian)
-            sudo adduser $USER sudo
+            adduser $USER sudo
             ;;
         fedora|rocky|alma|rhel|centos|alpine)
-            sudo usermod -G wheel $USER
+            usermod -G wheel $USER
             ;;
     esac
 fi

--- a/src/test/docker/el10/Dockerfile
+++ b/src/test/docker/el10/Dockerfile
@@ -1,0 +1,18 @@
+FROM fluxrm/flux-core:el10
+
+ARG USER=flux
+ARG UID=1000
+USER root
+
+# copy scripts into image
+COPY scripts/ /scripts
+# Install extra buildrequires for flux-sched:
+RUN /scripts/install-deps.sh -y --allowerasing \
+ && dnf clean all
+
+# Add configured user to image with sudo access:
+#
+RUN /scripts/add_docker_user.sh
+
+USER $USER
+WORKDIR /home/$USER

--- a/src/test/docker/fedora40/Dockerfile
+++ b/src/test/docker/fedora40/Dockerfile
@@ -4,12 +4,13 @@ LABEL maintainer="Tom Scogland <scogland1@llnl.gov>"
 
 ARG USER=flux
 ARG UID=1000
+USER root
 
 # copy scripts into image
 COPY scripts/ /scripts
 #  Install flux-sched dependencies
-RUN sudo /scripts/install-deps.sh -y \
- && sudo dnf clean all
+RUN /scripts/install-deps.sh -y \
+ && dnf clean all
 
 # Add configured user to image with sudo access:
 #

--- a/src/test/docker/jammy/Dockerfile
+++ b/src/test/docker/jammy/Dockerfile
@@ -2,13 +2,14 @@ FROM fluxrm/flux-core:jammy
 
 ARG USER=flux
 ARG UID=1000
+USER root
 
 # copy scripts into image
 COPY scripts/ /scripts
 # Install extra buildrequires for flux-sched:
-RUN sudo apt update \
- && sudo /scripts/install-deps.sh -y \
- && sudo rm -rf /var/lib/apt/lists/*
+RUN apt update \
+ && /scripts/install-deps.sh -y \
+ && rm -rf /var/lib/apt/lists/*
 
 # Add configured user to image with sudo access:
 #

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -203,6 +203,14 @@ matrix.add_multiarch_build(
     ),
 )
 matrix.add_multiarch_build(
+    name="el10",
+    default_suffix=" - test-install",
+    args=common_args,
+    env=dict(
+        TEST_INSTALL="t",
+    ),
+)
+matrix.add_multiarch_build(
     name="alpine",
     default_suffix=" - test-install",
     args=common_args,


### PR DESCRIPTION
This PR adds an el10 build to go with the recent addition over in flux-core.

Some other minor fixes were required to get this working due to apparent PAM stack differences in the el10 image.