### PR TITLE
docker: remove unnecessary `sudo` from el9

### DIFF
--- a/src/test/docker/el9/Dockerfile
+++ b/src/test/docker/el9/Dockerfile
@@ -7,8 +7,8 @@ USER root
 # copy scripts into image
 COPY scripts/ /scripts
 # Install extra buildrequires for flux-sched:
-RUN sudo /scripts/install-deps.sh -y --allowerasing gcc-toolset-13-{gcc,gcc-c++,gdb} \
- && sudo dnf clean all
+RUN /scripts/install-deps.sh -y --allowerasing gcc-toolset-13-{gcc,gcc-c++,gdb} \
+ && dnf clean all
 
 # Add configured user to image with sudo access:
 #


### PR DESCRIPTION
Problem: there is an unnecessary `sudo` call that is causing problems in CI.

Remove it.

Fixes #1464.