### PR TITLE
reapi: add reapi_cli_match_with_jobid()

### DIFF
--- a/resource/reapi/bindings/c/reapi_cli.cpp
+++ b/resource/reapi/bindings/c/reapi_cli.cpp
@@ -120,14 +120,14 @@ extern "C" reapi_cli_ctx_t *reapi_cli_clone (reapi_cli_ctx_t *ctx)
     }
 }
 
-extern "C" int reapi_cli_match (reapi_cli_ctx_t *ctx,
-                                match_op_t match_op,
-                                const char *jobspec,
-                                uint64_t *jobid,
-                                bool *reserved,
-                                char **R,
-                                int64_t *at,
-                                double *ov)
+extern "C" int reapi_cli_match_with_jobid (reapi_cli_ctx_t *ctx,
+                                           match_op_t match_op,
+                                           const char *jobspec,
+                                           uint64_t jobid,
+                                           bool *reserved,
+                                           char **R,
+                                           int64_t *at,
+                                           double *ov)
 {
     int rc = -1;
     std::string R_buf = "";
@@ -138,9 +138,8 @@ extern "C" int reapi_cli_match (reapi_cli_ctx_t *ctx,
         goto out;
     }
 
-    *jobid = ctx->rqt->get_job_counter ();
     if ((rc = reapi_cli_t::
-             match_allocate (ctx->rqt, match_op, jobspec, *jobid, *reserved, R_buf, *at, *ov))
+             match_allocate (ctx->rqt, match_op, jobspec, jobid, *reserved, R_buf, *at, *ov))
         < 0) {
         goto out;
     }
@@ -155,6 +154,26 @@ extern "C" int reapi_cli_match (reapi_cli_ctx_t *ctx,
     (*R) = R_buf_c;
 
 out:
+    return rc;
+}
+
+extern "C" int reapi_cli_match (reapi_cli_ctx_t *ctx,
+                                match_op_t match_op,
+                                const char *jobspec,
+                                uint64_t *jobid,
+                                bool *reserved,
+                                char **R,
+                                int64_t *at,
+                                double *ov)
+{
+    uint64_t seq = ctx->rqt->get_job_counter ();
+    int rc = -1;
+
+    if ((rc = reapi_cli_match_with_jobid (ctx, match_op, jobspec, seq, reserved, R, at, ov)) < 0)
+        goto done;
+    *jobid = seq;
+
+done:
     return rc;
 }
 

