### PR TITLE
match_op: Expose utils to convert between match_op_t and strings

### DIFF
--- a/qmanager/modules/CMakeLists.txt
+++ b/qmanager/modules/CMakeLists.txt
@@ -11,4 +11,5 @@ target_link_libraries(sched-fluxion-qmanager PRIVATE
     flux::schedutil
     PkgConfig::JANSSON
     cppwrappers
+    match_op
     )

--- a/resource/CMakeLists.txt
+++ b/resource/CMakeLists.txt
@@ -99,6 +99,7 @@ target_link_libraries(resource PUBLIC
     PkgConfig::UUID
     Boost::graph
     jobspec_conv
+    match_op
     )
 add_sanitizers(resource)
 

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -1460,7 +1460,7 @@ out:
 
 static int run (std::shared_ptr<resource_ctx_t> &ctx,
                 int64_t jobid,
-                const char *cmd,
+                match_op_t op,
                 const std::string &jstr,
                 int64_t *at,
                 flux_error_t *errp)
@@ -1468,19 +1468,7 @@ static int run (std::shared_ptr<resource_ctx_t> &ctx,
     int rc = -1;
     try {
         Flux::Jobspec::Jobspec j{jstr};
-
-        dfu_traverser_t &tr = *(ctx->traverser);
-
-        if (std::string ("allocate") == cmd)
-            rc = tr.run (j, ctx->writers, match_op_t::MATCH_ALLOCATE, jobid, at);
-        else if (std::string ("allocate_with_satisfiability") == cmd)
-            rc = tr.run (j, ctx->writers, match_op_t::MATCH_ALLOCATE_W_SATISFIABILITY, jobid, at);
-        else if (std::string ("allocate_orelse_reserve") == cmd)
-            rc = tr.run (j, ctx->writers, match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE, jobid, at);
-        else if (std::string ("satisfiability") == cmd)
-            rc = tr.run (j, ctx->writers, match_op_t::MATCH_SATISFIABILITY, jobid, at);
-        else
-            errno = EINVAL;
+        rc = ctx->traverser->run (j, ctx->writers, op, jobid, at);
     } catch (const Flux::Jobspec::parse_error &e) {
         errno = EINVAL;
         if (errp && e.what ()) {
@@ -1573,9 +1561,8 @@ int run_match (std::shared_ptr<resource_ctx_t> &ctx,
     bool rsv = false;
 
     start = std::chrono::system_clock::now ();
-    if (strcmp ("allocate", cmd) != 0 && strcmp ("allocate_orelse_reserve", cmd) != 0
-        && strcmp ("allocate_with_satisfiability", cmd) != 0
-        && strcmp ("satisfiability", cmd) != 0) {
+    match_op_t op = match_op_from_string (cmd);
+    if (!match_op_valid (op)) {
         rc = -1;
         errno = EINVAL;
         flux_log (ctx->h, LOG_ERR, "%s: unknown cmd: %s", __FUNCTION__, cmd);
@@ -1584,7 +1571,7 @@ int run_match (std::shared_ptr<resource_ctx_t> &ctx,
 
     epoch = std::chrono::duration_cast<std::chrono::seconds> (start.time_since_epoch ());
     *at = *now = epoch.count ();
-    if ((rc = run (ctx, jobid, cmd, jstr, at, errp)) < 0) {
+    if ((rc = run (ctx, jobid, op, jstr, at, errp)) < 0) {
         elapsed = std::chrono::system_clock::now () - start;
         *overhead = elapsed.count ();
         update_match_perf (*overhead, jobid, false);

--- a/resource/policies/base/CMakeLists.txt
+++ b/resource/policies/base/CMakeLists.txt
@@ -1,2 +1,6 @@
+add_library(match_op STATIC
+    match_op.h
+    match_op.cpp
+    )
 
 add_subdirectory( test )

--- a/resource/policies/base/match_op.cpp
+++ b/resource/policies/base/match_op.cpp
@@ -1,0 +1,65 @@
+/*****************************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+#include <cstring>
+#include <utility>
+#include <array>
+#include <cerrno>
+
+#include "match_op.h"
+
+constexpr auto opt_map = std::to_array<std::pair<match_op_t, const char *>> (
+    {{MATCH_ALLOCATE, "allocate"},
+     {MATCH_ALLOCATE_ORELSE_RESERVE, "allocate_orelse_reserve"},
+     {MATCH_ALLOCATE_W_SATISFIABILITY, "allocate_with_satisfiability"},
+     {MATCH_SATISFIABILITY, "satisfiability"}});
+
+static_assert (opt_map.size () == END_MATCH_OP_T - MATCH_UNKNOWN - 1,
+               "opt_map is missing a match_op_t entry");
+
+const char *match_op_to_string (match_op_t match_op)
+{
+    if (match_op < 0 || match_op >= END_MATCH_OP_T) {
+        errno = EINVAL;
+        return nullptr;
+    }
+
+    for (const auto &[op, op_str] : opt_map)
+        if (op == match_op)
+            return op_str;
+
+    errno = ENOENT;
+    return nullptr;
+}
+
+match_op_t match_op_from_string (const char *str)
+{
+    if (!str) {
+        errno = EINVAL;
+        return MATCH_UNKNOWN;
+    }
+
+    for (const auto &[op, op_str] : opt_map)
+        if (strcmp (op_str, str) == 0)
+            return op;
+
+    errno = ENOENT;
+    return MATCH_UNKNOWN;
+}
+
+bool match_op_valid (match_op_t match_op)
+{
+    bool rc;
+    int saved_errno = errno;
+
+    rc = (match_op_to_string (match_op) != nullptr);
+    errno = saved_errno;
+    return rc;
+}

--- a/resource/policies/base/match_op.h
+++ b/resource/policies/base/match_op.h
@@ -1,5 +1,23 @@
+/*****************************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
 #ifndef MATCH_OP_H
 #define MATCH_OP_H
+
+#ifndef __cplusplus
+#include <stdbool.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef enum match_op_t {
     MATCH_UNKNOWN,
@@ -10,30 +28,14 @@ typedef enum match_op_t {
     END_MATCH_OP_T
 } match_op_t;
 
-static const char *match_op_to_string (match_op_t match_op)
-{
-    switch (match_op) {
-        case MATCH_ALLOCATE:
-            return "allocate";
-        case MATCH_ALLOCATE_ORELSE_RESERVE:
-            return "allocate_orelse_reserve";
-        case MATCH_ALLOCATE_W_SATISFIABILITY:
-            return "allocate_with_satisfiability";
-        case MATCH_SATISFIABILITY:
-            return "satisfiability";
-        default:
-            return "error";
-    }
-}
+const char *match_op_to_string (match_op_t match_op);
 
-static bool match_op_valid (match_op_t match_op)
-{
-    if ((match_op != MATCH_ALLOCATE) && (match_op != MATCH_ALLOCATE_W_SATISFIABILITY)
-        && (match_op != MATCH_ALLOCATE_ORELSE_RESERVE) && (match_op != MATCH_SATISFIABILITY)) {
-        return false;
-    }
+match_op_t match_op_from_string (const char *str);
 
-    return true;
+bool match_op_valid (match_op_t match_op);
+
+#ifdef __cplusplus
 }
+#endif
 
 #endif  // MATCH_OP_H

--- a/resource/policies/base/match_op.h
+++ b/resource/policies/base/match_op.h
@@ -6,7 +6,8 @@ typedef enum match_op_t {
     MATCH_ALLOCATE,
     MATCH_ALLOCATE_W_SATISFIABILITY,
     MATCH_ALLOCATE_ORELSE_RESERVE,
-    MATCH_SATISFIABILITY
+    MATCH_SATISFIABILITY,
+    END_MATCH_OP_T
 } match_op_t;
 
 static const char *match_op_to_string (match_op_t match_op)

--- a/resource/reapi/bindings/CMakeLists.txt
+++ b/resource/reapi/bindings/CMakeLists.txt
@@ -12,6 +12,7 @@ target_link_libraries( reapi_cli PRIVATE
 target_link_libraries( reapi_cli PUBLIC
     flux::core
     flux::idset
+    match_op
     )
 install(TARGETS reapi_cli LIBRARY DESTINATION "${FLUX_LIB_DIR}")
 
@@ -24,6 +25,9 @@ add_library (reapi_module STATIC
     )
 target_link_libraries( reapi_module PRIVATE
     flux::core
+    )
+target_link_libraries( reapi_module PUBLIC
+    match_op
     )
 
 if(BUILD_TESTING)

--- a/resource/reapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli_impl.hpp
@@ -121,8 +121,7 @@ int reapi_cli_t::match_allocate (void *h,
 
     if (!match_op_valid (match_op)) {
         m_err_msg += __FUNCTION__;
-        m_err_msg +=
-            ": ERROR: Invalid Match Option: " + std::string (match_op_to_string (match_op)) + "\n";
+        m_err_msg += ": ERROR: Invalid Match Option: " + std::to_string (match_op) + "\n";
         errno = EINVAL;
         return -1;
     }

--- a/resource/reapi/bindings/c++/reapi_module_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_module_impl.hpp
@@ -42,7 +42,7 @@ int reapi_module_t::match_allocate (void *h,
     const char *status = NULL;
     const char *cmd = match_op_to_string (match_op);
 
-    if (!fh || jobspec == "" || jobid > INT64_MAX) {
+    if (!fh || !cmd || jobspec == "" || jobid > INT64_MAX) {
         errno = EINVAL;
         goto out;
     }
@@ -150,7 +150,7 @@ int reapi_module_t::match_allocate_multi (void *h,
     flux_future_t *f = nullptr;
     const char *cmd = match_op_to_string (match_op);
 
-    if (!fh || !jobs) {
+    if (!fh || !cmd || !jobs) {
         errno = EINVAL;
         goto error;
     }

--- a/resource/reapi/test/reapi_cli_test_cxx.cpp
+++ b/resource/reapi/test/reapi_cli_test_cxx.cpp
@@ -2,6 +2,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <resource/reapi/bindings/c++/reapi_cli.hpp>
+#include <resource/policies/base/match_op.h>
 #include <fstream>
 #include <cstdlib>
 
@@ -23,6 +24,56 @@ TEST_CASE ("Initialize REAPI CLI", "[initialize C++]")
     std::shared_ptr<resource_query_t> ctx = nullptr;
     ctx = std::make_shared<resource_query_t> (rgraph, options);
     REQUIRE (ctx);
+}
+
+TEST_CASE ("Convert between strings and match_op_ts", "[match C++]")
+{
+    errno = 0;
+
+    // MATCH_UNKNOWN is invalid and converts to nullptr + ENOENT
+    CHECK (!match_op_valid (MATCH_UNKNOWN));
+    CHECK (errno == 0);
+
+    CHECK (match_op_to_string (MATCH_UNKNOWN) == nullptr);
+    CHECK (errno == ENOENT);
+    errno = 0;
+
+    // invalid strings convert to MATCH_UNKNOWN + ENOENT
+    CHECK (match_op_from_string ("0xDEADBEEF") == MATCH_UNKNOWN);
+    CHECK (errno == ENOENT);
+    errno = 0;
+
+    // out-of-bounds enum values are invalid and convert to nullptr + EINVAL
+    for (match_op_t OOB_match_op :
+         {(match_op_t)(-1), END_MATCH_OP_T, (match_op_t)(END_MATCH_OP_T + 1)}) {
+        CHECK (!match_op_valid (OOB_match_op));
+        CHECK (errno == 0);
+
+        CHECK (match_op_to_string (OOB_match_op) == nullptr);
+        CHECK (errno == EINVAL);
+        errno = 0;
+    }
+
+    // nullptr converts to MATCH_UNKNOWN + EINVAL (since invalid ptr)
+    CHECK (match_op_from_string (nullptr) == MATCH_UNKNOWN);
+    CHECK (errno == EINVAL);
+    errno = 0;
+
+    // valid match_op_t are valid
+    // and match_op_t <-> string conversion is idempotent
+    for (int op = MATCH_UNKNOWN + 1; op != END_MATCH_OP_T; op++) {
+        CHECK (match_op_valid ((match_op_t)op));
+        CHECK (match_op_from_string (match_op_to_string ((match_op_t)op)) == op);
+    }
+    CHECK (errno == 0);
+
+    // each match_op_t has the correct string representation
+    CHECK (match_op_from_string ("allocate") == MATCH_ALLOCATE);
+    CHECK (match_op_from_string ("allocate_orelse_reserve") == MATCH_ALLOCATE_ORELSE_RESERVE);
+    CHECK (match_op_from_string ("allocate_with_satisfiability")
+           == MATCH_ALLOCATE_W_SATISFIABILITY);
+    CHECK (match_op_from_string ("satisfiability") == MATCH_SATISFIABILITY);
+    CHECK (errno == 0);
 }
 
 TEST_CASE ("Match basic jobspec", "[match C++]")

--- a/resource/utilities/command.cpp
+++ b/resource/utilities/command.cpp
@@ -297,16 +297,8 @@ int cmd_match (std::shared_ptr<detail::resource_query_t> &ctx,
         std::cerr << "ERROR: malformed command" << std::endl;
         return 0;
     }
-    std::string subcmd = args[1];
-    if (subcmd == "allocate") {
-        match_op = match_op_t::MATCH_ALLOCATE;
-    } else if (subcmd == "allocate_orelse_reserve") {
-        match_op = match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE;
-    } else if (subcmd == "allocate_with_satisfiability") {
-        match_op = match_op_t::MATCH_ALLOCATE_W_SATISFIABILITY;
-    } else if (subcmd == "satisfiability") {
-        match_op = match_op_t::MATCH_SATISFIABILITY;
-    } else {
+    match_op = match_op_from_string ((args[1]).c_str ());
+    if (!match_op_valid (match_op)) {
         std::cerr << "ERROR: unknown subcmd " << args[1] << std::endl;
         return 0;
     }
@@ -331,16 +323,8 @@ int cmd_match_multi (std::shared_ptr<detail::resource_query_t> &ctx,
         std::cerr << "ERROR: malformed command" << std::endl;
         return 0;
     }
-    std::string subcmd = args[1];
-    if (subcmd == "allocate") {
-        match_op = match_op_t::MATCH_ALLOCATE;
-    } else if (subcmd == "allocate_orelse_reserve") {
-        match_op = match_op_t::MATCH_ALLOCATE_ORELSE_RESERVE;
-    } else if (subcmd == "allocate_with_satisfiability") {
-        match_op = match_op_t::MATCH_ALLOCATE_W_SATISFIABILITY;
-    } else if (subcmd == "satisfiability") {
-        match_op = match_op_t::MATCH_SATISFIABILITY;
-    } else {
+    match_op = match_op_from_string ((args[1]).c_str ());
+    if (!match_op_valid (match_op)) {
         std::cerr << "ERROR: unknown subcmd " << args[1] << std::endl;
         return 0;
     }


### PR DESCRIPTION
Problem: match_op.h's utils for converting between match_op_ts and strings are static functions, so they are not available outside of the translation unit. However, these conversions do need to take place elsewhere (the resource module, resource query). As a result, there are several hard-coded converters outside of the translation unit:
* resource_match.cpp:run
* resource_match.cpp:run_match (checking for whether the match option string is valid)
* command.cpp:cmd_match
* command.cpp:cmd_match_multi

These different converters are prone to error because it is easy to misspell duplicated strings.
Additionally, this makes adding a new match_op_t value more difficult because the developer needs to track down all of these places and manually add their new match_op and associated string to each one.

This PR makes a `match_option` static library and links `qmanager`, the `resource` library, and the `REAPI CLI` against it.
Additionally, it makes each of these four hard-coded converters use the conversion utilities in the `match_option` library.

To add a new match option to this scheme, add it to the `match_op_t` enum in resource/policies/base/match_op.h (between the last valid match option and END_MATCH_OP_T) and add a conversion entry to the `match_options` map in resource/policies/base/match_op.cpp. The conversion functions and `match_op_valid` function will work with the new entries.

This PR depends on #1514 for its conversion idempotence test in reapi_test_cxx.