### PR TITLE
leave interner open after resource module unload

### DIFF
--- a/resource/modules/feasibility.cpp
+++ b/resource/modules/feasibility.cpp
@@ -293,9 +293,9 @@ static int init_resource_graph (std::shared_ptr<resource_ctx_t> &ctx)
         return -1;
     }
 
-    // prevent users from consuming unbounded memory with arbitrary resource types
-    subsystem_t::storage_t::finalize ();
-    resource_type_t::storage_t::finalize ();
+    // No finalize for string interners here, because the graph was initialized
+    // by resource, and this one has to match. Finalizing again here may work,
+    // but could cause a race condition in rare cases.
     return 0;
 }
 

--- a/resource/modules/resource.cpp
+++ b/resource/modules/resource.cpp
@@ -1545,6 +1545,8 @@ extern "C" int mod_main (flux_t *h, int argc, char **argv)
     }
 
 done:
+    subsystem_t::storage_t::unfinalize ();
+    resource_type_t::storage_t::unfinalize ();
     return rc;
 }
 

--- a/src/common/libintern/interner.cpp
+++ b/src/common/libintern/interner.cpp
@@ -66,6 +66,11 @@ void dense_storage_finalize (dense_inner_storage &storage)
     auto ul = std::unique_lock (*storage.mtx);
     storage.finalized = true;
 }
+void dense_storage_unfinalize (dense_inner_storage &storage)
+{
+    auto ul = std::unique_lock (*storage.mtx);
+    storage.finalized = false;
+}
 void dense_storage_open (dense_inner_storage &storage)
 {
     auto ul = std::unique_lock (*storage.mtx);

--- a/src/common/libintern/interner.hpp
+++ b/src/common/libintern/interner.hpp
@@ -38,6 +38,7 @@ view_and_id get_both (dense_inner_storage &ds, std::string_view s, char bytes_su
 const std::string *get_by_id (dense_inner_storage &ds, size_t string_id);
 
 void dense_storage_finalize (dense_inner_storage &storage);
+void dense_storage_unfinalize (dense_inner_storage &storage);
 void dense_storage_open (dense_inner_storage &storage);
 void dense_storage_close (dense_inner_storage &storage);
 
@@ -91,6 +92,14 @@ struct dense_storage {
     {
         detail::dense_storage_finalize (get_storage ());
     }
+
+    /// allow new strings to be added again, only call this when the owning module or agent is
+    /// ending
+    static void unfinalize ()
+    {
+        detail::dense_storage_unfinalize (get_storage ());
+    }
+
     /// open the interner for additions and auto-close on scope exit
     [[nodiscard]] static auto open_for_scope ()
     {

--- a/src/common/libintern/test/interned_string_test.cpp
+++ b/src/common/libintern/test/interned_string_test.cpp
@@ -12,7 +12,8 @@ using namespace std::string_view_literals;
 struct tag1 {};
 struct tag2 {};
 using tt1 = interned_string<dense_storage<tag1, uint8_t>>;
-using tt2 = interned_string<dense_storage<tag2, uint32_t>>;
+using ds2 = dense_storage<tag2, uint32_t>;
+using tt2 = interned_string<ds2>;
 
 TEST_CASE ("interner: intern a single literal, get back the same", "[interner]")
 {
@@ -40,6 +41,20 @@ TEST_CASE ("interner: strings with different tags compare different", "[interner
     REQUIRE (l.get () == r.get ());
     REQUIRE (l.id () == r.id ());
     REQUIRE (l.get ().data () != r.get ().data ());
+}
+
+TEST_CASE ("interner: finalize prevents new strings, open and unfinalize open", "[interner]")
+{
+    auto t = tt2 ("test"sv);
+    ds2::finalize ();
+    CHECK_THROWS (tt2 ("test5"sv));
+    {
+        auto _ = ds2::open_for_scope ();
+
+        REQUIRE_NOTHROW (tt2 ("test5"sv));
+    }
+    ds2::unfinalize ();
+    REQUIRE_NOTHROW (tt2 ("test6"sv));
 }
 
 TEST_CASE ("interner: smaller ID limits properly", "[interner]")


### PR DESCRIPTION
In @1443 we had a crash caused by the interner still being in a finalized state when the resource module was reloaded.  That should have been cleared by destructors, but on some platforms (like alpine) they do not run, and there must be another corner case where the data lib isn't fully reloaded.

Solution: Add an unfinalize for the dense interner and call it when the resource module is being unloaded, this way initialization on a reload can proceed without issue.  I also added a test that we do and do not get exceptions in appropriate conditions as part of the interner tests.

fixes #1443