### PR TITLE
resource: match int types

### DIFF
--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -45,7 +45,7 @@ struct jobmeta_t {
     int64_t jobid = -1;
     int64_t at = -1;
     int64_t now = -1;
-    uint64_t duration = SYSTEM_DEFAULT_DURATION;  // will need config ultimately
+    int64_t duration = SYSTEM_DEFAULT_DURATION;  // will need config ultimately
     std::shared_ptr<Jobspec::Constraint> constraint;
 
     bool is_queue_set () const

--- a/resource/traversers/dfu_impl_update.cpp
+++ b/resource/traversers/dfu_impl_update.cpp
@@ -861,8 +861,8 @@ int dfu_impl_t::update (vtx_t root, std::shared_ptr<match_writers_t> &writers, j
     bool emit_shadow = modify_traversal (root, false);
     // Regardless of value of `x`, value for `excl_parent` parameter starts as `false`
     if ((rc = upd_dfv (root, writers, needs, x, jobmeta, true, dfu, emit_shadow, false)) > 0) {
-        uint64_t starttime = jobmeta.at;
-        uint64_t endtime = jobmeta.at + jobmeta.duration;
+        int64_t starttime = jobmeta.at;
+        int64_t endtime = jobmeta.at + jobmeta.duration;
         if (writers->emit_tm (starttime, endtime) == -1) {
             m_err_msg += __FUNCTION__;
             m_err_msg += ": emit_tm returned -1.\n";
@@ -927,8 +927,8 @@ int dfu_impl_t::update (vtx_t root,
     bool emit_shadow = modify_traversal (root, false);
     // Regardless of value of `x`, value for `excl_parent` parameter starts as `false`
     if ((rc = upd_dfv (root, writers, needs, x, jobmeta, false, dfu, emit_shadow, false)) > 0) {
-        uint64_t starttime = jobmeta.at;
-        uint64_t endtime = jobmeta.at + jobmeta.duration;
+        int64_t starttime = jobmeta.at;
+        int64_t endtime = jobmeta.at + jobmeta.duration;
         if (writers->emit_tm (starttime, endtime) == -1) {
             m_err_msg += __FUNCTION__;
             m_err_msg += ": emit_tm returned -1.\n";

--- a/resource/writers/match_writers.cpp
+++ b/resource/writers/match_writers.cpp
@@ -1110,7 +1110,7 @@ int rv1_match_writers_t::emit_edg (const std::string &prefix,
     return rc;
 }
 
-int rv1_match_writers_t::emit_tm (uint64_t start_tm, uint64_t end_tm)
+int rv1_match_writers_t::emit_tm (int64_t start_tm, int64_t end_tm)
 {
     m_starttime = start_tm;
     m_expiration = end_tm;
@@ -1231,7 +1231,7 @@ int rv1_nosched_match_writers_t::emit_vtx (const std::string &prefix,
     return rlite.emit_vtx (prefix, g, u, needs, agfilter_data, exclusive, excl_parent);
 }
 
-int rv1_nosched_match_writers_t::emit_tm (uint64_t start_tm, uint64_t end_tm)
+int rv1_nosched_match_writers_t::emit_tm (int64_t start_tm, int64_t end_tm)
 {
     m_starttime = start_tm;
     m_expiration = end_tm;

--- a/resource/writers/match_writers.hpp
+++ b/resource/writers/match_writers.hpp
@@ -61,7 +61,7 @@ class match_writers_t {
     {
         return 0;
     }
-    virtual int emit_tm (uint64_t starttime, uint64_t expiration)
+    virtual int emit_tm (int64_t starttime, int64_t expiration)
     {
         return 0;
     }
@@ -274,7 +274,7 @@ class rv1_match_writers_t : public match_writers_t {
                   const resource_graph_t &g,
                   const edg_t &e,
                   bool excl_parent) override;
-    virtual int emit_tm (uint64_t start_tm, uint64_t end_tm);
+    virtual int emit_tm (int64_t start_tm, int64_t end_tm);
     virtual int emit_attrs (const std::string &k, const std::string &v);
 
    protected:
@@ -304,7 +304,7 @@ class rv1_nosched_match_writers_t : public match_writers_t {
                   const std::map<std::string, std::string> &agfilter_data,
                   bool exclusive,
                   bool excl_parent) override;
-    virtual int emit_tm (uint64_t start_tm, uint64_t end_tm);
+    virtual int emit_tm (int64_t start_tm, int64_t end_tm);
 
    private:
     rlite_match_writers_t rlite;


### PR DESCRIPTION
Problem: a couple of values are converted from int64_t to uint64_t and then back again

Make them int64_t throughout

I was looking through #1435 and was wondering why these types seemed to be randomly mixed?

`m_starttime` and `m_expiration` are `int64_t` in [`rv1_match_writers_t`](https://github.com/flux-framework/flux-sched/blob/master/resource/writers/match_writers.hpp#L287-L288) and [`rv1_nosched_match_writers_t`](https://github.com/flux-framework/flux-sched/blob/master/resource/writers/match_writers.hpp#L311-L312), as is [`jobmeta.at`](https://github.com/flux-framework/flux-sched/blob/master/resource/traversers/dfu_impl.hpp#L46). The only class variable that is currently a `uint64_t` is [`jobmeta.duration`](https://github.com/flux-framework/flux-sched/blob/master/resource/traversers/dfu_impl.hpp#L48) and that discrepancy actually leads to a [type mismatch in this operation](https://github.com/flux-framework/flux-sched/blob/master/resource/traversers/dfu_impl_update.cpp#L865), and it is even initialized to `SYSTEM_DEFAULT_DURATION` [which is itself an `int64_t`](https://github.com/flux-framework/flux-sched/blob/master/resource/config/system_defaults.hpp#L18).

Overall it seems like [`jobmeta.at` is being converted to `uint64_t`](https://github.com/flux-framework/flux-sched/blob/master/resource/traversers/dfu_impl_update.cpp#L864) only to match the signature of [`emit_tm (uint64_t, uint64_t)`](https://github.com/flux-framework/flux-sched/blob/master/resource/writers/match_writers.cpp#L1113-L1118) but this function immediately stores its values back into the `m_starttime` and `m_expiration` variables of type `int64_t` as noted above, so it seems like just keeping everything as `int64_t` throughout would be more consistent?