### PR TITLE
reapi: add resource status get/set API

### DIFF
--- a/resource/reapi/bindings/CMakeLists.txt
+++ b/resource/reapi/bindings/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries( reapi_cli PRIVATE
     )
 target_link_libraries( reapi_cli PUBLIC
     flux::core
+    flux::idset
     )
 install(TARGETS reapi_cli LIBRARY DESTINATION "${FLUX_LIB_DIR}")
 

--- a/resource/reapi/bindings/c++/reapi.hpp
+++ b/resource/reapi/bindings/c++/reapi.hpp
@@ -17,10 +17,12 @@ extern "C" {
 #include "config.h"
 #endif
 #include <flux/core.h>
+#include <flux/idset.h>
 }
 
 #include <cstdint>
 #include <string>
+#include "resource/schema/resource_data.hpp"
 
 namespace Flux {
 namespace resource_model {
@@ -277,6 +279,66 @@ class reapi_t {
     {
         return -1;
     }
+
+    /*! Set resource status (up or down) for a resource at the specified path.
+     *
+     *  \param h         Opaque handle. How it is used is an implementation
+     *                   detail. However, when it is used within a Flux's
+     *                   service module, it is expected to be a pointer
+     *                   to a flux_t object.
+     *  \param resource_path    Path to resource (e.g., "/cluster0/rack0/node3")
+     *  \param status    resource_pool_t::status_t::UP or resource_pool_t::status_t::DOWN
+     *  \return          0 on success; -1 on error with errno set:
+     *                       EINVAL: invalid parameters, resource path not found,
+     *                               or unexpected internal error
+     */
+    static int set_status (void *h,
+                           const std::string &resource_path,
+                           resource_pool_t::status_t status);
+
+    /*! Get resource status for a resource at the specified path.
+     *
+     *  \param h         Opaque handle. How it is used is an implementation
+     *                   detail. However, when it is used within a Flux's
+     *                   service module, it is expected to be a pointer
+     *                   to a flux_t object.
+     *  \param resource_path    Path to resource (e.g., "/cluster0/rack0/node3")
+     *  \param status    Reference to receive status
+     *  \return          0 on success; -1 on error with errno set:
+     *                       EINVAL: invalid parameters, resource path not found,
+     *                               or unexpected internal error
+     */
+    static int get_status (void *h,
+                           const std::string &resource_path,
+                           resource_pool_t::status_t &status);
+
+    /*! Set resource status (up or down) for the subtree root (typically node) at each ranks in a
+     * set. Unknown ranks are silently ignored.
+     *
+     *  \param h         Opaque handle. How it is used is an implementation
+     *                   detail. However, when it is used within a Flux's
+     *                   service module, it is expected to be a pointer
+     *                   to a flux_t object.
+     *  \param ranks     RFC 22 idset string representing a set of ranks, or "all".
+     *  \param status    resource_pool_t::status_t::UP or resource_pool_t::status_t::DOWN
+     *  \return          0 on success; -1 on error with errno set:
+     *                       EINVAL: invalid parameters or unexpected internal error
+     */
+    static int set_rank_status (void *h, std::string_view ranks, resource_pool_t::status_t status);
+
+    /*! Get resource status for the node at a rank.
+     *
+     *  \param h         Opaque handle. How it is used is an implementation
+     *                   detail. However, when it is used within a Flux's
+     *                   service module, it is expected to be a pointer
+     *                   to a flux_t object.
+     *  \param rank      Rank number as a string, e.g. "1"
+     *  \param status    Reference to receive status
+     *  \return          0 on success; -1 on error with errno set:
+     *                       EINVAL: invalid parameters, rank not found,
+     *                               or unexpected internal error
+     */
+    static int get_rank_status (void *h, std::string_view rank, resource_pool_t::status_t &status);
 };
 
 }  // namespace resource_model

--- a/resource/reapi/bindings/c++/reapi_cli.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli.hpp
@@ -16,6 +16,7 @@ extern "C" {
 #include "config.h"
 #endif
 #include <flux/core.h>
+#include <flux/idset.h>
 #include <cstdint>
 #include <cerrno>
 }
@@ -174,6 +175,16 @@ class reapi_cli_t : public reapi_t {
                      double &min,
                      double &max,
                      double &avg);
+    static int set_status (void *h,
+                           const std::string &resource_path,
+                           resource_pool_t::status_t status);
+    static int get_status (void *h,
+                           const std::string &resource_path,
+                           resource_pool_t::status_t &status);
+
+    static int set_rank_status (void *h, std::string_view ranks, resource_pool_t::status_t status);
+    static int get_rank_status (void *h, std::string_view rank, resource_pool_t::status_t &status);
+
     static const std::string &get_err_message ();
     static void clear_err_message ();
 

--- a/resource/reapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli_impl.hpp
@@ -29,8 +29,6 @@ namespace Flux {
 namespace resource_model {
 namespace detail {
 
-const int NOT_YET_IMPLEMENTED = -1;
-
 static double get_elapsed_time (timeval &st, timeval &et)
 {
     double ts1 = (double)st.tv_sec + (double)st.tv_usec / 1000000.0f;
@@ -171,7 +169,8 @@ int reapi_cli_t::update_allocate (void *h,
                                   double &ov,
                                   std::string &R_out)
 {
-    return NOT_YET_IMPLEMENTED;
+    errno = ENOSYS;  // not implemented
+    return -1;
 }
 
 int reapi_cli_t::match_allocate_multi (void *h,
@@ -179,7 +178,8 @@ int reapi_cli_t::match_allocate_multi (void *h,
                                        const char *jobs,
                                        queue_adapter_base_t *adapter)
 {
-    return NOT_YET_IMPLEMENTED;
+    errno = ENOSYS;  // not implemented
+    return -1;
 }
 
 int reapi_cli_t::cancel (void *h, const uint64_t jobid, bool noent_ok)
@@ -363,7 +363,8 @@ int reapi_cli_t::stat (void *h,
                        double &max,
                        double &avg)
 {
-    return NOT_YET_IMPLEMENTED;
+    errno = ENOSYS;  // not implemented
+    return -1;
 }
 
 const std::string &reapi_cli_t::get_err_message ()

--- a/resource/reapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli_impl.hpp
@@ -16,6 +16,7 @@ extern "C" {
 #include "config.h"
 #endif
 #include <flux/core.h>
+#include <flux/idset.h>
 }
 
 #include <stdexcept>
@@ -41,6 +42,52 @@ static double get_elapsed_time (timeval &st, timeval &et)
 ////////////////////////////////////////////////////////////////////////////////
 
 std::string reapi_cli_t::m_err_msg = "";
+
+// Helper: parse RFC 22 idset string to std::set<int64_t>
+// Handles "all" as a special case (returns all ranks from rq->db->metadata.by_rank)
+// Unknown ranks are not rejected here (mark() tolerates them to support a
+// future "grow" operation).
+// Returns 0 on success, -1 on error with errno set
+static int parse_ranks (resource_query_t *rq,
+                        std::string_view idset_str,
+                        std::set<int64_t> &ranks_out,
+                        std::string &err_msg)
+{
+    ranks_out.clear ();
+
+    // Check for empty string
+    if (idset_str.empty ()) {
+        errno = EINVAL;
+        err_msg = "empty idset string";
+        return -1;
+    }
+
+    // Handle "all" special case
+    if (idset_str == "all") {
+        for (const auto &kv : rq->db->metadata.by_rank) {
+            if (kv.first >= 0)
+                ranks_out.insert (kv.first);
+        }
+        return 0;
+    }
+
+    // Parse regular idset string using idset_decode_ex with explicit length
+    struct idset *ids = idset_decode_ex (idset_str.data (), idset_str.length (), 0, 0, NULL);
+    if (!ids) {
+        errno = EINVAL;
+        err_msg = std::string ("invalid idset string: ") + std::string (idset_str);
+        return -1;
+    }
+
+    unsigned int rank = idset_first (ids);
+    while (rank != IDSET_INVALID_ID) {
+        ranks_out.insert (static_cast<int64_t> (rank));
+        rank = idset_next (ids, rank);
+    }
+
+    idset_destroy (ids);
+    return 0;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // REAPI CLI Class Public API Definitions
@@ -364,6 +411,144 @@ int reapi_cli_t::stat (void *h,
                        double &avg)
 {
     errno = ENOSYS;  // not implemented
+    return -1;
+}
+
+int reapi_cli_t::set_status (void *h,
+                             const std::string &resource_path,
+                             resource_pool_t::status_t status)
+{
+    int rc = -1;
+    resource_query_t *rq = static_cast<resource_query_t *> (h);
+
+    if (!rq || resource_path.empty ()) {
+        errno = EINVAL;
+        return -1;
+    }
+    rc = rq->traverser->mark (resource_path, status);
+    if (rc < 0) {
+        m_err_msg = __FUNCTION__;
+        m_err_msg += ": " + rq->traverser->err_message ();
+    }
+    return rc;
+}
+
+int reapi_cli_t::get_status (void *h,
+                             const std::string &resource_path,
+                             resource_pool_t::status_t &status)
+{
+    resource_query_t *rq = static_cast<resource_query_t *> (h);
+
+    if (!rq || resource_path.empty ()) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    auto vit = rq->db->metadata.by_path.find (resource_path);
+    if (vit == rq->db->metadata.by_path.end ()) {
+        errno = EINVAL;
+        m_err_msg = __FUNCTION__;
+        m_err_msg += ": resource path not found: " + resource_path;
+        return -1;
+    }
+
+    // Get the first vertex at this path
+    if (vit->second.empty ()) {
+        errno = EINVAL;
+        m_err_msg = __FUNCTION__;
+        m_err_msg += ": no vertices at path: " + resource_path;
+        return -1;
+    }
+
+    vtx_t v = vit->second.front ();
+    status = rq->db->resource_graph[v].status;
+    return 0;
+}
+
+int reapi_cli_t::set_rank_status (void *h,
+                                  std::string_view ranks_str,
+                                  resource_pool_t::status_t status)
+{
+    resource_query_t *rq = static_cast<resource_query_t *> (h);
+    std::set<int64_t> ranks;
+    std::string err_msg;
+
+    if (!rq) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (parse_ranks (rq, ranks_str, ranks, err_msg) < 0) {
+        m_err_msg = __FUNCTION__;
+        m_err_msg += ": " + err_msg;
+        return -1;
+    }
+
+    // Mark the ranks
+    int rc = rq->traverser->mark (ranks, status);
+    if (rc < 0) {
+        m_err_msg = __FUNCTION__;
+        m_err_msg += ": failed to mark ranks " + std::string (ranks_str);
+    }
+    return rc;
+}
+
+int reapi_cli_t::get_rank_status (void *h,
+                                  std::string_view rank_str,
+                                  resource_pool_t::status_t &status)
+{
+    resource_query_t *rq = static_cast<resource_query_t *> (h);
+    std::set<int64_t> ranks;
+    std::string err_msg;
+
+    if (!rq) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (parse_ranks (rq, rank_str, ranks, err_msg) < 0) {
+        m_err_msg = __FUNCTION__;
+        m_err_msg += ": " + err_msg;
+        return -1;
+    }
+
+    // Ensure exactly one rank is specified
+    if (ranks.size () != 1) {
+        errno = EINVAL;
+        m_err_msg = __FUNCTION__;
+        m_err_msg += ": must specify exactly one rank, got ";
+        m_err_msg += rank_str;
+        return -1;
+    }
+
+    int64_t rank = *ranks.begin ();
+
+    // Look up the rank
+    auto it = rq->db->metadata.by_rank.find (rank);
+    if (it == rq->db->metadata.by_rank.end ()) {
+        errno = EINVAL;
+        m_err_msg = __FUNCTION__;
+        m_err_msg += ": rank not found: ";
+        m_err_msg += rank_str;
+        return -1;
+    }
+
+    // Report status at node granularity, matching how the resource module
+    // reports rank status (it walks node vertices and reads their status; see
+    // status_request_cb() in resource/modules/resource.cpp).  A rank maps to a
+    // broker that owns one node, so read the status of that node vertex.
+    for (vtx_t v : it->second) {
+        auto type = rq->db->resource_graph[v].type;
+        if (type == node_rt || type == storage_node_rt) {
+            status = rq->db->resource_graph[v].status;
+            return 0;
+        }
+    }
+
+    errno = EINVAL;
+    m_err_msg = __FUNCTION__;
+    m_err_msg += ": no node vertex at rank: ";
+    m_err_msg += rank_str;
     return -1;
 }
 

--- a/resource/reapi/bindings/c++/reapi_module.hpp
+++ b/resource/reapi/bindings/c++/reapi_module.hpp
@@ -17,6 +17,7 @@ extern "C" {
 #endif
 #include <flux/core.h>
 #include <jansson.h>
+#include <flux/idset.h>
 }
 
 #include <cstdint>
@@ -75,6 +76,16 @@ class reapi_module_t : public reapi_t {
                      double &min,
                      double &max,
                      double &avg);
+
+    static int set_status (void *h,
+                           const std::string &resource_path,
+                           resource_pool_t::status_t status);
+    static int get_status (void *h,
+                           const std::string &resource_path,
+                           resource_pool_t::status_t &status);
+
+    static int set_rank_status (void *h, std::string_view ranks, resource_pool_t::status_t status);
+    static int get_rank_status (void *h, std::string_view rank, resource_pool_t::status_t &status);
 };
 
 }  // namespace detail

--- a/resource/reapi/bindings/c++/reapi_module_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_module_impl.hpp
@@ -407,6 +407,38 @@ out:
     return rc;
 }
 
+int reapi_module_t::set_status (void *h,
+                                const std::string &resource_path,
+                                resource_pool_t::status_t status)
+{
+    errno = ENOSYS;  // unimplemented
+    return -1;
+}
+
+int reapi_module_t::get_status (void *h,
+                                const std::string &resource_path,
+                                resource_pool_t::status_t &status)
+{
+    errno = ENOSYS;  // unimplemented
+    return -1;
+}
+
+int reapi_module_t::set_rank_status (void *h,
+                                     std::string_view ranks,
+                                     resource_pool_t::status_t status)
+{
+    errno = ENOSYS;  // unimplemented
+    return -1;
+}
+
+int reapi_module_t::get_rank_status (void *h,
+                                     std::string_view rank,
+                                     resource_pool_t::status_t &status)
+{
+    errno = ENOSYS;  // unimplemented
+    return -1;
+}
+
 }  // namespace detail
 }  // namespace resource_model
 }  // namespace Flux

--- a/resource/reapi/bindings/c++/test/CMakeLists.txt
+++ b/resource/reapi/bindings/c++/test/CMakeLists.txt
@@ -7,3 +7,8 @@ add_executable(reapi_cli_clone_test reapi_cli_clone_test.cpp)
 add_sanitizers(reapi_cli_clone_test)
 target_link_libraries(reapi_cli_clone_test PRIVATE reapi_cli libtap fluxion-data)
 flux_add_test(NAME reapi_cli_clone_test COMMAND reapi_cli_clone_test)
+
+add_executable(reapi_cli_status_test reapi_cli_status_test.cpp)
+add_sanitizers(reapi_cli_status_test)
+target_link_libraries(reapi_cli_status_test PRIVATE reapi_cli libtap fluxion-data yaml-cpp PkgConfig::JANSSON)
+flux_add_test(NAME reapi_cli_status_test COMMAND reapi_cli_status_test)

--- a/resource/reapi/bindings/c++/test/reapi_cli_clone_test.cpp
+++ b/resource/reapi/bindings/c++/test/reapi_cli_clone_test.cpp
@@ -341,34 +341,39 @@ static int test_clone_copies_up_down_status ()
         BAIL_OUT ("resource_query_t constructor failed");
     }
 
