### PR TITLE
pass `json_t` objects instead of json strings for `allocate_with_satisfiability`

### DIFF
--- a/qmanager/policies/queue_policy_bf_base_impl.hpp
+++ b/qmanager/policies/queue_policy_bf_base_impl.hpp
@@ -52,22 +52,20 @@ int queue_policy_bf_base_t<reapi_type>::next_match_iter ()
 
     auto &job = m_jobs[m_in_progress_iter->second];
     m_try_reserve = m_reservation_cnt < m_reservation_depth;
-    json_t *jobarray_ptr =
-        json_pack ("[{s:I s:s}]", "jobid", job->id, "jobspec", job->jobspec.c_str ());
+    json_t *jobspec_obj;
+    json_error_t err;
+    if (!(jobspec_obj = json_loads (job->jobspec.c_str (), 0, &err))) {
+        errno = ENOMEM;
+        return -1;
+    }
+    json_t *jobarray_ptr = json_pack ("[{s:I s:o}]", "jobid", job->id, "jobspec", jobspec_obj);
     if (!jobarray_ptr) {
         errno = ENOMEM;
         return -1;
     }
     auto _jdecref = [] (json_t *p) { json_decref (p); };
     std::unique_ptr<json_t, decltype (_jdecref)> jobarray (jobarray_ptr, _jdecref);
-    char *jobs_ptr = json_dumps (jobarray.get (), JSON_INDENT (0));
-    if (!jobs_ptr) {
-        errno = ENOMEM;
-        return -1;
-    }
-    auto _free = [] (char *p) { free (p); };
-    std::unique_ptr<char, decltype (_free)> jobs_str (jobs_ptr, _free);
-    return reapi_type::match_allocate_multi (m_handle, m_try_reserve, jobs_str.get (), this);
+    return reapi_type::match_allocate_multi (m_handle, m_try_reserve, jobarray.get (), this);
 }
 
 template<class reapi_type>

