### PR TITLE
use constant strings where appropriate in some internal functions

### DIFF
--- a/resource/jobinfo/jobinfo.cpp
+++ b/resource/jobinfo/jobinfo.cpp
@@ -47,27 +47,22 @@ job_info_t::job_info_t (uint64_t j,
 {
 }
 
-void get_jobstate_str (job_lifecycle_t state, std::string &status)
+const char *get_jobstate_str (job_lifecycle_t state)
 {
     switch (state) {
-        case job_lifecycle_t::ALLOCATED:
-            status = "ALLOCATED";
-            break;
-        case job_lifecycle_t::RESERVED:
-            status = "RESERVED";
-            break;
-        case job_lifecycle_t::CANCELED:
-            status = "CANCELED";
-            break;
-        case job_lifecycle_t::ERROR:
-            status = "ERROR";
-            break;
         case job_lifecycle_t::INIT:
+            return "INIT";
+        case job_lifecycle_t::ALLOCATED:
+            return "ALLOCATED";
+        case job_lifecycle_t::RESERVED:
+            return "RESERVED";
+        case job_lifecycle_t::CANCELED:
+            return "CANCELED";
+        case job_lifecycle_t::ERROR:
+            return "ERROR";
         default:
-            status = "INIT";
-            break;
+            return "UNKNOWN";
     }
-    return;
 }
 
 }  // namespace resource_model

--- a/resource/jobinfo/jobinfo.hpp
+++ b/resource/jobinfo/jobinfo.hpp
@@ -44,7 +44,7 @@ struct job_info_t {
     double overhead = 0.0f;
 };
 
-void get_jobstate_str (job_lifecycle_t state, std::string &status);
+const char *get_jobstate_str (job_lifecycle_t state);
 
 }  // namespace resource_model
 }  // namespace Flux

--- a/resource/modules/resource.cpp
+++ b/resource/modules/resource.cpp
@@ -351,9 +351,9 @@ static void match_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_t
     int64_t now = 0;
     int64_t jobid = -1;
     double overhead = 0.0f;
-    std::string status = "";
     const char *cmd = NULL;
     const char *js_str = NULL;
+    const char *status = nullptr;
     std::stringstream R;
 
     std::shared_ptr<resource_ctx_t> ctx = getctx ((flux_t *)arg);
