### PR TITLE
[go-sdk]: Implement reapi cli update allocate

### DIFF
--- a/resource/reapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli_impl.hpp
@@ -171,7 +171,123 @@ int reapi_cli_t::update_allocate (void *h,
                                   double &ov,
                                   std::string &R_out)
 {
-    return NOT_YET_IMPLEMENTED;
+    resource_query_t *rq = static_cast<resource_query_t *> (h);
+    int rc = -1;
+    at = 0;
+    ov = 0.0f;
+    job_lifecycle_t st;
+    std::shared_ptr<job_info_t> job_info = nullptr;
+    std::shared_ptr<resource_reader_base_t> reader;
+    struct timeval start_time, end_time;
+    std::stringstream o;
+    std::string graph_R = R;
+    uint64_t duration = 0;
+
+    if (!rq || R == "" || jobid > (uint64_t)INT64_MAX) {
+        errno = EINVAL;
+        return -1;
+    }
+    // Do not clobber a jobid the graph already tracks (mirrors cancel()).
+    if (rq->allocation_exists (jobid) || rq->reservation_exists (jobid)) {
+        errno = EEXIST;
+        return -1;
+    }
+
+    /* The allocation R from match_allocate is rv1: the JGF subgraph the jgf
+     * reader consumes lives under the "scheduling" key, and the planner span is
+     * in "execution" (expiration - starttime). Pull both out; if R is already a
+     * bare JGF graph, use it as-is with a long fallback duration.
+     */
+    {
+        json_error_t jerr;
+        json_t *root = json_loads (R.c_str (), 0, &jerr);
+        if (root) {
+            json_t *sched = json_object_get (root, "scheduling");
+            if (sched) {
+                char *s = json_dumps (sched, JSON_COMPACT);
+                if (s) {
+                    graph_R = s;
+                    free (s);
+                }
+            }
+            json_t *exec = json_object_get (root, "execution");
+            if (exec) {
+                json_t *jst = json_object_get (exec, "starttime");
+                json_t *jex = json_object_get (exec, "expiration");
+                if (json_is_integer (jst) && json_is_integer (jex)) {
+                    int64_t s0 = json_integer_value (jst);
+                    int64_t e0 = json_integer_value (jex);
+                    if (s0 >= 0)
+                        at = s0;
+                    if (e0 > s0)
+                        duration = (uint64_t)(e0 - s0);
+                }
+            }
+            json_decref (root);
+        }
+    }
+    if (duration == 0)        // bare JGF, or R without an execution window
+        duration = 31536000;  // ~1y: hold until we explicitly cancel
+
+    if (gettimeofday (&start_time, NULL) < 0) {
+        m_err_msg += __FUNCTION__;
+        m_err_msg += ": ERROR: gettimeofday: " + std::string (strerror (errno)) + "\n";
+        return -1;
+    }
+
+    /* Replay, not match: read the allocation graph with a JGF reader and mark
+     * exactly those vertices allocated under jobid. The traverser sets errno and
+     * an error message on failure rather than throwing.
+     */
+    if (!(reader = create_resource_reader ("jgf"))) {
+        errno = ENOMEM;
+        m_err_msg += __FUNCTION__;
+        m_err_msg += ": ERROR: could not create jgf resource reader\n";
+        return -1;
+    }
+    if ((rc = rq->traverser->run (graph_R, rq->writers, reader, (int64_t)jobid, at, duration))
+        < 0) {
+        if (rq->get_traverser_err_msg () != "") {
+            m_err_msg += __FUNCTION__;
+            m_err_msg += ": ERROR: " + rq->get_traverser_err_msg () + "\n";
+            rq->clear_traverser_err_msg ();
+        } else {
+            m_err_msg += __FUNCTION__;
+            m_err_msg += ": ERROR: update replay: " + std::string (strerror (errno)) + "\n";
+        }
+        return -1;
+    }
+
+    if (rq->writers->emit (o) < 0) {
+        m_err_msg += __FUNCTION__;
+        m_err_msg += ": ERROR: update writer emit: " + std::string (strerror (errno)) + "\n";
+        return -1;
+    }
+    R_out = o.str ();
+
+    if (gettimeofday (&end_time, NULL) < 0) {
+        m_err_msg += __FUNCTION__;
+        m_err_msg += ": ERROR: gettimeofday: " + std::string (strerror (errno)) + "\n";
+        return -1;
+    }
+    ov = get_elapsed_time (start_time, end_time);
+
+    /* Record the allocation so cancel()/info() recognize this jobid, exactly as
+     * match_allocate does for an allocated (non-reserved) job.
+     */
+    st = job_lifecycle_t::ALLOCATED;
+    rq->set_allocation (jobid);
+    job_info = std::make_shared<job_info_t> (jobid, st, at, "", "", ov);
+    if (job_info == nullptr) {
+        errno = ENOMEM;
+        m_err_msg += __FUNCTION__;
+        m_err_msg += ": ERROR: can't allocate memory: " + std::string (strerror (errno)) + "\n";
+        return -1;
+    }
+    rq->set_job (jobid, job_info);
+    rq->incr_job_counter ();
+
+    return 0;
 }
 
 int reapi_cli_t::match_allocate_multi (void *h,

--- a/resource/reapi/bindings/c++/test/CMakeLists.txt
+++ b/resource/reapi/bindings/c++/test/CMakeLists.txt
@@ -7,3 +7,8 @@ add_executable(reapi_cli_clone_test reapi_cli_clone_test.cpp)
 add_sanitizers(reapi_cli_clone_test)
 target_link_libraries(reapi_cli_clone_test PRIVATE reapi_cli libtap fluxion-data)
 flux_add_test(NAME reapi_cli_clone_test COMMAND reapi_cli_clone_test)
+
+add_executable(reapi_cli_update_test reapi_cli_update_test.cpp)
+add_sanitizers(reapi_cli_update_test)
+target_link_libraries(reapi_cli_update_test PRIVATE reapi_cli libtap fluxion-data PkgConfig::JANSSON)
+flux_add_test(NAME reapi_cli_update_test COMMAND reapi_cli_update_test)

--- a/resource/reapi/bindings/c++/test/reapi_cli_update_test.cpp
+++ b/resource/reapi/bindings/c++/test/reapi_cli_update_test.cpp
@@ -1,0 +1,343 @@
+/*****************************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+}
+
+#include <cerrno>
+#include "resource/reapi/bindings/c++/reapi_cli.hpp"
+#include "resource/policies/base/match_op.h"
+#include "resource/store/resource_graph_store.hpp"
+#include "resource/schema/resource_data.hpp"
+#include "resource/schema/data_std.hpp"
+#include "src/common/libtap/tap.h"
+
+using namespace Flux::resource_model;
+using namespace Flux::resource_model::detail;
+
+static const char *tiny_jgf = R"({
+    "graph": {
+        "nodes": [
+            {"id": "0", "metadata": {"type": "cluster", "basename": "tiny", "name": "tiny0", "size": 1, "paths": {"containment": "/tiny0"}}},
+            {"id": "1", "metadata": {"type": "node", "basename": "node", "name": "node0", "size": 1, "rank": 0, "paths": {"containment": "/tiny0/node0"}}},
+            {"id": "2", "metadata": {"type": "core", "basename": "core", "name": "core0", "size": 1, "id": 0, "rank": 0, "paths": {"containment": "/tiny0/node0/core0"}}}
+        ],
+        "edges": [{"source": "0", "target": "1"}, {"source": "1", "target": "2"}]
+    }
+})";
+
+// match_format must be rv1 so the emitted R carries the "scheduling" key that
+// update_allocate replays via the JGF reader.
+static const char *tiny_params = R"({
+    "load_format": "jgf",
+    "matcher_policy": "high",
+    "match_format": "rv1",
+    "matcher_name": "CA"
+})";
+
+static const char *simple_jobspec = R"({
+    "version": 1,
+    "resources": [
+        {
+            "type": "node",
+            "count": 1,
+            "with": [
+                {
+                    "type": "slot",
+                    "count": 1,
+                    "label": "task",
+                    "with": [{"type": "core", "count": 1}]
+                }
+            ]
+        }
+    ],
+    "tasks": [{"command": ["sleep", "0"], "slot": "task", "count": {"per_slot": 1}}],
+    "attributes": {"system": {"duration": 60.0}}
+})";
+
+// update_allocate replays an allocation R (captured from match_allocate) into a
+// fresh, allocation-free graph -- the scheduler-restart recovery path. After
+// replay the resources must be held under the same jobid, exactly as if they
+// had been matched.
+static int test_update_replays_allocation ()
+{
+    // Original graph: match-allocate to capture an rv1 R + jobid.
+    resource_query_t *rq = nullptr;
+    try {
+        rq = new resource_query_t (tiny_jgf, tiny_params);
+    } catch (...) {
+        BAIL_OUT ("couldn't create resource_query_t");
+    }
+    void *h = static_cast<void *> (rq);
+
+    uint64_t jobid = 1;
+    bool reserved = false;
+    std::string R;
+    int64_t at = 0;
+    double ov = 0.0;
+
+    int rc =
+        reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, simple_jobspec, jobid, reserved, R, at, ov);
+    if (rc < 0) {
+        delete rq;
+        BAIL_OUT ("match_allocate failed");
+    }
+    ok (rc == 0 && !R.empty (), "match_allocate produced an rv1 R to replay");
+
+    // Fresh graph with no allocation history, as after a scheduler restart.
+    resource_query_t *fresh = nullptr;
+    try {
+        fresh = new resource_query_t (tiny_jgf, tiny_params);
+    } catch (...) {
+        delete rq;
+        BAIL_OUT ("couldn't create fresh resource_query_t");
+    }
+    void *hf = static_cast<void *> (fresh);
+
+    // Replay the captured R under the same jobid.
+    int64_t at_out = 0;
+    double ov_out = 0.0;
+    std::string R_out;
+    rc = reapi_cli_t::update_allocate (hf, jobid, R, at_out, ov_out, R_out);
+    ok (rc == 0, "update_allocate replayed the allocation into the fresh graph");
+    ok (!R_out.empty (), "update_allocate emitted an R for the replayed allocation");
+
+    // The replayed jobid must now be tracked (set_job bookkeeping).
+    std::string mode;
+    bool rsv = false;
+    int64_t at_info = 0;
+    double ov_info = 0.0;
+    rc = reapi_cli_t::info (hf, jobid, mode, rsv, at_info, ov_info);
+    ok (rc == 0, "info finds the replayed jobid on the fresh graph");
+
+    // Those resources are now busy: a fresh match for the same spec must fail.
+    uint64_t jobid2 = 2;
+    std::string R2;
+    errno = 0;
+    rc = reapi_cli_t::match_allocate (hf,
+                                      MATCH_ALLOCATE,
+                                      simple_jobspec,
+                                      jobid2,
+                                      reserved,
+                                      R2,
+                                      at,
+                                      ov);
+    ok (rc == -1 && errno == EBUSY,
+        "re-match after replay fails with EBUSY (replay is holding the resource)");
+
+    delete fresh;
+    delete rq;
+    return 0;
+}
+
+// update_allocate must refuse to clobber a jobid the graph already tracks.
+static int test_update_rejects_duplicate ()
+{
+    resource_query_t *rq = nullptr;
+    try {
+        rq = new resource_query_t (tiny_jgf, tiny_params);
+    } catch (...) {
+        BAIL_OUT ("couldn't create resource_query_t");
+    }
+    void *h = static_cast<void *> (rq);
+
+    uint64_t jobid = 1;
+    bool reserved = false;
+    std::string R;
+    int64_t at = 0;
+    double ov = 0.0;
+    int rc =
+        reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, simple_jobspec, jobid, reserved, R, at, ov);
+    if (rc < 0) {
+        delete rq;
+        BAIL_OUT ("match_allocate failed");
+    }
+
+    resource_query_t *fresh = nullptr;
+    try {
+        fresh = new resource_query_t (tiny_jgf, tiny_params);
+    } catch (...) {
+        delete rq;
+        BAIL_OUT ("couldn't create fresh resource_query_t");
+    }
+    void *hf = static_cast<void *> (fresh);
+
+    int64_t at_out = 0;
+    double ov_out = 0.0;
+    std::string R_out;
+    rc = reapi_cli_t::update_allocate (hf, jobid, R, at_out, ov_out, R_out);
+    if (rc < 0) {
+        delete fresh;
+        delete rq;
+        BAIL_OUT ("first update_allocate failed");
+    }
+
+    // Replaying the same jobid again must be refused.
+    errno = 0;
+    rc = reapi_cli_t::update_allocate (hf, jobid, R, at_out, ov_out, R_out);
+    ok (rc == -1 && errno == EEXIST, "duplicate update_allocate fails with EEXIST");
+
+    delete fresh;
+    delete rq;
+    return 0;
+}
+
+// update_allocate must reject an empty R rather than crash.
+static int test_update_rejects_empty_R ()
+{
+    resource_query_t *rq = nullptr;
+    try {
+        rq = new resource_query_t (tiny_jgf, tiny_params);
+    } catch (...) {
+        BAIL_OUT ("couldn't create resource_query_t");
+    }
+    void *h = static_cast<void *> (rq);
+
+    uint64_t jobid = 1;
+    int64_t at_out = 0;
+    double ov_out = 0.0;
+    std::string R_out;
+    errno = 0;
+    int rc = reapi_cli_t::update_allocate (h, jobid, "", at_out, ov_out, R_out);
+    ok (rc == -1 && errno == EINVAL, "update_allocate with empty R fails with EINVAL");
+
+    delete rq;
+    return 0;
+}
+
+// Null handle hits the !rq half of the EINVAL guard.
+static int test_update_rejects_null_handle ()
+{
+    uint64_t jobid = 1;
+    int64_t at_out = 0;
+    double ov_out = 0.0;
+    std::string R_out;
+    errno = 0;
+    int rc = reapi_cli_t::update_allocate (nullptr, jobid, "{}", at_out, ov_out, R_out);
+    ok (rc == -1 && errno == EINVAL, "update_allocate with null handle fails with EINVAL");
+    return 0;
+}
+
+// A bare JGF allocation R (no rv1 "scheduling"/"execution" envelope) exercises
+// the else branches and the default-duration fallback. We capture an rv1 R,
+// pull out just its "scheduling" subgraph, and replay that bare graph.
+static int test_update_replays_bare_jgf ()
+{
+    resource_query_t *rq = nullptr;
+    try {
+        rq = new resource_query_t (tiny_jgf, tiny_params);
+    } catch (...) {
+        BAIL_OUT ("couldn't create resource_query_t");
+    }
+    void *h = static_cast<void *> (rq);
+
+    uint64_t jobid = 1;
+    bool reserved = false;
+    std::string R;
+    int64_t at = 0;
+    double ov = 0.0;
+    int rc =
+        reapi_cli_t::match_allocate (h, MATCH_ALLOCATE, simple_jobspec, jobid, reserved, R, at, ov);
+    if (rc < 0) {
+        delete rq;
+        BAIL_OUT ("match_allocate failed");
+    }
+
+    // Extract the bare "scheduling" subgraph from the rv1 R.
+    std::string bare_R;
+    json_error_t jerr;
+    json_t *root = json_loads (R.c_str (), 0, &jerr);
+    if (root) {
+        json_t *sched = json_object_get (root, "scheduling");
+        if (sched) {
+            char *s = json_dumps (sched, JSON_COMPACT);
+            if (s) {
+                bare_R = s;
+                free (s);
+            }
+        }
+        json_decref (root);
+    }
+    if (bare_R.empty ()) {
+        delete rq;
+        BAIL_OUT ("could not extract scheduling subgraph from rv1 R");
+    }
+
+    resource_query_t *fresh = nullptr;
+    try {
+        fresh = new resource_query_t (tiny_jgf, tiny_params);
+    } catch (...) {
+        delete rq;
+        BAIL_OUT ("couldn't create fresh resource_query_t");
+    }
+    void *hf = static_cast<void *> (fresh);
+
+    int64_t at_out = 0;
+    double ov_out = 0.0;
+    std::string R_out;
+    rc = reapi_cli_t::update_allocate (hf, jobid, bare_R, at_out, ov_out, R_out);
+    ok (rc == 0, "update_allocate replays a bare JGF graph (no rv1 envelope)");
+
+    delete fresh;
+    delete rq;
+    return 0;
+}
+
+// A syntactically valid JGF that references a vertex absent from the graph makes
+// the reader/traverser fail, exercising the rc < 0 error branch.
+static int test_update_traverser_failure ()
+{
+    resource_query_t *rq = nullptr;
+    try {
+        rq = new resource_query_t (tiny_jgf, tiny_params);
+    } catch (...) {
+        BAIL_OUT ("couldn't create resource_query_t");
+    }
+    void *h = static_cast<void *> (rq);
+
+    // Valid JSON/JGF shape, but the vertex ids/paths don't exist in tiny_jgf.
+    static const char *bogus_R = R"({
+        "graph": {
+            "nodes": [
+                {"id": "999", "metadata": {"type": "core", "basename": "core", "name": "core99", "size": 1, "id": 99, "rank": 0, "exclusive": true, "paths": {"containment": "/tiny0/node0/core99"}}}
+            ],
+            "edges": []
+        }
+    })";
+
+    uint64_t jobid = 1;
+    int64_t at_out = 0;
+    double ov_out = 0.0;
+    std::string R_out;
+    errno = 0;
+    int rc = reapi_cli_t::update_allocate (h, jobid, bogus_R, at_out, ov_out, R_out);
+    ok (rc == -1, "update_allocate fails when the replay graph does not match");
+
+    delete rq;
+    return 0;
+}
+
+int main (int argc, char *argv[])
+{
+    plan (10);
+
+    test_update_replays_allocation ();
+    test_update_rejects_duplicate ();
+    test_update_rejects_empty_R ();
+    test_update_rejects_null_handle ();
+    test_update_replays_bare_jgf ();
+    test_update_traverser_failure ();
+
+    done_testing ();
+    return 0;
+}

--- a/resource/reapi/bindings/go/src/test/CMakeLists.txt
+++ b/resource/reapi/bindings/go/src/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(TARGET main)
 set(SRCS main.go)
-set(CGO_CFLAGS "-I${CMAKE_BINARY_DIR}")
+set(CGO_CFLAGS "-I${CMAKE_BINARY_DIR} -I${CMAKE_SOURCE_DIR}")
 
 # This is currently passed but not used because when passed into add_custom_command the spaces are escaped
 set(CGO_LIBRARY_FLAGS -Wl,-R


### PR DESCRIPTION
I am working on having an automated restore of the entire scheduler graph in [fluence](https;//github.com/converged-computing/fluence) and @milroy advised to use the current strategy that Flux uses in production - an [update_allocate](https://github.com/flux-framework/flux-sched/blob/7ab23ef92ef4d9a493de869add1f8b00065a7d53/resource/reapi/bindings/c/reapi_cli.cpp#L217) that takes a jobid and resources. I checked that we have the function implemented in the Go client as [UpdateAllocate](https://github.com/flux-framework/flux-sched/blob/7ab23ef92ef4d9a493de869add1f8b00065a7d53/resource/reapi/bindings/go/src/fluxcli/reapi_cli.go#L206) but I failed to notice that it is [not actually implemented](https://github.com/flux-framework/flux-sched/blob/7ab23ef92ef4d9a493de869add1f8b00065a7d53/resource/reapi/bindings/c%2B%2B/reapi_cli_impl.hpp#L167) yet for the C++ bindings. So I did that. 

I'm not going to venture into Go testing, because it's kind of a mess here for Go (and non-standard) and I've tested it with fluence: 

<img width="2159" height="757" alt="image" src="https://github.com/user-attachments/assets/b51dab2e-ad36-4be8-939d-347d666efd65" />

And I'll add tests to fluxion-go, which has the right structure for it.

Thanks.