--- a/qmanager/policies/queue_policy_fcfs_impl.hpp
+++ b/qmanager/policies/queue_policy_fcfs_impl.hpp
@@ -31,9 +31,15 @@ int queue_policy_fcfs_t<reapi_type>::pack_jobs (json_t *jobs)
     auto iter = m_pending.begin ();
     while (iter != m_pending.end () && qd < m_queue_depth) {
         json_t *jobdesc;
+        json_t *jobspec_obj;
+        json_error_t err;
         job = m_jobs[iter->second];
-        if (!(jobdesc =
-                  json_pack ("{s:I s:s}", "jobid", job->id, "jobspec", job->jobspec.c_str ()))) {
+        if (!(jobspec_obj = json_loads (job->jobspec.c_str (), 0, &err))) {
+            json_decref (jobs);
+            errno = ENOMEM;
+            return -1;
+        }
+        if (!(jobdesc = json_pack ("{s:I s:o}", "jobid", job->id, "jobspec", jobspec_obj))) {
             json_decref (jobs);
             errno = ENOMEM;
             return -1;
@@ -56,7 +62,6 @@ template<class reapi_type>
 int queue_policy_fcfs_t<reapi_type>::allocate_jobs (void *h, bool use_alloced_queue)
 {
     json_t *jobs = nullptr;
-    char *jobs_str = nullptr;
     job_map_iter iter;
 
     // move jobs in m_pending_provisional queue into
@@ -76,19 +81,12 @@ int queue_policy_fcfs_t<reapi_type>::allocate_jobs (void *h, bool use_alloced_qu
         return -1;
 
     set_sched_loop_active (true);
-    if (!(jobs_str = json_dumps (jobs, JSON_INDENT (0)))) {
-        errno = ENOMEM;
+    if (reapi_type::match_allocate_multi (h, false, jobs, this) < 0) {
         json_decref (jobs);
-        return -1;
-    }
-    json_decref (jobs);
-    if (reapi_type::match_allocate_multi (h, false, jobs_str, this) < 0) {
-        free (jobs_str);
         set_sched_loop_active (false);
         return -1;
-        ;
     };
-    free (jobs_str);
+    json_decref (jobs);
     return 0;
 }
 

--- a/resource/modules/resource.cpp
+++ b/resource/modules/resource.cpp
@@ -418,44 +418,48 @@ static void match_multi_request_cb (flux_t *h,
 {
     size_t index;
     json_t *value;
-    json_error_t err;
     int saved_errno;
     json_t *jobs = nullptr;
     uint64_t jobid = 0;
     std::string errmsg;
     const char *cmd = nullptr;
-    const char *jobs_str = nullptr;
     std::shared_ptr<resource_ctx_t> ctx = getctx ((flux_t *)arg);
 
     if (!flux_msg_is_streaming (msg)) {
         errno = EPROTO;
         goto error;
     }
-    if (flux_request_unpack (msg, NULL, "{s:s s:s}", "cmd", &cmd, "jobs", &jobs_str) < 0)
+    if (flux_request_unpack (msg, NULL, "{s:s s:o}", "cmd", &cmd, "jobs", &jobs) < 0)
         goto error;
-    if (!(jobs = json_loads (jobs_str, 0, &err))) {
-        errno = ENOMEM;
+    if (!json_is_array (jobs)) {
+        errno = EINVAL;
         goto error;
     }
 
     json_array_foreach (jobs, index, value) {
-        const char *js_str;
+        json_t *jobspec_obj = nullptr;
+        char *jobspec_str = nullptr;
         int64_t at = 0;
         int64_t now = 0;
         double overhead = 0.0f;
         std::stringstream R;
 
-        if (json_unpack (value, "{s:I s:s}", "jobid", &jobid, "jobspec", &js_str) < 0)
+        if (json_unpack (value, "{s:I s:o}", "jobid", &jobid, "jobspec", &jobspec_obj) < 0)
             goto error;
+        if (!(jobspec_str = json_dumps (jobspec_obj, JSON_COMPACT))) {
+            errno = ENOMEM;
+            goto error;
+        }
         if (is_existent_jobid (ctx, jobid)) {
             errno = EINVAL;
             flux_log_error (h,
                             "%s: existent job (%jd).",
                             __FUNCTION__,
                             static_cast<intmax_t> (jobid));
+            free (jobspec_str);
             goto error;
         }
-        if (run_match (ctx, jobid, cmd, js_str, &now, &at, &overhead, R, NULL) < 0) {
+        if (run_match (ctx, jobid, cmd, jobspec_str, &now, &at, &overhead, R, NULL) < 0) {
             if (errno != EBUSY && errno != ENODEV)
                 flux_log_error (ctx->h,
                                 "%s: match failed due to match error (id=%jd)",
@@ -466,9 +470,11 @@ static void match_multi_request_cb (flux_t *h,
             if (errno == EBUSY) {
                 ctx->jobs.erase (jobid);
             }
+            free (jobspec_str);
             goto error;
         }
 
+        free (jobspec_str);
         if (flux_respond_pack (h,
                                msg,
                                "{s:I s:s s:f s:s s:I}",
@@ -490,11 +496,9 @@ static void match_multi_request_cb (flux_t *h,
     errno = ENODATA;
     jobid = 0;
 error:
-    if (jobs) {
-        saved_errno = errno;
-        json_decref (jobs);
-        errno = saved_errno;
-    }
+    saved_errno = errno;
+    // jobs is borrowed from msg, no need to decref
+    errno = saved_errno;
     if (jobid != 0)
         errmsg += "jobid=" + std::to_string (jobid);
     if (flux_respond_error (h, msg, errno, !errmsg.empty () ? errmsg.c_str () : nullptr) < 0)

--- a/resource/reapi/bindings/c++/reapi_module.hpp
+++ b/resource/reapi/bindings/c++/reapi_module.hpp
@@ -16,6 +16,7 @@ extern "C" {
 #include "config.h"
 #endif
 #include <flux/core.h>
+#include <jansson.h>
 }
 
 #include <cstdint>
@@ -47,11 +48,11 @@ class reapi_module_t : public reapi_t {
                                double &ov);
     static int match_allocate_multi (void *h,
                                      bool orelse_reserve,
-                                     const char *jobs,
+                                     json_t *jobs,
                                      queue_adapter_base_t *adapter);
     static int match_allocate_multi (void *h,
                                      match_op_t match_op,
-                                     const char *jobs,
+                                     json_t *jobs,
                                      queue_adapter_base_t *adapter);
     static int update_allocate (void *h,
                                 const uint64_t jobid,

--- a/resource/reapi/bindings/c++/reapi_module_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_module_impl.hpp
@@ -142,7 +142,7 @@ void match_allocate_multi_cont (flux_future_t *f, void *arg)
 
 int reapi_module_t::match_allocate_multi (void *h,
                                           match_op_t match_op,
-                                          const char *jobs,
+                                          json_t *jobs,
                                           queue_adapter_base_t *adapter)
 {
     int rc = -1;
@@ -150,7 +150,7 @@ int reapi_module_t::match_allocate_multi (void *h,
     flux_future_t *f = nullptr;
     const char *cmd = match_op_to_string (match_op);
 
-    if (!fh) {
+    if (!fh || !jobs) {
         errno = EINVAL;
         goto error;
     }
@@ -158,7 +158,7 @@ int reapi_module_t::match_allocate_multi (void *h,
                              "sched-fluxion-resource.match_multi",
                              FLUX_NODEID_ANY,
                              FLUX_RPC_STREAMING,
-                             "{s:s s:s}",
+                             "{s:s s:O}",
                              "cmd",
                              cmd,
                              "jobs",
@@ -175,7 +175,7 @@ error:
 
 int reapi_module_t::match_allocate_multi (void *h,
                                           bool orelse_reserve,
-                                          const char *jobs,
+                                          json_t *jobs,
                                           queue_adapter_base_t *adapter)
 {
     match_op_t match_op = (orelse_reserve) ? match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE


### PR DESCRIPTION
This is the beginning of a fix for #1477, and is the initial low hanging fruit. It fixes the display of `allocate_with_satisfiability` RPCs in `flux module trace --full`, but not the `R` responses (yet):

```
2026-05-28T15:15:54.730 sched-fluxion-resource rx > sched-fluxion-resource.match_multi [459]
{
  "cmd": "allocate_with_satisfiability",
  "jobs": [
    {
      "jobid": 473654362112,
      "jobspec": {
        "resources": [
          {
            "type": "slot",
            "count": 1,
            "with": [
              {
                "type": "core",
                "count": 1
              }
            ],
            "label": "task"
          }
        ],
        "tasks": [
          {
            "command": [
              "hostname"
            ],
            "slot": "task",
            "count": {
              "per_slot": 1
            }
          }
        ],
        "attributes": {
          "system": {
            "duration": 0,
            "cwd": "/home/hobbs17.guest",
            "shell": {
              "options": {
                "rlimit": {
                  "cpu": -1,
                  "fsize": -1,
                  "data": -1,
                  "stack": 8388608,
                  "core": 0,
                  "nofile": 524288,
                  "as": -1,
                  "rss": -1,
                  "nproc": 63321
                }
              }
            }
          }
        },
        "version": 1
      }
    }
  ]
}
2026-05-28T15:15:54.731 sched-fluxion-resource tx < sched-fluxion-resource.match_multi [291] success
{
  "jobid": 473654362112,
  "status": "ALLOCATED",
  "overhead": 0.00058957200000000001,
  "R": "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"0\", \"children\": {\"core\": \"7\"}}], \"nodelist\": [\"lima-default\"], \"starttime\": 1780006554, \"expiration\": 9223372036}}\n",
  "at": 1780006554
}
2026-05-28T15:15:54.731 sched-fluxion-resource tx < sched-fluxion-resource.match_multi [0] ENODATA
2026-05-28T15:15:54.748 sched-fluxion-resource rx > sched-fluxion-resource.cancel [23]
{
  "jobid": 473654362112
}
2026-05-28T15:15:54.749 sched-fluxion-resource tx < sched-fluxion-resource.cancel [3] success
{}
```