-    // Mark the node (vertex 1) as DOWN
-    auto &g = rq->db->resource_graph;
-    vtx_iterator_t vi, vi_end;
-    vtx_t node_vtx = boost::graph_traits<resource_graph_t>::null_vertex ();
-    for (boost::tie (vi, vi_end) = boost::vertices (g); vi != vi_end; ++vi) {
-        if (g[*vi].type == node_rt) {
-            node_vtx = *vi;
-            g[*vi].status = resource_pool_t::status_t::DOWN;
-            break;
-        }
-    }
-    ok (node_vtx != boost::graph_traits<resource_graph_t>::null_vertex (),
-        "found node vertex to mark down");
+    void *h = static_cast<void *> (rq);
+
+    // Set rank 0 to DOWN using public API
+    int rc = reapi_cli_t::set_rank_status (h, "0", resource_pool_t::status_t::DOWN);
+    ok (rc == 0, "set rank 0 to DOWN succeeded");
+
+    // Verify it's down
+    resource_pool_t::status_t status;
+    rc = reapi_cli_t::get_rank_status (h, "0", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::DOWN, "rank 0 is DOWN");
 
     // Clone the resource query
     resource_query_t *clone = new resource_query_t (*rq);
     ok (clone != nullptr, "clone succeeded");
 
-    // Verify the status was copied
-    auto &clone_g = clone->db->resource_graph;
-    ok (clone_g[node_vtx].status == resource_pool_t::status_t::DOWN,
-        "node status DOWN was copied to clone");
+    void *h_clone = static_cast<void *> (clone);
 
