### PR TITLE
cmake: bump jansson requirement to v2.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ execute_process(
 pkg_check_modules(yaml-cpp REQUIRED IMPORTED_TARGET yaml-cpp)
 pkg_check_modules(LIBEDIT REQUIRED IMPORTED_TARGET libedit)
 pkg_check_modules(HWLOC REQUIRED IMPORTED_TARGET hwloc>=2)
-pkg_check_modules(JANSSON REQUIRED IMPORTED_TARGET jansson>=2.10)
+pkg_check_modules(JANSSON REQUIRED IMPORTED_TARGET jansson>=2.11)
 pkg_check_modules(UUID REQUIRED IMPORTED_TARGET uuid)
 
 set(Boost_USE_STATIC_LIBS OFF)


### PR DESCRIPTION
Problem: `resource/writers/match_writers.cpp` uses features from `jansson` that were added in v2.11, but only v2.10 is currently required in `CMakeLists.txt`

Bump required version to 2.11

Specifically, some of the `json_pack` format strings use the `o*` and `s*` specifiers, [which were added in version 2.11](https://jansson.readthedocs.io/en/latest/apiref.html#c.json_int_t:~:text=s*%20(string)%20%5Bconst%20char%20*%5D)

The new specifiers were added in https://github.com/flux-framework/flux-sched/pull/1299