### PR TITLE
[WIP] Add support for non-exclusive slot resources

### DIFF
--- a/resource/traversers/dfu.cpp
+++ b/resource/traversers/dfu.cpp
@@ -367,7 +367,7 @@ int dfu_traverser_t::run (Jobspec::Jobspec &jobspec,
                             .count ();
     detail::jobmeta_t meta;
     vtx_t root = get_graph_db ()->metadata.roots.at (dom);
-    bool x = traverser->exclusivity (jobspec.resources, root);
+    bool x = traverser->resolve_exclusivity (jobspec.resources, root, false);
     const auto exclusive_types = traverser->get_exclusive_resource_types ();
     std::unordered_map<resource_type_t, int64_t> dfv;
 

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -63,13 +63,24 @@ bool dfu_impl_t::exclusivity (const std::vector<Jobspec::Resource> &resources, v
 {
     // If one of the resources matches with the visiting vertex, u
     // and it requested exclusive access, return true;
-    bool exclusive = false;
     for (auto &resource : resources) {
         if (resource_type_t{resource.type} == (*m_graph)[u].type)
             if (resource.exclusive == Jobspec::tristate_t::TRUE)
-                exclusive = true;
+                return true;
     }
-    return exclusive;
+    return false;
+}
+
+bool dfu_impl_t::non_exclusivity (const std::vector<Jobspec::Resource> &resources, vtx_t u)
+{
+    // If one of the resources matches with the visiting vertex, u
+    // and it explicitly requested non-exclusive access, return true;
+    for (auto &resource : resources) {
+        if (resource_type_t{resource.type} == (*m_graph)[u].type)
+            if (resource.exclusive == Jobspec::tristate_t::FALSE)
+                return true;
+    }
+    return false;
 }
 
 int dfu_impl_t::by_avail (const jobmeta_t &meta,
@@ -118,19 +129,12 @@ int dfu_impl_t::by_excl (const jobmeta_t &meta,
     int saved_errno = errno;
     uint64_t duration = meta.duration;
 
-    // If a non-exclusive resource request is explicitly given on a
-    // resource that lies under slot, this spec is invalid.
-    if (exclusive_in && resource.exclusive == Jobspec::tristate_t::FALSE) {
-        errno = EINVAL;
-        m_err_msg += "by_excl: exclusivity conflicts at jobspec=";
-        m_err_msg += resource.label + " : vertex=" + (*m_graph)[u].name;
-        goto done;
-    }
-
-    // If a resource request is under slot or an explicit exclusivity is
-    // requested, we check the validity of the visiting vertex using
-    // its x_checker planner.
-    if (exclusive_in || resource.exclusive == Jobspec::tristate_t::TRUE) {
+    // Check exclusivity if:
+    // 1. Explicitly requested as TRUE, OR
+    // 2. Inherited from parent (exclusive_in) AND not explicitly set to FALSE
+    // This allows explicit FALSE to override inherited slot exclusivity.
+    if (resource.exclusive == Jobspec::tristate_t::TRUE ||
+        (exclusive_in && resource.exclusive != Jobspec::tristate_t::FALSE)) {
         // If it's exclusive, the traversal type is an allocation, and
         // there are no other allocations on the vertex, then proceed. This
         // check prevents the observed multiple booking issue, where
@@ -608,7 +612,9 @@ int dfu_impl_t::aux_upv (const jobmeta_t &meta,
     int64_t avail = 0, at = meta.at;
     uint64_t duration = meta.duration;
     planner_t *p = NULL;
-    bool x_in = *excl;
+    // Check if this resource explicitly requests non-exclusive access.
+    // If so, override inherited exclusivity for this subtree.
+    bool x_in = non_exclusivity (resources, u) ? false : (*excl || exclusivity (resources, u));
 
     static const auto &root = m_graph_db->metadata.roots.find (aux);
     if (root == m_graph_db->metadata.roots.end ())
@@ -728,7 +734,7 @@ int dfu_impl_t::dom_slot (const jobmeta_t &meta,
                 }
                 eval_edg_t ev_edg ((*egroup_i).edges[0].count,
                                    (*egroup_i).edges[0].count,
-                                   1,
+                                   (*egroup_i).edges[0].exclusive,
                                    (*egroup_i).edges[0].edge);
                 score += (*egroup_i).score;
                 edg_group.edges.push_back (ev_edg);
@@ -758,7 +764,9 @@ int dfu_impl_t::dom_dfv (const jobmeta_t &meta,
     match_kind_t sm;
     int64_t avail = 0, at = meta.at;
     uint64_t duration = meta.duration;
-    bool x_in = *excl || exclusivity (resources, u);
+    // Check if this resource explicitly requests non-exclusive access.
+    // If so, override inherited exclusivity for this subtree.
+    bool x_in = non_exclusivity (resources, u) ? false : (*excl || exclusivity (resources, u));
     bool x_inout = x_in;
     bool check_pres = pristine;
     unsigned int nslots = 0;

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -59,28 +59,25 @@ bool dfu_impl_t::stop_explore (edg_t e, subsystem_t subsystem) const
             || m_color.is_black ((*m_graph)[u].idata.colors[subsystem]));
 }
 
-bool dfu_impl_t::exclusivity (const std::vector<Jobspec::Resource> &resources, vtx_t u)
+bool dfu_impl_t::resolve_exclusivity (const std::vector<Jobspec::Resource> &resources,
+                                       vtx_t u,
+                                       bool parent_excl)
 {
-    // If one of the resources matches with the visiting vertex, u
-    // and it requested exclusive access, return true;
+    // Resolve exclusivity for vertex u in a single pass:
+    // - If resource matches and has explicit TRUE -> return true
+    // - If resource matches and has explicit FALSE -> return false
+    // - If resource matches and has UNSPECIFIED -> inherit from parent
+    // - If no match found -> inherit from parent
     for (auto &resource : resources) {
-        if (resource_type_t{resource.type} == (*m_graph)[u].type)
+        if (resource_type_t{resource.type} == (*m_graph)[u].type) {
             if (resource.exclusive == Jobspec::tristate_t::TRUE)
                 return true;
-    }
-    return false;
-}
-
-bool dfu_impl_t::non_exclusivity (const std::vector<Jobspec::Resource> &resources, vtx_t u)
-{
-    // If one of the resources matches with the visiting vertex, u
-    // and it explicitly requested non-exclusive access, return true;
-    for (auto &resource : resources) {
-        if (resource_type_t{resource.type} == (*m_graph)[u].type)
             if (resource.exclusive == Jobspec::tristate_t::FALSE)
-                return true;
+                return false;
+            // UNSPECIFIED: fall through to return parent_excl
+        }
     }
-    return false;
+    return parent_excl;
 }
 
 int dfu_impl_t::by_avail (const jobmeta_t &meta,
@@ -612,9 +609,9 @@ int dfu_impl_t::aux_upv (const jobmeta_t &meta,
     int64_t avail = 0, at = meta.at;
     uint64_t duration = meta.duration;
     planner_t *p = NULL;
-    // Check if this resource explicitly requests non-exclusive access.
-    // If so, override inherited exclusivity for this subtree.
-    bool x_in = non_exclusivity (resources, u) ? false : (*excl || exclusivity (resources, u));
+    // Resolve exclusivity for this vertex, allowing explicit FALSE to override
+    // inherited exclusivity from parent.
+    bool x_in = resolve_exclusivity (resources, u, *excl);
 
     static const auto &root = m_graph_db->metadata.roots.find (aux);
     if (root == m_graph_db->metadata.roots.end ())
@@ -764,9 +761,9 @@ int dfu_impl_t::dom_dfv (const jobmeta_t &meta,
     match_kind_t sm;
     int64_t avail = 0, at = meta.at;
     uint64_t duration = meta.duration;
-    // Check if this resource explicitly requests non-exclusive access.
-    // If so, override inherited exclusivity for this subtree.
-    bool x_in = non_exclusivity (resources, u) ? false : (*excl || exclusivity (resources, u));
+    // Resolve exclusivity for this vertex, allowing explicit FALSE to override
+    // inherited exclusivity from parent.
+    bool x_in = resolve_exclusivity (resources, u, *excl);
     bool x_inout = x_in;
     bool check_pres = pristine;
     unsigned int nslots = 0;

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -130,27 +130,23 @@ class dfu_impl_t {
     void reset_color ();
     int reset_exclusive_resource_types (const std::set<resource_type_t> &x_types);
 
-    /*! Exclusive request? Return true if a resource in resources vector
-     *  matches resource vertex u and its exclusivity field value is TRUE.
-     *  (Note that when the system default configuration is added, it can
-     *  return true even if the exclusive field value is UNSPECIFIED
-     *  if the system default is configured that way.
+    /*! Resolve exclusivity for a vertex in a single pass. Checks if a resource
+     *  in resources vector matches vertex u and returns:
+     *  - true if exclusivity field is TRUE
+     *  - false if exclusivity field is FALSE
+     *  - parent_excl if exclusivity is UNSPECIFIED or no match found
      *
-     *  \param resources Resource request vector.
-     *  \param u         visiting resource vertex.
-     *  \return          true or false.
-     */
-    bool exclusivity (const std::vector<Jobspec::Resource> &resources, vtx_t u);
-
-    /*! Non-exclusive request? Return true if a resource in resources vector
-     *  matches resource vertex u and its exclusivity field value is FALSE.
-     *  This allows resources under slots to opt-out of inherited exclusivity.
+     *  This allows explicit FALSE to override inherited slot exclusivity while
+     *  maintaining backward compatibility with UNSPECIFIED (inherit) behavior.
      *
-     *  \param resources Resource request vector.
-     *  \param u         visiting resource vertex.
-     *  \return          true or false.
+     *  \param resources   Resource request vector.
+     *  \param u           visiting resource vertex.
+     *  \param parent_excl inherited exclusivity from parent.
+     *  \return            resolved exclusivity boolean.
      */
-    bool non_exclusivity (const std::vector<Jobspec::Resource> &resources, vtx_t u);
+    bool resolve_exclusivity (const std::vector<Jobspec::Resource> &resources,
+                              vtx_t u,
+                              bool parent_excl);
 
     /*! Prime the resource graph with subtree plans. The subtree plans are
      *  instantiated on certain resource vertices and updated with the

--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -142,6 +142,16 @@ class dfu_impl_t {
      */
     bool exclusivity (const std::vector<Jobspec::Resource> &resources, vtx_t u);
 
+    /*! Non-exclusive request? Return true if a resource in resources vector
+     *  matches resource vertex u and its exclusivity field value is FALSE.
+     *  This allows resources under slots to opt-out of inherited exclusivity.
+     *
+     *  \param resources Resource request vector.
+     *  \param u         visiting resource vertex.
+     *  \return          true or false.
+     */
+    bool non_exclusivity (const std::vector<Jobspec::Resource> &resources, vtx_t u);
+
     /*! Prime the resource graph with subtree plans. The subtree plans are
      *  instantiated on certain resource vertices and updated with the
      *  information on their subtree resources. For example, the subtree plan

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -75,6 +75,7 @@ set(ALL_TESTS
   t3039-resource-force-load-format.t
   t3040-jgf-shorthand-match-format.t
   t3041-jgf-shorthand-load-format.t
+  t3050-resource-slot-nonexclusive.t
   t3300-system-dontblock.t
   t3301-system-latestart.t
   t4000-match-params.t

--- a/t/data/resource/commands/slot-nonexclusive/cmds-ssd-shared-test.in
+++ b/t/data/resource/commands/slot-nonexclusive/cmds-ssd-shared-test.in
@@ -1,0 +1,7 @@
+# Test 1: Allocate with shared SSDs, should succeed
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/slot-nonexclusive/ssd-shared.yaml
+# Test 2: Allocate again with shared SSDs, should succeed (SSDs are shareable)
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/slot-nonexclusive/ssd-shared.yaml
+# Test 3: Try a third time, should fail (only 2 chassis available)
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/slot-nonexclusive/ssd-shared.yaml
+quit

--- a/t/data/resource/commands/slot-nonexclusive/cmds-ssd-test.in
+++ b/t/data/resource/commands/slot-nonexclusive/cmds-ssd-test.in
@@ -1,0 +1,5 @@
+# Test 1: Allocate with exclusive SSDs (implicit), should succeed
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/slot-nonexclusive/ssd-exclusive.yaml
+# Test 2: Try to allocate again with exclusive SSDs, should fail (no more chassis)
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/slot-nonexclusive/ssd-exclusive.yaml
+quit

--- a/t/data/resource/commands/slot-nonexclusive/cmds01.in
+++ b/t/data/resource/commands/slot-nonexclusive/cmds01.in
@@ -1,0 +1,3 @@
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/slot-nonexclusive/test001.yaml
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/slot-nonexclusive/test002.yaml
+quit

--- a/t/data/resource/commands/slot-nonexclusive/cmds02.in
+++ b/t/data/resource/commands/slot-nonexclusive/cmds02.in
@@ -1,0 +1,3 @@
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/slot-nonexclusive/test001.yaml
+match allocate @TEST_SRCDIR@/data/resource/jobspecs/slot-nonexclusive/test003.yaml
+quit

--- a/t/data/resource/jobspecs/slot-nonexclusive/ssd-exact.yaml
+++ b/t/data/resource/jobspecs/slot-nonexclusive/ssd-exact.yaml
@@ -1,0 +1,20 @@
+version: 9999
+resources:
+  - type: chassis
+    count: 1
+    with:
+      - type: ssd
+        count: 2
+        exclusive: false
+      - type: node
+        count: 1
+        with:
+          - type: core
+            count: 1
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: [ "app" ]
+    count:
+      per_slot: 1

--- a/t/data/resource/jobspecs/slot-nonexclusive/ssd-exclusive.yaml
+++ b/t/data/resource/jobspecs/slot-nonexclusive/ssd-exclusive.yaml
@@ -1,0 +1,25 @@
+version: 9999
+resources:
+  - type: slot
+    count: 1
+    label: testslot
+    with:
+      - type: chassis
+        count: 1
+        with:
+          - type: ssd
+            count: 3
+            # exclusive: true is implicit (inherited from slot)
+          - type: node
+            count: 1
+            with:
+              - type: core
+                count: 1
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: [ "app" ]
+    slot: testslot
+    count:
+      per_slot: 1

--- a/t/data/resource/jobspecs/slot-nonexclusive/ssd-impossible.yaml
+++ b/t/data/resource/jobspecs/slot-nonexclusive/ssd-impossible.yaml
@@ -1,0 +1,15 @@
+version: 9999
+resources:
+  - type: chassis
+    count: 1
+    with:
+      - type: ssd
+        count: 999
+        # Request more SSDs than exist - should fail
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: [ "app" ]
+    count:
+      per_slot: 1

--- a/t/data/resource/jobspecs/slot-nonexclusive/ssd-limit-test-exclusive.yaml
+++ b/t/data/resource/jobspecs/slot-nonexclusive/ssd-limit-test-exclusive.yaml
@@ -1,0 +1,15 @@
+version: 9999
+resources:
+  - type: chassis
+    count: 1
+    with:
+      - type: ssd
+        count: 2
+        # implicit exclusive: true (no override)
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: [ "app" ]
+    count:
+      per_slot: 1

--- a/t/data/resource/jobspecs/slot-nonexclusive/ssd-limit-test-shared.yaml
+++ b/t/data/resource/jobspecs/slot-nonexclusive/ssd-limit-test-shared.yaml
@@ -1,0 +1,15 @@
+version: 9999
+resources:
+  - type: chassis
+    count: 1
+    with:
+      - type: ssd
+        count: 2
+        exclusive: false
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: [ "app" ]
+    count:
+      per_slot: 1

--- a/t/data/resource/jobspecs/slot-nonexclusive/ssd-shared.yaml
+++ b/t/data/resource/jobspecs/slot-nonexclusive/ssd-shared.yaml
@@ -1,0 +1,25 @@
+version: 9999
+resources:
+  - type: slot
+    count: 1
+    label: testslot
+    with:
+      - type: chassis
+        count: 1
+        with:
+          - type: ssd
+            count: 3
+            exclusive: false
+          - type: node
+            count: 1
+            with:
+              - type: core
+                count: 1
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: [ "app" ]
+    slot: testslot
+    count:
+      per_slot: 1

--- a/t/data/resource/jobspecs/slot-nonexclusive/test001.yaml
+++ b/t/data/resource/jobspecs/slot-nonexclusive/test001.yaml
@@ -1,0 +1,28 @@
+version: 9999
+resources:
+  - type: slot
+    count: 1
+    label: testslot
+    with:
+      - type: node
+        count: 1
+        with:
+          - type: socket
+            count: 1
+            with: 
+              - type: core
+                count: 4
+                exclusive: false
+              - type: gpu
+                count: 1
+                exclusive: false
+              - type: memory
+                count: 1
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: [ "app" ]
+    slot: testslot
+    count:
+      per_slot: 1

--- a/t/data/resource/jobspecs/slot-nonexclusive/test002.yaml
+++ b/t/data/resource/jobspecs/slot-nonexclusive/test002.yaml
@@ -1,0 +1,20 @@
+version: 9999
+resources:
+  - type: slot
+    count: 1
+    label: testslot
+    with:
+      - type: node
+        count: 1
+        with:
+          - type: gpu
+            count: 1
+            exclusive: false
+attributes:
+  system:
+    duration: 1800
+tasks:
+  - command: [ "gpu_app" ]
+    slot: testslot
+    count:
+      per_slot: 1

--- a/t/data/resource/jobspecs/slot-nonexclusive/test003.yaml
+++ b/t/data/resource/jobspecs/slot-nonexclusive/test003.yaml
@@ -1,0 +1,19 @@
+version: 9999
+resources:
+  - type: slot
+    count: 1
+    label: testslot
+    with:
+      - type: node
+        count: 1
+        with:
+          - type: core
+            count: 2
+attributes:
+  system:
+    duration: 1800
+tasks:
+  - command: [ "cpu_app" ]
+    slot: testslot
+    count:
+      per_slot: 1

--- a/t/data/resource/jobspecs/slot-nonexclusive/test004.yaml
+++ b/t/data/resource/jobspecs/slot-nonexclusive/test004.yaml
@@ -1,0 +1,16 @@
+version: 9999
+resources:
+  - type: node
+    count: 1
+    with:
+      - type: socket
+        count: 1
+        with:
+          - type: core
+            count: 4
+          - type: gpu
+            count: 1
+            exclusive: false
+attributes:
+  system:
+    duration: 3600

--- a/t/t3050-resource-slot-nonexclusive.t
+++ b/t/t3050-resource-slot-nonexclusive.t
@@ -1,0 +1,113 @@
+#!/bin/sh
+
+test_description='Test that resources with explicit exclusive:false under slots can be shared'
+
+. $(dirname $0)/sharness.sh
+
+cmd_dir="${SHARNESS_TEST_SRCDIR}/data/resource/commands/slot-nonexclusive"
+exp_dir="${SHARNESS_TEST_SRCDIR}/data/resource/expected/slot-nonexclusive"
+jgf="${SHARNESS_TEST_SRCDIR}/data/resource/jgfs/rabbit.json"
+query="../../resource/utilities/resource-query"
+
+#
+# Test that SSDs with explicit exclusive:false can be matched
+#
+
+cmds001="${cmd_dir}/cmds-ssd-shared-test.in"
+test001_desc="match shared SSDs under slot multiple times"
+test_expect_success "${test001_desc}" '
+    sed "s~@TEST_SRCDIR@~${SHARNESS_TEST_SRCDIR}~g" ${cmds001} > cmds001 &&
+    ${query} -L ${jgf} -f jgf -t 001.R.out < cmds001 &&
+    grep "JOBID=1" 001.R.out &&
+    grep "JOBID=2" 001.R.out &&
+    grep "No matching resources found" 001.R.out
+'
+
+#
+# Test that exclusive SSDs are exhausted after both chassis are used
+#
+test002_desc="exclusive SSDs limit allocations to available chassis"
+test_expect_success "${test002_desc}" '
+    cat > ssd-exclusive-2.yaml <<-EOF &&
+	version: 9999
+	resources:
+	  - type: slot
+	    count: 1
+	    label: testslot
+	    with:
+	      - type: chassis
+	        count: 1
+	        with:
+	          - type: ssd
+	            count: 2
+	            # implicit exclusive: true
+	          - type: node
+	            count: 1
+	            with:
+	              - type: core
+	                count: 1
+	attributes:
+	  system:
+	    duration: 3600
+	tasks:
+	  - command: [ "app" ]
+	    slot: testslot
+	    count:
+	      per_slot: 1
+	EOF
+    cat > cmds002 <<-EOF &&
+	match allocate ${PWD}/ssd-exclusive-2.yaml
+	match allocate ${PWD}/ssd-exclusive-2.yaml
+	match allocate ${PWD}/ssd-exclusive-2.yaml
+	quit
+	EOF
+    ${query} -L ${jgf} -f jgf -t 002.R.out < cmds002 &&
+    test $(grep -c "RESOURCES=ALLOCATED" 002.R.out) -eq 2 &&
+    grep "No matching resources found" 002.R.out
+'
+
+#
+# Test that shared SSDs also work (same limit due to chassis exhaustion)
+# This test verifies the implementation doesn'\''t break normal allocation patterns
+#
+test003_desc="shared SSDs allow same allocations when chassis is the constraint"
+test_expect_success "${test003_desc}" '
+    cat > ssd-shared-2.yaml <<-EOF &&
+	version: 9999
+	resources:
+	  - type: slot
+	    count: 1
+	    label: testslot
+	    with:
+	      - type: chassis
+	        count: 1
+	        with:
+	          - type: ssd
+	            count: 2
+	            exclusive: false
+	          - type: node
+	            count: 1
+	            with:
+	              - type: core
+	                count: 1
+	attributes:
+	  system:
+	    duration: 3600
+	tasks:
+	  - command: [ "app" ]
+	    slot: testslot
+	    count:
+	      per_slot: 1
+	EOF
+    cat > cmds003 <<-EOF &&
+	match allocate ${PWD}/ssd-shared-2.yaml
+	match allocate ${PWD}/ssd-shared-2.yaml
+	match allocate ${PWD}/ssd-shared-2.yaml
+	quit
+	EOF
+    ${query} -L ${jgf} -f jgf -t 003.R.out < cmds003 &&
+    test $(grep -c "RESOURCES=ALLOCATED" 003.R.out) -eq 2 &&
+    grep "No matching resources found" 003.R.out
+'
+
+test_done


### PR DESCRIPTION
This PR adds the capability to specify non-exclusive resources under a slot. The use case supports rabbit allocations as well as other scenarios where a job might need exclusive node access but non-exclusive access to related pool vertices.

Further testing is needed to determine if complex rabbit allocation scenarios are supported by these changes, and how to handle combinations of `exclusive: true` and `exclusive: false` resources in the same slot subtree. The current status is WIP.