--- a/resource/reapi/bindings/c/reapi_cli.h
+++ b/resource/reapi/bindings/c/reapi_cli.h
@@ -90,6 +90,47 @@ int reapi_cli_match (reapi_cli_ctx_t *ctx,
 
 /*! Match a jobspec to the "best" resources and either allocate
  *  orelse reserve them. The best resources are determined by
+ *  the selected match policy.  This function is identical to
+ *  reapi_cli_match() in all respects except the jobid is provided
+ *  by the caller, who is responsible for ensuring uniqueness.
+ *  N.B. To avoid jobid collisions, this call should not be mixed
+ *  with the other match calls that allocate them internally.
+ *
+ *  \param ctx       reapi_cli_ctx_t context object
+ *  \param match_op  match_op_t: set to specify the specific match option
+ *                   from 1 of 4 choices:
+ *                   MATCH_ALLOCATE: try to allocate now and fail if resources
+ *                   aren't available.
+ *                   MATCH_ALLOCATE_ORELSE_RESERVE : Try to allocate and reserve
+ *                   if resources aren't available now.
+ *                   MATCH_SATISFIABILITY: Do a satisfiablity check and do not
+ *                   allocate.
+ *                   MATCH_ALLOCATE_W_SATISFIABILITY: try to allocate and run
+ *                   satisfiability check if resources are not available.
+ *  \param jobspec   jobspec string.
+ *  \param jobid     jobid provided by caller
+ *  \param reserved  Boolean into which to return true if this job has been
+ *                   reserved instead of allocated.
+ *  \param R         String into which to return the resource set either
+ *                   allocated or reserved.
+ *  \param at        If allocated, 0 is returned; if reserved, actual time
+ *                   at which the job is reserved.
+ *  \param ov        Double into which to return performance overhead
+ *                   in terms of elapse time needed to complete
+ *                   the match operation.
+ *  \return          0 on success; -1 on error.
+ */
+int reapi_cli_match_with_jobid (reapi_cli_ctx_t *ctx,
+                                match_op_t match_op,
+                                const char *jobspec,
+                                uint64_t jobid,
+                                bool *reserved,
+                                char **R,
+                                int64_t *at,
+                                double *ov);
+
+/*! Match a jobspec to the "best" resources and either allocate
+ *  orelse reserve them. The best resources are determined by
  *  the selected match policy.
  *
  *  \param ctx       reapi_cli_ctx_t context object

--- a/resource/reapi/bindings/c/test/reapi_cli_test.c
+++ b/resource/reapi/bindings/c/test/reapi_cli_test.c
@@ -40,6 +40,28 @@ static const char *tiny_params =
     "{\"load_format\": \"jgf\", \"matcher_policy\": \"high\", "
     "\"match_format\": \"rv1\", \"matcher_name\": \"CA\"}";
 
+static const char *simple_jobspec =
+    "{"
+    "\"version\": 1,"
+    "\"resources\": ["
+    "{"
+    "\"type\": \"node\","
+    "\"count\": 1,"
+    "\"with\": ["
+    "{"
+    "\"type\": \"slot\","
+    "\"count\": 1,"
+    "\"label\": \"task\","
+    "\"with\": [{\"type\": \"core\", \"count\": 1}]"
+    "}"
+    "]"
+    "}"
+    "],"
+    "\"tasks\": [{\"command\": [\"sleep\", \"0\"], \"slot\": \"task\", \"count\": {\"per_slot\": "
+    "1}}],"
+    "\"attributes\": {\"system\": {\"duration\": 60.0}}"
+    "}";
+
 static int test_clone ()
 {
     reapi_cli_ctx_t *ctx = reapi_cli_new ();
@@ -65,11 +87,71 @@ static int test_clone ()
     return 0;
 }
 
+static int test_match_with_jobid ()
+{
+    reapi_cli_ctx_t *ctx = reapi_cli_new ();
+    if (!ctx)
+        BAIL_OUT ("reapi_cli_new failed");
+
+    int rc = reapi_cli_initialize (ctx, tiny_jgf, tiny_params);
+    if (rc < 0)
+        BAIL_OUT ("reapi_cli_initialize failed: %s", reapi_cli_get_err_msg (ctx));
+
+    uint64_t jobid = 100;
+    bool reserved = false;
+    char *R = NULL;
+    int64_t at = 0;
+    double ov = 0.0;
+
+    // Test reapi_cli_match_with_jobid with explicit jobid
+    errno = 0;
+    rc = reapi_cli_match_with_jobid (ctx,
+                                     MATCH_ALLOCATE,
+                                     simple_jobspec,
+                                     jobid,
+                                     &reserved,
+                                     &R,
+                                     &at,
+                                     &ov);
+    ok (rc == 0, "reapi_cli_match_with_jobid succeeded");
+    ok (R != NULL, "reapi_cli_match_with_jobid returned R string");
+    free (R);
+    R = NULL;
+
+    // Cancel the allocation
+    rc = reapi_cli_cancel (ctx, jobid, false);
+    ok (rc == 0, "reapi_cli_cancel succeeded for allocated job");
+
+    // Try to allocate with same jobid - currently not an error, resources just get reallocated
+    // (Duplicate jobid detection may be a future feature)
+    // errno = 0;
+    // rc = reapi_cli_match_with_jobid (ctx, MATCH_ALLOCATE, simple_jobspec, jobid, &reserved, &R,
+    // &at, &ov); ok (rc == -1 && errno == EEXIST,
+    //     "reapi_cli_match_with_jobid returns -1 with errno=EEXIST for duplicate jobid");
+
+    // Test with NULL context
+    errno = 0;
+    rc = reapi_cli_match_with_jobid (NULL,
+                                     MATCH_ALLOCATE,
+                                     simple_jobspec,
+                                     200,
+                                     &reserved,
+                                     &R,
+                                     &at,
+                                     &ov);
+    ok (rc == -1 && errno == EINVAL,
+        "reapi_cli_match_with_jobid returns -1 with errno=EINVAL for NULL context");
+
+    reapi_cli_destroy (ctx);
+    return 0;
+}
+
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
 
     test_clone ();
+    test_match_with_jobid ();
 
     done_testing ();
     return EXIT_SUCCESS;


### PR DESCRIPTION
Problem: the C reapi_cli match functions allocate jobids internally, but when used in a Flux scheduler, Flux allocates the jobids and provides them in the alloc request.

Add a new function variant: `reapi_cli_match_with_jobid()` with a jobid input parameter. 

Note that `reapi_module_match()` already accepts a jobid input parameter.  In an abundance of caution,  I did not force the `reeapi_cli` version to agree which would have been cleaner but would break the API.

This was peeled off of
- #1481