@@ -443,7 +443,6 @@ static void match_multi_request_cb (flux_t *h,
         int64_t at = 0;
         int64_t now = 0;
         double overhead = 0.0f;
-        std::string status = "";
         std::stringstream R;
 
         if (json_unpack (value, "{s:I s:s}", "jobid", &jobid, "jobspec", &js_str) < 0)
@@ -470,14 +469,13 @@ static void match_multi_request_cb (flux_t *h,
             goto error;
         }
 
-        status = get_status_string (now, at);
         if (flux_respond_pack (h,
                                msg,
                                "{s:I s:s s:f s:s s:I}",
                                "jobid",
                                jobid,
                                "status",
-                               status.c_str (),
+                               get_status_string (now, at),
                                "overhead",
                                overhead,
                                "R",

--- a/resource/modules/resource.cpp
+++ b/resource/modules/resource.cpp
@@ -275,7 +275,7 @@ static void update_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_
     double overhead = 0.0f;
     int64_t jobid = 0;
     uint64_t duration = 0;
-    std::string status = "";
+    const char *status = nullptr;
     std::stringstream o;
     std::chrono::time_point<std::chrono::system_clock> start;
     std::chrono::duration<double> elapsed;
@@ -319,7 +319,7 @@ static void update_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_
         goto error;
     }
 
-    if (status == "")
+    if (!status)
         status = get_status_string (at, at);
 
     if (flux_respond_pack (h,
@@ -328,7 +328,7 @@ static void update_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_
                            "jobid",
                            jobid,
                            "status",
-                           status.c_str (),
+                           status,
                            "overhead",
                            overhead,
                            "R",
@@ -394,7 +394,7 @@ static void match_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_t
                            "jobid",
                            jobid,
                            "status",
-                           status.c_str (),
+                           status,
                            "overhead",
                            overhead,
                            "R",

--- a/resource/modules/resource.cpp
+++ b/resource/modules/resource.cpp
@@ -303,7 +303,7 @@ static void update_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_
         elapsed = std::chrono::system_clock::now () - start;
         // If a jobid with matching R exists, no need to update
         overhead = elapsed.count ();
-        get_jobstate_str (ctx->jobs[jobid]->state, status);
+        status = get_jobstate_str (ctx->jobs[jobid]->state);
         o << ctx->jobs[jobid]->R;
         at = ctx->jobs[jobid]->scheduled_at;
         flux_log (ctx->h,
@@ -591,7 +591,6 @@ static void info_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_t 
     std::shared_ptr<resource_ctx_t> ctx = getctx ((flux_t *)arg);
     int64_t jobid = -1;
     std::shared_ptr<job_info_t> info = NULL;
-    std::string status = "";
 
     if (flux_request_unpack (msg, NULL, "{s:I}", "jobid", &jobid) < 0)
         goto error;
@@ -602,14 +601,13 @@ static void info_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_t 
     }
 
     info = ctx->jobs[jobid];
-    get_jobstate_str (info->state, status);
     if (flux_respond_pack (h,
                            msg,
                            "{s:I s:s s:I s:f}",
                            "jobid",
                            jobid,
                            "status",
-                           status.c_str (),
+                           get_jobstate_str (info->state),
                            "at",
                            info->scheduled_at,
                            "overhead",

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -1124,7 +1124,7 @@ static int mark_now (std::shared_ptr<resource_ctx_t> &ctx,
               LOG_DEBUG,
               "resource status changed (rankset=[%s] status=%s)",
               ids,
-              resource_pool_t::status_to_str (status).c_str ());
+              resource_pool_t::status_to_str (status));
 
     // Updated the ranks
     ctx->m_resources_down_updated = true;

--- a/resource/modules/resource_match.hpp
+++ b/resource/modules/resource_match.hpp
@@ -122,7 +122,7 @@ struct resource_ctx_t : public resource_interface_t {
 // Request Handler Routines
 ////////////////////////////////////////////////////////////////////////////////
 
-inline std::string get_status_string (int64_t now, int64_t at)
+inline const char *get_status_string (int64_t now, int64_t at)
 {
     return (at == now) ? "ALLOCATED" : "RESERVED";
 }

--- a/resource/reapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli_impl.hpp
@@ -312,7 +312,7 @@ int reapi_cli_t::info (void *h,
     }
 
     info = rq->get_job (jobid);
-    get_jobstate_str (info->state, mode);
+    mode = get_jobstate_str (info->state);
     reserved = (info->state == job_lifecycle_t::RESERVED) ? true : false;
     at = info->scheduled_at;
     ov = info->overhead;

--- a/resource/schema/resource_data.cpp
+++ b/resource/schema/resource_data.cpp
@@ -44,22 +44,16 @@ resource_relation_t::~resource_relation_t () = default;
 const resource_pool_t::string_to_status resource_pool_t::str_to_status =
     {{"up", resource_pool_t::status_t::UP}, {"down", resource_pool_t::status_t::DOWN}};
 
-const std::string resource_pool_t::status_to_str (status_t s)
+const char *resource_pool_t::status_to_str (status_t s)
 {
-    std::string str;
     switch (s) {
         case status_t::UP:
-            str = "UP";
-            break;
+            return "UP";
         case status_t::DOWN:
-            str = "DOWN";
-            break;
+            return "DOWN";
         default:
-            str = "";
-            errno = EINVAL;
-            break;
+            return "UNKNOWN";
     }
-    return str;
 }
 
 }  // namespace resource_model

--- a/resource/schema/resource_data.hpp
+++ b/resource/schema/resource_data.hpp
@@ -40,7 +40,7 @@ struct resource_pool_t : public resource_t {
 
     typedef std::unordered_map<std::string, status_t> string_to_status;
     static const string_to_status str_to_status;
-    static const std::string status_to_str (status_t s);
+    static const char *status_to_str (status_t s);
 
     // Resource pool data
     std::map<subsystem_t, std::string> paths;

--- a/resource/utilities/command.cpp
+++ b/resource/utilities/command.cpp
@@ -915,8 +915,7 @@ int cmd_list (std::shared_ptr<detail::resource_query_t> &ctx,
 {
     for (auto &kv : ctx->jobs) {
         std::shared_ptr<job_info_t> info = kv.second;
-        std::string mode;
-        get_jobstate_str (info->state, mode);
+        const char *mode = get_jobstate_str (info->state);
         std::cout << "INFO: " << info->jobid << ", " << mode << ", " << info->scheduled_at << ", "
                   << info->jobspec_fn << ", " << info->overhead << std::endl;
     }
@@ -928,7 +927,6 @@ int cmd_info (std::shared_ptr<detail::resource_query_t> &ctx,
               std::ostream &out)
 {
     std::shared_ptr<job_info_t> info = nullptr;
-    std::string mode;
 
     if (args.size () != 2) {
         std::cerr << "ERROR: malformed command" << std::endl;
@@ -942,7 +940,7 @@ int cmd_info (std::shared_ptr<detail::resource_query_t> &ctx,
         return 0;
     }
 
-    get_jobstate_str (info->state, mode);
+    const char *mode = get_jobstate_str (info->state);
     std::cout << "INFO: " << info->jobid << ", " << mode << ", " << info->scheduled_at << ", "
               << info->jobspec_fn << ", " << info->overhead << std::endl;
     return 0;


### PR DESCRIPTION
Problem: get_jobstate_str() fills a std::string& output parameter, which allocates memory, but the returned value could be a constant.

Change the signature to return a const char * pointing to a string literal, and update all existing callers to use simple assignment.