### PR TITLE
testsuite: add Catch2-based REAPI CLI tests

### DIFF
--- a/resource/reapi/CMakeLists.txt
+++ b/resource/reapi/CMakeLists.txt
@@ -1,2 +1,2 @@
-
 add_subdirectory( bindings )
+add_subdirectory( test )

--- a/resource/reapi/test/CMakeLists.txt
+++ b/resource/reapi/test/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(reapi_cli_cxx_test reapi_cli_test_cxx.cpp)
+add_sanitizers(reapi_cli_cxx_test)
+target_link_libraries(reapi_cli_cxx_test PRIVATE reapi_cli intern Catch2::Catch2WithMain)
+flux_add_test(NAME reapi_cli_cxx_test COMMAND reapi_cli_cxx_test)
+
+add_executable(reapi_cli_c_test reapi_cli_test_c.cpp)
+add_sanitizers(reapi_cli_c_test)
+target_link_libraries(reapi_cli_c_test PRIVATE reapi_cli intern Catch2::Catch2WithMain)
+flux_add_test(NAME reapi_cli_c_test COMMAND reapi_cli_c_test)

--- a/resource/reapi/test/reapi_cli_test_c.cpp
+++ b/resource/reapi/test/reapi_cli_test_c.cpp
@@ -11,8 +11,10 @@ TEST_CASE ("Initialize REAPI CLI", "[initialize C]")
 {
     const std::string options = "{}";
     std::stringstream buffer;
-    std::ifstream inputFile ("../../../t/data/resource/grugs/tiny.graphml");
+    const char *test_srcdir = std::getenv ("SHARNESS_TEST_SRCDIR");
+    REQUIRE (test_srcdir);
 
+    std::ifstream inputFile (std::string (test_srcdir) + "/data/resource/grugs/tiny.graphml");
     REQUIRE (inputFile.is_open ());
 
     buffer << inputFile.rdbuf ();
@@ -28,18 +30,21 @@ TEST_CASE ("Match basic jobspec", "[match C]")
     int rc = -1;
     const std::string options = "{}";
     std::stringstream gbuffer, jbuffer;
-    std::ifstream graphfile ("../../../t/data/resource/grugs/tiny.graphml");
-    std::ifstream jobspecfile ("../../../t/data/resource/jobspecs/basics/test006.yaml");
+    const char *test_srcdir = std::getenv ("SHARNESS_TEST_SRCDIR");
+    REQUIRE (test_srcdir);
 
+    std::ifstream graphfile (std::string (test_srcdir) + "/data/resource/grugs/tiny.graphml");
     REQUIRE (graphfile.is_open ());
-
-    jbuffer << jobspecfile.rdbuf ();
-    std::string jobspec = jbuffer.str ();
-
-    REQUIRE (jobspecfile.is_open ());
 
     gbuffer << graphfile.rdbuf ();
     std::string rgraph = gbuffer.str ();
+
+    std::ifstream jobspecfile (std::string (test_srcdir)
+                               + "/data/resource/jobspecs/basics/test006.yaml");
+    REQUIRE (jobspecfile.is_open ());
+
+    jbuffer << jobspecfile.rdbuf ();
+    std::string jobspec = jbuffer.str ();
 
     reapi_cli_ctx_t *ctx = nullptr;
     ctx = reapi_cli_new ();

--- a/resource/reapi/test/reapi_cli_test_c.cpp
+++ b/resource/reapi/test/reapi_cli_test_c.cpp
@@ -1,0 +1,64 @@
+#define CATCH_CONFIG_MAIN
+
+#include <catch2/catch_test_macros.hpp>
+#include <resource/reapi/bindings/c/reapi_cli.h>
+#include <fstream>
+#include <iostream>
+
+namespace Flux::resource_model::detail {
+
+TEST_CASE ("Initialize REAPI CLI", "[initialize C]")
+{
+    const std::string options = "{}";
+    std::stringstream buffer;
+    std::ifstream inputFile ("../../../t/data/resource/grugs/tiny.graphml");
+
+    REQUIRE (inputFile.is_open ());
+
+    buffer << inputFile.rdbuf ();
+    std::string rgraph = buffer.str ();
+
+    reapi_cli_ctx_t *ctx = nullptr;
+    ctx = reapi_cli_new ();
+    REQUIRE (ctx);
+}
+
+TEST_CASE ("Match basic jobspec", "[match C]")
+{
+    int rc = -1;
+    const std::string options = "{}";
+    std::stringstream gbuffer, jbuffer;
+    std::ifstream graphfile ("../../../t/data/resource/grugs/tiny.graphml");
+    std::ifstream jobspecfile ("../../../t/data/resource/jobspecs/basics/test006.yaml");
+
+    REQUIRE (graphfile.is_open ());
+
+    jbuffer << jobspecfile.rdbuf ();
+    std::string jobspec = jbuffer.str ();
+
+    REQUIRE (jobspecfile.is_open ());
+
+    gbuffer << graphfile.rdbuf ();
+    std::string rgraph = gbuffer.str ();
+
+    reapi_cli_ctx_t *ctx = nullptr;
+    ctx = reapi_cli_new ();
+    REQUIRE (ctx);
+
+    rc = reapi_cli_initialize (ctx, rgraph.c_str (), options.c_str ());
+    REQUIRE (rc == 0);
+
+    match_op_t match_op = match_op_t::MATCH_ALLOCATE;
+    bool reserved = false;
+    char *R;
+    uint64_t jobid = 1;
+    double ov = 0.0;
+    int64_t at = 0;
+
+    rc = reapi_cli_match (ctx, match_op, jobspec.c_str (), &jobid, &reserved, &R, &at, &ov);
+    CHECK (rc == 0);
+    CHECK (reserved == false);
+    CHECK (at == 0);
+}
+
+}  // namespace Flux::resource_model::detail

--- a/resource/reapi/test/reapi_cli_test_cxx.cpp
+++ b/resource/reapi/test/reapi_cli_test_cxx.cpp
@@ -1,0 +1,67 @@
+#define CATCH_CONFIG_MAIN
+
+#include <catch2/catch_test_macros.hpp>
+#include <resource/reapi/bindings/c++/reapi_cli.hpp>
+#include <fstream>
+
+namespace Flux::resource_model::detail {
+
+TEST_CASE ("Initialize REAPI CLI", "[initialize C++]")
+{
+    const std::string options = "{}";
+    std::stringstream buffer;
+    std::ifstream inputFile ("../../../t/data/resource/grugs/tiny.graphml");
+
+    REQUIRE (inputFile.is_open ());
+
+    buffer << inputFile.rdbuf ();
+    std::string rgraph = buffer.str ();
+
+    std::shared_ptr<resource_query_t> ctx = nullptr;
+    ctx = std::make_shared<resource_query_t> (rgraph, options);
+    REQUIRE (ctx);
+}
+
+TEST_CASE ("Match basic jobspec", "[match C++]")
+{
+    int rc = -1;
+    const std::string options = "{}";
+    std::stringstream gbuffer, jbuffer;
+    std::ifstream graphfile ("../../../t/data/resource/grugs/tiny.graphml");
+    std::ifstream jobspecfile ("../../../t/data/resource/jobspecs/basics/test006.yaml");
+
+    REQUIRE (graphfile.is_open ());
+
+    gbuffer << graphfile.rdbuf ();
+    std::string rgraph = gbuffer.str ();
+
+    REQUIRE (jobspecfile.is_open ());
+
+    jbuffer << jobspecfile.rdbuf ();
+    std::string jobspec = jbuffer.str ();
+
+    std::shared_ptr<resource_query_t> ctx = nullptr;
+    ctx = std::make_shared<resource_query_t> (rgraph, options);
+    REQUIRE (ctx);
+
+    match_op_t match_op = match_op_t::MATCH_ALLOCATE;
+    bool reserved = false;
+    std::string R = "";
+    uint64_t jobid = 1;
+    double ov = 0.0;
+    int64_t at = 0;
+
+    rc = detail::reapi_cli_t::match_allocate (ctx.get (),
+                                              match_op,
+                                              jobspec,
+                                              jobid,
+                                              reserved,
+                                              R,
+                                              at,
+                                              ov);
+    CHECK (rc == 0);
+    CHECK (reserved == false);
+    CHECK (at == 0);
+}
+
+}  // namespace Flux::resource_model::detail

--- a/resource/reapi/test/reapi_cli_test_cxx.cpp
+++ b/resource/reapi/test/reapi_cli_test_cxx.cpp
@@ -3,6 +3,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <resource/reapi/bindings/c++/reapi_cli.hpp>
 #include <fstream>
+#include <cstdlib>
 
 namespace Flux::resource_model::detail {
 
@@ -10,8 +11,10 @@ TEST_CASE ("Initialize REAPI CLI", "[initialize C++]")
 {
     const std::string options = "{}";
     std::stringstream buffer;
-    std::ifstream inputFile ("../../../t/data/resource/grugs/tiny.graphml");
+    const char *test_srcdir = std::getenv ("SHARNESS_TEST_SRCDIR");
+    REQUIRE (test_srcdir);
 
+    std::ifstream inputFile (std::string (test_srcdir) + "/data/resource/grugs/tiny.graphml");
     REQUIRE (inputFile.is_open ());
 
     buffer << inputFile.rdbuf ();
@@ -27,14 +30,17 @@ TEST_CASE ("Match basic jobspec", "[match C++]")
     int rc = -1;
     const std::string options = "{}";
     std::stringstream gbuffer, jbuffer;
-    std::ifstream graphfile ("../../../t/data/resource/grugs/tiny.graphml");
-    std::ifstream jobspecfile ("../../../t/data/resource/jobspecs/basics/test006.yaml");
+    const char *test_srcdir = std::getenv ("SHARNESS_TEST_SRCDIR");
+    REQUIRE (test_srcdir);
 
+    std::ifstream graphfile (std::string (test_srcdir) + "/data/resource/grugs/tiny.graphml");
     REQUIRE (graphfile.is_open ());
 
     gbuffer << graphfile.rdbuf ();
     std::string rgraph = gbuffer.str ();
 
+    std::ifstream jobspecfile (std::string (test_srcdir)
+                               + "/data/resource/jobspecs/basics/test006.yaml");
     REQUIRE (jobspecfile.is_open ());
 
     jbuffer << jobspecfile.rdbuf ();

--- a/t/t4014-match-feasibility.t
+++ b/t/t4014-match-feasibility.t
@@ -103,11 +103,10 @@ test_expect_success 'loading feasibility from non-load-file resource module work
 '
 
 test_expect_success 'loading job-validator conf works' '
-{ cat >conf.tmp << 'EOF'
-[ingest.validator]
-plugins = ["jobspec", "feasibility"]
-EOF
-} &&
+	cat <<-'EOF' >conf.tmp &&
+	[ingest.validator]
+	plugins = ["jobspec", "feasibility"]
+	EOF
     flux config load conf.tmp && rm conf.tmp &&
     flux config get | grep feasibility &&
     flux job-validator --list-plugins | grep feasibility


### PR DESCRIPTION
This PR adds simple Catch2-based initialization and match_allocate tests for the C and C++ CLI REAPI.
While these tests are similar to the existing C and C++ CLI REAPI tests, the Catch2 framework will make writing more sophisticated tests easier in the future.

Additionally, this PR fixes t4014's formatting.

