### PR TITLE
reapi: add optional match format parameter to cli find() and add C bindings

### DIFF
--- a/resource/reapi/bindings/c++/reapi.hpp
+++ b/resource/reapi/bindings/c++/reapi.hpp
@@ -18,10 +18,12 @@ extern "C" {
 #endif
 #include <flux/core.h>
 #include <flux/idset.h>
+#include <jansson.h>
 }
 
 #include <cstdint>
 #include <string>
+#include <optional>
 #include "resource/schema/resource_data.hpp"
 
 namespace Flux {
@@ -224,6 +226,27 @@ class reapi_t {
     {
         return -1;
     }
+
+    /*! Find resources matching the criteria and return them in R format.
+     *
+     *  \param h         Opaque handle. How it is used is an implementation
+     *                   detail. However, when it is used within a Flux's
+     *                   service module, it is expected to be a pointer
+     *                   to a flux_t object.
+     *  \param criteria  Search criteria string (e.g., "sched-now=allocated",
+     *                   "status=down", etc.)
+     *  \param o         JSON object to receive the matching resources in R format
+     *                   or nullptr if nothing was matched
+     *  \param format    Optional output format string (e.g., "rv1_nosched", "jgf").
+     *                   If std::nullopt (default), uses the context's configured
+     *                   match_format. If specified, creates a temporary writer
+     *                   for that format.
+     *  \return          0 on success; -1 on error.
+     */
+    static int find (void *h,
+                     std::string criteria,
+                     json_t *&o,
+                     std::optional<std::string> format = std::nullopt);
 
     /*! Get the information on the allocation or reservation corresponding
      *  to jobid.

--- a/resource/reapi/bindings/c++/reapi_cli.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli.hpp
@@ -28,6 +28,7 @@ extern "C" {
 #include "resource/policies/dfu_match_policy_factory.hpp"
 #include "resource/traversers/dfu.hpp"
 #include "resource/policies/base/match_op.h"
+#include "resource/writers/match_writers.hpp"
 
 namespace Flux {
 namespace resource_model {
@@ -157,7 +158,10 @@ class reapi_cli_t : public reapi_t {
                        const std::string &R,
                        bool noent_ok,
                        bool &full_removal);
-    static int find (void *h, std::string criteria, json_t *&o);
+    static int find (void *h,
+                     std::string criteria,
+                     json_t *&o,
+                     std::optional<std::string> format = std::nullopt);
     static int info (void *h,
                      const uint64_t jobid,
                      std::string &mode,

--- a/resource/reapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli_impl.hpp
@@ -452,7 +452,7 @@ out:
     return rc;
 }
 
-int reapi_cli_t::find (void *h, std::string criteria, json_t *&o)
+int reapi_cli_t::find (void *h, std::string criteria, json_t *&o, std::optional<std::string> format)
 {
     resource_query_t *rq = static_cast<resource_query_t *> (h);
 
@@ -461,7 +461,36 @@ int reapi_cli_t::find (void *h, std::string criteria, json_t *&o)
         return -1;
     }
 
-    if (rq->traverser_find (criteria) < 0) {
+    std::shared_ptr<match_writers_t> writer;
+    if (format.has_value ()) {
+        // User specified a format - validate it before creating a writer.
+        // get_writers_type() falls back to the simple writer for any
+        // unrecognized string, so an explicit check is required to reject
+        // an invalid format rather than silently using SIMPLE.
+        if (!known_match_format (format.value ())) {
+            m_err_msg += __FUNCTION__;
+            m_err_msg += ": ERROR: unknown match format '";
+            m_err_msg += format.value ();
+            m_err_msg += "'\n";
+            errno = EINVAL;
+            return -1;
+        }
+        match_format_t fmt = match_writers_factory_t::get_writers_type (format.value ());
+        writer = match_writers_factory_t::create (fmt);
+        if (!writer) {
+            m_err_msg += __FUNCTION__;
+            m_err_msg += ": ERROR: failed to create writer for format '";
+            m_err_msg += format.value ();
+            m_err_msg += "'\n";
+            errno = EINVAL;
+            return -1;
+        }
+    } else {
+        // Use context's configured writer
+        writer = rq->writers;
+    }
+
+    if (rq->traverser->find (writer, criteria) < 0) {
         if (rq->get_traverser_err_msg () != "") {
             m_err_msg += __FUNCTION__;
             m_err_msg += rq->get_traverser_err_msg ();
@@ -470,7 +499,7 @@ int reapi_cli_t::find (void *h, std::string criteria, json_t *&o)
         return -1;
     }
 
-    if (rq->writers->emit_json (&o) < 0) {
+    if (writer->emit_json (&o) < 0) {
         m_err_msg += __FUNCTION__;
         m_err_msg += ": ERROR: find writer emit: " + std::string (strerror (errno)) + "\n";
         return -1;

--- a/resource/reapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli_impl.hpp
@@ -454,7 +454,6 @@ out:
 
 int reapi_cli_t::find (void *h, std::string criteria, json_t *&o)
 {
-    int rc = -1;
     resource_query_t *rq = static_cast<resource_query_t *> (h);
 
     if (!rq) {
@@ -462,22 +461,22 @@ int reapi_cli_t::find (void *h, std::string criteria, json_t *&o)
         return -1;
     }
 
-    if ((rc = rq->traverser_find (criteria)) < 0) {
+    if (rq->traverser_find (criteria) < 0) {
         if (rq->get_traverser_err_msg () != "") {
             m_err_msg += __FUNCTION__;
             m_err_msg += rq->get_traverser_err_msg ();
             rq->clear_traverser_err_msg ();
         }
-        return rc;
+        return -1;
     }
 
-    if ((rc = rq->writers->emit_json (&o)) < 0) {
+    if (rq->writers->emit_json (&o) < 0) {
         m_err_msg += __FUNCTION__;
         m_err_msg += ": ERROR: find writer emit: " + std::string (strerror (errno)) + "\n";
-        return rc;
+        return -1;
     }
 
-    return rc;
+    return 0;
 }
 
 int reapi_cli_t::info (void *h,

--- a/resource/reapi/bindings/c++/reapi_module.hpp
+++ b/resource/reapi/bindings/c++/reapi_module.hpp
@@ -24,6 +24,7 @@ extern "C" {
 #include <string>
 #include "resource/reapi/bindings/c++/reapi.hpp"
 #include "resource/policies/base/match_op.h"
+#include "resource/writers/match_writers.hpp"
 
 namespace Flux {
 namespace resource_model {
@@ -67,6 +68,10 @@ class reapi_module_t : public reapi_t {
                        const std::string &R,
                        bool noent_ok,
                        bool &full_removal);
+    static int find (void *h,
+                     std::string criteria,
+                     json_t *&o,
+                     std::optional<std::string> format = std::nullopt);
     static int info (void *h, const uint64_t jobid, bool &reserved, int64_t &at, double &ov);
     static int stat (void *h,
                      int64_t &V,

--- a/resource/reapi/bindings/c++/reapi_module_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_module_impl.hpp
@@ -315,6 +315,15 @@ out:
     return rc;
 }
 
+int reapi_module_t::find (void *h,
+                          std::string criteria,
+                          json_t *&o,
+                          std::optional<std::string> format)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
 int reapi_module_t::info (void *h, const uint64_t jobid, bool &reserved, int64_t &at, double &ov)
 {
     int rc = -1;

--- a/resource/reapi/bindings/c++/test/CMakeLists.txt
+++ b/resource/reapi/bindings/c++/test/CMakeLists.txt
@@ -22,3 +22,8 @@ add_executable(reapi_cli_update_allocate_test reapi_cli_update_allocate_test.cpp
 add_sanitizers(reapi_cli_update_allocate_test)
 target_link_libraries(reapi_cli_update_allocate_test PRIVATE reapi_cli libtap PkgConfig::JANSSON)
 flux_add_test(NAME reapi_cli_update_allocate_test COMMAND reapi_cli_update_allocate_test)
+
+add_executable(reapi_cli_find_test reapi_cli_find_test.cpp)
+add_sanitizers(reapi_cli_find_test)
+target_link_libraries(reapi_cli_find_test PRIVATE reapi_cli libtap PkgConfig::JANSSON)
+flux_add_test(NAME reapi_cli_find_test COMMAND reapi_cli_find_test)

--- a/resource/reapi/bindings/c++/test/reapi_cli_find_test.cpp
+++ b/resource/reapi/bindings/c++/test/reapi_cli_find_test.cpp
@@ -1,0 +1,236 @@
+/*****************************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+}
+
+#include <cerrno>
+#include <jansson.h>
+#include "resource/reapi/bindings/c++/reapi_cli.hpp"
+#include "resource/policies/base/match_op.h"
+#include "src/common/libtap/tap.h"
+
+using namespace Flux::resource_model;
+using namespace Flux::resource_model::detail;
+
+static int test_find_allocated ()
+{
+    std::string jgf = R"({
+        "graph": {
+            "nodes": [
+                {"id": "0", "metadata": {"type": "cluster", "basename": "tiny", "name": "tiny0", "size": 1, "paths": {"containment": "/tiny0"}}},
+                {"id": "1", "metadata": {"type": "node", "basename": "node", "name": "node0", "size": 1, "rank": 0, "paths": {"containment": "/tiny0/node0"}}},
+                {"id": "2", "metadata": {"type": "core", "basename": "core", "name": "core0", "size": 1, "id": 0, "rank": 0, "paths": {"containment": "/tiny0/node0/core0"}}},
+                {"id": "3", "metadata": {"type": "core", "basename": "core", "name": "core1", "size": 1, "id": 1, "rank": 0, "paths": {"containment": "/tiny0/node0/core1"}}}
+            ],
+            "edges": [
+                {"source": "0", "target": "1"},
+                {"source": "1", "target": "2"},
+                {"source": "1", "target": "3"}
+            ]
+        }
+    })";
+
+    // Use rv1_nosched format like resource broker module does
+    std::string params =
+        "{\"load_format\": \"jgf\", \"matcher_policy\": \"high\", "
+        "\"match_format\": \"rv1_nosched\", \"matcher_name\": \"CA\"}";
+
+    resource_query_t *rq = nullptr;
+    try {
+        rq = new resource_query_t (jgf, params);
+    } catch (...) {
+        BAIL_OUT ("couldn't create resource_query_t");
+    }
+
+    void *h = static_cast<void *> (rq);
+    bool reserved = false;
+    std::string R;
+    int64_t at = 0;
+    double ov = 0.0;
+
+    std::string jobspec = R"({
+        "version": 1,
+        "resources": [
+            {
+                "type": "node",
+                "count": 1,
+                "with": [
+                    {
+                        "type": "slot",
+                        "count": 1,
+                        "label": "task",
+                        "with": [{"type": "core", "count": 1}]
+                    }
+                ]
+            }
+        ],
+        "tasks": [{"command": ["app"], "slot": "task", "count": {"per_slot": 1}}],
+        "attributes": {"system": {"duration": 60.0}}
+    })";
+
+    // Allocate two jobs
+    uint64_t jobid1 = 1;
+    int rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec, jobid1, reserved, R, at, ov);
+    if (rc != 0)
+        BAIL_OUT ("match_allocate failed for jobid 1");
+    ok (rc == 0, "allocated job 1");
+
+    uint64_t jobid2 = 2;
+    rc = reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, jobspec, jobid2, reserved, R, at, ov);
+    if (rc != 0)
+        BAIL_OUT ("match_allocate failed for jobid 2");
+    ok (rc == 0, "allocated job 2");
+
+    // Use find() to get all allocated resources
+    // Pass explicit format string to test the optional parameter
+    json_t *R_alloc = nullptr;
+    errno = 0;
+    rc = reapi_cli_t::find (h, "sched-now=allocated", R_alloc, "rv1_nosched");
+    ok (rc == 0, "find sched-now=allocated succeeded");
+    ok (R_alloc != nullptr, "find returned non-NULL R");
+
+    // Verify we got valid JSON with execution key
+    if (R_alloc) {
+        ok (json_is_object (R_alloc), "R is a JSON object");
+        json_t *execution = json_object_get (R_alloc, "execution");
+        ok (execution != nullptr, "R has execution key");
+
+        json_t *r_lite = json_object_get (execution, "R_lite");
+        ok (r_lite != nullptr, "execution has R_lite");
+        ok (json_is_array (r_lite), "R_lite is an array");
+
+        // Should have entries for allocated resources
+        size_t array_size = json_array_size (r_lite);
+        ok (array_size > 0, "R_lite has entries for allocated resources");
+
+        json_decref (R_alloc);
+    }
+
+    delete rq;
+    return 0;
+}
+
+static int test_find_empty ()
+{
+    std::string jgf = R"({
+        "graph": {
+            "nodes": [
+                {"id": "0", "metadata": {"type": "cluster", "basename": "tiny", "name": "tiny0", "size": 1, "paths": {"containment": "/tiny0"}}},
+                {"id": "1", "metadata": {"type": "node", "basename": "node", "name": "node0", "size": 1, "rank": 0, "paths": {"containment": "/tiny0/node0"}}},
+                {"id": "2", "metadata": {"type": "core", "basename": "core", "name": "core0", "size": 1, "id": 0, "rank": 0, "paths": {"containment": "/tiny0/node0/core0"}}}
+            ],
+            "edges": [
+                {"source": "0", "target": "1"},
+                {"source": "1", "target": "2"}
+            ]
+        }
+    })";
+
+    std::string params =
+        "{\"load_format\": \"jgf\", \"matcher_policy\": \"high\", "
+        "\"match_format\": \"rv1_nosched\", \"matcher_name\": \"CA\"}";
+
+    resource_query_t *rq = nullptr;
+    try {
+        rq = new resource_query_t (jgf, params);
+    } catch (...) {
+        BAIL_OUT ("couldn't create resource_query_t");
+    }
+
+    void *h = static_cast<void *> (rq);
+
+    // Find allocated resources when none are allocated
+    // Test with std::nullopt (default) to use context's format
+    json_t *R_alloc = nullptr;
+    errno = 0;
+    int rc = reapi_cli_t::find (h, "sched-now=allocated", R_alloc, std::nullopt);
+    ok (rc == 0, "find sched-now=allocated with no allocations succeeded");
+
+    // When no resources match, emit_json returns NULL (expected behavior)
+    ok (R_alloc == nullptr, "find returned NULL for empty result");
+
+    delete rq;
+    return 0;
+}
+
+static int test_find_null_ctx ()
+{
+    void *h = nullptr;
+    json_t *o = nullptr;
+
+    errno = 0;
+    int rc = reapi_cli_t::find (h, "sched-now=allocated", o);
+
+    ok (rc == -1 && errno == EINVAL, "find returns -1 with errno=EINVAL for NULL context");
+
+    return 0;
+}
+
+static int test_find_invalid_format ()
+{
+    std::string jgf = R"({
+        "graph": {
+            "nodes": [
+                {"id": "0", "metadata": {"type": "cluster", "basename": "tiny", "name": "tiny0", "size": 1, "paths": {"containment": "/tiny0"}}},
+                {"id": "1", "metadata": {"type": "node", "basename": "node", "name": "node0", "size": 1, "rank": 0, "paths": {"containment": "/tiny0/node0"}}},
+                {"id": "2", "metadata": {"type": "core", "basename": "core", "name": "core0", "size": 1, "id": 0, "rank": 0, "paths": {"containment": "/tiny0/node0/core0"}}}
+            ],
+            "edges": [
+                {"source": "0", "target": "1"},
+                {"source": "1", "target": "2"}
+            ]
+        }
+    })";
+
+    std::string params =
+        "{\"load_format\": \"jgf\", \"matcher_policy\": \"high\", "
+        "\"match_format\": \"rv1_nosched\", \"matcher_name\": \"CA\"}";
+
+    resource_query_t *rq = nullptr;
+    try {
+        rq = new resource_query_t (jgf, params);
+    } catch (...) {
+        BAIL_OUT ("couldn't create resource_query_t");
+    }
+
+    void *h = static_cast<void *> (rq);
+
+    // An unrecognized format must be rejected rather than silently falling
+    // back to the simple writer.
+    json_t *R_alloc = nullptr;
+    errno = 0;
+    int rc = reapi_cli_t::find (h, "sched-now=allocated", R_alloc, "bogus_format");
+    ok (rc == -1 && errno == EINVAL, "find returns -1 with errno=EINVAL for unknown format");
+    ok (R_alloc == nullptr, "find left R unset for unknown format");
+
+    delete rq;
+    return 0;
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_find_allocated ();
+    test_find_empty ();
+    test_find_null_ctx ();
+    test_find_invalid_format ();
+
+    done_testing ();
+    return EXIT_SUCCESS;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/resource/reapi/bindings/c/reapi_cli.cpp
+++ b/resource/reapi/bindings/c/reapi_cli.cpp
@@ -20,6 +20,7 @@ extern "C" {
 #include <cstdint>
 #include <cerrno>
 #include <cstring>
+#include <jansson.h>
 #include "resource/reapi/bindings/c++/reapi_cli.hpp"
 #include "resource/reapi/bindings/c++/reapi_cli_impl.hpp"
 #include "resource/schema/data_std.hpp"
@@ -324,6 +325,49 @@ extern "C" int reapi_cli_info (reapi_cli_ctx_t *ctx,
     }
 
     (*mode) = mode_buf_c;
+
+out:
+    return rc;
+}
+
+extern "C" int reapi_cli_find (reapi_cli_ctx_t *ctx,
+                               const char *criteria,
+                               const char *format,
+                               char **R)
+{
+    int rc = -1;
+    json_t *o = nullptr;
+    char *json_str = nullptr;
+    std::optional<std::string> format_opt = std::nullopt;
+
+    if (!ctx || !ctx->rqt || !criteria || !R) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (format)
+        format_opt = std::string (format);
+
+    if ((rc = reapi_cli_t::find (ctx->rqt, criteria, o, format_opt)) < 0) {
+        ctx->err_msg = reapi_cli_t::get_err_message ();
+        reapi_cli_t::clear_err_message ();
+        goto out;
+    }
+
+    if (o) {
+        if (!(json_str = json_dumps (o, JSON_COMPACT))) {
+            ctx->err_msg = __FUNCTION__;
+            ctx->err_msg += ": ERROR: can't serialize JSON\n";
+            json_decref (o);
+            errno = ENOMEM;
+            rc = -1;
+            goto out;
+        }
+        json_decref (o);
+        *R = json_str;
+    } else {
+        *R = nullptr;
+    }
 
 out:
     return rc;

--- a/resource/reapi/bindings/c/reapi_cli.h
+++ b/resource/reapi/bindings/c/reapi_cli.h
@@ -238,6 +238,19 @@ int reapi_cli_info (reapi_cli_ctx_t *ctx,
                     int64_t *at,
                     double *ov);
 
+/*! Find resources matching the criteria and return them in R format.
+ *
+ *  \param ctx       reapi_cli_ctx_t context object
+ *  \param criteria  Search criteria string (e.g., "sched-now=allocated",
+ *                   "status=down", etc.)
+ *  \param format    Optional output format string (e.g., "rv1_nosched", "jgf").
+ *                   If NULL, uses the context's configured match_format.
+ *  \param R         JSON string containing matching resources in R format, or
+ *                   NULL if nothing matched. Caller must free with free().
+ *  \return          0 on success; -1 on error.
+ */
+int reapi_cli_find (reapi_cli_ctx_t *ctx, const char *criteria, const char *format, char **R);
+
 /*! Get the performance information about the resource infrastructure.
  *
  *  \param ctx       reapi_cli_ctx_t context object

--- a/resource/reapi/bindings/c/reapi_module.cpp
+++ b/resource/reapi/bindings/c/reapi_module.cpp
@@ -167,6 +167,15 @@ extern "C" int reapi_module_info (reapi_module_ctx_t *ctx,
     return reapi_module_t::info (ctx->h, jobid, *reserved, *at, *ov);
 }
 
+extern "C" int reapi_module_find (reapi_module_ctx_t *ctx,
+                                  const char *criteria,
+                                  const char *format,
+                                  char **R)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
 extern "C" int reapi_module_stat (reapi_module_ctx_t *ctx,
                                   int64_t *V,
                                   int64_t *E,

--- a/resource/reapi/bindings/c/reapi_module.h
+++ b/resource/reapi/bindings/c/reapi_module.h
@@ -175,6 +175,19 @@ int reapi_module_info (reapi_module_ctx_t *ctx,
                        int64_t *at,
                        double *ov);
 
+/*! Find resources matching the criteria and return them in R format.
+ *
+ *  \param ctx       reapi_module_ctx_t context object
+ *  \param criteria  Search criteria string (e.g., "sched-now=allocated",
+ *                   "status=down", etc.)
+ *  \param format    Optional output format string (e.g., "rv1_nosched", "jgf").
+ *                   If NULL, uses the context's configured match_format.
+ *  \param R         JSON string containing matching resources in R format, or
+ *                   NULL if nothing matched. Caller must free with free().
+ *  \return          0 on success; -1 on error (ENOSYS - not implemented).
+ */
+int reapi_module_find (reapi_module_ctx_t *ctx, const char *criteria, const char *format, char **R);
+
 /*! Get the performance information about the resource infrastructure.
  *
  *  \param ctx       reapi_module_ctx_t context object

--- a/resource/reapi/bindings/c/test/reapi_cli_test.c
+++ b/resource/reapi/bindings/c/test/reapi_cli_test.c
@@ -409,6 +409,80 @@ static int test_cancel_ex ()
     return 0;
 }
 
+static int test_find ()
+{
+    reapi_cli_ctx_t *ctx = reapi_cli_new ();
+    if (!ctx)
+        BAIL_OUT ("reapi_cli_new failed");
+
+    int rc = reapi_cli_initialize (ctx, tiny_jgf, tiny_params);
+    if (rc < 0)
+        BAIL_OUT ("reapi_cli_initialize failed: %s", reapi_cli_get_err_msg (ctx));
+
+    // Allocate a job first
+    uint64_t jobid = 1;
+    bool reserved = false;
+    char *R = NULL;
+    int64_t at = 0;
+    double ov = 0.0;
+
+    rc = reapi_cli_match_with_jobid (ctx,
+                                     MATCH_ALLOCATE,
+                                     simple_jobspec,
+                                     jobid,
+                                     &reserved,
+                                     &R,
+                                     &at,
+                                     &ov);
+    if (rc < 0)
+        BAIL_OUT ("reapi_cli_match_with_jobid failed");
+    ok (rc == 0, "allocated job for find test");
+    free (R);
+    R = NULL;
+
+    // Test find with allocated resources (using default format)
+    char *R_found = NULL;
+    rc = reapi_cli_find (ctx, "sched-now=allocated", NULL, &R_found);
+    ok (rc == 0, "reapi_cli_find with allocated resources succeeded");
+    ok (R_found != NULL, "reapi_cli_find returned non-NULL R string");
+    if (R_found)
+        free (R_found);
+
+    // Test find with explicit format
+    R_found = NULL;
+    rc = reapi_cli_find (ctx, "sched-now=allocated", "rv1_nosched", &R_found);
+    ok (rc == 0, "reapi_cli_find with explicit format succeeded");
+    ok (R_found != NULL, "reapi_cli_find with format returned non-NULL R string");
+    if (R_found)
+        free (R_found);
+
+    // Test find with an unknown format (must be rejected, not silently
+    // defaulted to the simple writer)
+    R_found = NULL;
+    errno = 0;
+    rc = reapi_cli_find (ctx, "sched-now=allocated", "bogus_format", &R_found);
+    ok (rc == -1 && errno == EINVAL,
+        "reapi_cli_find returns -1 with errno=EINVAL for unknown format");
+
+    // Cancel and test find with no allocated resources
+    rc = reapi_cli_cancel (ctx, jobid, false);
+    ok (rc == 0, "reapi_cli_cancel succeeded");
+
+    R_found = NULL;
+    rc = reapi_cli_find (ctx, "sched-now=allocated", NULL, &R_found);
+    ok (rc == 0, "reapi_cli_find with no allocations succeeded");
+    ok (R_found == NULL, "reapi_cli_find returned NULL for empty result");
+
+    // Test with NULL context
+    errno = 0;
+    rc = reapi_cli_find (NULL, "sched-now=allocated", NULL, &R_found);
+    ok (rc == -1 && errno == EINVAL,
+        "reapi_cli_find returns -1 with errno=EINVAL for NULL context");
+
+    reapi_cli_destroy (ctx);
+    return 0;
+}
+
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
@@ -419,6 +493,7 @@ int main (int argc, char *argv[])
     test_status_by_path ();
     test_null_parameters ();
     test_cancel_ex ();
+    test_find ();
 
     done_testing ();
     return EXIT_SUCCESS;


### PR DESCRIPTION
Problem: the reapi_cli `find()` implementation always uses the context's match_format, but schedulers based on reapi_cli will need to generate resource objects in the `rv1_noexec` format in order to answer `resource-status` queries, regardless of the match format configured for `match_allocate()`.

Add an optional format parameter to `find()`.
Fill in missing reapi.hpp declaration and add reapi_module stub for `find()`.
Fix an API inconsistency where `find()` could return > 0 on success.
Add a `reapi_cli_find()` C binding.
Add unit tests.

This is in lieu of the R caching solution initially proposed in
- #1481

This is how the resource broker module builds the query response and is more useful as a debug tool because it samples the live graph state instead of inferring it.