### PR TITLE
Remove r_out

### DIFF
--- a/resource/CMakeLists.txt
+++ b/resource/CMakeLists.txt
@@ -9,7 +9,7 @@ set_target_properties(fluxion-data PROPERTIES
 install(TARGETS fluxion-data LIBRARY NAMELINK_SKIP)
 add_subdirectory(libjobspec)
 add_subdirectory(planner)
-set(RESOURCE_HEADERS 
+set(RESOURCE_HEADERS
     utilities/command.hpp
     policies/dfu_match_high_id_first.hpp
     policies/dfu_match_low_id_first.hpp

--- a/resource/reapi/bindings/CMakeLists.txt
+++ b/resource/reapi/bindings/CMakeLists.txt
@@ -8,6 +8,8 @@ add_library ( reapi_cli SHARED
 target_link_libraries( reapi_cli PRIVATE
     resource
     jobspec_conv
+    )
+target_link_libraries( reapi_cli PUBLIC
     flux::core
     )
 install(TARGETS reapi_cli LIBRARY DESTINATION "${FLUX_LIB_DIR}")

--- a/resource/reapi/bindings/c++/reapi_cli.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli.hpp
@@ -51,7 +51,6 @@ struct resource_params_t {
     std::string matcher_policy;   /* Matcher policy name */
     std::string traverser_policy; /* Traverser policy name */
     std::string o_fname;          /* Output file to dump the filtered graph */
-    std::ofstream r_out;          /* Output file stream for emitted R */
     std::string r_fname;          /* Output file to dump the emitted R */
     std::string o_fext;           /* File extension */
     std::string prune_filters;    /* Raw prune-filter specification */

--- a/resource/utilities/resource-query.cpp
+++ b/resource/utilities/resource-query.cpp
@@ -623,8 +623,6 @@ void get_rgraph (std::string &rgraph, json_t *options)
 
 static void fini_resource_query (std::shared_ptr<detail::resource_query_t> &ctx)
 {
-    if (ctx->params.r_fname != "")
-        ctx->params.r_out.close ();
     if (ctx->params.o_fname != "")
         write_to_graph (ctx);
 }


### PR DESCRIPTION
in #1487 @garlick noted that `r_out` can't be copy constucted, which is true, but it's also unused. Excise it so we can clean some things up.

I also ran into a header resolution issue exposed by the new errno test as part of this, reapi_cli was inappropriately marking its dependence on flux::core as private.