### PR TITLE
t: remove reference to flux perilog-run in alloc-check

### DIFF
--- a/t/t1024-alloc-check.t
+++ b/t/t1024-alloc-check.t
@@ -29,8 +29,9 @@ test_expect_success 'load fluxion modules' '
 #
 test_expect_success 'configure epilog with delay' '
 	flux config load <<-EOT &&
-	[job-manager]
-	epilog.command = [ "flux", "perilog-run", "epilog", "-e", "sleep,2" ]
+	[job-manager.epilog]
+	per-rank = true
+	command = [ "sleep", "2" ]
 	EOT
 	flux jobtap load perilog.so
 '


### PR DESCRIPTION
Problem: the alloc-check test maintained a deprecated reference to the removed flux perilog-run command. This wasn't getting caught because by the time the epilog was invoked, the test had stopped checking for the error that was being returned by flux-core. When running the testsuite locally on our clusters, the testsuite fails.

Solution: use the per-rank=true flag which takes a little bit longer, but is supported by flux-core.

Closes #1511