-    // Verify independence: mark original's node back UP
-    g[node_vtx].status = resource_pool_t::status_t::UP;
-    ok (g[node_vtx].status == resource_pool_t::status_t::UP, "original node marked UP");
-    ok (clone_g[node_vtx].status == resource_pool_t::status_t::DOWN,
-        "clone node remains DOWN (independent)");
+    // Verify the clone has rank 0 DOWN
+    rc = reapi_cli_t::get_rank_status (h_clone, "0", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::DOWN,
+        "clone preserves status: rank 0 is DOWN in clone");
+
+    // Verify independence: set rank 0 to UP in clone
+    rc = reapi_cli_t::set_rank_status (h_clone, "0", resource_pool_t::status_t::UP);
+    ok (rc == 0, "set rank 0 to UP in clone succeeded");
+
+    rc = reapi_cli_t::get_rank_status (h_clone, "0", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::UP, "rank 0 is UP in clone");
+
+    // Verify original is still DOWN (independence)
+    rc = reapi_cli_t::get_rank_status (h, "0", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::DOWN,
+        "original rank 0 still DOWN (clone is independent)");
 
     delete clone;
     delete rq;

--- a/resource/reapi/bindings/c++/test/reapi_cli_status_test.cpp
+++ b/resource/reapi/bindings/c++/test/reapi_cli_status_test.cpp
@@ -1,0 +1,555 @@
+/*****************************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+}
+
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include "resource/reapi/bindings/c++/reapi_cli.hpp"
+#include "src/common/libtap/tap.h"
+
+using namespace Flux::resource_model;
+using namespace Flux::resource_model::detail;
+
+static void diag_json (json_t *obj)
+{
+    char *str = json_dumps (obj, JSON_COMPACT);
+    if (str) {
+        diag ("%s", str);
+        free (str);
+    }
+}
+
+static const char *two_node_jgf = R"({
+  "version": 1,
+  "graph": {
+    "nodes": [
+      {"id": "0", "metadata": {"type": "cluster", "basename": "cluster", "name": "cluster0", "paths": {"containment": "/cluster0"}}},
+      {"id": "1", "metadata": {"type": "node", "basename": "node", "name": "node0", "id": 0, "uniq_id": 0, "rank": 0, "paths": {"containment": "/cluster0/node0"}}},
+      {"id": "2", "metadata": {"type": "core", "basename": "core", "name": "core0", "id": 0, "uniq_id": 0, "paths": {"containment": "/cluster0/node0/core0"}}},
+      {"id": "3", "metadata": {"type": "core", "basename": "core", "name": "core1", "id": 1, "uniq_id": 1, "paths": {"containment": "/cluster0/node0/core1"}}},
+      {"id": "4", "metadata": {"type": "node", "basename": "node", "name": "node1", "id": 1, "uniq_id": 1, "rank": 1, "paths": {"containment": "/cluster0/node1"}}},
+      {"id": "5", "metadata": {"type": "core", "basename": "core", "name": "core0", "id": 0, "uniq_id": 2, "paths": {"containment": "/cluster0/node1/core0"}}},
+      {"id": "6", "metadata": {"type": "core", "basename": "core", "name": "core1", "id": 1, "uniq_id": 3, "paths": {"containment": "/cluster0/node1/core1"}}}
+    ],
+    "edges": [
+      {"source": "0", "target": "1", "metadata": {"name": {"containment": "contains"}}},
+      {"source": "1", "target": "2", "metadata": {"name": {"containment": "contains"}}},
+      {"source": "1", "target": "3", "metadata": {"name": {"containment": "contains"}}},
+      {"source": "0", "target": "4", "metadata": {"name": {"containment": "contains"}}},
+      {"source": "4", "target": "5", "metadata": {"name": {"containment": "contains"}}},
+      {"source": "4", "target": "6", "metadata": {"name": {"containment": "contains"}}}
+    ]
+  }
+})";
+
+static const char *params = R"({
+    "load_format": "jgf",
+    "matcher_policy": "high",
+    "match_format": "rv1",
+    "matcher_name": "CA"
+})";
+
+static void test_set_status_by_path ()
+{
+    resource_query_t *ctx = nullptr;
+    resource_pool_t::status_t status;
+    int rc;
+
+    ctx = new resource_query_t (two_node_jgf, params);
+    ok (ctx != nullptr, "set_status_by_path: resource_query_t created");
+
+    // Test setting node to down
+    rc = reapi_cli_t::set_status (ctx, "/cluster0/node0", resource_pool_t::status_t::DOWN);
+    ok (rc == 0, "set_status_by_path: set node0 to down succeeds");
+
+    // Verify it's down
+    rc = reapi_cli_t::get_status (ctx, "/cluster0/node0", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::DOWN,
+        "set_status_by_path: node0 status is down");
+
+    // Test setting back to up
+    rc = reapi_cli_t::set_status (ctx, "/cluster0/node0", resource_pool_t::status_t::UP);
+    ok (rc == 0, "set_status_by_path: set node0 to up succeeds");
+
+    rc = reapi_cli_t::get_status (ctx, "/cluster0/node0", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::UP,
+        "set_status_by_path: node0 status is up");
+
+    // Test invalid path
+    errno = 0;
+    rc = reapi_cli_t::set_status (ctx, "/cluster0/nonexistent", resource_pool_t::status_t::DOWN);
+    ok (rc == -1 && errno == EINVAL, "set_status_by_path: invalid path returns EINVAL");
+
+    // Test empty path
+    errno = 0;
+    rc = reapi_cli_t::set_status (ctx, "", resource_pool_t::status_t::DOWN);
+    ok (rc == -1 && errno == EINVAL, "set_status_by_path: empty path returns EINVAL");
+
+    delete ctx;
+}
+
+static void test_set_status_by_rank ()
+{
+    resource_query_t *ctx = nullptr;
+    resource_pool_t::status_t status;
+    int rc;
+
+    ctx = new resource_query_t (two_node_jgf, params);
+    ok (ctx != nullptr, "set_status_by_rank: resource_query_t created");
+
+    // Test setting rank 0 to down
+    rc = reapi_cli_t::set_rank_status (ctx, "0", resource_pool_t::status_t::DOWN);
+    ok (rc == 0, "set_status_by_rank: set rank 0 to down succeeds");
+
+    // Verify it's down
+    rc = reapi_cli_t::get_rank_status (ctx, "0", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::DOWN,
+        "set_status_by_rank: rank 0 status is down");
+
+    // Test setting back to up
+    rc = reapi_cli_t::set_rank_status (ctx, "0", resource_pool_t::status_t::UP);
+    ok (rc == 0, "set_status_by_rank: set rank 0 to up succeeds");
+
+    rc = reapi_cli_t::get_rank_status (ctx, "0", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::UP,
+        "set_status_by_rank: rank 0 status is up");
+
+    // Test invalid rank (should succeed since unknown ranks are silently ignored)
+    errno = 0;
+    rc = reapi_cli_t::set_rank_status (ctx, "999", resource_pool_t::status_t::DOWN);
+    ok (rc == 0, "set_status_by_rank: invalid rank is silently ignored");
+
+    delete ctx;
+}
+
+static void test_set_status_all_ranks ()
+{
+    resource_query_t *ctx = nullptr;
+    resource_pool_t::status_t status;
+    int rc;
+
+    ctx = new resource_query_t (two_node_jgf, params);
+    ok (ctx != nullptr, "set_status_all_ranks: resource_query_t created");
+
+    // Set all ranks to down using "all"
+    rc = reapi_cli_t::set_rank_status (ctx, "all", resource_pool_t::status_t::DOWN);
+    ok (rc == 0, "set_status_all_ranks: set all ranks to down succeeds");
+
+    // Verify both ranks are down
+    rc = reapi_cli_t::get_rank_status (ctx, "0", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::DOWN,
+        "set_status_all_ranks: rank 0 is down");
+
+    rc = reapi_cli_t::get_rank_status (ctx, "1", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::DOWN,
+        "set_status_all_ranks: rank 1 is down");
+
+    // Set all back to up
+    rc = reapi_cli_t::set_rank_status (ctx, "all", resource_pool_t::status_t::UP);
+    ok (rc == 0, "set_status_all_ranks: set all ranks to up succeeds");
+
+    rc = reapi_cli_t::get_rank_status (ctx, "0", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::UP, "set_status_all_ranks: rank 0 is up");
+
+    rc = reapi_cli_t::get_rank_status (ctx, "1", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::UP, "set_status_all_ranks: rank 1 is up");
+
+    delete ctx;
+}
+
+static void test_set_status_by_idset ()
+{
+    resource_query_t *ctx = nullptr;
+    resource_pool_t::status_t status;
+    int rc;
+
+    ctx = new resource_query_t (two_node_jgf, params);
+    ok (ctx != nullptr, "set_status_by_idset: resource_query_t created");
+
+    // Mark both ranks down with idset string
+    rc = reapi_cli_t::set_rank_status (ctx, "0-1", resource_pool_t::status_t::DOWN);
+    ok (rc == 0, "set_status_by_idset: set ranks 0-1 down succeeds");
+
+    // Verify both are down
+    rc = reapi_cli_t::get_rank_status (ctx, "0", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::DOWN,
+        "set_status_by_idset: rank 0 is down");
+
+    rc = reapi_cli_t::get_rank_status (ctx, "1", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::DOWN,
+        "set_status_by_idset: rank 1 is down");
+
+    // Mark only rank 0 back up
+    rc = reapi_cli_t::set_rank_status (ctx, "0", resource_pool_t::status_t::UP);
+    ok (rc == 0, "set_status_by_idset: set rank 0 up succeeds");
+
+    // Verify rank 0 is up, rank 1 still down
+    rc = reapi_cli_t::get_rank_status (ctx, "0", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::UP, "set_status_by_idset: rank 0 is up");
+
+    rc = reapi_cli_t::get_rank_status (ctx, "1", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::DOWN,
+        "set_status_by_idset: rank 1 still down");
+
+    // Test with empty idset string (error case)
+    errno = 0;
+    rc = reapi_cli_t::set_rank_status (ctx, "", resource_pool_t::status_t::DOWN);
+    ok (rc == -1 && errno == EINVAL, "set_status_by_idset: empty idset returns EINVAL");
+
+    // Test with invalid idset string
+    errno = 0;
+    rc = reapi_cli_t::set_rank_status (ctx, "invalid", resource_pool_t::status_t::DOWN);
+    ok (rc == -1 && errno == EINVAL, "set_status_by_idset: invalid idset returns EINVAL");
+
+    delete ctx;
+}
+
+static void test_status_independence ()
+{
+    resource_query_t *ctx = nullptr;
+    resource_pool_t::status_t status;
+    int rc;
+
+    ctx = new resource_query_t (two_node_jgf, params);
+    ok (ctx != nullptr, "status_independence: resource_query_t created");
+
+    // Set node0 to down - children remain independent
+    rc = reapi_cli_t::set_status (ctx, "/cluster0/node0", resource_pool_t::status_t::DOWN);
+    ok (rc == 0, "status_independence: set node0 to down succeeds");
+
+    // Cores are independent - not automatically affected by parent
+    rc = reapi_cli_t::get_status (ctx, "/cluster0/node0/core0", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::UP,
+        "status_independence: core0 status is independent");
+
+    rc = reapi_cli_t::get_status (ctx, "/cluster0/node0/core1", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::UP,
+        "status_independence: core1 status is independent");
+
+    // Check that node1 is unaffected
+    rc = reapi_cli_t::get_status (ctx, "/cluster0/node1", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::UP,
+        "status_independence: node1 is still up");
+
+    delete ctx;
+}
+
+static void test_rank_status_node_level ()
+{
+    resource_query_t *ctx = nullptr;
+    resource_pool_t::status_t status;
+    int rc;
+
+    ctx = new resource_query_t (two_node_jgf, params);
+    ok (ctx != nullptr, "rank_status_node_level: resource_query_t created");
+
+    // Initially all should be up
+    rc = reapi_cli_t::get_rank_status (ctx, "0", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::UP,
+        "rank_status_node_level: rank 0 starts as up");
+
+    // Set the node at rank 0 to down
+    rc = reapi_cli_t::set_status (ctx, "/cluster0/node0", resource_pool_t::status_t::DOWN);
+    ok (rc == 0, "rank_status_node_level: set node0 to down succeeds");
+
+    // Rank query reflects node status
+    rc = reapi_cli_t::get_rank_status (ctx, "0", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::DOWN,
+        "rank_status_node_level: rank 0 is down when node is down");
+
+    // Set the node back to up
+    rc = reapi_cli_t::set_status (ctx, "/cluster0/node0", resource_pool_t::status_t::UP);
+    ok (rc == 0, "rank_status_node_level: set node back to up succeeds");
+
+    // Rank should be up again
+    rc = reapi_cli_t::get_rank_status (ctx, "0", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::UP,
+        "rank_status_node_level: rank 0 is up when node is up");
+
+    delete ctx;
+}
+
+static void test_get_status_errors ()
+{
+    resource_query_t *ctx = nullptr;
+    resource_pool_t::status_t status;
+    int rc;
+
+    ctx = new resource_query_t (two_node_jgf, params);
+    ok (ctx != nullptr, "get_status_errors: resource_query_t created");
+
+    // Test get with invalid path
+    errno = 0;
+    rc = reapi_cli_t::get_status (ctx, "/cluster0/nonexistent", status);
+    ok (rc == -1 && errno == EINVAL, "get_status_errors: invalid path returns EINVAL");
+
+    // Test get with empty path
+    errno = 0;
+    rc = reapi_cli_t::get_status (ctx, "", status);
+    ok (rc == -1 && errno == EINVAL, "get_status_errors: empty path returns EINVAL");
+
+    // Test get with invalid rank
+    errno = 0;
+    rc = reapi_cli_t::get_rank_status (ctx, "999", status);
+    ok (rc == -1 && errno == EINVAL, "get_status_errors: invalid rank returns EINVAL");
+
+    // Test get with "all" (requires exactly one rank)
+    errno = 0;
+    rc = reapi_cli_t::get_rank_status (ctx, "all", status);
+    ok (rc == -1 && errno == EINVAL, "get_status_errors: \"all\" returns EINVAL");
+
+    // Test get with multiple ranks (requires exactly one rank)
+    errno = 0;
+    rc = reapi_cli_t::get_rank_status (ctx, "0-1", status);
+    ok (rc == -1 && errno == EINVAL, "get_status_errors: multiple ranks returns EINVAL");
+
+    // Test get with null context
+    errno = 0;
+    rc = reapi_cli_t::get_status (nullptr, "/cluster0/node0", status);
+    ok (rc == -1 && errno == EINVAL, "get_status_errors: null context returns EINVAL");
+
+    // Test get_rank_status with null context
+    errno = 0;
+    rc = reapi_cli_t::get_rank_status (nullptr, "0", status);
+    ok (rc == -1 && errno == EINVAL, "get_status_errors: null context (rank) returns EINVAL");
+
+    // Test set_rank_status with null context
+    errno = 0;
+    rc = reapi_cli_t::set_rank_status (nullptr, "0", resource_pool_t::status_t::DOWN);
+    ok (rc == -1 && errno == EINVAL, "get_status_errors: null context (set rank) returns EINVAL");
+
+    // Test set_rank_status with invalid idset
+    errno = 0;
+    rc = reapi_cli_t::set_rank_status (ctx, "not-a-rank", resource_pool_t::status_t::DOWN);
+    ok (rc == -1 && errno == EINVAL,
+        "get_status_errors: set_rank_status invalid idset returns EINVAL");
+
+    delete ctx;
+}
+
+// Test removed: with bool status type, there are no invalid status values
+
+static void test_allocation_with_down_node ()
+{
+    resource_query_t *ctx = nullptr;
+    int rc;
+
+    try {
+        ctx = new resource_query_t (two_node_jgf, params);
+    } catch (...) {
+        BAIL_OUT ("allocation_with_down_node: failed to create resource_query_t");
+    }
+
+    // Mark both nodes down
+    rc = reapi_cli_t::set_rank_status (ctx, "0", resource_pool_t::status_t::DOWN);
+    ok (rc == 0, "allocation_with_down_node: mark node0 down succeeds");
+
+    rc = reapi_cli_t::set_rank_status (ctx, "1", resource_pool_t::status_t::DOWN);
+    ok (rc == 0, "allocation_with_down_node: mark node1 down succeeds");
+
+    // Try to allocate with all nodes down - should fail
+    const char *one_core_jobspec = R"({
+        "version": 1,
+        "resources": [
+            {
+                "type": "node",
+                "count": 1,
+                "with": [
+                    {
+                        "type": "slot",
+                        "count": 1,
+                        "label": "task",
+                        "with": [{"type": "core", "count": 1}]
+                    }
+                ]
+            }
+        ],
+        "tasks": [{"command": ["sleep", "60"], "slot": "task", "count": {"per_slot": 1}}],
+        "attributes": {"system": {"duration": 60}}
+    })";
+
+    std::string R;
+    bool reserved = false;
+    int64_t at = 0;
+    double ov = 0.0;
+    errno = 0;
+    rc = reapi_cli_t::match_allocate (ctx,
+                                      match_op_t::MATCH_ALLOCATE,
+                                      one_core_jobspec,
+                                      1,
+                                      reserved,
+                                      R,
+                                      at,
+                                      ov);
+
+    ok (rc == -1, "allocation_with_down_node: allocation fails when all nodes are down");
+
+    delete ctx;
+}
+
+static void test_allocation_with_mixed_status ()
+{
+    resource_query_t *ctx = nullptr;
+    int rc;
+
+    try {
+        ctx = new resource_query_t (two_node_jgf, params);
+    } catch (...) {
+        BAIL_OUT ("allocation_with_mixed_status: failed to create resource_query_t");
+    }
+
+    // Mark rank 0 down, leave rank 1 up
+    rc = reapi_cli_t::set_rank_status (ctx, "0", resource_pool_t::status_t::DOWN);
+    ok (rc == 0, "allocation_with_mixed_status: mark rank 0 down succeeds");
+
+    // Verify rank 1 is still up
+    resource_pool_t::status_t status;
+    rc = reapi_cli_t::get_rank_status (ctx, "1", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::UP,
+        "allocation_with_mixed_status: rank 1 is up");
+
+    // Try to allocate with one node down - should succeed on the up node
+    const char *one_core_jobspec = R"({
+        "version": 1,
+        "resources": [
+            {
+                "type": "node",
+                "count": 1,
+                "with": [
+                    {
+                        "type": "slot",
+                        "count": 1,
+                        "label": "task",
+                        "with": [{"type": "core", "count": 1}]
+                    }
+                ]
+            }
+        ],
+        "tasks": [{"command": ["sleep", "60"], "slot": "task", "count": {"per_slot": 1}}],
+        "attributes": {"system": {"duration": 60}}
+    })";
+
+    std::string R;
+    bool reserved = false;
+    int64_t at = 0;
+    double ov = 0.0;
+    errno = 0;
+    rc = reapi_cli_t::match_allocate (ctx,
+                                      match_op_t::MATCH_ALLOCATE,
+                                      one_core_jobspec,
+                                      1,
+                                      reserved,
+                                      R,
+                                      at,
+                                      ov);
+
+    ok (rc == 0, "allocation_with_mixed_status: allocation succeeds with one node down");
+
+    // Parse R to verify which rank was used
+    json_error_t error;
+    json_t *R_json = json_loads (R.c_str (), 0, &error);
+    if (!R_json) {
+        delete ctx;
+        BAIL_OUT ("allocation_with_mixed_status: failed to parse R JSON: %s", error.text);
+    }
+
+    // Extract rank from R_lite[0].rank
+    const char *rank_str = nullptr;
+    if (json_unpack (R_json, "{s:{s:[{s:s}]}}", "execution", "R_lite", "rank", &rank_str) < 0) {
+        diag ("R = ");
+        diag_json (R_json);
+        json_decref (R_json);
+        delete ctx;
+        BAIL_OUT ("allocation_with_mixed_status: failed to unpack rank from R");
+    }
+
+    if (strcmp (rank_str, "1") != 0) {
+        diag ("R = ");
+        diag_json (R_json);
+    }
+    ok (strcmp (rank_str, "1") == 0,
+        "allocation_with_mixed_status: allocation used rank 1 (up node), not rank 0 (down node)");
+
+    json_decref (R_json);
+    delete ctx;
+}
+
+static void test_child_resource_status ()
+{
+    resource_query_t *ctx = nullptr;
+    resource_pool_t::status_t status;
+    int rc;
+
+    ctx = new resource_query_t (two_node_jgf, params);
+    ok (ctx != nullptr, "child_resource_status: resource_query_t created");
+
+    // Set core0 on node0 to down, independent of node status
+    rc = reapi_cli_t::set_status (ctx, "/cluster0/node0/core0", resource_pool_t::status_t::DOWN);
+    ok (rc == 0, "child_resource_status: set core0 to down succeeds");
+
+    // Verify core0 is down
+    rc = reapi_cli_t::get_status (ctx, "/cluster0/node0/core0", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::DOWN,
+        "child_resource_status: core0 status is down");
+
+    // Verify node0 is still up (parent status is independent)
+    rc = reapi_cli_t::get_status (ctx, "/cluster0/node0", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::UP,
+        "child_resource_status: node0 status is still up (independent of child)");
+
+    // Verify core1 on node0 is still up (sibling status is independent)
+    rc = reapi_cli_t::get_status (ctx, "/cluster0/node0/core1", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::UP,
+        "child_resource_status: core1 status is still up (independent of sibling)");
+
+    // Set core0 back to up
+    rc = reapi_cli_t::set_status (ctx, "/cluster0/node0/core0", resource_pool_t::status_t::UP);
+    ok (rc == 0, "child_resource_status: set core0 back to up succeeds");
+
+    rc = reapi_cli_t::get_status (ctx, "/cluster0/node0/core0", status);
+    ok (rc == 0 && status == resource_pool_t::status_t::UP,
+        "child_resource_status: core0 is back to up");
+
+    delete ctx;
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_set_status_by_path ();
+    test_set_status_by_rank ();
+    test_set_status_all_ranks ();
+    test_set_status_by_idset ();
+    test_status_independence ();
+    test_rank_status_node_level ();
+    test_get_status_errors ();
+    // test_invalid_status_strings removed: no invalid bool values
+    test_allocation_with_down_node ();
+    test_allocation_with_mixed_status ();
+    test_child_resource_status ();
+
+    done_testing ();
+
+    return EXIT_SUCCESS;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/reapi/bindings/c/reapi_cli.cpp
+++ b/resource/reapi/bindings/c/reapi_cli.cpp
@@ -19,12 +19,48 @@ extern "C" {
 #include <cstdlib>
 #include <cstdint>
 #include <cerrno>
+#include <cstring>
 #include "resource/reapi/bindings/c++/reapi_cli.hpp"
 #include "resource/reapi/bindings/c++/reapi_cli_impl.hpp"
+#include "resource/schema/data_std.hpp"
+#include "resource/reapi/bindings/c/resource_status.h"
 
 using namespace Flux;
 using namespace Flux::resource_model;
 using namespace Flux::resource_model::detail;
+
+// Conversion helpers between C and C++ status enums
+// Returns 0 on success, -1 on error with errno set
+static inline int resource_status_to_cpp (resource_status_t status, resource_pool_t::status_t &out)
+{
+    switch (status) {
+        case RESOURCE_UP:
+            out = resource_pool_t::status_t::UP;
+            return 0;
+        case RESOURCE_DOWN:
+            out = resource_pool_t::status_t::DOWN;
+            return 0;
+        default:
+            errno = EINVAL;
+            return -1;
+    }
+}
+
+static inline int resource_status_from_cpp (resource_pool_t::status_t status,
+                                            resource_status_t &out)
+{
+    switch (status) {
+        case resource_pool_t::status_t::UP:
+            out = RESOURCE_UP;
+            return 0;
+        case resource_pool_t::status_t::DOWN:
+            out = RESOURCE_DOWN;
+            return 0;
+        default:
+            errno = EINVAL;
+            return -1;
+    }
+}
 
 struct reapi_cli_ctx {
     resource_query_t *rqt;
@@ -328,6 +364,142 @@ extern "C" void reapi_cli_clear_err_msg (reapi_cli_ctx_t *ctx)
         ctx->rqt->clear_resource_query_err_msg ();
     reapi_cli_t::clear_err_message ();
     ctx->err_msg = "";
+}
+
+extern "C" int reapi_cli_set_status (reapi_cli_ctx_t *ctx,
+                                     const char *resource_path,
+                                     resource_status_t status)
+{
+    if (!ctx || !ctx->rqt || !resource_path) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    resource_pool_t::status_t cpp_status;
+    if (resource_status_to_cpp (status, cpp_status) < 0)
+        return -1;
+
+    try {
+        return reapi_cli_t::set_status (ctx->rqt, resource_path, cpp_status);
+    } catch (std::system_error &e) {
+        ctx->err_msg = __FUNCTION__;
+        ctx->err_msg += ": ERROR: System error: " + std::string (e.what ()) + "\n";
+        errno = e.code ().value ();
+        return -1;
+    } catch (std::exception &e) {
+        // Translate C++ exceptions to errno - unexpected errors default to EINVAL.
+        errno = EINVAL;
+        ctx->err_msg = __FUNCTION__;
+        ctx->err_msg += ": ERROR: " + std::string (e.what ()) + "\n";
+        return -1;
+    } catch (...) {
+        errno = EINVAL;
+        ctx->err_msg = __FUNCTION__;
+        ctx->err_msg += ": ERROR: unknown exception\n";
+        return -1;
+    }
+}
+
+extern "C" int reapi_cli_get_status (reapi_cli_ctx_t *ctx,
+                                     const char *resource_path,
+                                     resource_status_t *status)
+{
+    if (!ctx || !ctx->rqt || !resource_path || !status) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    try {
+        resource_pool_t::status_t cpp_status;
+        int rc = reapi_cli_t::get_status (ctx->rqt, resource_path, cpp_status);
+        if (rc == 0 && resource_status_from_cpp (cpp_status, *status) < 0)
+            return -1;
+        return rc;
+    } catch (std::system_error &e) {
+        ctx->err_msg = __FUNCTION__;
+        ctx->err_msg += ": ERROR: System error: " + std::string (e.what ()) + "\n";
+        errno = e.code ().value ();
+        return -1;
+    } catch (std::exception &e) {
+        // Translate C++ exceptions to errno - unexpected errors default to EINVAL.
+        errno = EINVAL;
+        ctx->err_msg = __FUNCTION__;
+        ctx->err_msg += ": ERROR: " + std::string (e.what ()) + "\n";
+        return -1;
+    } catch (...) {
+        errno = EINVAL;
+        ctx->err_msg = __FUNCTION__;
+        ctx->err_msg += ": ERROR: unknown exception\n";
+        return -1;
+    }
+}
+
+extern "C" int reapi_cli_set_rank_status (reapi_cli_ctx_t *ctx,
+                                          const char *ranks,
+                                          resource_status_t status)
+{
+    if (!ctx || !ctx->rqt) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    resource_pool_t::status_t cpp_status;
+    if (resource_status_to_cpp (status, cpp_status) < 0)
+        return -1;
+
+    try {
+        return reapi_cli_t::set_rank_status (ctx->rqt, ranks, cpp_status);
+    } catch (std::system_error &e) {
+        ctx->err_msg = __FUNCTION__;
+        ctx->err_msg += ": ERROR: System error: " + std::string (e.what ()) + "\n";
+        errno = e.code ().value ();
+        return -1;
+    } catch (std::exception &e) {
+        // Translate C++ exceptions to errno - unexpected errors default to EINVAL.
+        errno = EINVAL;
+        ctx->err_msg = __FUNCTION__;
+        ctx->err_msg += ": ERROR: " + std::string (e.what ()) + "\n";
+        return -1;
+    } catch (...) {
+        errno = EINVAL;
+        ctx->err_msg = __FUNCTION__;
+        ctx->err_msg += ": ERROR: unknown exception\n";
+        return -1;
+    }
+}
+
+extern "C" int reapi_cli_get_rank_status (reapi_cli_ctx_t *ctx,
+                                          const char *rank,
+                                          resource_status_t *status)
+{
+    if (!ctx || !ctx->rqt || !status) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    try {
+        resource_pool_t::status_t cpp_status;
+        int rc = reapi_cli_t::get_rank_status (ctx->rqt, rank, cpp_status);
+        if (rc == 0 && resource_status_from_cpp (cpp_status, *status) < 0)
+            return -1;
+        return rc;
+    } catch (std::system_error &e) {
+        ctx->err_msg = __FUNCTION__;
+        ctx->err_msg += ": ERROR: System error: " + std::string (e.what ()) + "\n";
+        errno = e.code ().value ();
+        return -1;
+    } catch (std::exception &e) {
+        // Translate C++ exceptions to errno - unexpected errors default to EINVAL.
+        errno = EINVAL;
+        ctx->err_msg = __FUNCTION__;
+        ctx->err_msg += ": ERROR: " + std::string (e.what ()) + "\n";
+        return -1;
+    } catch (...) {
+        errno = EINVAL;
+        ctx->err_msg = __FUNCTION__;
+        ctx->err_msg += ": ERROR: unknown exception\n";
+        return -1;
+    }
 }
 
 /*

--- a/resource/reapi/bindings/c/reapi_cli.h
+++ b/resource/reapi/bindings/c/reapi_cli.h
@@ -20,6 +20,7 @@ extern "C" {
 #endif
 #include <flux/core.h>
 #include "resource/policies/base/match_op.h"
+#include "resource_status.h"
 
 typedef struct reapi_cli_ctx reapi_cli_ctx_t;
 
@@ -270,6 +271,54 @@ const char *reapi_cli_get_err_msg (reapi_cli_ctx_t *ctx);
  *  \param ctx       reapi_cli_ctx_t context object
  */
 void reapi_cli_clear_err_msg (reapi_cli_ctx_t *ctx);
