### PR TITLE
reapi: add support for partial cancel with rv1exec match format

### DIFF
--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -1395,20 +1395,12 @@ static int parse_R (std::shared_ptr<resource_ctx_t> &ctx,
             rc = -1;
             goto freemem_out;
         }
-        if (writer_uri) {
-            if (std::string (writer_uri) == "fluxion:jgf_shorthand")
-                format = "jgf_shorthand";
-            else {
-                flux_log (ctx->h,
-                          LOG_ERR,
-                          "%s: unrecognized reader URI '%s'",
-                          __FUNCTION__,
-                          writer_uri);
-                rc = -1;
-                goto freemem_out;
-            }
-        } else {  // if URI not present, assume JGF
-            format = "jgf";
+        flux_error_t error2;
+        format = reader_name_from_writer (writer_uri, &error2);
+        if (format.empty ()) {
+            flux_log (ctx->h, LOG_ERR, "%s: %s", __FUNCTION__, error2.text);
+            rc = -1;
+            goto freemem_out;
         }
     } else {
         // Use the rv1exec reader
@@ -1674,7 +1666,10 @@ int run_remove (std::shared_ptr<resource_ctx_t> &ctx,
     dfu_traverser_t &tr = *(ctx->traverser);
 
     if (part_cancel) {
-        // RV1exec only reader supported in production currently
+        // RV1exec only reader supported in production currently.
+        // When writer-based reader selection is extended to partial cancel,
+        // this should detect the format from R via reader_name_from_writer()
+        // as parse_R() and the reapi remove_job() bindings do.
         std::shared_ptr<resource_reader_base_t> reader;
         if ((reader = create_resource_reader ("rv1exec")) == nullptr) {
             rc = -1;

--- a/resource/readers/resource_reader_factory.cpp
+++ b/resource/readers/resource_reader_factory.cpp
@@ -14,6 +14,7 @@ extern "C" {
 #endif
 }
 
+#include <cstdio>
 #include "resource/readers/resource_reader_factory.hpp"
 #include "resource/readers/resource_reader_grug.hpp"
 #include "resource/readers/resource_reader_hwloc.hpp"
@@ -23,6 +24,14 @@ extern "C" {
 
 namespace Flux {
 namespace resource_model {
+
+namespace {
+void set_error (flux_error_t *errp, const char *msg)
+{
+    if (errp)
+        snprintf (errp->text, sizeof (errp->text), "%s", msg);
+}
+}  // namespace
 
 bool known_resource_reader (const std::string &name)
 {
@@ -56,6 +65,40 @@ std::shared_ptr<resource_reader_base_t> create_resource_reader (const std::strin
         reader = nullptr;
     }
     return reader;
+}
+
+std::string reader_name_from_writer (const char *writer_uri, flux_error_t *errp)
+{
+    // RFC 40: writer absent, or "fluxion" with no path, defaults to "jgf".
+    if (writer_uri == nullptr)
+        return "jgf";
+
+    std::string uri (writer_uri);
+    // A writer URI's scheme names the producing scheduler (RFC 20).  We can
+    // only interpret data written by fluxion.
+    std::string scheme, path;
+    auto colon = uri.find (':');
+    if (colon == std::string::npos) {
+        scheme = uri;
+    } else {
+        scheme = uri.substr (0, colon);
+        path = uri.substr (colon + 1);
+    }
+    if (scheme != "fluxion") {
+        set_error (errp, "unsupported scheduling.writer scheme (not fluxion)");
+        errno = EINVAL;
+        return "";
+    }
+    // Map the fluxion-defined path to the reader that parses it.  An empty path
+    // ("fluxion" or "fluxion:") defaults to jgf per RFC 40.
+    if (path.empty () || path == "jgf")
+        return "jgf";
+    if (path == "jgf_shorthand")
+        return "jgf_shorthand";
+
+    set_error (errp, "unsupported fluxion scheduling.writer format");
+    errno = EINVAL;
+    return "";
 }
 
 }  // namespace resource_model

--- a/resource/readers/resource_reader_factory.hpp
+++ b/resource/readers/resource_reader_factory.hpp
@@ -13,6 +13,7 @@
 
 #include <string>
 #include <memory>
+#include <flux/core/types.h>
 #include "resource/readers/resource_reader_base.hpp"
 
 namespace Flux {
@@ -20,6 +21,28 @@ namespace resource_model {
 
 bool known_resource_reader (const std::string &name);
 std::shared_ptr<resource_reader_base_t> create_resource_reader (const std::string &name);
+
+/*! Map an RFC 20/40 scheduling.writer URI to the name of the reader that can
+ *  parse the R it was written with.
+ *
+ *  Per RFC 20, writer is a URI whose scheme names the scheduler and whose path
+ *  is interpreted by that scheduler.  Per RFC 40:
+ *    - writer absent (writer_uri == nullptr) -> "fluxion" assumed -> "jgf"
+ *    - "fluxion" (no path)                   -> path assumed "jgf" -> "jgf"
+ *    - "fluxion:jgf"                         -> "jgf"
+ *    - "fluxion:jgf_shorthand"               -> "jgf_shorthand"
+ *  A non-fluxion scheme (another scheduler's data) or an unsupported fluxion
+ *  path is not something we can read.
+ *
+ *  Note: the caller handles the case where scheduling is absent entirely, which
+ *  per RFC 20 is bare Rv1 and uses the "rv1exec" reader.
+ *
+ *  \param writer_uri  value of scheduling.writer, or nullptr if the key is absent
+ *  \param errp        optional; on error, filled with a human-readable message
+ *  \return            reader name, or an empty string with errno=EINVAL if the
+ *                     writer is unrecognized or unsupported
+ */
+std::string reader_name_from_writer (const char *writer_uri, flux_error_t *errp = nullptr);
 
 }  // namespace resource_model
 }  // namespace Flux

--- a/resource/reapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli_impl.hpp
@@ -985,23 +985,83 @@ int resource_query_t::remove_job (const uint64_t jobid)
 int resource_query_t::remove_job (const uint64_t jobid, const std::string &R, bool &full_removal)
 {
     int rc = -1;
+    json_error_t error;
+    json_t *r_obj = nullptr;
+    json_t *scheduling = nullptr;
+    json_t *writer = nullptr;
+    std::string format;
+    std::string reader_input;
     std::shared_ptr<resource_reader_base_t> reader;
 
     if (jobid > (uint64_t)std::numeric_limits<int64_t>::max ()) {
         errno = EOVERFLOW;
         return rc;
     }
-    if (R == "") {
+
+    // Parse R to determine format and extract appropriate input for reader
+    r_obj = json_loads (R.c_str (), 0, &error);
+    if (!r_obj) {
+        m_err_msg = __FUNCTION__;
+        m_err_msg += ": ERROR: failed to parse R as JSON: ";
+        m_err_msg += error.text;
+        m_err_msg += "\n";
         errno = EINVAL;
         return rc;
     }
-    if ((reader = create_resource_reader (params.load_format)) == nullptr) {
+
+    // Check for scheduling key - if absent, use rv1exec for execution.R_lite
+    scheduling = json_object_get (r_obj, "scheduling");
+    if (!scheduling) {
+        format = "rv1exec";
+        reader_input = R;
+    } else {
+        // Detect the reader format from scheduling.writer per RFC 20/40.
+        writer = json_object_get (scheduling, "writer");
+        const char *writer_str = nullptr;
+        if (writer) {
+            writer_str = json_string_value (writer);
+            if (!writer_str) {
+                m_err_msg = __FUNCTION__;
+                m_err_msg += ": ERROR: scheduling.writer is not a string\n";
+                json_decref (r_obj);
+                errno = EINVAL;
+                return rc;
+            }
+        }
+        flux_error_t error2;
+        format = reader_name_from_writer (writer_str, &error2);
+        if (format.empty ()) {
+            m_err_msg = __FUNCTION__;
+            m_err_msg += ": ERROR: ";
+            m_err_msg += error2.text;
+            m_err_msg += "\n";
+            json_decref (r_obj);
+            return rc;
+        }
+
+        // Extract scheduling section for scheduler-specific formats
+        char *scheduling_str = json_dumps (scheduling, JSON_COMPACT);
+        if (!scheduling_str) {
+            m_err_msg = __FUNCTION__;
+            m_err_msg += ": ERROR: failed to serialize scheduling section\n";
+            json_decref (r_obj);
+            errno = ENOMEM;
+            return rc;
+        }
+        reader_input = scheduling_str;
+        free (scheduling_str);
+    }
+
+    json_decref (r_obj);
+
+    if ((reader = create_resource_reader (format)) == nullptr) {
         m_err_msg = __FUNCTION__;
-        m_err_msg += ": ERROR: can't create reader\n";
+        m_err_msg += ": ERROR: can't create reader for format ";
+        m_err_msg += format + "\n";
         return rc;
     }
 
-    rc = traverser->remove (R, reader, static_cast<int64_t> (jobid), full_removal);
+    rc = traverser->remove (reader_input, reader, static_cast<int64_t> (jobid), full_removal);
     if (rc == 0) {
         if (full_removal) {
             auto job_info_it = jobs.find (jobid);

--- a/resource/reapi/bindings/c++/test/CMakeLists.txt
+++ b/resource/reapi/bindings/c++/test/CMakeLists.txt
@@ -12,3 +12,8 @@ add_executable(reapi_cli_status_test reapi_cli_status_test.cpp)
 add_sanitizers(reapi_cli_status_test)
 target_link_libraries(reapi_cli_status_test PRIVATE reapi_cli libtap fluxion-data yaml-cpp PkgConfig::JANSSON)
 flux_add_test(NAME reapi_cli_status_test COMMAND reapi_cli_status_test)
+
+add_executable(reapi_cli_cancel_test reapi_cli_cancel_test.cpp)
+add_sanitizers(reapi_cli_cancel_test)
+target_link_libraries(reapi_cli_cancel_test PRIVATE reapi_cli libtap PkgConfig::JANSSON)
+flux_add_test(NAME reapi_cli_cancel_test COMMAND reapi_cli_cancel_test)

--- a/resource/reapi/bindings/c++/test/reapi_cli_cancel_test.cpp
+++ b/resource/reapi/bindings/c++/test/reapi_cli_cancel_test.cpp
@@ -1,0 +1,472 @@
+/*****************************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+}
+
+#include <cerrno>
+#include <jansson.h>
+#include "resource/reapi/bindings/c++/reapi_cli.hpp"
+#include "resource/policies/base/match_op.h"
+#include "src/common/libtap/tap.h"
+
+using namespace Flux::resource_model;
+using namespace Flux::resource_model::detail;
+
+static const char *tiny_jgf = R"({
+    "graph": {
+        "nodes": [
+            {"id": "0", "metadata": {"type": "cluster", "basename": "tiny", "name": "tiny0", "size": 1, "paths": {"containment": "/tiny0"}}},
+            {"id": "1", "metadata": {"type": "node", "basename": "node", "name": "node0", "size": 1, "rank": 0, "paths": {"containment": "/tiny0/node0"}}},
+            {"id": "2", "metadata": {"type": "core", "basename": "core", "name": "core0", "size": 1, "id": 0, "rank": 0, "paths": {"containment": "/tiny0/node0/core0"}}},
+            {"id": "3", "metadata": {"type": "core", "basename": "core", "name": "core1", "size": 1, "id": 1, "rank": 0, "paths": {"containment": "/tiny0/node0/core1"}}}
+        ],
+        "edges": [
+            {"source": "0", "target": "1"},
+            {"source": "1", "target": "2"},
+            {"source": "1", "target": "3"}
+        ]
+    }
+})";
+
+static const char *two_core_jobspec = R"({
+    "version": 1,
+    "resources": [
+        {
+            "type": "node",
+            "count": 1,
+            "with": [
+                {
+                    "type": "slot",
+                    "count": 2,
+                    "label": "task",
+                    "with": [{"type": "core", "count": 1}]
+                }
+            ]
+        }
+    ],
+    "tasks": [{"command": ["sleep", "0"], "slot": "task", "count": {"per_slot": 1}}],
+    "attributes": {"system": {"duration": 60.0}}
+})";
+
+static const char *two_node_jgf = R"({
+    "graph": {
+        "nodes": [
+            {"id": "0", "metadata": {"type": "cluster", "basename": "tiny", "name": "tiny0", "size": 1, "paths": {"containment": "/tiny0"}}},
+            {"id": "1", "metadata": {"type": "node", "basename": "node", "name": "node0", "size": 1, "rank": 0, "paths": {"containment": "/tiny0/node0"}}},
+            {"id": "2", "metadata": {"type": "core", "basename": "core", "name": "core0", "size": 1, "id": 0, "rank": 0, "paths": {"containment": "/tiny0/node0/core0"}}},
+            {"id": "3", "metadata": {"type": "node", "basename": "node", "name": "node1", "size": 1, "rank": 1, "paths": {"containment": "/tiny0/node1"}}},
+            {"id": "4", "metadata": {"type": "core", "basename": "core", "name": "core0", "size": 1, "id": 0, "rank": 1, "paths": {"containment": "/tiny0/node1/core0"}}}
+        ],
+        "edges": [
+            {"source": "0", "target": "1"},
+            {"source": "1", "target": "2"},
+            {"source": "0", "target": "3"},
+            {"source": "3", "target": "4"}
+        ]
+    }
+})";
+
+static const char *two_node_jobspec = R"({
+    "version": 1,
+    "resources": [
+        {
+            "type": "node",
+            "count": 2,
+            "with": [
+                {
+                    "type": "slot",
+                    "count": 1,
+                    "label": "task",
+                    "with": [{"type": "core", "count": 1}]
+                }
+            ]
+        }
+    ],
+    "tasks": [{"command": ["sleep", "0"], "slot": "task", "count": {"per_slot": 1}}],
+    "attributes": {"system": {"duration": 60.0}}
+})";
+
+static int test_cancel_full ()
+{
+    // Test full cancel using simple 3-parameter overload
+    std::string params =
+        "{\"load_format\": \"jgf\", \"matcher_policy\": \"high\", "
+        "\"match_format\": \"rv1\", \"matcher_name\": \"CA\"}";
+
+    resource_query_t *rq = nullptr;
+    try {
+        rq = new resource_query_t (tiny_jgf, params);
+    } catch (...) {
+        BAIL_OUT ("couldn't create resource_query_t");
+    }
+
+    void *h = static_cast<void *> (rq);
+    uint64_t jobid = 1;
+    bool reserved = false;
+    std::string R;
+    int64_t at = 0;
+    double ov = 0.0;
+
+    // Allocate a job (precondition for the cancel under test)
+    int rc = reapi_cli_t::match_allocate (h,
+                                          MATCH_ALLOCATE,
+                                          two_core_jobspec,
+                                          jobid,
+                                          reserved,
+                                          R,
+                                          at,
+                                          ov);
+
+    if (rc != 0)
+        BAIL_OUT ("match_allocate failed to set up full cancel test");
+
+    // Test full cancel using the simple 3-parameter cancel overload
+    errno = 0;
+    rc = reapi_cli_t::cancel (h, jobid, false);
+    ok (rc == 0, "cancel (3-parameter) succeeds for full cancel");
+
+    delete rq;
+    return 0;
+}
+
+static int test_cancel_with_r ()
+{
+    // Test 4-parameter cancel with full R (auto-detects format from R)
+    // Load graph from JGF and emit matches in rv1 format
+    //
+    // TODO: This test currently fails because JGF partial_cancel doesn't work
+    // with the R returned from match_allocate. The scheduling.graph contains
+    // resource structure but not allocation span metadata (which job owns which
+    // resources). JGF partial_cancel expects to find allocation spans in the
+    // input graph, but they only exist in the main resource graph managed by
+    // the scheduler. This needs to be fixed before JGF format detection can work.
+    std::string params =
+        "{\"load_format\": \"jgf\", \"matcher_policy\": \"high\", "
+        "\"match_format\": \"rv1\", \"matcher_name\": \"CA\"}";
+
+    resource_query_t *rq = nullptr;
+    try {
+        rq = new resource_query_t (tiny_jgf, params);
+    } catch (...) {
+        BAIL_OUT ("couldn't create resource_query_t");
+    }
+
+    void *h = static_cast<void *> (rq);
+    uint64_t jobid = 10;
+    bool reserved = false;
+    std::string R;
+    int64_t at = 0;
+    double ov = 0.0;
+
+    // Allocate a job (precondition for the cancel under test)
+    int rc = reapi_cli_t::match_allocate (h,
+                                          MATCH_ALLOCATE,
+                                          two_core_jobspec,
+                                          jobid,
+                                          reserved,
+                                          R,
+                                          at,
+                                          ov);
+    if (rc != 0)
+        BAIL_OUT ("match_allocate failed to set up full R cancel test");
+
+    // Cancel with 4-parameter overload (auto-detects format from R)
+    bool full_removal = false;
+    errno = 0;
+    rc = reapi_cli_t::cancel (h, jobid, R, false, full_removal);
+    todo ("JGF partial_cancel not yet supported with R from match_allocate");
+    ok (rc == 0, "cancel (4-parameter) with full R succeeds");
+    ok (full_removal == true, "cancel with full R reports full_removal=true");
+    end_todo;
+
+    // Verify job state is CANCELED
+    std::string mode;
+    bool reserved_out;
+    int64_t at_out;
+    double ov_out;
+    rc = reapi_cli_t::info (h, jobid, mode, reserved_out, at_out, ov_out);
+    ok (rc == 0, "job exists in jobs table");
+    todo ("JGF partial_cancel not yet supported with R from match_allocate");
+    ok (mode == "CANCELED", "job state is CANCELED");
+    end_todo;
+
+    // Verify allocation no longer exists
+    errno = 0;
+    rc = reapi_cli_t::cancel (h, jobid, false);
+    todo ("JGF partial_cancel not yet supported with R from match_allocate");
+    ok (rc == -1 && errno == ENOENT, "allocation no longer exists");
+    end_todo;
+
+    delete rq;
+    return 0;
+}
+
+static int test_cancel_partial ()
+{
+    // Test partial cancel - allocate 2 nodes, release 1, verify partial removal
+    // Note: partial cancel only works at node granularity with rv1exec format
+    std::string params =
+        "{\"load_format\": \"jgf\", \"matcher_policy\": \"high\", "
+        "\"match_format\": \"rv1\", \"matcher_name\": \"CA\"}";
+
+    resource_query_t *rq = nullptr;
+    try {
+        rq = new resource_query_t (two_node_jgf, params);
+    } catch (...) {
+        BAIL_OUT ("couldn't create resource_query_t");
+    }
+
+    void *h = static_cast<void *> (rq);
+    uint64_t jobid = 2;
+    bool reserved = false;
+    std::string R;
+    int64_t at = 0;
+    double ov = 0.0;
+
+    // Allocate 2 nodes (precondition for the partial cancel under test)
+    int rc = reapi_cli_t::match_allocate (h,
+                                          MATCH_ALLOCATE,
+                                          two_node_jobspec,
+                                          jobid,
+                                          reserved,
+                                          R,
+                                          at,
+                                          ov);
+    if (rc != 0)
+        BAIL_OUT ("match_allocate failed to allocate 2 nodes");
+    ok (rc == 0, "allocated 2 nodes");
+
+    // Parse the R to extract just one node for partial cancel
+    // R is in rv1 format with R_lite array containing 2 nodes
+    json_error_t error;
+    json_t *r_obj = json_loads (R.c_str (), 0, &error);
+    if (!r_obj)
+        BAIL_OUT ("couldn't parse R as JSON: %s", error.text);
+
+    // Create a valid rv1 with just one node by modifying the rank idset
+    // R_lite compresses homogeneous nodes, so it has one entry with rank="0-1"
+    json_t *exec = json_object_get (r_obj, "execution");
+    json_t *r_lite = json_object_get (exec, "R_lite");
+    if (!r_lite || !json_is_array (r_lite)) {
+        json_decref (r_obj);
+        BAIL_OUT ("R missing execution.R_lite array");
+    }
+
+    size_t r_lite_size = json_array_size (r_lite);
+    if (r_lite_size < 1) {
+        json_decref (r_obj);
+        BAIL_OUT ("R_lite is empty");
+    }
+
+    // Get the first (and likely only) entry and change rank from "0-1" to just "0"
+    json_t *node_entry = json_array_get (r_lite, 0);
+    json_object_set_new (node_entry, "rank", json_string ("0"));
+
+    // Remove scheduling section for partial cancel - only R_lite matters
+    // Per RFC 20, R without scheduling key uses rv1exec format
+    json_object_del (r_obj, "scheduling");
+
+    char *partial_r = json_dumps (r_obj, JSON_COMPACT);
+    json_decref (r_obj);
+
+    if (!partial_r)
+        BAIL_OUT ("couldn't serialize partial R");
+
+    // Test partial cancel with 4-parameter overload (auto-detects format from R)
+    // R without scheduling key should be detected as rv1exec format
+    bool full_removal = false;
+    errno = 0;
+    rc = reapi_cli_t::cancel (h, jobid, partial_r, false, full_removal);
+    ok (rc == 0, "cancel (4-param) auto-detects rv1exec format from R");
+    ok (full_removal == false, "partial cancel reports full_removal=false");
+
+    // Verify we can't cancel the same resources again
+    errno = 0;
+    bool full_removal_dup = false;
+    rc = reapi_cli_t::cancel (h, jobid, partial_r, false, full_removal_dup);
+    ok (rc == -1, "second cancel of same partial R fails");
+    free (partial_r);
+
+    // Verify job still exists after partial cancel and is still allocated
+    std::string mode;
+    bool reserved_out;
+    int64_t at_out;
+    double ov_out;
+    rc = reapi_cli_t::info (h, jobid, mode, reserved_out, at_out, ov_out);
+    ok (rc == 0, "job still exists after partial cancel");
+    ok (mode == "ALLOCATED", "job state is still ALLOCATED after partial cancel");
+
+    // Now cancel the remainder (rank 1)
+    // Create R with just rank 1
+    json_t *r_obj2 = json_loads (R.c_str (), 0, &error);
+    json_t *exec2 = json_object_get (r_obj2, "execution");
+    json_t *r_lite2 = json_object_get (exec2, "R_lite");
+    json_t *node_entry2 = json_array_get (r_lite2, 0);
+    json_object_set_new (node_entry2, "rank", json_string ("1"));
+
+    // Remove scheduling section for partial cancel
+    json_object_del (r_obj2, "scheduling");
+
+    char *remainder_r = json_dumps (r_obj2, JSON_COMPACT);
+    json_decref (r_obj2);
+
+    bool full_removal2 = false;
+    errno = 0;
+    rc = reapi_cli_t::cancel (h, jobid, remainder_r, false, full_removal2);
+    ok (rc == 0, "cancel remainder succeeds");
+    ok (full_removal2 == true, "canceling remainder reports full_removal=true");
+
+    free (remainder_r);
+
+    // Verify job state is now CANCELED after full removal
+    rc = reapi_cli_t::info (h, jobid, mode, reserved_out, at_out, ov_out);
+    ok (rc == 0, "job still exists in jobs table after full removal");
+    ok (mode == "CANCELED", "job state is CANCELED after full removal");
+
+    // Verify allocation no longer exists (should get ENOENT on further cancel attempts)
+    errno = 0;
+    rc = reapi_cli_t::cancel (h, jobid, false);
+    ok (rc == -1 && errno == ENOENT, "allocation no longer exists after canceling all resources");
+
+    delete rq;
+    return 0;
+}
+
+static int test_cancel_nonexistent_job ()
+{
+    // Test cancel with format error handling
+    std::string params =
+        "{\"load_format\": \"jgf\", \"matcher_policy\": \"high\", "
+        "\"match_format\": \"rv1\", \"matcher_name\": \"CA\"}";
+
+    resource_query_t *rq = nullptr;
+    try {
+        rq = new resource_query_t (tiny_jgf, params);
+    } catch (...) {
+        BAIL_OUT ("couldn't create resource_query_t");
+    }
+
+    void *h = static_cast<void *> (rq);
+    uint64_t nonexistent_jobid = 99999;
+
+    // Test with nonexistent job and noent_ok=false (using simple overload)
+    errno = 0;
+    int rc = reapi_cli_t::cancel (h, nonexistent_jobid, false);
+    ok (rc == -1 && errno == ENOENT, "cancel returns -1 with errno=ENOENT for nonexistent job");
+
+    // Test with nonexistent job and noent_ok=true
+    errno = 0;
+    rc = reapi_cli_t::cancel (h, nonexistent_jobid, true);
+    ok (rc == 0, "cancel succeeds with noent_ok=true for nonexistent job");
+
+    delete rq;
+    return 0;
+}
+
+static int test_cancel_bad_writer ()
+{
+    // Format detection extracts the reader format from scheduling.writer per
+    // RFC 20/40.  A writer URI that resolves to an unknown reader format should
+    // fail cleanly with EINVAL when the reader cannot be created, rather than
+    // proceeding with an invalid reader.
+    std::string params =
+        "{\"load_format\": \"jgf\", \"matcher_policy\": \"high\", "
+        "\"match_format\": \"rv1\", \"matcher_name\": \"CA\"}";
+
+    resource_query_t *rq = nullptr;
+    try {
+        rq = new resource_query_t (tiny_jgf, params);
+    } catch (...) {
+        BAIL_OUT ("couldn't create resource_query_t");
+    }
+
+    void *h = static_cast<void *> (rq);
+    uint64_t jobid = 1;
+    bool reserved = false;
+    std::string R;
+    int64_t at = 0;
+    double ov = 0.0;
+
+    // Allocate a job so cancel reaches format detection in remove_job.
+    // (cancel checks allocation_exists() first and returns ENOENT otherwise.)
+    // This is a precondition for the test, not the behavior under test, so a
+    // failure here means the test itself is broken -> bail out loudly.
+    int rc = reapi_cli_t::match_allocate (h,
+                                          MATCH_ALLOCATE,
+                                          two_core_jobspec,
+                                          jobid,
+                                          reserved,
+                                          R,
+                                          at,
+                                          ov);
+    if (rc != 0)
+        BAIL_OUT ("match_allocate failed to set up bad-writer test");
+
+    bool full_removal = false;
+
+    // "fluxion:notaformat" -> strips "fluxion:" prefix -> format "notaformat",
+    // which is not a known reader.
+    std::string r_bad_fluxion =
+        R"({"version": 1, "execution": {"R_lite": [{"rank": "0", "children": {"core": "0"}}]}, "scheduling": {"writer": "fluxion:notaformat"}})";
+    errno = 0;
+    rc = reapi_cli_t::cancel (h, jobid, r_bad_fluxion, false, full_removal);
+    ok (rc == -1 && errno == EINVAL,
+        "cancel with scheduling.writer=fluxion:notaformat fails with EINVAL");
+
+    // "notfluxion:somethingelse" -> not a fluxion writer -> format used verbatim,
+    // which is not a known reader.
+    std::string r_bad_writer =
+        R"({"version": 1, "execution": {"R_lite": [{"rank": "0", "children": {"core": "0"}}]}, "scheduling": {"writer": "notfluxion:somethingelse"}})";
+    errno = 0;
+    rc = reapi_cli_t::cancel (h, jobid, r_bad_writer, false, full_removal);
+    ok (rc == -1 && errno == EINVAL,
+        "cancel with scheduling.writer=notfluxion:somethingelse fails with EINVAL");
+
+    delete rq;
+    return 0;
+}
+
+static int test_cancel_null_ctx ()
+{
+    // Test cancel with NULL context
+    uint64_t jobid = 1;
+    bool full_removal = false;
+    std::string R = "{}";
+
+    errno = 0;
+    int rc = reapi_cli_t::cancel (nullptr, jobid, R, false, full_removal);
+
+    ok (rc == -1 && errno == EINVAL, "cancel returns -1 with errno=EINVAL for NULL context");
+
+    return 0;
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_cancel_full ();
+    test_cancel_with_r ();
+    test_cancel_partial ();
+    test_cancel_nonexistent_job ();
+    test_cancel_bad_writer ();
+    test_cancel_null_ctx ();
+
+    done_testing ();
+    return EXIT_SUCCESS;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/reapi/bindings/c/test/CMakeLists.txt
+++ b/resource/reapi/bindings/c/test/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_executable(reapi_cli_test reapi_cli_test.c)
 add_sanitizers(reapi_cli_test)
-target_link_libraries(reapi_cli_test PRIVATE reapi_cli libtap)
+target_link_libraries(reapi_cli_test PRIVATE reapi_cli libtap PkgConfig::JANSSON)
 flux_add_test(NAME reapi_cli_test COMMAND reapi_cli_test)

--- a/resource/reapi/bindings/c/test/reapi_cli_test.c
+++ b/resource/reapi/bindings/c/test/reapi_cli_test.c
@@ -16,6 +16,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <jansson.h>
 #include "resource/reapi/bindings/c/reapi_cli.h"
 #include "resource/policies/base/match_op.h"
 #include "src/common/libtap/tap.h"
@@ -326,6 +327,88 @@ static int test_null_parameters ()
     return 0;
 }
 
+static int test_cancel_ex ()
+{
+    reapi_cli_ctx_t *ctx = reapi_cli_new ();
+    if (!ctx)
+        BAIL_OUT ("reapi_cli_new failed");
+
+    int rc = reapi_cli_initialize (ctx, tiny_jgf, tiny_params);
+    if (rc < 0)
+        BAIL_OUT ("reapi_cli_initialize failed: %s", reapi_cli_get_err_msg (ctx));
+
+    uint64_t jobid = 1;
+    bool reserved = false;
+    char *R = NULL;
+    int64_t at = 0;
+    double ov = 0.0;
+
+    // Allocate a job first
+    rc = reapi_cli_match_allocate (ctx, false, simple_jobspec, &jobid, &reserved, &R, &at, &ov);
+    if (rc < 0)
+        BAIL_OUT ("reapi_cli_match_allocate failed: %s", reapi_cli_get_err_msg (ctx));
+
+    // Parse R to remove scheduling section and create partial R
+    // This tests rv1exec format auto-detection (production use case)
+    json_error_t error;
+    json_t *r_obj = json_loads (R, 0, &error);
+    if (!r_obj)
+        BAIL_OUT ("couldn't parse R as JSON");
+
+    // Remove scheduling section to get rv1exec format
+    json_object_del (r_obj, "scheduling");
+
+    // For partial cancel, modify rank to cancel only rank 0
+    // (assuming the allocation has multiple ranks or we'll get full_removal=true)
+    json_t *exec = json_object_get (r_obj, "execution");
+    json_t *r_lite = json_object_get (exec, "R_lite");
+    json_t *entry = json_array_get (r_lite, 0);
+    json_object_set_new (entry, "rank", json_string ("0"));
+
+    char *partial_r = json_dumps (r_obj, JSON_COMPACT);
+    json_decref (r_obj);
+    if (!partial_r)
+        BAIL_OUT ("couldn't serialize partial R");
+
+    // Test reapi_cli_partial_cancel with partial R (auto-detects rv1exec format)
+    bool full_removal = false;
+    errno = 0;
+    rc = reapi_cli_partial_cancel (ctx, jobid, partial_r, false, &full_removal);
+    ok (rc == 0, "reapi_cli_partial_cancel with partial R succeeds");
+    // Note: full_removal depends on whether the allocation had multiple ranks
+    diag ("partial_cancel full_removal=%s", full_removal ? "true" : "false");
+
+    free (partial_r);
+    free (R);
+
+    // Test with nonexistent job and noent_ok=false
+    const char *dummy_r = "{\"version\":1,\"execution\":{\"R_lite\":[{\"rank\":\"0\"}]}}";
+    errno = 0;
+    rc = reapi_cli_partial_cancel (ctx, 99999, dummy_r, false, &full_removal);
+    ok (rc == -1 && errno == ENOENT,
+        "reapi_cli_partial_cancel returns -1 with errno=ENOENT for nonexistent job");
+
+    // Test with nonexistent job and noent_ok=true
+    errno = 0;
+    rc = reapi_cli_partial_cancel (ctx, 99999, dummy_r, true, &full_removal);
+    ok (rc == 0, "reapi_cli_partial_cancel succeeds with noent_ok=true for nonexistent job");
+
+    // Test with NULL context
+    errno = 0;
+    rc = reapi_cli_partial_cancel (NULL, 1, dummy_r, false, &full_removal);
+    ok (rc == -1 && errno == EINVAL,
+        "reapi_cli_partial_cancel returns -1 with errno=EINVAL for NULL context");
+
+    // Test with NULL R
+    errno = 0;
+    rc = reapi_cli_partial_cancel (ctx, 1, NULL, false, &full_removal);
+    ok (rc == -1 && errno == EINVAL,
+        "reapi_cli_partial_cancel returns -1 with errno=EINVAL for NULL R");
+
+    reapi_cli_destroy (ctx);
+    return 0;
+}
+
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
@@ -335,6 +418,7 @@ int main (int argc, char *argv[])
     test_status_by_rank ();
     test_status_by_path ();
     test_null_parameters ();
+    test_cancel_ex ();
 
     done_testing ();
     return EXIT_SUCCESS;


### PR DESCRIPTION
Problem: When used to implement a flux scheduler that initializes with JGF, reapi_cli needs to handle partial cancel with the `rv1exec` match format (since the job manager cannot provide R with scheduling key), but the reapi_cli hard codes the cancel match format to the format used to initialize the graph.

Add a 6-arg C++ `cancel()` method and corresponding C `reapi_cli_cancel_ex()` function that allow the match format to be specified.

This was peeled off of
- #1481