### PR TITLE
reapi: implement update_allocate()

### DIFF
--- a/resource/reapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli_impl.hpp
@@ -25,6 +25,7 @@ extern "C" {
 #include <boost/algorithm/string.hpp>
 #include "resource/reapi/bindings/c++/reapi_cli.hpp"
 #include "resource/readers/resource_reader_factory.hpp"
+#include "resource/config/system_defaults.hpp"
 
 namespace Flux {
 namespace resource_model {
@@ -216,8 +217,151 @@ int reapi_cli_t::update_allocate (void *h,
                                   double &ov,
                                   std::string &R_out)
 {
-    errno = ENOSYS;  // not implemented
-    return -1;
+    resource_query_t *rq = static_cast<resource_query_t *> (h);
+    int rc = -1;
+    std::string fmt;
+    std::string R_sched;  // only populated when RFC 20 has a scheduling section
+    int64_t at_parsed = 0;
+    uint64_t duration = 0;
+    std::shared_ptr<resource_reader_base_t> rd;
+    struct timeval st, et;
+    json_t *o = nullptr;
+    json_t *scheduling = nullptr;
+    int version = 0;
+    double tstart = 0.0, expiration = 0.0;
+
+    if (!rq || R.empty ()) {
+        errno = EINVAL;
+        goto out;
+    }
+    if (rq->allocation_exists (jobid) || rq->reservation_exists (jobid)) {
+        m_err_msg += __FUNCTION__;
+        m_err_msg += ": ERROR: existing jobid " + std::to_string (jobid) + "\n";
+        errno = EEXIST;
+        goto out;
+    }
+
+    if (!(o = json_loads (R.c_str (), 0, nullptr))) {
+        m_err_msg += __FUNCTION__;
+        m_err_msg += ": ERROR: failed to parse R string\n";
+        errno = EINVAL;
+        goto out;
+    }
+
+    // RFC 20 envelope: extract timing from execution section
+    if (json_unpack (o,
+                     "{s:i s:{s?F s?F} s?o}",
+                     "version",
+                     &version,
+                     "execution",
+                     "starttime",
+                     &tstart,
+                     "expiration",
+                     &expiration,
+                     "scheduling",
+                     &scheduling)
+            == 0
+        && version == 1) {
+        at_parsed = static_cast<int64_t> (tstart);
+        // An absent or non-positive expiration (dur == 0) falls back to the
+        // system-wide maximum duration rather than an unbounded span.
+        uint64_t dur = (expiration > tstart) ? static_cast<uint64_t> (expiration - tstart) : 0;
+        duration = dur ? dur : static_cast<uint64_t> (SYSTEM_MAX_DURATION);
+
+        // scheduling JGF present: re-encode it as the traverser input string
+        if (scheduling) {
+            char *s = nullptr;
+            if (!(s = json_dumps (scheduling, JSON_COMPACT))) {
+                m_err_msg += __FUNCTION__;
+                m_err_msg += ": ERROR: can't encode scheduling JGF\n";
+                errno = ENOMEM;
+                goto out;
+            }
+            R_sched = s;
+            free (s);
+            // Map scheduling.writer to a reader format per RFC 20/40 using the
+            // shared helper (also used by resource_query_t::remove_job()).
+            const char *writer = nullptr;
+            flux_error_t werr;
+            json_unpack (scheduling, "{s?s}", "writer", &writer);
+            fmt = reader_name_from_writer (writer, &werr);
+            if (fmt.empty ()) {
+                m_err_msg += __FUNCTION__;
+                m_err_msg += ": ERROR: ";
+                m_err_msg += werr.text;
+                m_err_msg += "\n";
+                // errno set by reader_name_from_writer()
+                goto out;
+            }
+        } else {
+            fmt = "rv1exec";  // R passed directly below
+        }
+    } else {
+        // bare JGF or unrecognised: pass R directly with the load format
+        at_parsed = 0;
+        duration = static_cast<uint64_t> (SYSTEM_MAX_DURATION);
+        fmt = rq->params.load_format;
+    }
+
+    json_decref (o);
+    o = nullptr;
+
+    if ((rd = create_resource_reader (fmt)) == nullptr) {
+        m_err_msg += __FUNCTION__;
+        m_err_msg += ": ERROR: can't create reader: " + fmt + "\n";
+        errno = EINVAL;
+        goto out;
+    }
+
+    gettimeofday (&st, NULL);
+
+    {
+        // Use the extracted scheduling JGF string when present; otherwise pass R
+        // directly to avoid an unnecessary copy.
+        const std::string &to_traverse = R_sched.empty () ? R : R_sched;
+        auto guard = resource_type_t::storage_t::open_for_scope ();
+        rc = rq->traverser->run (to_traverse, rq->writers, rd, (int64_t)jobid, at_parsed, duration);
+    }
+
+    if (rq->get_traverser_err_msg () != "") {
+        m_err_msg += __FUNCTION__;
+        m_err_msg += ": ERROR: " + rq->get_traverser_err_msg () + "\n";
+        rq->clear_traverser_err_msg ();
+    }
+    if (rc != 0)
+        goto out;
+
+    // Scoped so the goto out statements above don't cross oss's initialization.
+    {
+        std::stringstream oss;
+        if (rq->writers->emit (oss) < 0) {
+            m_err_msg += __FUNCTION__;
+            m_err_msg += ": ERROR: writer emit failed\n";
+            rc = -1;
+            goto out;
+        }
+        R_out = oss.str ();
+    }
+
+    gettimeofday (&et, NULL);
+    ov = get_elapsed_time (st, et);
+    at = at_parsed;
+
+    rq->set_allocation (jobid);
+    {
+        auto job_info =
+            std::make_shared<job_info_t> (jobid, job_lifecycle_t::ALLOCATED, at_parsed, "", "", ov);
+        if (!job_info) {
+            errno = ENOMEM;
+            rc = -1;
+            goto out;
+        }
+        rq->set_job (jobid, job_info);
+    }
+
+out:
+    json_decref (o);
+    return rc;
 }
 
 int reapi_cli_t::match_allocate_multi (void *h,

--- a/resource/reapi/bindings/c++/test/CMakeLists.txt
+++ b/resource/reapi/bindings/c++/test/CMakeLists.txt
@@ -17,3 +17,8 @@ add_executable(reapi_cli_cancel_test reapi_cli_cancel_test.cpp)
 add_sanitizers(reapi_cli_cancel_test)
 target_link_libraries(reapi_cli_cancel_test PRIVATE reapi_cli libtap PkgConfig::JANSSON)
 flux_add_test(NAME reapi_cli_cancel_test COMMAND reapi_cli_cancel_test)
+
+add_executable(reapi_cli_update_allocate_test reapi_cli_update_allocate_test.cpp)
+add_sanitizers(reapi_cli_update_allocate_test)
+target_link_libraries(reapi_cli_update_allocate_test PRIVATE reapi_cli libtap PkgConfig::JANSSON)
+flux_add_test(NAME reapi_cli_update_allocate_test COMMAND reapi_cli_update_allocate_test)

--- a/resource/reapi/bindings/c++/test/reapi_cli_update_allocate_test.cpp
+++ b/resource/reapi/bindings/c++/test/reapi_cli_update_allocate_test.cpp
@@ -1,0 +1,300 @@
+/*****************************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+}
+
+#include <cerrno>
+#include <jansson.h>
+#include "resource/reapi/bindings/c++/reapi_cli.hpp"
+#include "resource/policies/base/match_op.h"
+#include "src/common/libtap/tap.h"
+
+using namespace Flux::resource_model;
+using namespace Flux::resource_model::detail;
+
+static int test_update_allocate_basic ()
+{
+    std::string jgf = R"({
+        "graph": {
+            "nodes": [
+                {"id": "0", "metadata": {"type": "cluster", "basename": "tiny", "name": "tiny0", "size": 1, "paths": {"containment": "/tiny0"}}},
+                {"id": "1", "metadata": {"type": "node", "basename": "node", "name": "node0", "size": 1, "rank": 0, "paths": {"containment": "/tiny0/node0"}}},
+                {"id": "2", "metadata": {"type": "core", "basename": "core", "name": "core0", "size": 1, "id": 0, "rank": 0, "paths": {"containment": "/tiny0/node0/core0"}}}
+            ],
+            "edges": [{"source": "0", "target": "1"}, {"source": "1", "target": "2"}]
+        }
+    })";
+
+    std::string params =
+        "{\"load_format\": \"jgf\", \"matcher_policy\": \"high\", "
+        "\"match_format\": \"rv1\", \"matcher_name\": \"CA\"}";
+
+    resource_query_t *rq = nullptr;
+    try {
+        rq = new resource_query_t (jgf, params);
+    } catch (...) {
+        ok (1, "# SKIP: couldn't create resource_query_t");
+        return 0;
+    }
+
+    void *h = static_cast<void *> (rq);
+    uint64_t jobid = 1;
+    bool reserved = false;
+    std::string R;
+    int64_t at = 0;
+    double ov = 0.0;
+
+    std::string jobspec = R"({
+        "version": 1,
+        "resources": [
+            {
+                "type": "node",
+                "count": 1,
+                "with": [
+                    {
+                        "type": "slot",
+                        "count": 1,
+                        "label": "task",
+                        "with": [{"type": "core", "count": 1}]
+                    }
+                ]
+            }
+        ],
+        "tasks": [{"command": ["sleep", "0"], "slot": "task", "count": {"per_slot": 1}}],
+        "attributes": {"system": {"duration": 60.0}}
+    })";
+
+    // Allocate a job to get an R string
+    errno = 0;
+    int rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec, jobid, reserved, R, at, ov);
+    if (rc != 0)
+        BAIL_OUT ("match_allocate failed for jobid 1");
+
+    ok (rc == 0, "match_allocate succeeded for jobid 1");
+
+    // Cancel the job to free resources
+    rc = reapi_cli_t::cancel (h, jobid, false);
+    ok (rc == 0, "cancel succeeded for jobid 1");
+
+    // Test update_allocate with a different jobid
+    uint64_t jobid2 = 2;
+    std::string R_out;
+    int64_t at_out = 0;
+    double ov_out = 0.0;
+
+    errno = 0;
+    rc = reapi_cli_t::update_allocate (h, jobid2, R, at_out, ov_out, R_out);
+    ok (rc == 0, "update_allocate succeeded for jobid 2");
+    ok (!R_out.empty (), "update_allocate returned non-empty R_out");
+
+    delete rq;
+    return 0;
+}
+
+static int test_update_allocate_duplicate_jobid ()
+{
+    std::string jgf = R"({
+        "graph": {
+            "nodes": [
+                {"id": "0", "metadata": {"type": "cluster", "basename": "tiny", "name": "tiny0", "size": 1, "paths": {"containment": "/tiny0"}}},
+                {"id": "1", "metadata": {"type": "node", "basename": "node", "name": "node0", "size": 1, "rank": 0, "paths": {"containment": "/tiny0/node0"}}},
+                {"id": "2", "metadata": {"type": "core", "basename": "core", "name": "core0", "size": 1, "id": 0, "rank": 0, "paths": {"containment": "/tiny0/node0/core0"}}}
+            ],
+            "edges": [{"source": "0", "target": "1"}, {"source": "1", "target": "2"}]
+        }
+    })";
+
+    std::string params =
+        "{\"load_format\": \"jgf\", \"matcher_policy\": \"high\", "
+        "\"match_format\": \"rv1\", \"matcher_name\": \"CA\"}";
+
+    resource_query_t *rq = nullptr;
+    try {
+        rq = new resource_query_t (jgf, params);
+    } catch (...) {
+        ok (1, "# SKIP: couldn't create resource_query_t");
+        return 0;
+    }
+
+    void *h = static_cast<void *> (rq);
+    uint64_t jobid = 1;
+    bool reserved = false;
+    std::string R;
+    int64_t at = 0;
+    double ov = 0.0;
+
+    std::string jobspec = R"({
+        "version": 1,
+        "resources": [
+            {
+                "type": "node",
+                "count": 1,
+                "with": [
+                    {
+                        "type": "slot",
+                        "count": 1,
+                        "label": "task",
+                        "with": [{"type": "core", "count": 1}]
+                    }
+                ]
+            }
+        ],
+        "tasks": [{"command": ["sleep", "0"], "slot": "task", "count": {"per_slot": 1}}],
+        "attributes": {"system": {"duration": 60.0}}
+    })";
+
+    // Allocate a job
+    errno = 0;
+    int rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec, jobid, reserved, R, at, ov);
+    if (rc != 0)
+        BAIL_OUT ("match_allocate failed for jobid 1");
+
+    // Try update_allocate with the same jobid - should fail with EEXIST
+    std::string R_out;
+    int64_t at_out = 0;
+    double ov_out = 0.0;
+
+    errno = 0;
+    rc = reapi_cli_t::update_allocate (h, jobid, R, at_out, ov_out, R_out);
+    ok (rc == -1 && errno == EEXIST,
+        "update_allocate returns -1 with errno=EEXIST for duplicate jobid");
+
+    delete rq;
+    return 0;
+}
+
+static int test_update_allocate_no_expiration ()
+{
+    std::string jgf = R"({
+        "graph": {
+            "nodes": [
+                {"id": "0", "metadata": {"type": "cluster", "basename": "tiny", "name": "tiny0", "size": 1, "paths": {"containment": "/tiny0"}}},
+                {"id": "1", "metadata": {"type": "node", "basename": "node", "name": "node0", "size": 1, "rank": 0, "paths": {"containment": "/tiny0/node0"}}},
+                {"id": "2", "metadata": {"type": "core", "basename": "core", "name": "core0", "size": 1, "id": 0, "rank": 0, "paths": {"containment": "/tiny0/node0/core0"}}}
+            ],
+            "edges": [{"source": "0", "target": "1"}, {"source": "1", "target": "2"}]
+        }
+    })";
+
+    std::string params =
+        "{\"load_format\": \"jgf\", \"matcher_policy\": \"high\", "
+        "\"match_format\": \"rv1\", \"matcher_name\": \"CA\"}";
+
+    resource_query_t *rq = nullptr;
+    try {
+        rq = new resource_query_t (jgf, params);
+    } catch (...) {
+        ok (1, "# SKIP: couldn't create resource_query_t");
+        return 0;
+    }
+
+    void *h = static_cast<void *> (rq);
+    uint64_t jobid = 1;
+    bool reserved = false;
+    std::string R;
+    int64_t at = 0;
+    double ov = 0.0;
+
+    std::string jobspec = R"({
+        "version": 1,
+        "resources": [
+            {
+                "type": "node",
+                "count": 1,
+                "with": [
+                    {
+                        "type": "slot",
+                        "count": 1,
+                        "label": "task",
+                        "with": [{"type": "core", "count": 1}]
+                    }
+                ]
+            }
+        ],
+        "tasks": [{"command": ["sleep", "0"], "slot": "task", "count": {"per_slot": 1}}],
+        "attributes": {"system": {"duration": 60.0}}
+    })";
+
+    // Allocate a job to get an R string, then free the resources
+    errno = 0;
+    int rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec, jobid, reserved, R, at, ov);
+    if (rc != 0)
+        BAIL_OUT ("match_allocate failed for jobid 1");
+    rc = reapi_cli_t::cancel (h, jobid, false);
+    if (rc != 0)
+        BAIL_OUT ("cancel failed for jobid 1");
+
+    // Strip execution.expiration so update_allocate sees R with no expiration
+    json_t *o = json_loads (R.c_str (), 0, nullptr);
+    if (!o)
+        BAIL_OUT ("failed to parse R");
+    json_t *execution = json_object_get (o, "execution");
+    if (!execution || json_object_del (execution, "expiration") < 0)
+        BAIL_OUT ("R has no execution.expiration to remove");
+    char *s = json_dumps (o, JSON_COMPACT);
+    if (!s)
+        BAIL_OUT ("failed to re-encode R");
+    std::string R_no_exp = s;
+    free (s);
+    json_decref (o);
+
+    // update_allocate should succeed, defaulting duration to the system max
+    uint64_t jobid2 = 2;
+    std::string R_out;
+    int64_t at_out = 0;
+    double ov_out = 0.0;
+
+    errno = 0;
+    rc = reapi_cli_t::update_allocate (h, jobid2, R_no_exp, at_out, ov_out, R_out);
+    ok (rc == 0, "update_allocate succeeded for R with no expiration key");
+    ok (!R_out.empty (), "update_allocate returned non-empty R_out");
+
+    delete rq;
+    return 0;
+}
+
+static int test_update_allocate_null_ctx ()
+{
+    void *h = nullptr;
+    uint64_t jobid = 1;
+    std::string R = "{}";
+    std::string R_out;
+    int64_t at = 0;
+    double ov = 0.0;
+
+    errno = 0;
+    int rc = reapi_cli_t::update_allocate (h, jobid, R, at, ov, R_out);
+
+    ok (rc == -1 && errno == EINVAL,
+        "update_allocate returns -1 with errno=EINVAL for NULL context");
+
+    return 0;
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_update_allocate_basic ();
+    test_update_allocate_duplicate_jobid ();
+    test_update_allocate_no_expiration ();
+    test_update_allocate_null_ctx ();
+
+    done_testing ();
+    return EXIT_SUCCESS;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
Problem: the reapi_cli `update_allocate()` method is required for a scheduler based on reapi_cli to participate in the job manager hello protocol, but it is not implemented.

The C wrapper already exists so filling in the C++ implementation takes care of both bindings.

Add an implementation and unit tests.

This was peeled off of
- #1481