### PR TITLE
ci: fix fluxrm/flux-sched:latest docker image tag

### DIFF
--- a/src/test/docker-deploy.sh
+++ b/src/test/docker-deploy.sh
@@ -19,10 +19,3 @@ echo $DOCKER_PASSWORD | docker login -u "$DOCKER_USERNAME" --password-stdin
 
 log "docker push ${DOCKER_TAG}"
 docker push ${DOCKER_TAG}
-
-#  If this is the jammy build, then also tag without image name:
-if echo "$DOCKER_TAG" | grep -q "jammy"; then
-    t="${DOCKER_REPO}:${GITHUB_TAG:-latest}"
-    log "docker push ${t}"
-    docker tag "$DOCKER_TAG" ${t} && docker push ${t}
-fi

--- a/src/test/docker-manifest.py
+++ b/src/test/docker-manifest.py
@@ -7,6 +7,8 @@ import json
 import subprocess
 from collections import defaultdict
 
+DOCKER_REPO = "fluxrm/flux-sched"
+
 matrix = json.loads(
     subprocess.run(
         ["src/test/generate-matrix.py"], capture_output=True, text=True
@@ -16,14 +18,40 @@ matrix = json.loads(
 tags = defaultdict(list)
 for entry in matrix["include"]:
     if "DOCKER_TAG" in entry["env"]:
-        tags[entry["image"]].append(entry["env"]["DOCKER_TAG"])
+        image = entry["image"]
+        base = f"{DOCKER_REPO}:{image}"
+        docker_tag = entry["env"]["DOCKER_TAG"]
+        tags[base].append(docker_tag)
+        # This is also a tagged version
+        if entry.get("tag"):
+            tag = entry["tag"]
+            tags[f"{base}-{tag}"].append(docker_tag)
 
-# Collect only those images with multiple tags:
-tags = {k: v for k, v in tags.items() if len(v) > 1}
+# Collect only those images with multiple tags or where image name does
+# not equal tag name. This latter check ensures that non-multi-arch docker
+# images for tags, e.g. fluxrm/flux-sched:el8-v0.81.0, have a corresponding
+# image without the version tag, e.g. fluxrm/flux-sched:el8. This allows
+# CI from other projects to immediately pick up the new version when pulling
+# latest docker images after a tag. (See flux-core#7225).
+tags = {k: v for k, v in tags.items() if len(v) > 1 or v[0] != k}
 
-for image in tags.keys():
-    tag = f"fluxrm/flux-sched:{image}"
-    print(f"docker manifest create {tag} ", *tags[image])
-    subprocess.run(["docker", "manifest", "create", tag, *tags[image]])
-    print(f"docker manifest push {tag} ")
+# The noble image is the canonical "latest" build. Create a latest
+# manifest (and for tagged releases, also a versioned manifest) pointing
+# to the same per-arch images as the el10 manifest.
+latest_distro = "noble"
+latest_key = f"{DOCKER_REPO}:{latest_distro}"
+if latest_key in tags:
+    latest_sources = tags[latest_key]
+    github_tag = next(
+        (entry["tag"] for entry in matrix["include"] if entry.get("tag")),
+        None,
+    )
+    tags[f"{DOCKER_REPO}:latest"] = latest_sources
+    if github_tag:
+        tags[f"{DOCKER_REPO}:{github_tag}"] = latest_sources
+
+for tag in tags.keys():
+    print(f"docker manifest create {tag}", *tags[tag])
+    subprocess.run(["docker", "manifest", "create", tag, *tags[tag]])
+    print(f"docker manifest push {tag}")
     subprocess.run(["docker", "manifest", "push", tag])


### PR DESCRIPTION
Problem: The docker-deploy.sh script pushes fluxrm/flux-sched:latest by tagging a single-arch jammy image, which does not work correctly with the multiarch manifest-based workflow.

Copy the fixed docker-deploy.sh and docker-manifest.py scripts from flux-core, modified for flux-sched. Choose noble as the distro for the `latest` tag by request.