### PR TITLE
cmake preset: use colons to separate ASAN options

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -86,7 +86,7 @@
         "verbosity": "verbose"
       },
       "environment": {
-        "ASAN_OPTIONS": "detect_leaks=0,start_deactivated=true,replace_str=true,verify_asan_link_order=false"
+        "ASAN_OPTIONS": "detect_leaks=0:start_deactivated=true:replace_str=true:verify_asan_link_order=false"
       },
       "execution": {
         "noTestsAction": "error",


### PR DESCRIPTION
Problem: Multiple ASAN options are separated by comma in the CMake Presets file.  They should be separated by colon.

Update ASAN_OPTIONS to use colons.

----

mirroring fix in flux-core https://github.com/flux-framework/flux-core/pull/7553