+
+/*! Set resource status (up or down) for a resource at the specified path.
+ *
+ *  \param ctx           reapi_cli_ctx_t context object
+ *  \param resource_path Path to resource (e.g., "/cluster0/rack0/node3")
+ *  \param status        RESOURCE_UP or RESOURCE_DOWN
+ *  \return              0 on success; -1 on error with errno set:
+ *                           EINVAL: invalid parameters, resource path not found,
+ *                                   or unexpected internal error
+ */
+int reapi_cli_set_status (reapi_cli_ctx_t *ctx,
+                          const char *resource_path,
+                          resource_status_t status);
+
+/*! Get resource status for a resource at the specified path.
+ *
+ *  \param ctx           reapi_cli_ctx_t context object
+ *  \param resource_path Path to resource (e.g., "/cluster0/rack0/node3")
+ *  \param status        Pointer to receive status
+ *  \return              0 on success; -1 on error with errno set:
+ *                           EINVAL: invalid parameters, resource path not found,
+ *                                   or unexpected internal error
+ */
+int reapi_cli_get_status (reapi_cli_ctx_t *ctx,
+                          const char *resource_path,
+                          resource_status_t *status);
+
+/*! Set resource status (up or down) for the subtree root (typically node) of each rank in a set.
+ *  Unknown ranks are silently ignored.
+ *
+ *  \param ctx           reapi_cli_ctx_t context object
+ *  \param ranks         RFC 22 idset string representing rank set, or "all"
+ *  \param status        RESOURCE_UP or RESOURCE_DOWN
+ *  \return              0 on success; -1 on error with errno set:
+ *                           EINVAL: invalid parameters or unexpected internal error
+ */
+int reapi_cli_set_rank_status (reapi_cli_ctx_t *ctx, const char *ranks, resource_status_t status);
+
+/*! Get resource status for the node at a rank.
+ *
+ *  \param ctx           reapi_cli_ctx_t context object
+ *  \param rank          Single rank number, as a string e.g. "2"
+ *  \param status        Pointer to receive status
+ *  \return              0 on success; -1 on error with errno set:
+ *                           EINVAL: invalid parameters, rank not found,
+ *                                   or unexpected internal error
+ */
+int reapi_cli_get_rank_status (reapi_cli_ctx_t *ctx, const char *rank, resource_status_t *status);
 
 #ifdef __cplusplus
 }

