### PR TITLE
resource: support amending R with JGF in a subinstance

### DIFF
--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -883,7 +883,9 @@ done:
     return rc;
 }
 
-static int unpack_parent_job_resources (std::shared_ptr<resource_ctx_t> &ctx, json_t **p_r_lite_p)
+static int unpack_parent_job_resources (std::shared_ptr<resource_ctx_t> &ctx,
+                                        json_t **p_r_lite_p,
+                                        bool *parent_has_jgf_p)
 {
     int rc = 0;
     int saved_errno;
@@ -897,11 +899,13 @@ static int unpack_parent_job_resources (std::shared_ptr<resource_ctx_t> &ctx, js
         goto done;
     if ((rc = unpack_resources (p_resources, &p_grow_set, &p_r_lite, &p_jgf, duration)) < 0)
         goto done;
-    if (!p_grow_set || !p_r_lite || !p_jgf) {
+    if (!p_grow_set || !p_r_lite) {
+        // Parent must have R_lite, but JGF is optional
         errno = EINVAL;
         rc = -1;
         goto done;
     }
+    *parent_has_jgf_p = (p_jgf != NULL);
     if ((*p_r_lite_p = json_deep_copy (p_r_lite)) == NULL) {
         errno = ENOMEM;
         rc = -1;
@@ -921,16 +925,24 @@ static int grow_resource_db_jgf (std::shared_ptr<resource_ctx_t> &ctx, json_t *r
     int rc = -1;
     int saved_errno;
     json_t *p_r_lite = NULL;
+    bool parent_has_jgf = false;
     resource_graph_db_t &db = *(ctx->db);
     char *jgf_str = NULL;
     vtx_t v = boost::graph_traits<resource_graph_t>::null_vertex ();
 
-    if ((rc = unpack_parent_job_resources (ctx, &p_r_lite)) < 0) {
-        flux_log_error (ctx->h, "%s: unpack_parent_job_resources", __FUNCTION__);
-        goto done;
+    if ((rc = unpack_parent_job_resources (ctx, &p_r_lite, &parent_has_jgf)) < 0) {
+        // Parent resources unavailable or no parent - this is OK
+        // JGF ranks should already be correct
+        flux_log (ctx->h,
+                  LOG_DEBUG,
+                  "%s: parent resources unavailable, skipping remapping",
+                  __FUNCTION__);
+        p_r_lite = NULL;
+        rc = 0;
     }
     if (db.metadata.roots.find (containment_sub) == db.metadata.roots.end ()) {
-        if (p_r_lite && (rc = remap_jgf_namespace (ctx, r_lite, p_r_lite)) < 0) {
+        // Only remap if parent has JGF - otherwise assume JGF ranks match R_lite
+        if (p_r_lite && parent_has_jgf && (rc = remap_jgf_namespace (ctx, r_lite, p_r_lite)) < 0) {
             flux_log_error (ctx->h, "%s: remap_jgf_namespace", __FUNCTION__);
             goto done;
         }

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -930,6 +930,13 @@ static int grow_resource_db_jgf (std::shared_ptr<resource_ctx_t> &ctx, json_t *r
     char *jgf_str = NULL;
     vtx_t v = boost::graph_traits<resource_graph_t>::null_vertex ();
 
+    // Validate that jgf is a proper JGF object with a graph key
+    if (!jgf || !json_is_object (jgf) || !json_object_get (jgf, "graph")) {
+        errno = EINVAL;
+        flux_log_error (ctx->h, "%s: invalid JGF in scheduling section", __FUNCTION__);
+        goto done;
+    }
+
     if ((rc = unpack_parent_job_resources (ctx, &p_r_lite, &parent_has_jgf)) < 0) {
         // Parent resources unavailable or no parent - this is OK
         // JGF ranks should already be correct

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -97,6 +97,7 @@ set(ALL_TESTS
   t4016-match-flexible.t
   t5000-valgrind.t
   t5100-issues-test-driver.t
+  t5200-jgf-load-no-parent-jgf.t
   t6000-graph-size.t
   t6001-match-formats.t
   t6002-graph-hwloc.t

--- a/t/t5200-jgf-load-no-parent-jgf.t
+++ b/t/t5200-jgf-load-no-parent-jgf.t
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+test_description='Test loading JGF when parent has only R_lite (no JGF)'
+
+. `dirname $0`/sharness.sh
+
+if ! command -v hwloc-ls >/dev/null; then
+	skip_all='Skipping JGF load tests because hwloc-ls not found'
+	test_done
+fi
+
+SIZE=1
+test_under_flux ${SIZE}
+
+BUILDDIR=${SHARNESS_BUILD_DIRECTORY}
+export FLUX_URI_RESOLVE_LOCAL=t
+
+test_expect_success 'amend R with JGF' '
+	hwloc-ls --of xml > test.xml &&
+	printf "find status=up\nquit" | \
+	    ${BUILDDIR}/resource/utilities/resource-query \
+	    -L test.xml -f hwloc -F jgf -S CA -P high \
+	    -W cluster,node,socket,core,gpu | head -1 > test.jgf &&
+	test -s test.jgf &&
+	flux kvs get resource.R | \
+	jq --slurpfile jgf test.jgf ".scheduling = \$jgf[0]" > test.R
+'
+
+test_expect_success 'parent instance has R_lite but no JGF' '
+	flux kvs get resource.R | jq -e ".scheduling == null"
+'
+
+test_expect_success 'create modprobe script to reload test.R' '
+	mkdir rc1.d &&
+	cat <<-EOF >rc1.d/load-jgf.py &&
+	from flux.modprobe import task
+	@task("load-jgf",
+	      ranks="0",
+	      before=["sched-fluxion-resource"],
+	      after=["resource"]
+	)
+	def load_jgf(context):
+	    context.bash("flux resource reload test.R")
+	EOF
+	flux run -N1 \
+	    --env=-FLUX_MODPROBE_DISABLE \
+	    --env=FLUX_MODPROBE_PATH=${FLUX_MODPROBE_PATH}:$(pwd) \
+	    flux dmesg -H
+'
+
+test_expect_success 'run subinstance with JGF loaded' '
+	jobid=$(flux alloc -N1 --bg \
+		--env=-FLUX_MODPROBE_DISABLE \
+		--env=FLUX_MODPROBE_PATH=${FLUX_MODPROBE_PATH}:$(pwd))
+'
+
+test_expect_success 'JGF was loaded in subinstance' '
+	flux proxy $jobid flux dmesg -H | grep sched-fluxion-resource &&
+	flux proxy $jobid flux dmesg -H | grep "loaded with JGF"
+'
+
+test_expect_success 'can query resources with JGF' '
+	flux proxy $jobid flux ion-resource find status=up
+'
+
+test_done


### PR DESCRIPTION
While investigating flux-framework/flux-core#7521 and #1033, I hit a roadblock because sched-fluxion-resource currently _requires_ that a subinstance job's R was originally encoded with JGF, even when the R has been amended with JGF before the Fluxion resource module has been loaded.

This PR works around that issue by skipping namespace remapping unless the parent R has JGF. If JGF is present R but missing in the parent's record of R, assume that the JGF doesn't need remapping.

This was enough to get my tests working (example use case added as a sharness test), so this could be merged now, but hopefully with Rv2 this double fetch of the job's R from parent can be removed.

