### PR TITLE
NEWS.md: add release notes for v0.50.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+flux-sched version 0.50.1 - 2026-04-24
+--------------------------------------
+
+### Fixes
+ * traversers: `storage_node` constraints (#1454)
+ * resource: match int types (#1457)
+ * leave interner open after resource module unload (#1453)
+ * t: fix intermittent t1029 failures (#1446)
+
+### Build/Testsuite/Documentation
+ * cmake: bump jansson requirement to v2.11 (#1455)
+ * cmake preset: use colons to separate ASAN options (#1458)
+ * ci: add el10 build (#1444)
+
+
 flux-sched version 0.50.0 - 2026-04-02
 --------------------------------------
 


### PR DESCRIPTION
There have been a bunch of important fixes since `0.50.0`, and for TOSS updates in the coming weeks it would be good to include those fixes if possible.

@garlick I think you had mentioned a preference for only having very targeted patches to the existing RPM but a lot of these seem either very useful or at worst harmless.