--- a/resource/reapi/bindings/c/reapi_module.cpp
+++ b/resource/reapi/bindings/c/reapi_module.cpp
@@ -202,6 +202,38 @@ extern "C" void *reapi_module_get_handle (reapi_module_ctx_t *ctx)
     return ctx->h;
 }
 
+extern "C" int reapi_module_set_status (reapi_module_ctx_t *ctx,
+                                        const char *resource_path,
+                                        resource_status_t status)
+{
+    errno = ENOSYS;  // unimplemented
+    return -1;
+}
+
+extern "C" int reapi_module_get_status (reapi_module_ctx_t *ctx,
+                                        const char *resource_path,
+                                        resource_status_t *status)
+{
+    errno = ENOSYS;  // unimplemented
+    return -1;
+}
+
+extern "C" int reapi_module_set_rank_status (reapi_module_ctx_t *ctx,
+                                             const char *ranks,
+                                             resource_status_t status)
+{
+    errno = ENOSYS;  // unimplemented
+    return -1;
+}
+
+extern "C" int reapi_module_get_rank_status (reapi_module_ctx_t *ctx,
+                                             const char *rank,
+                                             resource_status_t *status)
+{
+    errno = ENOSYS;  // unimplemented
+    return -1;
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/resource/reapi/bindings/c/reapi_module.h
+++ b/resource/reapi/bindings/c/reapi_module.h
@@ -20,6 +20,7 @@ extern "C" {
 #endif
 #include <flux/core.h>
 #include "resource/policies/base/match_op.h"
+#include "resource_status.h"
 
 typedef struct reapi_module_ctx reapi_module_ctx_t;
 
@@ -212,6 +213,58 @@ int reapi_module_set_handle (reapi_module_ctx_t *ctx, void *handle);
  *  \return          handle
  */
 void *reapi_module_get_handle (reapi_module_ctx_t *ctx);
+
+/*! Set resource status (up or down) for a resource at the specified path.
+ *
+ *  \param ctx           reapi_cli_ctx_t context object
+ *  \param resource_path Path to resource (e.g., "/cluster0/rack0/node3")
+ *  \param status        RESOURCE_UP or RESOURCE_DOWN
+ *  \return              0 on success; -1 on error with errno set:
+ *                           EINVAL: invalid parameters, resource path not found,
+ *                                   or unexpected internal error
+ */
+int reapi_module_set_status (reapi_module_ctx_t *ctx,
+                             const char *resource_path,
+                             resource_status_t status);
+
+/*! Get resource status for a resource at the specified path.
+ *
+ *  \param ctx           reapi_module_ctx_t context object
+ *  \param resource_path Path to resource (e.g., "/cluster0/rack0/node3")
+ *  \param status        Pointer to receive status
+ *  \return              0 on success; -1 on error with errno set:
+ *                           EINVAL: invalid parameters, resource path not found,
+ *                                   or unexpected internal error
+ */
+int reapi_module_get_status (reapi_module_ctx_t *ctx,
+                             const char *resource_path,
+                             resource_status_t *status);
+
+/*! Set resource status (up or down) for all resources at each rank in a set.
+ *  Unknown ranks are silently ignored.
+ *
+ *  \param ctx           reapi_module_ctx_t context object
+ *  \param ranks         RFC 22 idset string representing a set of ranks, or "all"
+ *  \param status        RESOURCE_UP or RESOURCE_DOWN
+ *  \return              0 on success; -1 on error with errno set:
+ *                           EINVAL: invalid parameters or unexpected internal error
+ */
+int reapi_module_set_rank_status (reapi_module_ctx_t *ctx,
+                                  const char *ranks,
+                                  resource_status_t status);
+
+/*! Get resource status for the node at a rank.
+ *
+ *  \param ctx           reapi_module_ctx_t context object
+ *  \param rank          Rank in string form, e.g. "2"
+ *  \param status        Pointer to receive status
+ *  \return              0 on success; -1 on error with errno set:
+ *                           EINVAL: invalid parameters, rank not found,
+ *                                   or unexpected internal error
+ */
+int reapi_module_get_rank_status (reapi_module_ctx_t *ctx,
+                                  const char *rank,
+                                  resource_status_t *status);
 
 #ifdef __cplusplus
 }

--- a/resource/reapi/bindings/c/resource_status.h
+++ b/resource/reapi/bindings/c/resource_status.h
@@ -1,0 +1,24 @@
+/*****************************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+#ifndef RESOURCE_STATUS_H
+#define RESOURCE_STATUS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum resource_status_t { RESOURCE_UP = 0, RESOURCE_DOWN = 1 } resource_status_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RESOURCE_STATUS_H

--- a/resource/reapi/bindings/c/test/reapi_cli_test.c
+++ b/resource/reapi/bindings/c/test/reapi_cli_test.c
@@ -146,12 +146,195 @@ static int test_match_with_jobid ()
     return 0;
 }
 
+static int test_status_by_rank ()
+{
+    reapi_cli_ctx_t *ctx = reapi_cli_new ();
+    if (!ctx)
+        BAIL_OUT ("reapi_cli_new failed");
+
+    int rc = reapi_cli_initialize (ctx, tiny_jgf, tiny_params);
+    if (rc < 0)
+        BAIL_OUT ("reapi_cli_initialize failed: %s", reapi_cli_get_err_msg (ctx));
+
+    reapi_cli_clear_err_msg (ctx);
+
+    // Test setting rank 0 to down
+    errno = 0;
+    rc = reapi_cli_set_rank_status (ctx, "0", RESOURCE_DOWN);
+    ok (rc == 0, "reapi_cli_set_rank_status succeeded for rank 0 down");
+
+    // Verify it's down
+    resource_status_t status;
+    const char *err_msg;
+    rc = reapi_cli_get_rank_status (ctx, "0", &status);
+    ok (rc == 0 && status == RESOURCE_DOWN, "reapi_cli_get_rank_status returns DOWN for rank 0");
+
+    // Test setting rank 0 back to up
+    errno = 0;
+    rc = reapi_cli_set_rank_status (ctx, "0", RESOURCE_UP);
+    ok (rc == 0, "reapi_cli_set_rank_status succeeded for rank 0 up");
+
+    // Verify it's up
+    rc = reapi_cli_get_rank_status (ctx, "0", &status);
+    ok (rc == 0 && status == RESOURCE_UP, "reapi_cli_get_rank_status returns UP for rank 0");
+
+    // Test with nonexistent rank (should succeed since unknown ranks are silently ignored)
+    errno = 0;
+    rc = reapi_cli_set_rank_status (ctx, "999", RESOURCE_DOWN);
+    ok (rc == 0, "reapi_cli_set_rank_status succeeds for nonexistent rank (silently ignored)");
+
+    // Test get with nonexistent rank
+    errno = 0;
+    rc = reapi_cli_get_rank_status (ctx, "999", &status);
+    ok (rc == -1 && errno == EINVAL,
+        "reapi_cli_get_rank_status returns -1 with errno=EINVAL for nonexistent rank");
+
+    err_msg = reapi_cli_get_err_msg (ctx);
+    ok (err_msg != NULL && strlen (err_msg) > 0,
+        "error message is set after get_rank_status failure");
+    reapi_cli_clear_err_msg (ctx);
+
+    reapi_cli_destroy (ctx);
+    return 0;
+}
+
+static int test_status_by_path ()
+{
+    reapi_cli_ctx_t *ctx = reapi_cli_new ();
+    if (!ctx)
+        BAIL_OUT ("reapi_cli_new failed");
+
+    int rc = reapi_cli_initialize (ctx, tiny_jgf, tiny_params);
+    if (rc < 0)
+        BAIL_OUT ("reapi_cli_initialize failed: %s", reapi_cli_get_err_msg (ctx));
+
+    reapi_cli_clear_err_msg (ctx);
+
+    // Test setting node to down
+    errno = 0;
+    rc = reapi_cli_set_status (ctx, "/tiny0/node0", RESOURCE_DOWN);
+    ok (rc == 0, "reapi_cli_set_status succeeded for /tiny0/node0 down");
+
+    // Verify it's down
+    resource_status_t status;
+    rc = reapi_cli_get_status (ctx, "/tiny0/node0", &status);
+    ok (rc == 0 && status == RESOURCE_DOWN, "reapi_cli_get_status returns DOWN for /tiny0/node0");
+
+    // Test setting back to up
+    errno = 0;
+    rc = reapi_cli_set_status (ctx, "/tiny0/node0", RESOURCE_UP);
+    ok (rc == 0, "reapi_cli_set_status succeeded for /tiny0/node0 up");
+
+    // Verify it's up
+    rc = reapi_cli_get_status (ctx, "/tiny0/node0", &status);
+    ok (rc == 0 && status == RESOURCE_UP, "reapi_cli_get_status returns UP for /tiny0/node0");
+
+    // Test with invalid path
+    errno = 0;
+    rc = reapi_cli_set_status (ctx, "/nonexistent", RESOURCE_DOWN);
+    ok (rc == -1 && errno == EINVAL,
+        "reapi_cli_set_status returns -1 with errno=EINVAL for invalid path");
+
+    const char *err_msg = reapi_cli_get_err_msg (ctx);
+    ok (err_msg != NULL && strlen (err_msg) > 0, "error message is set after set_status failure");
+    reapi_cli_clear_err_msg (ctx);
+
+    // Test get with invalid path
+    errno = 0;
+    rc = reapi_cli_get_status (ctx, "/nonexistent", &status);
+    ok (rc == -1 && errno == EINVAL,
+        "reapi_cli_get_status returns -1 with errno=EINVAL for invalid path");
+
+    err_msg = reapi_cli_get_err_msg (ctx);
+    ok (err_msg != NULL && strlen (err_msg) > 0, "error message is set after get_status failure");
+    reapi_cli_clear_err_msg (ctx);
+
+    reapi_cli_destroy (ctx);
+    return 0;
+}
+
+static int test_null_parameters ()
+{
+    reapi_cli_ctx_t *ctx = reapi_cli_new ();
+    resource_status_t status;
+    int rc;
+
+    if (!ctx)
+        BAIL_OUT ("reapi_cli_new failed");
+
+    rc = reapi_cli_initialize (ctx, tiny_jgf, tiny_params);
+    if (rc < 0)
+        BAIL_OUT ("reapi_cli_initialize failed: %s", reapi_cli_get_err_msg (ctx));
+
+    reapi_cli_clear_err_msg (ctx);
+
+    // Test get_status with NULL status pointer
+    errno = 0;
+    rc = reapi_cli_get_status (ctx, "/tiny0/node0", NULL);
+    ok (rc == -1 && errno == EINVAL,
+        "reapi_cli_get_status returns -1 with errno=EINVAL for NULL status pointer");
+
+    // Test get_rank_status with NULL status pointer
+    errno = 0;
+    rc = reapi_cli_get_rank_status (ctx, "0", NULL);
+    ok (rc == -1 && errno == EINVAL,
+        "reapi_cli_get_rank_status returns -1 with errno=EINVAL for NULL status pointer");
+
+    // Test set_rank_status with empty string
+    errno = 0;
+    rc = reapi_cli_set_rank_status (ctx, "", RESOURCE_DOWN);
+    ok (rc == -1 && errno == EINVAL,
+        "reapi_cli_set_rank_status returns -1 with errno=EINVAL for empty string");
+
+    // Test get_rank_status with invalid idset
+    errno = 0;
+    rc = reapi_cli_get_rank_status (ctx, "not-a-rank", &status);
+    ok (rc == -1 && errno == EINVAL,
+        "reapi_cli_get_rank_status returns -1 with errno=EINVAL for invalid idset");
+
+    // Test get_rank_status with multiple ranks (requires exactly one rank)
+    errno = 0;
+    rc = reapi_cli_get_rank_status (ctx, "0-1", &status);
+    ok (rc == -1 && errno == EINVAL,
+        "reapi_cli_get_rank_status returns -1 with errno=EINVAL for multiple ranks");
+
+    // Test set_rank_status with NULL context
+    errno = 0;
+    rc = reapi_cli_set_rank_status (NULL, "0", RESOURCE_DOWN);
+    ok (rc == -1 && errno == EINVAL,
+        "reapi_cli_set_rank_status returns -1 with errno=EINVAL for NULL context");
+
+    // Test get_rank_status with NULL context
+    errno = 0;
+    rc = reapi_cli_get_rank_status (NULL, "0", &status);
+    ok (rc == -1 && errno == EINVAL,
+        "reapi_cli_get_rank_status returns -1 with errno=EINVAL for NULL context");
+
+    // Test set_status with NULL path
+    errno = 0;
+    rc = reapi_cli_set_status (ctx, NULL, RESOURCE_DOWN);
+    ok (rc == -1 && errno == EINVAL,
+        "reapi_cli_set_status returns -1 with errno=EINVAL for NULL path");
+
+    // Test get_status with NULL path
+    errno = 0;
+    rc = reapi_cli_get_status (ctx, NULL, &status);
+    ok (rc == -1 && errno == EINVAL,
+        "reapi_cli_get_status returns -1 with errno=EINVAL for NULL path");
+
+    reapi_cli_destroy (ctx);
+    return 0;
+}
+
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
 
     test_clone ();
     test_match_with_jobid ();
+    test_status_by_rank ();
+    test_status_by_path ();
+    test_null_parameters ();
 
     done_testing ();
     return EXIT_SUCCESS;


### PR DESCRIPTION
Problem: reapi_cli doesn't offer interfaces for marking resources up|down, but this will be required for use in the flux-core python scheduler framework as discussed in
- flux-framework/flux-core#7496

This was peeled off of
- #1481

New C++ methods (implemented in reapi_cli, stubbed in reapi_module) EDIT updated 4 June 2026:
```c++
    /*! Set resource status (up or down) for a resource at the specified path.
     *
     *  \param h         Opaque handle. How it is used is an implementation
     *                   detail. However, when it is used within a Flux's
     *                   service module, it is expected to be a pointer
     *                   to a flux_t object.
     *  \param resource_path    Path to resource (e.g., "/cluster0/rack0/node3")
     *  \param status    resource_pool_t::status_t::UP or resource_pool_t::status_t::DOWN
     *  \return          0 on success; -1 on error with errno set:
     *                       EINVAL: invalid parameters, resource path not found,
     *                               or unexpected internal error
     */
    static int set_status (void *h, const std::string &resource_path, resource_pool_t::status_t status);

    /*! Get resource status for a resource at the specified path.
     *
     *  \param h         Opaque handle. How it is used is an implementation
     *                   detail. However, when it is used within a Flux's
     *                   service module, it is expected to be a pointer
     *                   to a flux_t object.
     *  \param resource_path    Path to resource (e.g., "/cluster0/rack0/node3")
     *  \param status    Reference to receive status
     *  \return          0 on success; -1 on error with errno set:
     *                       EINVAL: invalid parameters, resource path not found,
     *                               or unexpected internal error
     */
    static int get_status (void *h, const std::string &resource_path, resource_pool_t::status_t &status);

    /*! Set resource status (up or down) for the subtree root (typically node) at each ranks in a
     * set. Unknown ranks are silently ignored.
     *
     *  \param h         Opaque handle. How it is used is an implementation
     *                   detail. However, when it is used within a Flux's
     *                   service module, it is expected to be a pointer
     *                   to a flux_t object.
     *  \param ranks     RFC 22 idset string representing a set of ranks, or "all".
     *  \param status    resource_pool_t::status_t::UP or resource_pool_t::status_t::DOWN
     *  \return          0 on success; -1 on error with errno set:
     *                       EINVAL: invalid parameters or unexpected internal error
     */
    static int set_rank_status (void *h, std::string_view ranks, resource_pool_t::status_t status);

    /*! Get resource status for the node at a rank.
     *
     *  \param h         Opaque handle. How it is used is an implementation
     *                   detail. However, when it is used within a Flux's
     *                   service module, it is expected to be a pointer
     *                   to a flux_t object.
     *  \param rank      Rank number as a string, e.g. "1"
     *  \param status    Reference to receive status
     *  \return          0 on success; -1 on error with errno set:
     *                       EINVAL: invalid parameters, rank not found,
     *                               or unexpected internal error
     */
    static int get_rank_status (void *h, std::string_view rank, resource_pool_t::status_t &status);
```
added a new C header `resource_status.h` to define a C style status enum:
```c
typedef enum resource_status_t {
    RESOURCE_UP = 0,
    RESOURCE_DOWN = 1
} resource_status_t;
```
and implemented these new API functions
```c
/*! Set resource status (up or down) for a resource at the specified path.
 *
 *  \param ctx           reapi_cli_ctx_t context object
 *  \param resource_path Path to resource (e.g., "/cluster0/rack0/node3")
 *  \param status        RESOURCE_UP or RESOURCE_DOWN
 *  \return              0 on success; -1 on error with errno set:
 *                           EINVAL: invalid parameters, resource path not found,
 *                                   or unexpected internal error
 */
int reapi_cli_set_status (reapi_cli_ctx_t *ctx,
                          const char *resource_path,
                          resource_status_t status);

/*! Get resource status for a resource at the specified path.
 *
 *  \param ctx           reapi_cli_ctx_t context object
 *  \param resource_path Path to resource (e.g., "/cluster0/rack0/node3")
 *  \param status        Pointer to receive status
 *  \return              0 on success; -1 on error with errno set:
 *                           EINVAL: invalid parameters, resource path not found,
 *                                   or unexpected internal error
 */
int reapi_cli_get_status (reapi_cli_ctx_t *ctx,
                          const char *resource_path,
                          resource_status_t *status);

/*! Set resource status (up or down) for the subtree root (typically node) of each rank in a set.
 *  Unknown ranks are silently ignored.
 *
 *  \param ctx           reapi_cli_ctx_t context object
 *  \param ranks         RFC 22 idset string representing rank set, or "all"
 *  \param status        RESOURCE_UP or RESOURCE_DOWN
 *  \return              0 on success; -1 on error with errno set:
 *                           EINVAL: invalid parameters or unexpected internal error
 */
int reapi_cli_set_rank_status (reapi_cli_ctx_t *ctx, const char *ranks, resource_status_t status);

/*! Get resource status for the node at a rank.
 *
 *  \param ctx           reapi_cli_ctx_t context object
 *  \param rank          Single rank number, as a string e.g. "2"
 *  \param status        Pointer to receive status
 *  \return              0 on success; -1 on error with errno set:
 *                           EINVAL: invalid parameters, rank not found,
 *                                   or unexpected internal error
 */
int reapi_cli_get_rank_status (reapi_cli_ctx_t *ctx, const char *rank, resource_status_t *status);
```

Note that the path versions of these interfaces are not required at this point for a python scheduler, but they could be handy in the future e.g. for marking rabbits up/down and they are more natural than the rank versions in fluxion space.