### PR TITLE
cmake: bump required flux-core version to 0.78

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Fluxion installs two modules that are loaded by the Flux broker:
 
 #### Building Fluxion
 
-Fluxion requires an installed flux-core package.  Instructions
+Fluxion requires an installed flux-core package ≥ v0.78.0. Instructions
 for installing flux-core can be found in [the flux-core
 README](https://github.com/flux-framework/flux-core/blob/master/README.md).
 

--- a/cmake/FindFluxCore.cmake
+++ b/cmake/FindFluxCore.cmake
@@ -10,7 +10,7 @@ else()
     endif()
 endif()
 
-pkg_check_modules(FLUX_CORE REQUIRED IMPORTED_TARGET flux-core)
+pkg_check_modules(FLUX_CORE REQUIRED IMPORTED_TARGET flux-core>=0.78)
 set(FLUX_PREFIX ${FLUX_CORE_PREFIX})
 set(LIBFLUX_VERSION ${FLUX_CORE_VERSION})
 


### PR DESCRIPTION
Problem: `flux-sched` since v0.47.0 depends on modprobe, introduced in `flux-core` v0.78.0

Add the required version into the `pkg_check_modules` call in `cmake/FindFluxCore.cmake`

Closes #1501 

Supersedes #1391