### PR TITLE
fix more errno violations

### DIFF
--- a/resource/planner/c/planner_c_interface.cpp
+++ b/resource/planner/c/planner_c_interface.cpp
@@ -194,6 +194,7 @@ static bool avail_during (planner_t *ctx, int64_t at, uint64_t duration, const i
             ok = true;
             break;
         } else if (request > point->remaining) {
+            errno = EBUSY;
             ok = false;
             break;
         }

--- a/resource/planner/c/planner_c_interface.cpp
+++ b/resource/planner/c/planner_c_interface.cpp
@@ -58,6 +58,10 @@ static scheduled_point_t *get_or_new_point (planner_t *ctx, int64_t at)
     try {
         if (!(point = ctx->plan->sp_tree_search (at))) {
             scheduled_point_t *state = ctx->plan->sp_tree_get_state (at);
+            if (!state) {
+                errno = EINVAL;
+                return nullptr;
+            }
             point = new scheduled_point_t ();
             point->at = at;
             point->in_mt_resource_tree = 0;

--- a/resource/planner/c/planner_c_interface.cpp
+++ b/resource/planner/c/planner_c_interface.cpp
@@ -211,6 +211,10 @@ static scheduled_point_t *avail_resources_during (planner_t *ctx, int64_t at, ui
     }
 
     scheduled_point_t *point = ctx->plan->sp_tree_get_state (at);
+    if (!point) {
+        errno = EINVAL;
+        return nullptr;
+    }
     scheduled_point_t *min = point;
     while (point) {
         if (point->at >= (at + (int64_t)duration))
@@ -484,6 +488,8 @@ extern "C" int64_t planner_avail_resources_during (planner_t *ctx, int64_t at, u
         return -1;
     }
     min_point = avail_resources_during (ctx, at, duration);
+    if (!min_point)
+        return -1;
     return min_point->remaining;
 }
 

--- a/resource/planner/c/planner_c_interface.cpp
+++ b/resource/planner/c/planner_c_interface.cpp
@@ -185,7 +185,7 @@ static bool avail_during (planner_t *ctx, int64_t at, uint64_t duration, const i
     bool ok = true;
     if (static_cast<int64_t> (at + duration) > ctx->plan->get_plan_end ()) {
         errno = ERANGE;
-        return -1;
+        return false;
     }
 
     scheduled_point_t *point = ctx->plan->sp_tree_get_state (at);

--- a/resource/planner/c/planner_c_interface.cpp
+++ b/resource/planner/c/planner_c_interface.cpp
@@ -496,11 +496,19 @@ extern "C" int64_t planner_avail_resources_during (planner_t *ctx, int64_t at, u
 extern "C" int64_t planner_avail_resources_at (planner_t *ctx, int64_t at)
 {
     const scheduled_point_t *state = nullptr;
-    if (!ctx || at > ctx->plan->get_plan_end () || at < ctx->plan->get_plan_start ()) {
+    if (!ctx) {
         errno = EINVAL;
         return -1;
     }
+    if (at > ctx->plan->get_plan_end () || at < ctx->plan->get_plan_start ()) {
+        errno = ERANGE;
+        return -1;
+    }
     state = ctx->plan->sp_tree_get_state (at);
+    if (!state) {
+        errno = ENOENT;
+        return -1;
+    }
     return state->remaining;
 }
 

--- a/resource/planner/test/planner_errno_test.cpp
+++ b/resource/planner/test/planner_errno_test.cpp
@@ -29,6 +29,18 @@ static int test_planner_avail_resources_at_errno ()
     ok (result == -1 && errno == EINVAL,
         "planner_avail_resources_at (NULL ctx) returns -1 with errno=EINVAL");
 
+    // Test with at beyond plan_end
+    errno = 0;
+    result = planner_avail_resources_at (ctx, 101);
+    ok (result == -1 && errno == ERANGE,
+        "planner_avail_resources_at returns -1 with errno=ERANGE when at > plan_end");
+
+    // Test with at before plan_start
+    errno = 0;
+    result = planner_avail_resources_at (ctx, -1);
+    ok (result == -1 && errno == ERANGE,
+        "planner_avail_resources_at returns -1 with errno=ERANGE when at < plan_start");
+
     planner_destroy (&ctx);
     return 0;
 }
@@ -43,6 +55,12 @@ static int test_planner_avail_resources_during_errno ()
     int64_t result = planner_avail_resources_during (nullptr, 50, 10);
     ok (result == -1 && errno == EINVAL,
         "planner_avail_resources_during (NULL ctx) returns -1 with errno=EINVAL");
+
+    // Test with at+duration > plan_end
+    errno = 0;
+    result = planner_avail_resources_during (ctx, 95, 10);
+    ok (result == -1 && errno == ERANGE,
+        "planner_avail_resources_during returns -1 with errno=ERANGE when at+duration > plan_end");
 
     planner_destroy (&ctx);
     return 0;
@@ -101,6 +119,57 @@ static int test_planner_rem_span_errno ()
     return 0;
 }
 
+static int test_planner_avail_during_ebusy ()
+{
+    // Create planner with 10 resources available from time 0 to 100
+    planner_t *ctx = planner_new (0, 100, 10, "core");
+    ok (ctx != nullptr, "planner_new succeeded");
+
+    // Allocate 8 resources from time 10 to 20
+    int64_t span_id = planner_add_span (ctx, 10, 10, 8);
+    ok (span_id >= 0, "planner_add_span succeeded");
+
+    // Try to allocate 5 resources during the same time - should fail with EBUSY
+    // (only 2 resources available, need 5)
+    errno = 0;
+    int rc = planner_avail_during (ctx, 10, 10, 5);
+    ok (rc == -1 && errno == EBUSY,
+        "planner_avail_during returns -1 with errno=EBUSY when resources unavailable");
+
+    // Verify resources are available before and after the span
+    errno = 0;
+    rc = planner_avail_during (ctx, 0, 10, 10);
+    ok (rc == 0, "planner_avail_during succeeds before allocated span");
+
+    errno = 0;
+    rc = planner_avail_during (ctx, 20, 10, 10);
+    ok (rc == 0, "planner_avail_during succeeds after allocated span");
+
+    planner_destroy (&ctx);
+    return 0;
+}
+
+static int test_planner_avail_during_erange ()
+{
+    // Create planner with time range 0 to 100
+    planner_t *ctx = planner_new (0, 100, 10, "core");
+    ok (ctx != nullptr, "planner_new succeeded");
+
+    // Try to check availability with at+duration > plan_end (95 + 10 = 105 > 100)
+    errno = 0;
+    int rc = planner_avail_during (ctx, 95, 10, 5);
+    ok (rc == -1 && errno == ERANGE,
+        "planner_avail_during returns -1 with errno=ERANGE when at+duration > plan_end");
+
+    // Verify it works when at+duration == plan_end
+    errno = 0;
+    rc = planner_avail_during (ctx, 90, 10, 5);
+    ok (rc == 0, "planner_avail_during succeeds when at+duration == plan_end");
+
+    planner_destroy (&ctx);
+    return 0;
+}
+
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
@@ -109,6 +178,8 @@ int main (int argc, char *argv[])
     test_planner_avail_resources_during_errno ();
     test_planner_span_functions_errno ();
     test_planner_rem_span_errno ();
+    test_planner_avail_during_ebusy ();
+    test_planner_avail_during_erange ();
 
     done_testing ();
     return EXIT_SUCCESS;

--- a/resource/policies/base/test/CMakeLists.txt
+++ b/resource/policies/base/test/CMakeLists.txt
@@ -12,3 +12,9 @@ target_link_libraries(matcher_util_api_test PRIVATE libtap resource
   )
 add_sanitizers(matcher_util_api_test)
 flux_add_test(NAME matcher_util_api_test COMMAND matcher_util_api_test)
+add_executable(policy_errno_test
+  ${CMAKE_CURRENT_SOURCE_DIR}/policy_errno_test.cpp
+  )
+target_link_libraries(policy_errno_test PRIVATE libtap resource)
+add_sanitizers(policy_errno_test)
+flux_add_test(NAME policy_errno_test COMMAND policy_errno_test)

--- a/resource/policies/base/test/policy_errno_test.cpp
+++ b/resource/policies/base/test/policy_errno_test.cpp
@@ -1,0 +1,55 @@
+/*****************************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+}
+
+#include <cerrno>
+#include "resource/policies/dfu_match_high_id_first.hpp"
+#include "resource/policies/dfu_match_multilevel_id_impl.hpp"
+#include "src/common/libtap/tap.h"
+
+using namespace Flux::resource_model;
+
+static int test_set_stop_on_k_matches_errno ()
+{
+    high_first_t policy;
+
+    // Test with invalid input (k > 1)
+    errno = 0;
+    int rc = policy.set_stop_on_k_matches (2);
+    ok (rc == -1, "set_stop_on_k_matches returns -1 for k > 1");
+    ok (errno == EINVAL, "set_stop_on_k_matches sets errno=EINVAL for k > 1");
+
+    // Test with valid input
+    errno = 0;
+    rc = policy.set_stop_on_k_matches (1);
+    ok (rc == 0, "set_stop_on_k_matches returns 0 for k = 1");
+    ok (errno == 0, "set_stop_on_k_matches preserves errno on success");
+
+    return 0;
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_set_stop_on_k_matches_errno ();
+
+    done_testing ();
+    return EXIT_SUCCESS;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/policies/dfu_match_locality.cpp
+++ b/resource/policies/dfu_match_locality.cpp
@@ -66,7 +66,11 @@ int greater_interval_first_t::dom_finish_graph (
         dfu.choose_accum_best_k (subsystem, resource.type, count, comp);
     }
     dfu.set_overall_score (score);
-    return (score == MATCH_MET) ? 0 : -1;
+    if (score != MATCH_MET) {
+        errno = EBUSY;
+        return -1;
+    }
+    return 0;
 }
 
 int greater_interval_first_t::dom_finish_slot (subsystem_t subsystem, scoring_api_t &dfu)
@@ -108,7 +112,11 @@ int greater_interval_first_t::dom_finish_vtx (vtx_t u,
     overall = (score == MATCH_MET) ? (score + g[u].id + 1) : score;
     dfu.set_overall_score (overall);
     decr ();
-    return (score == MATCH_MET) ? 0 : -1;
+    if (score != MATCH_MET) {
+        errno = EBUSY;
+        return -1;
+    }
+    return 0;
 }
 
 }  // namespace resource_model

--- a/resource/policies/dfu_match_multilevel_id_impl.hpp
+++ b/resource/policies/dfu_match_multilevel_id_impl.hpp
@@ -189,8 +189,10 @@ int multilevel_id_t<FOLD>::dom_finish_vtx (vtx_t u,
 template<typename FOLD>
 int multilevel_id_t<FOLD>::set_stop_on_k_matches (unsigned k)
 {
-    if (k > 1)
+    if (k > 1) {
+        errno = EINVAL;
         return -1;
+    }
     m_stop_on_k_matches = k;
     return 0;
 }

--- a/resource/policies/dfu_match_multilevel_id_impl.hpp
+++ b/resource/policies/dfu_match_multilevel_id_impl.hpp
@@ -179,7 +179,11 @@ int multilevel_id_t<FOLD>::dom_finish_vtx (vtx_t u,
     overall = (score == MATCH_MET) ? (score + m_multilevel_scores + g[u].id + 1) : score;
     dfu.set_overall_score (overall);
     decr ();
-    return (score == MATCH_MET) ? 0 : -1;
+    if (score != MATCH_MET) {
+        errno = EBUSY;
+        return -1;
+    }
+    return 0;
 }
 
 template<typename FOLD>

--- a/resource/policies/dfu_match_var_aware.cpp
+++ b/resource/policies/dfu_match_var_aware.cpp
@@ -59,7 +59,11 @@ int var_aware_t::dom_finish_graph (subsystem_t subsystem,
         dfu.choose_accum_best_k (subsystem, resource.type, count, comp);
     }
     dfu.set_overall_score (score);
-    return (score == MATCH_MET) ? 0 : -1;
+    if (score != MATCH_MET) {
+        errno = EBUSY;
+        return -1;
+    }
+    return 0;
 }
 
 int var_aware_t::dom_finish_slot (subsystem_t subsystem, scoring_api_t &dfu)
@@ -119,7 +123,11 @@ int var_aware_t::dom_finish_vtx (vtx_t u,
     overall = (score == MATCH_MET) ? (score + perf_class) : score;
     dfu.set_overall_score (overall);
     decr ();
-    return (score == MATCH_MET) ? 0 : -1;
+    if (score != MATCH_MET) {
+        errno = EBUSY;
+        return -1;
+    }
+    return 0;
 }
 
 }  // namespace resource_model

--- a/resource/reapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli_impl.hpp
@@ -191,7 +191,12 @@ int reapi_cli_t::cancel (void *h, const uint64_t jobid, bool noent_ok)
     } else {
         m_err_msg += __FUNCTION__;
         m_err_msg += ": ERROR: nonexistent job " + std::to_string (jobid) + "\n";
-        rc = noent_ok ? 0 : -1;
+        if (noent_ok) {
+            rc = 0;
+        } else {
+            errno = ENOENT;
+            rc = -1;
+        }
         goto out;
     }
 
@@ -222,7 +227,12 @@ int reapi_cli_t::cancel (void *h,
     } else {
         m_err_msg += __FUNCTION__;
         m_err_msg += ": WARNING: can't find allocation for jobid: " + std::to_string (jobid) + "\n";
-        rc = noent_ok ? 0 : -1;
+        if (noent_ok) {
+            rc = 0;
+        } else {
+            errno = ENOENT;
+            rc = -1;
+        }
         goto out;
     }
 
@@ -272,6 +282,7 @@ int reapi_cli_t::info (void *h,
     if (!(rq->job_exists (jobid))) {
         m_err_msg += __FUNCTION__;
         m_err_msg += ": ERROR: nonexistent job " + std::to_string (jobid) + "\n";
+        errno = ENOENT;
         return -1;
     }
 
@@ -291,6 +302,7 @@ int reapi_cli_t::info (void *h, const uint64_t jobid, std::shared_ptr<job_info_t
     if (!(rq->job_exists (jobid))) {
         m_err_msg += __FUNCTION__;
         m_err_msg += ": ERROR: nonexistent job " + std::to_string (jobid) + "\n";
+        errno = ENOENT;
         return -1;
     }
 

--- a/resource/reapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli_impl.hpp
@@ -68,6 +68,11 @@ int reapi_cli_t::match_allocate (void *h,
     int traverser_errno;
     bool matched = false;
 
+    if (!rq) {
+        errno = EINVAL;
+        return -1;
+    }
+
     if (!match_op_valid (match_op)) {
         m_err_msg += __FUNCTION__;
         m_err_msg +=
@@ -182,6 +187,11 @@ int reapi_cli_t::cancel (void *h, const uint64_t jobid, bool noent_ok)
     resource_query_t *rq = static_cast<resource_query_t *> (h);
     int rc = -1;
 
+    if (!rq) {
+        errno = EINVAL;
+        return -1;
+    }
+
     if (rq->allocation_exists (jobid)) {
         if ((rc = rq->remove_job (jobid)) == 0)
             rq->erase_allocation (jobid);
@@ -219,6 +229,11 @@ int reapi_cli_t::cancel (void *h,
     resource_query_t *rq = static_cast<resource_query_t *> (h);
     int rc = -1;
 
+    if (!rq) {
+        errno = EINVAL;
+        return -1;
+    }
+
     if (rq->allocation_exists (jobid)) {
         if ((rc = rq->remove_job (jobid, R, full_removal)) == 0) {
             if (full_removal)
@@ -251,6 +266,11 @@ int reapi_cli_t::find (void *h, std::string criteria, json_t *&o)
     int rc = -1;
     resource_query_t *rq = static_cast<resource_query_t *> (h);
 
+    if (!rq) {
+        errno = EINVAL;
+        return -1;
+    }
+
     if ((rc = rq->traverser_find (criteria)) < 0) {
         if (rq->get_traverser_err_msg () != "") {
             m_err_msg += __FUNCTION__;
@@ -279,6 +299,11 @@ int reapi_cli_t::info (void *h,
     resource_query_t *rq = static_cast<resource_query_t *> (h);
     std::shared_ptr<job_info_t> info = nullptr;
 
+    if (!rq) {
+        errno = EINVAL;
+        return -1;
+    }
+
     if (!(rq->job_exists (jobid))) {
         m_err_msg += __FUNCTION__;
         m_err_msg += ": ERROR: nonexistent job " + std::to_string (jobid) + "\n";
@@ -298,6 +323,11 @@ int reapi_cli_t::info (void *h,
 int reapi_cli_t::info (void *h, const uint64_t jobid, std::shared_ptr<job_info_t> &job)
 {
     resource_query_t *rq = static_cast<resource_query_t *> (h);
+
+    if (!rq) {
+        errno = EINVAL;
+        return -1;
+    }
 
     if (!(rq->job_exists (jobid))) {
         m_err_msg += __FUNCTION__;

--- a/resource/reapi/bindings/c++/reapi_module_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_module_impl.hpp
@@ -248,7 +248,6 @@ int reapi_module_t::cancel (void *h, const uint64_t jobid, bool noent_ok)
     int rc = -1;
     flux_t *fh = (flux_t *)h;
     flux_future_t *f = NULL;
-    int saved_errno;
 
     if (!fh || jobid > INT64_MAX) {
         errno = EINVAL;
@@ -263,10 +262,8 @@ int reapi_module_t::cancel (void *h, const uint64_t jobid, bool noent_ok)
                              (const int64_t)jobid))) {
         goto out;
     }
-    saved_errno = errno;
     if ((rc = flux_rpc_get (f, NULL)) < 0) {
         if (noent_ok && errno == ENOENT) {
-            errno = saved_errno;
             rc = 0;
         }
         goto out;
@@ -287,7 +284,6 @@ int reapi_module_t::cancel (void *h,
     int rc = -1;
     flux_t *fh = (flux_t *)h;
     flux_future_t *f = NULL;
-    int saved_errno;
     int ret_removal = 0;
 
     if (!fh || R == "" || jobid > INT64_MAX) {
@@ -305,10 +301,8 @@ int reapi_module_t::cancel (void *h,
                              R.c_str ()))) {
         goto out;
     }
-    saved_errno = errno;
     if ((rc = flux_rpc_get_unpack (f, "{s:i}", "full-removal", &ret_removal)) < 0) {
         if (noent_ok && (errno == ENOENT)) {
-            errno = saved_errno;
             rc = 0;
         }
         goto out;

--- a/resource/reapi/bindings/c++/test/reapi_cli_errno_test.cpp
+++ b/resource/reapi/bindings/c++/test/reapi_cli_errno_test.cpp
@@ -59,24 +59,36 @@ static int test_match_allocate_invalid_jobspec_with_ctx ()
     void *h = static_cast<void *> (rq);
     uint64_t jobid = 1;
     bool reserved = false;
-    std::string invalid_jobspec = "not valid json";
     std::string R;
     int64_t at = 0;
     double ov = 0.0;
 
-    // Test with invalid jobspec JSON
+    // Test with invalid JSON
     errno = 0;
-    int rc = reapi_cli_t::match_allocate (h,
-                                          MATCH_ALLOCATE,
-                                          invalid_jobspec,
-                                          jobid,
-                                          reserved,
-                                          R,
-                                          at,
-                                          ov);
+    std::string invalid_json = "not valid json";
+    int rc =
+        reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, invalid_json, jobid, reserved, R, at, ov);
 
     ok (rc == -1 && errno == EINVAL,
-        "match_allocate returns -1 with errno=EINVAL for invalid jobspec");
+        "match_allocate returns -1 with errno=EINVAL for invalid JSON");
+
+    // Test with valid JSON but missing required fields (no "resources" field)
+    errno = 0;
+    std::string incomplete_jobspec = R"({
+        "version": 1,
+        "tasks": [{"command": ["app"], "slot": "task", "count": {"per_slot": 1}}]
+    })";
+    rc = reapi_cli_t::match_allocate (h,
+                                      MATCH_ALLOCATE,
+                                      incomplete_jobspec,
+                                      jobid,
+                                      reserved,
+                                      R,
+                                      at,
+                                      ov);
+
+    ok (rc == -1 && errno == EINVAL,
+        "match_allocate returns -1 with errno=EINVAL for jobspec missing required fields");
 
     delete rq;
     return 0;
@@ -247,7 +259,256 @@ static int test_match_allocate_enodev ()
                                           ov);
 
     ok (rc == -1 && errno == ENODEV,
-        "match_allocate returns -1 with errno=ENODEV for infeasible request");
+        "match_allocate (satisfiability mode) returns -1 with errno=ENODEV for infeasible request");
+
+    // Test regular MATCH_ALLOCATE mode with infeasible request
+    // Regular mode returns EBUSY for infeasible (is_satisfiable translates to ENODEV)
+    // Before commit 38d34b75, resolve_graph() failure could leave errno=0
+    errno = 0;
+    jobid = 2;
+    rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec, jobid, reserved, R, at, ov);
+
+    ok (rc == -1 && errno == EBUSY,
+        "match_allocate (regular mode) returns -1 with errno=EBUSY for infeasible request");
+
+    delete rq;
+    return 0;
+}
+
+static int test_cancel_nonexistent_job ()
+{
+    // Create minimal context
+    resource_query_t *rq = nullptr;
+    try {
+        rq = new resource_query_t ();
+    } catch (...) {
+        ok (1, "# SKIP: couldn't create resource_query_t context");
+        return 0;
+    }
+
+    void *h = static_cast<void *> (rq);
+    uint64_t nonexistent_jobid = 99999;
+
+    // Test cancel with NULL context
+    errno = 0;
+    int rc = reapi_cli_t::cancel (nullptr, 1, false);
+    ok (rc == -1 && errno == EINVAL, "cancel returns -1 with errno=EINVAL for NULL context");
+
+    // Test cancel with nonexistent job and noent_ok=false
+    errno = 0;
+    rc = reapi_cli_t::cancel (h, nonexistent_jobid, false);
+
+    ok (rc == -1 && errno == ENOENT, "cancel returns -1 with errno=ENOENT for nonexistent job");
+
+    // Test cancel with nonexistent job and noent_ok=true
+    errno = 0;
+    rc = reapi_cli_t::cancel (h, nonexistent_jobid, true);
+
+    ok (rc == 0, "cancel returns 0 for nonexistent job when noent_ok=true");
+
+    delete rq;
+    return 0;
+}
+
+static int test_info_nonexistent_job ()
+{
+    // Create minimal context
+    resource_query_t *rq = nullptr;
+    try {
+        rq = new resource_query_t ();
+    } catch (...) {
+        ok (1, "# SKIP: couldn't create resource_query_t context");
+        return 0;
+    }
+
+    void *h = static_cast<void *> (rq);
+    uint64_t nonexistent_jobid = 99999;
+    std::string mode;
+    bool reserved;
+    int64_t at;
+    double ov;
+
+    // Test info with NULL context
+    errno = 0;
+    int rc = reapi_cli_t::info (nullptr, 1, mode, reserved, at, ov);
+    ok (rc == -1 && errno == EINVAL, "info returns -1 with errno=EINVAL for NULL context");
+
+    // Test info with nonexistent job
+    errno = 0;
+    rc = reapi_cli_t::info (h, nonexistent_jobid, mode, reserved, at, ov);
+
+    ok (rc == -1 && errno == ENOENT, "info returns -1 with errno=ENOENT for nonexistent job");
+
+    delete rq;
+    return 0;
+}
+
+static int test_cancel_partial_null_ctx ()
+{
+    // Test the partial cancel variant (with R string) for NULL context
+    uint64_t jobid = 1;
+    std::string R = "{}";
+    bool full_removal = false;
+
+    errno = 0;
+    int rc = reapi_cli_t::cancel (nullptr, jobid, R, false, full_removal);
+
+    ok (rc == -1 && errno == EINVAL,
+        "cancel (partial) returns -1 with errno=EINVAL for NULL context");
+
+    return 0;
+}
+
+static int test_find_null_ctx ()
+{
+    json_t *result = nullptr;
+    std::string criteria = "status=up";
+
+    errno = 0;
+    int rc = reapi_cli_t::find (nullptr, criteria, result);
+
+    ok (rc == -1 && errno == EINVAL, "find returns -1 with errno=EINVAL for NULL context");
+
+    return 0;
+}
+
+static int test_match_allocate_orelse_reserve ()
+{
+    // Test MATCH_ALLOCATE_ORELSE_RESERVE mode with infeasible request
+    // Should fail with errno=ENODEV (orelse_reserve uses satisfiability like
+    // MATCH_ALLOCATE_W_SATISFIABILITY)
+    std::string jgf = R"({
+        "graph": {
+            "nodes": [
+                {"id": "0", "metadata": {"type": "cluster", "basename": "tiny", "name": "tiny0", "size": 1, "paths": {"containment": "/tiny0"}}},
+                {"id": "1", "metadata": {"type": "node", "basename": "node", "name": "node0", "size": 1, "rank": 0, "paths": {"containment": "/tiny0/node0"}}},
+                {"id": "2", "metadata": {"type": "core", "basename": "core", "name": "core0", "size": 1, "id": 0, "rank": 0, "paths": {"containment": "/tiny0/node0/core0"}}}
+            ],
+            "edges": [{"source": "0", "target": "1"}, {"source": "1", "target": "2"}]
+        }
+    })";
+
+    std::string params =
+        "{\"load_format\": \"jgf\", \"matcher_policy\": \"high\", "
+        "\"match_format\": \"rv1\", \"matcher_name\": \"CA\"}";
+
+    resource_query_t *rq = nullptr;
+    try {
+        rq = new resource_query_t (jgf, params);
+    } catch (...) {
+        ok (1, "# SKIP: couldn't create resource_query_t");
+        return 0;
+    }
+
+    void *h = static_cast<void *> (rq);
+    uint64_t jobid = 200;
+    bool reserved = false;
+    std::string R;
+    int64_t at = 0;
+    double ov = 0.0;
+
+    // Request a resource type that doesn't exist (gpu) - infeasible
+    // MATCH_ALLOCATE_ORELSE_RESERVE uses satisfiability checking, so returns ENODEV for infeasible
+    std::string jobspec =
+        "{\"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": "
+        "[{\"type\": \"gpu\", \"count\": 1}]}], \"tasks\": [{\"command\": "
+        "[\"app\"], \"slot\": \"gpu\", \"count\": {\"per_slot\": 1}}], "
+        "\"attributes\": {\"system\": {\"duration\": 3600}}, \"version\": 1}";
+
+    errno = 0;
+    int rc = reapi_cli_t::match_allocate (h,
+                                          MATCH_ALLOCATE_ORELSE_RESERVE,
+                                          jobspec,
+                                          jobid,
+                                          reserved,
+                                          R,
+                                          at,
+                                          ov);
+    ok (rc == -1 && errno == ENODEV,
+        "match_allocate (orelse_reserve) returns -1 with errno=ENODEV for infeasible request");
+
+    delete rq;
+    return 0;
+}
+
+static int test_allocate_then_cancel ()
+{
+    // Test successful allocate -> cancel flow to ensure errno handling works end-to-end
+    std::string jgf = R"({
+        "graph": {
+            "nodes": [
+                {"id": "0", "metadata": {"type": "cluster", "basename": "tiny", "name": "tiny0", "size": 1, "paths": {"containment": "/tiny0"}}},
+                {"id": "1", "metadata": {"type": "node", "basename": "node", "name": "node0", "size": 1, "rank": 0, "paths": {"containment": "/tiny0/node0"}}},
+                {"id": "2", "metadata": {"type": "core", "basename": "core", "name": "core0", "size": 1, "id": 0, "rank": 0, "paths": {"containment": "/tiny0/node0/core0"}}}
+            ],
+            "edges": [{"source": "0", "target": "1"}, {"source": "1", "target": "2"}]
+        }
+    })";
+
+    std::string params =
+        "{\"load_format\": \"jgf\", \"matcher_policy\": \"high\", "
+        "\"match_format\": \"rv1\", \"matcher_name\": \"CA\"}";
+
+    resource_query_t *rq = nullptr;
+    try {
+        rq = new resource_query_t (jgf, params);
+    } catch (...) {
+        ok (1, "# SKIP: couldn't create resource_query_t");
+        return 0;
+    }
+
+    void *h = static_cast<void *> (rq);
+    uint64_t jobid = 100;
+    bool reserved = false;
+    std::string R;
+    int64_t at = 0;
+    double ov = 0.0;
+
+    std::string jobspec = R"({
+        "version": 1,
+        "resources": [
+            {
+                "type": "node",
+                "count": 1,
+                "with": [
+                    {
+                        "type": "slot",
+                        "count": 1,
+                        "label": "task",
+                        "with": [{"type": "core", "count": 1}]
+                    }
+                ]
+            }
+        ],
+        "tasks": [{"command": ["sleep", "0"], "slot": "task", "count": {"per_slot": 1}}],
+        "attributes": {"system": {"duration": 60.0}}
+    })";
+
+    // Allocate the job
+    errno = 0;
+    int rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec, jobid, reserved, R, at, ov);
+
+    if (rc != 0) {
+        ok (1, "# SKIP: allocation failed, can't test cancel");
+        delete rq;
+        return 0;
+    }
+
+    ok (rc == 0, "match_allocate succeeds");
+
+    // Cancel should succeed without errno being set on success path
+    errno = EAGAIN;  // Set to non-zero to verify success doesn't touch errno
+    rc = reapi_cli_t::cancel (h, jobid, false);
+
+    ok (rc == 0, "cancel succeeds for allocated job");
+    // errno should be undefined on success, so we can't really check it
+
+    // Try to cancel again - should get ENOENT
+    errno = 0;
+    rc = reapi_cli_t::cancel (h, jobid, false);
+
+    ok (rc == -1 && errno == ENOENT,
+        "cancel returns -1 with errno=ENOENT for already-canceled job");
 
     delete rq;
     return 0;
@@ -261,6 +522,12 @@ int main (int argc, char *argv[])
     test_match_allocate_invalid_jobspec_with_ctx ();
     test_match_allocate_ebusy ();
     test_match_allocate_enodev ();
+    test_cancel_nonexistent_job ();
+    test_cancel_partial_null_ctx ();
+    test_info_nonexistent_job ();
+    test_find_null_ctx ();
+    test_match_allocate_orelse_reserve ();
+    test_allocate_then_cancel ();
 
     done_testing ();
     return EXIT_SUCCESS;

--- a/resource/traversers/dfu.cpp
+++ b/resource/traversers/dfu.cpp
@@ -38,24 +38,25 @@ int dfu_traverser_t::is_satisfiable (Jobspec::Jobspec &jobspec,
 {
     int rc = 0;
     std::vector<uint64_t> agg;
-    int saved_errno = errno;
     subsystem_t dom = get_match_cb ()->dom_subsystem ();
 
     meta.alloc_type = jobmeta_t::alloc_type_t::AT_SATISFIABILITY;
     planner_multi_t *p = (*get_graph ())[root].idata.subplans.at (dom);
     meta.at = planner_multi_base_time (p) + planner_multi_duration (p) - meta.duration - 1;
     traverser->count_relevant_types (p, dfv, agg);
-    errno = 0;
     if ((rc = traverser->select (jobspec, root, meta, x)) < 0) {
+        // Translate resource unavailability to unsatisfiable
+        // EBUSY: not available even at far future
+        // ERANGE: exceeds total capacity
+        if (errno == EBUSY || errno == ERANGE) {
+            errno = ENODEV;
+        }
         rc = -1;
-        errno = (!errno) ? ENODEV : errno;
         traverser->update ();
     }
     m_total_preorder = traverser->get_preorder_count ();
     m_total_postorder = traverser->get_postorder_count ();
 
-    if (!errno)
-        errno = saved_errno;
     return rc;
 }
 
@@ -146,7 +147,6 @@ int dfu_traverser_t::schedule (Jobspec::Jobspec &jobspec,
     size_t len = 0;
     std::vector<uint64_t> agg;
     uint64_t duration = 0;
-    int saved_errno = errno;
     planner_multi_t *p = NULL;
     subsystem_t dom = get_match_cb ()->dom_subsystem ();
 
@@ -171,7 +171,12 @@ int dfu_traverser_t::schedule (Jobspec::Jobspec &jobspec,
             meta.at = planner_multi_base_time (p) + planner_multi_duration (p) - meta.duration - 1;
             traverser->count_relevant_types (p, dfv, agg);
             if (traverser->select (jobspec, root, meta, x) < 0) {
-                errno = (errno == EBUSY) ? ENODEV : errno;
+                // Translate resource unavailability to unsatisfiable
+                // EBUSY: not available even at far future
+                // ERANGE: exceeds total capacity
+                if (errno == EBUSY || errno == ERANGE) {
+                    errno = ENODEV;
+                }
                 traverser->update ();
             }
             m_total_preorder += traverser->get_preorder_count ();
@@ -182,7 +187,6 @@ int dfu_traverser_t::schedule (Jobspec::Jobspec &jobspec,
         }
         case match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE: {
             /* Or else reserve */
-            errno = 0;
             meta.alloc_type = jobmeta_t::alloc_type_t::AT_ALLOC_ORELSE_RESERVE;
             t = meta.at + 1;
             p = (*get_graph ())[root].idata.subplans.at (dom);
@@ -190,7 +194,7 @@ int dfu_traverser_t::schedule (Jobspec::Jobspec &jobspec,
             duration = meta.duration;
             traverser->count_relevant_types (p, dfv, agg);
             for (t = planner_multi_avail_time_first (p, t, duration, agg.data (), len);
-                 (t != -1 && rc && !errno);
+                 (t != -1 && rc);
                  t = planner_multi_avail_time_next (p)) {
                 meta.at = t;
                 rc = traverser->select (jobspec, root, meta, x);
@@ -207,9 +211,15 @@ int dfu_traverser_t::schedule (Jobspec::Jobspec &jobspec,
                 meta.alloc_type = jobmeta_t::alloc_type_t::AT_SATISFIABILITY;
                 meta.at = planner_multi_base_time (p) + planner_multi_duration (p) - duration - 1;
                 if (traverser->select (jobspec, root, meta, x) < 0) {
-                    errno = (errno == EBUSY) ? ENODEV : errno;
+                    // Translate resource unavailability to unsatisfiable
+                    // EBUSY: not available even at far future
+                    // ERANGE: exceeds total capacity
+                    if (errno == EBUSY || errno == ERANGE) {
+                        errno = ENODEV;
+                    }
                     traverser->update ();
                 }
+            } else if (rc < 0) {
                 m_total_preorder += traverser->get_preorder_count ();
                 m_total_postorder += traverser->get_postorder_count ();
                 // increment match traversal loop count
@@ -225,7 +235,6 @@ int dfu_traverser_t::schedule (Jobspec::Jobspec &jobspec,
     }
 
 out:
-    errno = (!errno) ? saved_errno : errno;
     // Update the perf temporary iteration count. If this schedule invocation
     // corresponds to the max match time this value will be output in the
     // stats RPC.
@@ -377,9 +386,11 @@ int dfu_traverser_t::run (Jobspec::Jobspec &jobspec,
         < 0)
         return -1;
 
-    if ((op == match_op_t::MATCH_SATISFIABILITY)
-        && (rc = is_satisfiable (jobspec, meta, x, root, dfv)) == 0) {
-        traverser->update ();
+    if (op == match_op_t::MATCH_SATISFIABILITY) {
+        rc = is_satisfiable (jobspec, meta, x, root, dfv);
+        if (rc == 0) {
+            traverser->update ();
+        }
     } else if ((rc = schedule (jobspec, meta, x, op, root, dfv)) == 0) {
         *at = meta.at;
         if (*at == graph_end) {

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -77,29 +77,24 @@ int dfu_impl_t::by_avail (const jobmeta_t &meta,
                           vtx_t u,
                           const std::vector<Jobspec::Resource> &resources)
 {
-    int rc = -1;
     int64_t avail = -1;
     planner_t *p = NULL;
     int64_t at = meta.at;
-    int saved_errno = errno;
     uint64_t duration = meta.duration;
 
     // Prune by the visiting resource vertex's availability
     // if rack has been allocated exclusively, no reason to descend further.
     p = (*m_graph)[u].schedule.plans;
     if ((avail = planner_avail_resources_during (p, at, duration)) == 0) {
-        goto done;
+        errno = EBUSY;
+        return -1;
     } else if (avail == -1) {
         m_err_msg += "by_avail: planner_avail_resources_during returned -1.\n";
         m_err_msg += strerror (errno);
         m_err_msg += ".\n";
-        goto done;
+        return -1;
     }
-    rc = 0;
-
-done:
-    errno = saved_errno;
-    return rc;
+    return 0;
 }
 
 int dfu_impl_t::by_excl (const jobmeta_t &meta,
@@ -108,11 +103,9 @@ int dfu_impl_t::by_excl (const jobmeta_t &meta,
                          bool exclusive_in,
                          const Jobspec::Resource &resource)
 {
-    int rc = -1;
     planner_t *p = NULL;
     int64_t at = meta.at;
     int64_t njobs = -1;
-    int saved_errno = errno;
     uint64_t duration = meta.duration;
 
     // If a non-exclusive resource request is explicitly given on a
@@ -121,7 +114,7 @@ int dfu_impl_t::by_excl (const jobmeta_t &meta,
         errno = EINVAL;
         m_err_msg += "by_excl: exclusivity conflicts at jobspec=";
         m_err_msg += resource.label + " : vertex=" + (*m_graph)[u].name;
-        goto done;
+        return -1;
     }
 
     // If a resource request is under slot or an explicit exclusivity is
@@ -137,27 +130,25 @@ int dfu_impl_t::by_excl (const jobmeta_t &meta,
         // resources at the leaf level this check will not catch
         // multiple booking.
         if (meta.alloc_type == jobmeta_t::alloc_type_t::AT_ALLOC
-            && !(*m_graph)[u].schedule.allocations.empty ())
-            goto done;
+            && !(*m_graph)[u].schedule.allocations.empty ()) {
+            errno = EBUSY;
+            return -1;
+        }
         p = (*m_graph)[u].idata.x_checker;
         njobs = planner_avail_resources_during (p, at, duration);
         if (njobs == -1) {
             m_err_msg += "by_excl: planner_avail_resources_during.\n";
             m_err_msg += strerror (errno);
             m_err_msg += ".\n";
-            goto restore_errno;
+            return -1;
         } else if (njobs < X_CHECKER_NJOBS) {
-            goto restore_errno;
+            errno = EBUSY;
+            return -1;
         }
     }
 
     // All cases reached this point indicate further walk is needed.
-    rc = 0;
-
-restore_errno:
-    errno = saved_errno;
-done:
-    return rc;
+    return 0;
 }
 
 int dfu_impl_t::by_subplan (const jobmeta_t &meta,
@@ -170,7 +161,6 @@ int dfu_impl_t::by_subplan (const jobmeta_t &meta,
     int64_t at = meta.at;
     uint64_t d = meta.duration;
     std::vector<uint64_t> aggs;
-    int saved_errno = errno;
     planner_multi_t *p = (*m_graph)[u].idata.subplans[s];
 
     if (!p) {
@@ -178,28 +168,28 @@ int dfu_impl_t::by_subplan (const jobmeta_t &meta,
         // TODO: handle the unlikely case
         // where the subplan is null for another
         // reason
-        rc = 0;
-        goto done;
+        return 0;
     }
     if (resource.user_data.empty ()) {
         // If user_data is empty, no data is available to prune with.
-        rc = 0;
-        goto done;
+        return 0;
     }
     count_relevant_types (p, resource.user_data, aggs);
     len = aggs.size ();
     if ((rc = planner_multi_avail_during (p, at, d, aggs.data (), len)) == -1) {
-        if (errno != ERANGE) {
+        // Don't log ERANGE or EBUSY - these are expected conditions:
+        // ERANGE: request exceeds capacity (unsatisfiable)
+        // EBUSY: resources temporarily unavailable
+        if (errno != ERANGE && errno != EBUSY) {
             m_err_msg += "by_subplan: planner_multi_avail_during returned -1.\n";
             m_err_msg += strerror (errno);
             m_err_msg += ".\n";
         }
-        goto done;
+        // errno already set by planner_multi_avail_during (ERANGE, EBUSY, etc)
+        return -1;
     }
 
-done:
-    errno = saved_errno;
-    return rc;
+    return 0;
 }
 
 int dfu_impl_t::by_status (const jobmeta_t &meta, vtx_t u)
@@ -258,21 +248,31 @@ int dfu_impl_t::prune (const jobmeta_t &meta,
 {
     int rc = 0;
 
-    if ((rc = by_status (meta, u)) == -1)
-        goto done;
+    if ((rc = by_status (meta, u)) == -1) {
+        errno = EBUSY;
+        return rc;
+    }
 
-    if ((rc = by_constraint (meta, u)) == -1)
-        goto done;
+    if ((rc = by_constraint (meta, u)) == -1) {
+        // Constraint mismatch on this vertex - set EBUSY not ENODEV
+        // because it doesn't mean the job is globally unsatisfiable,
+        // just that this particular vertex doesn't match
+        errno = EBUSY;
+        return rc;
+    }
 
     // if rack has been allocated exclusively, no reason to descend further.
-    if ((rc = by_avail (meta, s, u, resources)) == -1)
-        goto done;
+    if ((rc = by_avail (meta, s, u, resources)) == -1) {
+        // errno already set by by_avail
+        return rc;
+    }
 
-    if ((rc = prune_resources (meta, exclusive, s, u, resources)) == -1)
-        goto done;
+    if ((rc = prune_resources (meta, exclusive, s, u, resources)) == -1) {
+        // errno already set by prune_resources
+        return rc;
+    }
 
-done:
-    return rc;
+    return 0;
 }
 
 planner_multi_t *dfu_impl_t::subtree_plan (vtx_t u,
@@ -762,11 +762,16 @@ int dfu_impl_t::dom_dfv (const jobmeta_t &meta,
     const std::vector<Resource> &next = test (u, resources, check_pres, nslots, sm);
 
     m_preorder++;
-    if (sm == match_kind_t::NONE_MATCH)
+    if (sm == match_kind_t::NONE_MATCH) {
+        // Vertex type doesn't match - no resources here
+        errno = EBUSY;
         goto done;
+    }
     if ((prune (meta, x_in, dom, u, resources) == -1)
-        || (m_match->dom_discover_vtx (u, dom, resources, *m_graph) != 0))
+        || (m_match->dom_discover_vtx (u, dom, resources, *m_graph) != 0)) {
+        // errno already set by prune() or dom_discover_vtx()
         goto done;
+    }
     (*m_graph)[u].idata.colors[dom] = m_color.gray ();
     if (sm == match_kind_t::SLOT_MATCH)
         dom_slot (meta, u, next, nslots, check_pres, &x_inout, dfu);
@@ -777,17 +782,28 @@ int dfu_impl_t::dom_dfv (const jobmeta_t &meta,
 
     p = (*m_graph)[u].schedule.plans;
     if ((avail = planner_avail_resources_during (p, at, duration)) == 0) {
+        // No resources available at this vertex
+        errno = EBUSY;
         goto done;
     } else if (avail == -1) {
         m_err_msg += "dom_dfv: planner_avail_resources_during returned -1.\n";
         m_err_msg += strerror (errno);
         m_err_msg += ".\n";
+        // errno already set by planner
         goto done;
     }
-    if (m_match->dom_finish_vtx (u, dom, resources, *m_graph, dfu) != 0)
+    if (m_match->dom_finish_vtx (u, dom, resources, *m_graph, dfu) != 0) {
+        // errno should be set by dom_finish_vtx, but if not, use EINVAL
+        if (errno == 0)
+            errno = EINVAL;
         goto done;
-    if ((rc = resolve (dfu, to_parent)) != 0)
+    }
+    if ((rc = resolve (dfu, to_parent)) != 0) {
+        // errno should be set by resolve, but if not, use EINVAL
+        if (errno == 0)
+            errno = EINVAL;
         goto done;
+    }
     to_parent.set_avail (avail);
     to_parent.set_overall_score (dfu.overall_score ());
 

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -1278,6 +1278,11 @@ int dfu_impl_t::select (Jobspec::Jobspec &j, vtx_t root, jobmeta_t &meta, bool e
         egrp.edges.push_back (ev_edg);
         dfu.add (dom, (*m_graph)[root].type, egrp);
         rc = resolve_graph (root, j.resources, dfu, excl, &needs);
+        if (rc < 0) {
+            // resolve_graph() doesn't have an errno contract.
+            // Set errno = ENODEV (unsatisfiable) when it fails.
+            errno = ENODEV;
+        }
         m_graph_db->metadata.v_rt_edges[dom].set_for_trav_update (needs, x_in, m_sequence_number);
     }
     return rc;

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -793,15 +793,11 @@ int dfu_impl_t::dom_dfv (const jobmeta_t &meta,
         goto done;
     }
     if (m_match->dom_finish_vtx (u, dom, resources, *m_graph, dfu) != 0) {
-        // errno should be set by dom_finish_vtx, but if not, use EINVAL
-        if (errno == 0)
-            errno = EINVAL;
+        // errno set by dom_finish_vtx
         goto done;
     }
     if ((rc = resolve (dfu, to_parent)) != 0) {
-        // errno should be set by resolve, but if not, use EINVAL
-        if (errno == 0)
-            errno = EINVAL;
+        // errno set by resolve/enforce
         goto done;
     }
     to_parent.set_avail (avail);

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -84,7 +84,6 @@ int dfu_impl_t::by_avail (const jobmeta_t &meta,
     int saved_errno = errno;
     uint64_t duration = meta.duration;
 
-    errno = 0;
     // Prune by the visiting resource vertex's availability
     // if rack has been allocated exclusively, no reason to descend further.
     p = (*m_graph)[u].schedule.plans;
@@ -92,10 +91,8 @@ int dfu_impl_t::by_avail (const jobmeta_t &meta,
         goto done;
     } else if (avail == -1) {
         m_err_msg += "by_avail: planner_avail_resources_during returned -1.\n";
-        if (errno != 0) {
-            m_err_msg += strerror (errno);
-            m_err_msg += ".\n";
-        }
+        m_err_msg += strerror (errno);
+        m_err_msg += ".\n";
         goto done;
     }
     rc = 0;

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -187,10 +187,9 @@ int dfu_impl_t::by_subplan (const jobmeta_t &meta,
         goto done;
     }
     count_relevant_types (p, resource.user_data, aggs);
-    errno = 0;
     len = aggs.size ();
     if ((rc = planner_multi_avail_during (p, at, d, aggs.data (), len)) == -1) {
-        if (errno != 0 && errno != ERANGE) {
+        if (errno != ERANGE) {
             m_err_msg += "by_subplan: planner_multi_avail_during returned -1.\n";
             m_err_msg += strerror (errno);
             m_err_msg += ".\n";

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -1189,7 +1189,6 @@ int dfu_impl_t::prime_pruning_filter (subsystem_t s,
                                       std::map<resource_type_t, int64_t> &to_parent)
 {
     int rc = -1;
-    int saved_errno = errno;
     std::vector<uint64_t> avail;
     std::vector<const char *> types;
     std::map<resource_type_t, int64_t> dfv;
@@ -1234,11 +1233,11 @@ int dfu_impl_t::prime_pruning_filter (subsystem_t s,
     }
 
     if ((*m_graph)[u].idata.subplans[s] == NULL) {
-        errno = 0;
         planner_multi_t *p = NULL;
         if (!(p = subtree_plan (u, avail, types))) {
             m_err_msg += "prime: error initializing a multi-planner. ";
             m_err_msg += strerror (errno);
+            // errno should be set by subtree_plan/planner_multi_new
             goto done;
         }
         (*m_graph)[u].idata.subplans[s] = p;
@@ -1250,7 +1249,6 @@ int dfu_impl_t::prime_pruning_filter (subsystem_t s,
     }
     rc = 0;
 done:
-    errno = saved_errno;
     (*m_graph)[u].idata.colors[s] = m_color.black ();
     return rc;
 }

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -139,15 +139,12 @@ int dfu_impl_t::by_excl (const jobmeta_t &meta,
         if (meta.alloc_type == jobmeta_t::alloc_type_t::AT_ALLOC
             && !(*m_graph)[u].schedule.allocations.empty ())
             goto done;
-        errno = 0;
         p = (*m_graph)[u].idata.x_checker;
         njobs = planner_avail_resources_during (p, at, duration);
         if (njobs == -1) {
             m_err_msg += "by_excl: planner_avail_resources_during.\n";
-            if (errno != 0) {
-                m_err_msg += strerror (errno);
-                m_err_msg += ".\n";
-            }
+            m_err_msg += strerror (errno);
+            m_err_msg += ".\n";
             goto restore_errno;
         } else if (njobs < X_CHECKER_NJOBS) {
             goto restore_errno;

--- a/resource/writers/match_writers.cpp
+++ b/resource/writers/match_writers.cpp
@@ -466,12 +466,14 @@ json_t *jgf_match_writers_t::emit_vtx_base (const resource_graph_t &g,
         if (exclusive) {
             if (json_object_set_new (o, "exclusive", json_true ()) < 0) {
                 json_decref (o);
+                errno = ENOMEM;
                 return nullptr;
             }
         }
         if (needs != 1) {
             if (json_object_set_new (o, "size", json_integer (needs)) < 0) {
                 json_decref (o);
+                errno = ENOMEM;
                 return nullptr;
             }
         }


### PR DESCRIPTION
More claude spelunking for errno anti-patterns.

This is based on top of
- #1483

Claude's smmary of errno violations fixed:

✅ Planner NULL dereferences (3 instances)
✅ Planner type error inverting returns
✅ Planner missing errno in avail_during()
✅ Qmanager spurious errno = 0
✅ Pruning functions (by_avail, by_excl, by_subplan) - removed save/restore patterns
✅ Prime_pruning_filter - removed save/restore pattern
✅ Policy dom_finish callbacks - missing errno on -1 returns (4 functions)
✅ Policy set_stop_on_k_matches - missing errno
✅ Traverser resolve_graph - missing errno
✅ Traverser dom_dfv - removed defensive errno checks
✅ Traverser dfu_impl_update - missing errno
✅ Reapi cancel functions - removed save/restore patterns
✅ Writer emit_vtx_base - missing errno after json_object_set_new failures

  Legitimate patterns kept:
  - Save/restore in destructors/cleanup functions
  - Save/restore in utility functions returning bool (HostlistConstraint::match)
  - errno = 0 before C++ I/O operations
  - Readers/writers using m_err_msg instead of errno
  - CLI tools using std::cerr instead of errno 
  - Comparator functions returning -1/0/1 for ordering