### PR TITLE
modules: Merge resource_prop_t into resource_opt_t

### DIFF
--- a/qmanager/modules/qmanager_opts.cpp
+++ b/qmanager/modules/qmanager_opts.cpp
@@ -377,7 +377,6 @@ ret:
 int qmanager_opts_t::parse (const std::string &k, const std::string &v, std::string &info)
 {
     int rc = 0;
-    std::string dflt;
     std::map<std::string, std::string> tmp_mp;
     int key = static_cast<int> (qmanager_opts_key_t::UNKNOWN);
 

--- a/resource/modules/feasibility.cpp
+++ b/resource/modules/feasibility.cpp
@@ -38,7 +38,6 @@ static void set_default_args (std::shared_ptr<resource_ctx_t> &ctx)
     ct_opts.set_match_policy ("first", e);
     ct_opts.set_prune_filters ("ALL:core,ALL:node,ALL:gpu,ALL:ssd");
     ct_opts.set_match_format ("rv1_nosched");
-    ct_opts.set_update_interval (0);
     ctx->opts += ct_opts;
 }
 
@@ -250,6 +249,17 @@ error:
 static int init_resource_graph (std::shared_ptr<resource_ctx_t> &ctx)
 {
     int rc = 0;
+    const resource_opts_t &opts = ctx->opts.get_opt ();
+    const std::optional<std::string> &match_subsystems = opts.get_match_subsystems ();
+    const std::optional<std::string> &match_format = opts.get_match_format ();
+    const std::optional<std::string> &prune_filters = opts.get_prune_filters ();
+
+    // Check for all required module options.
+    rc += required_module_option (ctx, match_subsystems, "subsystems");
+    rc += required_module_option (ctx, match_format, "match-format");
+    rc += required_module_option (ctx, opts.get_load_format (), "load-format");
+    if (rc != 0)
+        return rc;
 
     // The feasibility module should only use "first". Exclusivity has no effect.
     if (!(ctx->matcher = create_match_cb ("first"))) {
@@ -265,26 +275,31 @@ static int init_resource_graph (std::shared_ptr<resource_ctx_t> &ctx)
                   LOG_ERR,
                   "%s: error processing subsystems %s",
                   __FUNCTION__,
-                  ctx->opts.get_opt ().get_match_subsystems ().c_str ());
+                  match_subsystems->c_str ());
         return rc;
     }
 
-    // Create a writers object for matched vertices and edges
-    match_format_t format =
-        match_writers_factory_t::get_writers_type (ctx->opts.get_opt ().get_match_format ());
-    if (!(ctx->writers = match_writers_factory_t::create (format)))
-        return -1;
-
-    if (ctx->opts.get_opt ().is_prune_filters_set ()
-        && ctx->matcher->set_pruning_types_w_spec (ctx->matcher->dom_subsystem (),
-                                                   ctx->opts.get_opt ().get_prune_filters ())
-               < 0) {
+    // Create a writers object for matched vertices and edges.
+    if (!(ctx->writers = match_writers_factory_t::create (
+              match_writers_factory_t::get_writers_type (*match_format)))) {
         flux_log (ctx->h,
                   LOG_ERR,
-                  "%s: error setting pruning types with: %s",
+                  "%s: error creating match writer with: %s",
                   __FUNCTION__,
-                  ctx->opts.get_opt ().get_prune_filters ().c_str ());
+                  match_format->c_str ());
         return -1;
+    }
+
+    if (prune_filters) {
+        if (ctx->matcher->set_pruning_types_w_spec (ctx->matcher->dom_subsystem (), *prune_filters)
+            < 0) {
+            flux_log (ctx->h,
+                      LOG_ERR,
+                      "%s: error setting pruning types with: %s",
+                      __FUNCTION__,
+                      prune_filters->c_str ());
+            return -1;
+        }
     }
 
     // Initialize the DFU traverser

--- a/resource/modules/resource.cpp
+++ b/resource/modules/resource.cpp
@@ -1215,7 +1215,7 @@ static void notify_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_
             flux_log_error (h, "%s: flux_msg_route_first", __FUNCTION__);
             goto error;
         }
-        if (ctx->opts.get_opt ().is_load_file_set ()) {
+        if (ctx->opts.get_opt ().get_load_file ()) {
             errno = ENODATA;
             // Since m_acquired_resources is null,
             flux_log_error (ctx->h, "%s: cannot notify when load-file set", __FUNCTION__);
@@ -1361,13 +1361,15 @@ static void status_request_cb (flux_t *h, flux_msg_handler_t *w, const flux_msg_
     json_t *R_alloc = nullptr;
     std::chrono::time_point<std::chrono::system_clock> now;
     std::chrono::duration<double> elapsed;
+    std::optional<int> update_interval;
     std::shared_ptr<resource_ctx_t> ctx = getctx ((flux_t *)arg);
 
     now = std::chrono::system_clock::now ();
     elapsed = now - ctx->m_resources_alloc_updated;
+    update_interval = ctx->opts.get_opt ().get_update_interval ();
     // Get R alloc whenever m_resources_alloc_updated or
     // the elapsed time is greater than configured limit
-    if ((elapsed.count () > static_cast<double> (ctx->opts.get_opt ().get_update_interval ()))
+    if ((update_interval && (elapsed.count () > static_cast<double> (*update_interval)))
         || ctx->m_resources_updated) {
         if (run_find (ctx, "sched-now=allocated", "rv1_nosched", &R_alloc) < 0)
             goto error;
@@ -1572,14 +1574,41 @@ error:
 static int init_resource_graph (std::shared_ptr<resource_ctx_t> &ctx)
 {
     int rc = 0;
+    const resource_opts_t &opts = ctx->opts.get_opt ();
+    const std::optional<std::string> &traverser_policy = opts.get_traverser_policy ();
+    const std::optional<std::string> &match_policy = opts.get_match_policy ();
+    const std::optional<std::string> &match_subsystems = opts.get_match_subsystems ();
+    const std::optional<std::string> &match_format = opts.get_match_format ();
+    const std::optional<std::string> &prune_filters = opts.get_prune_filters ();
+
+    // Check for all required module options.
+    rc += required_module_option (ctx, traverser_policy, "traverser");
+    rc += required_module_option (ctx, match_policy, "match-policy");
+    rc += required_module_option (ctx, match_subsystems, "subsystems");
+    rc += required_module_option (ctx, match_format, "match-format");
+    rc += required_module_option (ctx, opts.get_load_format (), "load-format");
+    if (rc != 0)
+        return rc;
 
     // Select the appropriate traverser based on CLI policy.
-    ctx->traverser =
-        std::make_shared<dfu_traverser_t> (ctx->opts.get_opt ().get_traverser_policy ());
+    try {
+        ctx->traverser = std::make_shared<dfu_traverser_t> (*traverser_policy);
+    } catch (std::bad_alloc &e) {
+        flux_log (ctx->h,
+                  LOG_ERR,
+                  "%s: can't create traverser for policy %s",
+                  __FUNCTION__,
+                  traverser_policy->c_str ());
+        return -1;
+    }
 
     // Select the appropriate matcher based on CLI policy.
-    if (!(ctx->matcher = create_match_cb (ctx->opts.get_opt ().get_match_policy ()))) {
-        flux_log (ctx->h, LOG_ERR, "%s: can't create match callback", __FUNCTION__);
+    if (!(ctx->matcher = create_match_cb (*match_policy))) {
+        flux_log (ctx->h,
+                  LOG_ERR,
+                  "%s: can't create match callback for policy %s",
+                  __FUNCTION__,
+                  match_policy->c_str ());
         return -1;
     }
     if ((rc = populate_resource_db (ctx)) != 0) {
@@ -1591,26 +1620,31 @@ static int init_resource_graph (std::shared_ptr<resource_ctx_t> &ctx)
                   LOG_ERR,
                   "%s: error processing subsystems %s",
                   __FUNCTION__,
-                  ctx->opts.get_opt ().get_match_subsystems ().c_str ());
+                  match_subsystems->c_str ());
         return rc;
     }
 
-    // Create a writers object for matched vertices and edges
-    match_format_t format =
-        match_writers_factory_t::get_writers_type (ctx->opts.get_opt ().get_match_format ());
-    if (!(ctx->writers = match_writers_factory_t::create (format)))
-        return -1;
-
-    if (ctx->opts.get_opt ().is_prune_filters_set ()
-        && ctx->matcher->set_pruning_types_w_spec (ctx->matcher->dom_subsystem (),
-                                                   ctx->opts.get_opt ().get_prune_filters ())
-               < 0) {
+    // Create a writers object for matched vertices and edges.
+    if (!(ctx->writers = match_writers_factory_t::create (
+              match_writers_factory_t::get_writers_type (*match_format)))) {
         flux_log (ctx->h,
                   LOG_ERR,
-                  "%s: error setting pruning types with: %s",
+                  "%s: error creating match writer with: %s",
                   __FUNCTION__,
-                  ctx->opts.get_opt ().get_prune_filters ().c_str ());
+                  match_format->c_str ());
         return -1;
+    }
+
+    if (prune_filters) {
+        if (ctx->matcher->set_pruning_types_w_spec (ctx->matcher->dom_subsystem (), *prune_filters)
+            < 0) {
+            flux_log (ctx->h,
+                      LOG_ERR,
+                      "%s: error setting pruning types with: %s",
+                      __FUNCTION__,
+                      prune_filters->c_str ());
+            return -1;
+        }
     }
 
     // Initialize the DFU traverser

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -146,8 +146,8 @@ static int create_reader (std::shared_ptr<resource_ctx_t> &ctx, const std::strin
 {
     if ((ctx->reader = create_resource_reader (format)) == nullptr)
         return -1;
-    if (ctx->opts.get_opt ().is_load_allowlist_set ()) {
-        if (ctx->reader->set_allowlist (ctx->opts.get_opt ().get_load_allowlist ()) < 0)
+    if (auto load_allowlist = ctx->opts.get_opt ().get_load_allowlist ()) {
+        if (ctx->reader->set_allowlist (*load_allowlist) < 0)
             flux_log (ctx->h, LOG_ERR, "%s: setting allowlist", __FUNCTION__);
         if (!ctx->reader->is_allowlist_supported ())
             flux_log (ctx->h, LOG_WARNING, "%s: allowlist unsupported", __FUNCTION__);
@@ -159,19 +159,22 @@ static int populate_resource_db_file (std::shared_ptr<resource_ctx_t> &ctx)
 {
     int rc = -1;
     int saved_errno;
+    // load_format and in_file_path are guaranteed to be set
+    std::string load_format = *(ctx->opts.get_opt ().get_load_format ());
+    std::string in_file_path = *(ctx->opts.get_opt ().get_load_file ());
     std::ifstream in_file;
     std::stringstream buffer{};
     graph_duration_t duration;
 
-    if (ctx->reader == nullptr
-        && create_reader (ctx, ctx->opts.get_opt ().get_load_format ()) < 0) {
+    if (ctx->reader == nullptr && create_reader (ctx, load_format) < 0) {
         flux_log (ctx->h, LOG_ERR, "%s: can't create reader", __FUNCTION__);
         goto done;
     }
 
     saved_errno = errno;
     errno = 0;
-    in_file.open (ctx->opts.get_opt ().get_load_file ().c_str (), std::ifstream::in);
+
+    in_file.open (in_file_path.c_str (), std::ifstream::in);
     if (!in_file.good ()) {
         if (errno == 0) {
             // C++ standard doesn't guarantee to set errno but
@@ -179,10 +182,7 @@ static int populate_resource_db_file (std::shared_ptr<resource_ctx_t> &ctx)
             // we manually set errno only when it is not set at all.
             errno = EIO;
         }
-        flux_log_error (ctx->h,
-                        "%s: opening %s",
-                        __FUNCTION__,
-                        ctx->opts.get_opt ().get_load_file ().c_str ());
+        flux_log_error (ctx->h, "%s: opening %s", __FUNCTION__, in_file_path.c_str ());
         goto done;
     }
     errno = saved_errno;
@@ -354,18 +354,18 @@ int populate_resource_db (std::shared_ptr<resource_ctx_t> &ctx)
     std::chrono::time_point<std::chrono::system_clock> start;
     std::chrono::duration<double> elapsed;
 
-    if (ctx->opts.get_opt ().is_reserve_vtx_vec_set ())
-        ctx->db->resource_graph.m_vertices.reserve (ctx->opts.get_opt ().get_reserve_vtx_vec ());
+    if (auto reserve_vtx_vec = ctx->opts.get_opt ().get_reserve_vtx_vec ())
+        ctx->db->resource_graph.m_vertices.reserve (*reserve_vtx_vec);
 
     start = std::chrono::system_clock::now ();
-    if (ctx->opts.get_opt ().is_load_file_set ()) {
+    if (auto load_file = ctx->opts.get_opt ().get_load_file ()) {
         if (populate_resource_db_file (ctx) < 0)
             goto done;
         flux_log (ctx->h,
                   LOG_INFO,
                   "%s: loaded resources from %s",
                   __FUNCTION__,
-                  ctx->opts.get_opt ().get_load_file ().c_str ());
+                  load_file->c_str ());
     } else {
         if (populate_resource_db_acquire (ctx) < 0) {
             flux_log (ctx->h, LOG_ERR, "%s: populate_resource_db_acquire", __FUNCTION__);
@@ -1250,7 +1250,7 @@ int select_subsystems (std::shared_ptr<resource_ctx_t> &ctx)
      * subsystem1[:relation1[:relation2...]],subsystem2[...
      */
     int rc = 0;
-    std::stringstream ss (ctx->opts.get_opt ().get_match_subsystems ());
+    std::stringstream ss (ctx->opts.get_opt ().get_match_subsystems ().value_or (""));
     subsystem_t subsystem;
     std::string token;
 

--- a/resource/modules/resource_match.cpp
+++ b/resource/modules/resource_match.cpp
@@ -191,8 +191,9 @@ static int populate_resource_db_file (std::shared_ptr<resource_ctx_t> &ctx)
     if ((rc = ctx->db->load (buffer.str (), ctx->reader)) < 0) {
         flux_log (ctx->h,
                   LOG_ERR,
-                  "%s: reader: %s",
+                  "%s: reader: invalid file for selected format (%s): %s",
                   __FUNCTION__,
+                  load_format.c_str (),
                   ctx->reader->err_message ().c_str ());
         goto done;
     }

--- a/resource/modules/resource_match.hpp
+++ b/resource/modules/resource_match.hpp
@@ -174,6 +174,18 @@ int run_remove_subgraph (std::shared_ptr<resource_ctx_t> &ctx, const std::string
 // Resource Graph and Traverser Initialization
 ////////////////////////////////////////////////////////////////////////////////
 
+template<typename T>
+inline int required_module_option (std::shared_ptr<resource_ctx_t> &ctx,
+                                   const std::optional<T> &opt,
+                                   const char *name)
+{
+    if (!opt) {
+        flux_log (ctx->h, LOG_ERR, "%s: '%s' is unset", __FUNCTION__, name);
+        return -1;
+    }
+    return 0;
+}
+
 int populate_resource_db (std::shared_ptr<resource_ctx_t> &ctx);
 
 int mark (std::shared_ptr<resource_ctx_t> &ctx, const char *ids, resource_pool_t::status_t status);

--- a/resource/modules/resource_match_opts.cpp
+++ b/resource/modules/resource_match_opts.cpp
@@ -534,8 +534,6 @@ ret:
 int resource_opts_t::parse (const std::string &k, const std::string &v, std::string &info)
 {
     int rc = 0;
-    std::string dflt;
-    std::map<std::string, std::string> tmp_mp;
     int key = static_cast<int> (resource_opts_key_t::UNKNOWN);
 
     if (m_tab.find (k) != m_tab.end ())

--- a/resource/modules/resource_match_opts.cpp
+++ b/resource/modules/resource_match_opts.cpp
@@ -24,205 +24,10 @@ using namespace Flux;
 using namespace Flux::resource_model;
 using namespace Flux::opts_manager;
 
-////////////////////////////////////////////////////////////////////////////////
-// Public API for Resource Match Option Class
-////////////////////////////////////////////////////////////////////////////////
-
-const std::string &resource_prop_t::get_load_file () const
-{
-    return m_load_file;
-}
-
-const std::string &resource_prop_t::get_load_format () const
-{
-    return m_load_format;
-}
-
-const std::string &resource_prop_t::get_load_allowlist () const
-{
-    return m_load_allowlist;
-}
-
-const std::string &resource_prop_t::get_match_policy () const
-{
-    return m_match_policy;
-}
-
-const std::string &resource_prop_t::get_match_format () const
-{
-    return m_match_format;
-}
-
-const std::string &resource_prop_t::get_match_subsystems () const
-{
-    return m_match_subsystems;
-}
-
-const int resource_prop_t::get_reserve_vtx_vec () const
-{
-    return m_reserve_vtx_vec;
-}
-
-const std::string &resource_prop_t::get_prune_filters () const
-{
-    return m_prune_filters;
-}
-
-const int resource_prop_t::get_update_interval () const
-{
-    return m_update_interval;
-}
-
-const std::string &resource_prop_t::get_traverser_policy () const
-{
-    return m_traverser_policy;
-}
-
-void resource_prop_t::set_load_file (const std::string &p)
-{
-    m_load_file = p;
-}
-
-bool resource_prop_t::set_load_format (const std::string &p)
-{
-    if (!known_resource_reader (p))
-        return false;
-    m_load_format = p;
-    return true;
-}
-
-void resource_prop_t::set_load_allowlist (const std::string &p)
-{
-    m_load_allowlist = p;
-}
-
-bool resource_prop_t::set_match_policy (const std::string &p, std::string &error_str)
-{
-    if (!known_match_policy (p, error_str))
-        return false;
-    m_match_policy = p;
-    return true;
-}
-
-bool resource_prop_t::set_match_format (const std::string &p)
-{
-    if (!known_match_format (p))
-        return false;
-    m_match_format = p;
-    return true;
-}
-
-void resource_prop_t::set_match_subsystems (const std::string &p)
-{
-    m_match_subsystems = p;
-}
-
-void resource_prop_t::set_reserve_vtx_vec (const int i)
-{
-    m_reserve_vtx_vec = i;
-}
-
-void resource_prop_t::set_prune_filters (const std::string &p)
-{
-    m_prune_filters = p;
-}
-
-bool resource_prop_t::set_traverser_policy (const std::string &p)
-{
-    if (!known_traverser_policy (p))
-        return false;
-    m_traverser_policy = p;
-    return true;
-}
-
-void resource_prop_t::add_to_prune_filters (const std::string &p)
-{
-    m_prune_filters += ",";
-    m_prune_filters += p;
-}
-
-void resource_prop_t::set_update_interval (const int i)
-{
-    m_update_interval = i;
-}
-
-bool resource_prop_t::is_load_file_set () const
-{
-    return m_load_file != RESOURCE_OPTS_UNSET_STR;
-}
-
-bool resource_prop_t::is_load_format_set () const
-{
-    return m_load_format != RESOURCE_OPTS_UNSET_STR;
-}
-
-bool resource_prop_t::is_load_allowlist_set () const
-{
-    return m_load_allowlist != RESOURCE_OPTS_UNSET_STR;
-}
-
-bool resource_prop_t::is_match_policy_set () const
-{
-    return m_match_policy != RESOURCE_OPTS_UNSET_STR;
-}
-
-bool resource_prop_t::is_match_format_set () const
-{
-    return m_match_format != RESOURCE_OPTS_UNSET_STR;
-}
-
-bool resource_prop_t::is_match_subsystems_set () const
-{
-    return m_match_subsystems != RESOURCE_OPTS_UNSET_STR;
-}
-
-bool resource_prop_t::is_reserve_vtx_vec_set () const
-{
-    return m_reserve_vtx_vec != 0;
-}
-
-bool resource_prop_t::is_prune_filters_set () const
-{
-    return m_prune_filters != RESOURCE_OPTS_UNSET_STR;
-}
-
-bool resource_prop_t::is_update_interval_set () const
-{
-    return m_update_interval != 0;
-}
-
-bool resource_prop_t::is_traverser_policy_set () const
-{
-    return m_traverser_policy != RESOURCE_OPTS_UNSET_STR;
-}
-
-json_t *resource_prop_t::jsonify () const
-{
-    return json_pack ("{ s:s? s:s? s:s? s:s? s:s? s:s? s:i s:s? s:i s:s? }",
-                      "load-file",
-                      is_load_file_set () ? get_load_file ().c_str () : nullptr,
-                      "load-format",
-                      is_load_format_set () ? get_load_format ().c_str () : nullptr,
-                      "load-allowlist",
-                      is_load_allowlist_set () ? get_load_allowlist ().c_str () : nullptr,
-                      "policy",
-                      is_match_policy_set () ? get_match_policy ().c_str () : nullptr,
-                      "match-format",
-                      is_match_format_set () ? get_match_format ().c_str () : nullptr,
-                      "subsystems",
-                      is_match_subsystems_set () ? get_match_subsystems ().c_str () : nullptr,
-                      "reserve-vtx-vec",
-                      is_reserve_vtx_vec_set () ? get_reserve_vtx_vec () : 0,
-                      "prune-filters",
-                      is_prune_filters_set () ? get_prune_filters ().c_str () : nullptr,
-                      "update-interval",
-                      is_update_interval_set () ? get_update_interval () : 0,
-                      "traverser",
-                      is_traverser_policy_set () ? get_traverser_policy ().c_str () : nullptr);
-}
+using enum Flux::opts_manager::resource_opts_t::opt_key_t;
 
 ////////////////////////////////////////////////////////////////////////////////
-// Private API for Resource Match Property Class
+// Private API for Resource Match Option Class
 ////////////////////////////////////////////////////////////////////////////////
 
 bool resource_opts_t::is_number (const std::string &num_str)
@@ -235,234 +40,142 @@ bool resource_opts_t::is_number (const std::string &num_str)
     return i == num_str.end ();
 }
 
+const std::map<std::string, resource_opts_t::opt_key_t> resource_opts_t::opt_key_map = {
+    {"load-file", LOAD_FILE},
+    {"load-format", LOAD_FORMAT},
+    {"load-allowlist", LOAD_ALLOWLIST},
+    {"policy", MATCH_POLICY},
+    {"match-policy", MATCH_POLICY},
+    {"match-format", MATCH_FORMAT},
+    {"subsystems", MATCH_SUBSYSTEMS},
+    {"reserve-vtx-vec", RESERVE_VTX_VEC},
+    {"prune-filters", PRUNE_FILTERS},
+    {"update-interval", UPDATE_INTERVAL},
+    {"traverser", TRAVERSER_POLICY},
+};
+
 ////////////////////////////////////////////////////////////////////////////////
-// Public API for Resource Match Property Class
+// Public API for Resource Match Option Class
 ////////////////////////////////////////////////////////////////////////////////
 
-resource_opts_t::resource_opts_t ()
+const std::optional<std::string> &resource_opts_t::get_load_file () const
 {
-    // Note: std::pair<>() is guaranteed to throw only an exception
-    // from its arguments which in this case std::bad_alloc -- i.e.,
-    // from std::string (const char *).
-    // map<>::insert() can also throw std::bad_alloc.
-
-    bool inserted = true;
-
-    auto ret = m_tab.insert (
-        std::pair<std::string, int> ("load-file",
-                                     static_cast<int> (
-                                         resource_opts_t ::resource_opts_key_t ::LOAD_FILE)));
-    inserted &= ret.second;
-    ret = m_tab.insert (
-        std::pair<std::string, int> ("load-format",
-                                     static_cast<int> (
-                                         resource_opts_t ::resource_opts_key_t ::LOAD_FORMAT)));
-    inserted &= ret.second;
-    ret = m_tab.insert (
-        std::pair<std::string, int> ("load-allowlist",
-                                     static_cast<int> (
-                                         resource_opts_t ::resource_opts_key_t ::LOAD_ALLOWLIST)));
-    inserted &= ret.second;
-    ret = m_tab.insert (
-        std::pair<std::string, int> ("policy",
-                                     static_cast<int> (
-                                         resource_opts_t ::resource_opts_key_t ::MATCH_POLICY)));
-    inserted &= ret.second;
-    ret = m_tab.insert (
-        std::pair<std::string, int> ("match-policy",
-                                     static_cast<int> (
-                                         resource_opts_t ::resource_opts_key_t ::MATCH_POLICY)));
-    inserted &= ret.second;
-    ret = m_tab.insert (
-        std::pair<std::string, int> ("match-format",
-                                     static_cast<int> (
-                                         resource_opts_t ::resource_opts_key_t ::MATCH_FORMAT)));
-    inserted &= ret.second;
-    ret = m_tab.insert (
-        std::pair<std::string,
-                  int> ("subsystems",
-                        static_cast<int> (
-                            resource_opts_t ::resource_opts_key_t ::MATCH_SUBSYSTEMS)));
-    inserted &= ret.second;
-    ret = m_tab.insert (
-        std::pair<std::string, int> ("reserve-vtx-vec",
-                                     static_cast<int> (
-                                         resource_opts_t ::resource_opts_key_t ::RESERVE_VTX_VEC)));
-    inserted &= ret.second;
-    ret = m_tab.insert (
-        std::pair<std::string, int> ("prune-filters",
-                                     static_cast<int> (
-                                         resource_opts_t ::resource_opts_key_t ::PRUNE_FILTERS)));
-    inserted &= ret.second;
-    ret = m_tab.insert (
-        std::pair<std::string, int> ("update-interval",
-                                     static_cast<int> (
-                                         resource_opts_t ::resource_opts_key_t ::UPDATE_INTERVAL)));
-    inserted &= ret.second;
-    ret = m_tab.insert (
-        std::pair<std::string,
-                  int> ("traverser",
-                        static_cast<int> (
-                            resource_opts_t ::resource_opts_key_t ::TRAVERSER_POLICY)));
-    inserted &= ret.second;
-
-    if (!inserted)
-        throw std::bad_alloc ();
+    return m_load_file;
 }
 
-const std::string &resource_opts_t::get_load_file () const
+const std::optional<std::string> &resource_opts_t::get_load_format () const
 {
-    return m_resource_prop.get_load_file ();
+    return m_load_format;
 }
 
-const std::string &resource_opts_t::get_load_format () const
+const std::optional<std::string> &resource_opts_t::get_load_allowlist () const
 {
-    return m_resource_prop.get_load_format ();
+    return m_load_allowlist;
 }
 
-const std::string &resource_opts_t::get_load_allowlist () const
+const std::optional<std::string> &resource_opts_t::get_match_policy () const
 {
-    return m_resource_prop.get_load_allowlist ();
+    return m_match_policy;
 }
 
-const std::string &resource_opts_t::get_match_policy () const
+const std::optional<std::string> &resource_opts_t::get_match_format () const
 {
-    return m_resource_prop.get_match_policy ();
+    return m_match_format;
 }
 
-const std::string &resource_opts_t::get_match_format () const
+const std::optional<std::string> &resource_opts_t::get_match_subsystems () const
 {
-    return m_resource_prop.get_match_format ();
+    return m_match_subsystems;
 }
 
-const std::string &resource_opts_t::get_match_subsystems () const
+const std::optional<int> &resource_opts_t::get_reserve_vtx_vec () const
 {
-    return m_resource_prop.get_match_subsystems ();
+    return m_reserve_vtx_vec;
 }
 
-const int resource_opts_t::get_reserve_vtx_vec () const
+const std::optional<std::string> &resource_opts_t::get_prune_filters () const
 {
-    return m_resource_prop.get_reserve_vtx_vec ();
+    return m_prune_filters;
 }
 
-const std::string &resource_opts_t::get_prune_filters () const
+const std::optional<int> &resource_opts_t::get_update_interval () const
 {
-    return m_resource_prop.get_prune_filters ();
+    return m_update_interval;
 }
 
-const int resource_opts_t::get_update_interval () const
+const std::optional<std::string> &resource_opts_t::get_traverser_policy () const
 {
-    return m_resource_prop.get_update_interval ();
+    return m_traverser_policy;
 }
 
-const resource_prop_t &resource_opts_t::get_resource_prop () const
+void resource_opts_t::set_load_file (const std::string &p)
 {
-    return m_resource_prop;
+    m_load_file = p;
 }
 
-const std::string &resource_opts_t::get_traverser_policy () const
+bool resource_opts_t::set_load_format (const std::string &p)
 {
-    return m_resource_prop.get_traverser_policy ();
+    if (!known_resource_reader (p))
+        return false;
+    m_load_format = p;
+    return true;
 }
 
-void resource_opts_t::set_load_file (const std::string &o)
+void resource_opts_t::set_load_allowlist (const std::string &p)
 {
-    m_resource_prop.set_load_file (o);
+    m_load_allowlist = p;
 }
 
-bool resource_opts_t::set_load_format (const std::string &o)
+bool resource_opts_t::set_match_policy (const std::string &p, std::string &error_str)
 {
-    return m_resource_prop.set_load_format (o);
+    if (!known_match_policy (p, error_str))
+        return false;
+    m_match_policy = p;
+    return true;
 }
 
-void resource_opts_t::set_load_allowlist (const std::string &o)
+bool resource_opts_t::set_match_format (const std::string &p)
 {
-    m_resource_prop.set_load_allowlist (o);
+    if (!known_match_format (p))
+        return false;
+    m_match_format = p;
+    return true;
 }
 
-bool resource_opts_t::set_match_policy (const std::string &o, std::string &e)
+void resource_opts_t::set_match_subsystems (const std::string &p)
 {
-    return m_resource_prop.set_match_policy (o, e);
-}
-
-bool resource_opts_t::set_match_format (const std::string &o)
-{
-    return m_resource_prop.set_match_format (o);
-}
-
-void resource_opts_t::set_match_subsystems (const std::string &o)
-{
-    m_resource_prop.set_match_subsystems (o);
+    m_match_subsystems = p;
 }
 
 void resource_opts_t::set_reserve_vtx_vec (const int i)
 {
-    m_resource_prop.set_reserve_vtx_vec (i);
+    m_reserve_vtx_vec = i;
 }
 
-void resource_opts_t::set_prune_filters (const std::string &o)
+void resource_opts_t::set_prune_filters (const std::string &p)
 {
-    m_resource_prop.set_prune_filters (o);
+    m_prune_filters = p;
+}
+
+bool resource_opts_t::set_traverser_policy (const std::string &p)
+{
+    if (!known_traverser_policy (p))
+        return false;
+    m_traverser_policy = p;
+    return true;
+}
+
+void resource_opts_t::add_to_prune_filters (const std::string &p)
+{
+    if (m_prune_filters)
+        *m_prune_filters += "," + p;
+    else
+        m_prune_filters = p;
 }
 
 void resource_opts_t::set_update_interval (const int i)
 {
-    m_resource_prop.set_update_interval (i);
-}
-
-bool resource_opts_t::set_traverser_policy (const std::string &o)
-{
-    return m_resource_prop.set_traverser_policy (o);
-}
-
-bool resource_opts_t::is_load_file_set () const
-{
-    return m_resource_prop.is_load_file_set ();
-}
-
-bool resource_opts_t::is_load_format_set () const
-{
-    return m_resource_prop.is_load_format_set ();
-}
-
-bool resource_opts_t::is_load_allowlist_set () const
-{
-    return m_resource_prop.is_load_allowlist_set ();
-}
-
-bool resource_opts_t::is_match_policy_set () const
-{
-    return m_resource_prop.is_match_policy_set ();
-}
-
-bool resource_opts_t::is_match_format_set () const
-{
-    return m_resource_prop.is_match_format_set ();
-}
-
-bool resource_opts_t::is_match_subsystems_set () const
-{
-    return m_resource_prop.is_match_subsystems_set ();
-}
-
-bool resource_opts_t::is_reserve_vtx_vec_set () const
-{
-    return m_resource_prop.is_reserve_vtx_vec_set ();
-}
-
-bool resource_opts_t::is_prune_filters_set () const
-{
-    return m_resource_prop.is_prune_filters_set ();
-}
-
-bool resource_opts_t::is_update_interval_set () const
-{
-    return m_resource_prop.is_update_interval_set ();
-}
-
-bool resource_opts_t::is_traverser_policy_set () const
-{
-    return m_resource_prop.is_traverser_policy_set ();
+    m_update_interval = i;
 }
 
 resource_opts_t &resource_opts_t::canonicalize ()
@@ -472,36 +185,122 @@ resource_opts_t &resource_opts_t::canonicalize ()
 
 resource_opts_t &resource_opts_t::operator+= (const resource_opts_t &src)
 {
-    if (src.m_resource_prop.is_load_file_set ())
-        m_resource_prop.set_load_file (src.m_resource_prop.get_load_file ());
-    if (src.m_resource_prop.is_load_format_set ())
-        m_resource_prop.set_load_format (src.m_resource_prop.get_load_format ());
-    if (src.m_resource_prop.is_load_allowlist_set ())
-        m_resource_prop.set_load_allowlist (src.m_resource_prop.get_load_allowlist ());
-    if (src.m_resource_prop.is_match_policy_set ()) {
+    if (auto src_load_file = src.get_load_file ())
+        set_load_file (*src_load_file);
+    if (auto src_load_format = src.get_load_format ())
+        set_load_format (*src_load_format);
+    if (auto src_load_allowlist = src.get_load_allowlist ())
+        set_load_allowlist (*src_load_allowlist);
+    if (auto src_match_policy = src.get_match_policy ()) {
         std::string e = "";
-        m_resource_prop.set_match_policy (src.m_resource_prop.get_match_policy (), e);
+        set_match_policy (*src_match_policy, e);
     }
-    if (src.m_resource_prop.is_match_format_set ())
-        m_resource_prop.set_match_format (src.m_resource_prop.get_match_format ());
-    if (src.m_resource_prop.is_match_subsystems_set ())
-        m_resource_prop.set_match_subsystems (src.m_resource_prop.get_match_subsystems ());
-    if (src.m_resource_prop.is_reserve_vtx_vec_set ())
-        m_resource_prop.set_reserve_vtx_vec (src.m_resource_prop.get_reserve_vtx_vec ());
-    if (src.m_resource_prop.is_prune_filters_set ())
-        m_resource_prop.set_prune_filters (src.m_resource_prop.get_prune_filters ());
-    if (src.m_resource_prop.is_update_interval_set ())
-        m_resource_prop.set_update_interval (src.m_resource_prop.get_update_interval ());
-    if (src.m_resource_prop.is_traverser_policy_set ())
-        m_resource_prop.set_traverser_policy (src.m_resource_prop.get_traverser_policy ());
+    if (auto src_match_format = src.get_match_format ())
+        set_match_format (*src_match_format);
+    if (auto src_match_subsystems = src.get_match_subsystems ())
+        set_match_subsystems (*src_match_subsystems);
+    if (auto src_reserve_vtx_vec = src.get_reserve_vtx_vec ())
+        set_reserve_vtx_vec (*src_reserve_vtx_vec);
+    if (auto src_prune_filters = src.get_prune_filters ())
+        set_prune_filters (*src_prune_filters);
+    if (auto src_update_interval = src.get_update_interval ())
+        set_update_interval (*src_update_interval);
+    if (auto src_traverser_policy = src.get_traverser_policy ())
+        set_traverser_policy (*src_traverser_policy);
     return *this;
 }
 
 bool resource_opts_t::operator() (const std::string &k1, const std::string &k2) const
 {
-    if (m_tab.find (k1) == m_tab.end () || m_tab.find (k2) == m_tab.end ())
+    if (opt_key_map.find (k1) == opt_key_map.end () || opt_key_map.find (k2) == opt_key_map.end ())
         return k1 < k2;
-    return m_tab.at (k1) < m_tab.at (k2);
+    return opt_key_map.at (k1) < opt_key_map.at (k2);
+}
+
+int resource_opts_t::parse (const std::string &k, const std::string &v, std::string &info)
+{
+    int rc = 0;
+    resource_opts_t::opt_key_t opt_key = UNKNOWN;
+
+    if (opt_key_map.find (k) != opt_key_map.end ())
+        opt_key = opt_key_map.at (k);
+
+    switch (opt_key) {
+        case LOAD_FILE:
+            set_load_file (v);
+            break;
+
+        case LOAD_FORMAT:
+            if (!set_load_format (v)) {
+                info += "Unknown resource reader (" + v + ")! ";
+                info += "Using default.";
+            }
+            break;
+
+        case LOAD_ALLOWLIST:
+            set_load_allowlist (v);
+            break;
+
+        case MATCH_POLICY:
+            if (!set_match_policy (v, info)) {
+                info += "Unknown match policy (" + v + ")! ";
+                errno = EINVAL;
+                rc = -1;
+                return rc;
+            }
+            break;
+
+        case MATCH_FORMAT:
+            if (!set_match_format (v)) {
+                info += "Unknown match format (" + v + ")! ";
+                info += "Using default.";
+            }
+            break;
+
+        case MATCH_SUBSYSTEMS:
+            set_match_subsystems (v);
+            break;
+
+        case RESERVE_VTX_VEC:
+            if (is_number (v)) {
+                int s = std::stoi (v);
+                if (!(s <= 0 || s > 2000000)) {
+                    set_reserve_vtx_vec (s);
+                }
+            }
+            break;
+
+        case PRUNE_FILTERS:
+            if (v.find_first_not_of (' ') != std::string::npos)
+                add_to_prune_filters (v);
+            break;
+
+        case UPDATE_INTERVAL:
+            if (is_number (v)) {
+                int s = std::stoi (v);
+                if (!(s <= 0 || s > 2000000)) {
+                    set_update_interval (s);
+                }
+            }
+            break;
+
+        case TRAVERSER_POLICY:
+            if (!set_traverser_policy (v)) {
+                info += "Unknown traverser policy (" + v + ")! ";
+                errno = EINVAL;
+                rc = -1;
+                return rc;
+            }
+            break;
+
+        case UNKNOWN:
+            info += "Unknown option (" + k + ").";
+            errno = EINVAL;
+            rc = -1;
+            break;
+    }
+
+    return rc;
 }
 
 int resource_opts_t::jsonify (std::string &json_out) const
@@ -510,8 +309,30 @@ int resource_opts_t::jsonify (std::string &json_out) const
     int save_errno;
     json_t *o{nullptr};
     const char *json_str{nullptr};
+    auto to_c_str = [] (auto &s) { return s.c_str (); };
 
-    if (!(o = m_resource_prop.jsonify ())) {
+    o = json_pack ("{ s:s? s:s? s:s? s:s? s:s? s:s? s:i s:s? s:i s:s? }",
+                   "load-file",
+                   get_load_file ().transform (to_c_str).value_or (nullptr),
+                   "load-format",
+                   get_load_format ().transform (to_c_str).value_or (nullptr),
+                   "load-allowlist",
+                   get_load_allowlist ().transform (to_c_str).value_or (nullptr),
+                   "policy",
+                   get_match_policy ().transform (to_c_str).value_or (nullptr),
+                   "match-format",
+                   get_match_format ().transform (to_c_str).value_or (nullptr),
+                   "subsystems",
+                   get_match_subsystems ().transform (to_c_str).value_or (nullptr),
+                   "reserve-vtx-vec",
+                   get_reserve_vtx_vec ().value_or (0),
+                   "prune-filters",
+                   get_prune_filters ().transform (to_c_str).value_or (nullptr),
+                   "update-interval",
+                   get_update_interval ().value_or (0),
+                   "traverser",
+                   get_traverser_policy ().transform (to_c_str).value_or (nullptr));
+    if (!o) {
         errno = ENOMEM;
         goto ret;
     }
@@ -528,96 +349,6 @@ ret:
         json_decref (o);
     free ((char *)json_str);
     errno = save_errno;
-    return rc;
-}
-
-int resource_opts_t::parse (const std::string &k, const std::string &v, std::string &info)
-{
-    int rc = 0;
-    int key = static_cast<int> (resource_opts_key_t::UNKNOWN);
-
-    if (m_tab.find (k) != m_tab.end ())
-        key = m_tab[k];
-
-    switch (key) {
-        case static_cast<int> (resource_opts_key_t::LOAD_FILE):
-            m_resource_prop.set_load_file (v);
-            break;
-
-        case static_cast<int> (resource_opts_key_t::LOAD_FORMAT):
-            if (!m_resource_prop.set_load_format (v)) {
-                info += "Unknown resource reader (" + v + ")! ";
-                info += "Using default.";
-            }
-            break;
-
-        case static_cast<int> (resource_opts_key_t::LOAD_ALLOWLIST):
-            m_resource_prop.set_load_allowlist (v);
-            break;
-
-        case static_cast<int> (resource_opts_key_t::MATCH_POLICY):
-            if (!m_resource_prop.set_match_policy (v, info)) {
-                info += "Unknown match policy (" + v + ")! ";
-                errno = EINVAL;
-                rc = -1;
-                return rc;
-            }
-            break;
-
-        case static_cast<int> (resource_opts_key_t::MATCH_FORMAT):
-            if (!m_resource_prop.set_match_format (v)) {
-                info += "Unknown match format (" + v + ")! ";
-                info += "Using default.";
-            }
-            break;
-
-        case static_cast<int> (resource_opts_key_t::MATCH_SUBSYSTEMS):
-            m_resource_prop.set_match_subsystems (v);
-            break;
-
-        case static_cast<int> (resource_opts_key_t::RESERVE_VTX_VEC):
-            if (is_number (v)) {
-                int s = std::stoi (v);
-                if (!(s <= 0 || s > 2000000)) {
-                    m_resource_prop.set_reserve_vtx_vec (s);
-                }
-            }
-            break;
-
-        case static_cast<int> (resource_opts_key_t::PRUNE_FILTERS):
-            if (v.find_first_not_of (' ') != std::string::npos) {
-                if (m_resource_prop.is_prune_filters_set ())
-                    m_resource_prop.add_to_prune_filters (v);
-                else
-                    m_resource_prop.set_prune_filters (v);
-            }
-            break;
-
-        case static_cast<int> (resource_opts_key_t::UPDATE_INTERVAL):
-            if (is_number (v)) {
-                int s = std::stoi (v);
-                if (!(s <= 0 || s > 2000000)) {
-                    m_resource_prop.set_update_interval (s);
-                }
-            }
-            break;
-
-        case static_cast<int> (resource_opts_key_t::TRAVERSER_POLICY):
-            if (!m_resource_prop.set_traverser_policy (v)) {
-                info += "Unknown traverser policy (" + v + ")! ";
-                errno = EINVAL;
-                rc = -1;
-                return rc;
-            }
-            break;
-
-        default:
-            info += "Unknown option (" + k + ").";
-            errno = EINVAL;
-            rc = -1;
-            break;
-    }
-
     return rc;
 }
 

--- a/resource/modules/resource_match_opts.cpp
+++ b/resource/modules/resource_match_opts.cpp
@@ -217,6 +217,8 @@ bool resource_opts_t::operator() (const std::string &k1, const std::string &k2) 
     return opt_key_map.at (k1) < opt_key_map.at (k2);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic error "-Wswitch-enum"
 int resource_opts_t::parse (const std::string &k, const std::string &v, std::string &info)
 {
     int rc = 0;
@@ -302,6 +304,7 @@ int resource_opts_t::parse (const std::string &k, const std::string &v, std::str
 
     return rc;
 }
+#pragma GCC diagnostic pop
 
 int resource_opts_t::jsonify (std::string &json_out) const
 {

--- a/resource/modules/resource_match_opts.hpp
+++ b/resource/modules/resource_match_opts.hpp
@@ -17,70 +17,17 @@ extern "C" {
 
 #include <map>
 #include <string>
+#include <optional>
 #include "src/common/liboptmgr/optmgr.hpp"
 
 namespace Flux {
 namespace opts_manager {
 
-const std::string RESOURCE_OPTS_UNSET_STR = "0xdeadbeef";
-
-class resource_prop_t {
-   public:
-    const std::string &get_load_file () const;
-    const std::string &get_load_format () const;
-    const std::string &get_load_allowlist () const;
-    const std::string &get_match_policy () const;
-    const std::string &get_match_format () const;
-    const std::string &get_match_subsystems () const;
-    const int get_reserve_vtx_vec () const;
-    const std::string &get_prune_filters () const;
-    const resource_prop_t &get_resource_prop () const;
-    const int get_update_interval () const;
-    const std::string &get_traverser_policy () const;
-
-    void set_load_file (const std::string &o);
-    bool set_load_format (const std::string &o);
-    void set_load_allowlist (const std::string &o);
-    bool set_match_policy (const std::string &o, std::string &e);
-    bool set_match_format (const std::string &o);
-    void set_match_subsystems (const std::string &o);
-    void set_reserve_vtx_vec (const int i);
-    void set_prune_filters (const std::string &o);
-    void add_to_prune_filters (const std::string &o);
-    void set_update_interval (const int i);
-    bool set_traverser_policy (const std::string &o);
-
-    bool is_load_file_set () const;
-    bool is_load_format_set () const;
-    bool is_load_allowlist_set () const;
-    bool is_match_policy_set () const;
-    bool is_match_format_set () const;
-    bool is_match_subsystems_set () const;
-    bool is_reserve_vtx_vec_set () const;
-    bool is_prune_filters_set () const;
-    bool is_update_interval_set () const;
-    bool is_traverser_policy_set () const;
-
-    json_t *jsonify () const;
-
-   private:
-    std::string m_load_file = RESOURCE_OPTS_UNSET_STR;
-    std::string m_load_format = RESOURCE_OPTS_UNSET_STR;
-    std::string m_load_allowlist = RESOURCE_OPTS_UNSET_STR;
-    std::string m_match_policy = RESOURCE_OPTS_UNSET_STR;
-    std::string m_match_format = RESOURCE_OPTS_UNSET_STR;
-    std::string m_match_subsystems = RESOURCE_OPTS_UNSET_STR;
-    int m_reserve_vtx_vec = 0;
-    std::string m_prune_filters = RESOURCE_OPTS_UNSET_STR;
-    int m_update_interval = 0;
-    std::string m_traverser_policy = RESOURCE_OPTS_UNSET_STR;
-};
-
 /*! resource match option set class
  */
 class resource_opts_t : public optmgr_parse_t {
    public:
-    enum class resource_opts_key_t : int {
+    enum class opt_key_t : int {
         LOAD_FILE = 1,
         LOAD_FORMAT = 10,
         LOAD_ALLOWLIST = 20,
@@ -94,25 +41,23 @@ class resource_opts_t : public optmgr_parse_t {
         UNKNOWN = 5000
     };
 
-    // These constructors can throw std::bad_alloc exception
-    resource_opts_t ();
+    resource_opts_t () = default;
     resource_opts_t (const resource_opts_t &o) = default;
     resource_opts_t &operator= (const resource_opts_t &o) = default;
     // No exception is thrown from move constructor and move assignment
     resource_opts_t (resource_opts_t &&o) = default;
     resource_opts_t &operator= (resource_opts_t &&o) = default;
 
-    const std::string &get_load_file () const;
-    const std::string &get_load_format () const;
-    const std::string &get_load_allowlist () const;
-    const std::string &get_match_policy () const;
-    const std::string &get_match_format () const;
-    const std::string &get_match_subsystems () const;
-    const int get_reserve_vtx_vec () const;
-    const std::string &get_prune_filters () const;
-    const resource_prop_t &get_resource_prop () const;
-    const int get_update_interval () const;
-    const std::string &get_traverser_policy () const;
+    const std::optional<std::string> &get_load_file () const;
+    const std::optional<std::string> &get_load_format () const;
+    const std::optional<std::string> &get_load_allowlist () const;
+    const std::optional<std::string> &get_match_policy () const;
+    const std::optional<std::string> &get_match_format () const;
+    const std::optional<std::string> &get_match_subsystems () const;
+    const std::optional<int> &get_reserve_vtx_vec () const;
+    const std::optional<std::string> &get_prune_filters () const;
+    const std::optional<int> &get_update_interval () const;
+    const std::optional<std::string> &get_traverser_policy () const;
 
     void set_load_file (const std::string &o);
     bool set_load_format (const std::string &o);
@@ -122,19 +67,9 @@ class resource_opts_t : public optmgr_parse_t {
     void set_match_subsystems (const std::string &o);
     void set_reserve_vtx_vec (const int i);
     void set_prune_filters (const std::string &o);
+    void add_to_prune_filters (const std::string &o);
     void set_update_interval (const int i);
     bool set_traverser_policy (const std::string &o);
-
-    bool is_load_file_set () const;
-    bool is_load_format_set () const;
-    bool is_load_allowlist_set () const;
-    bool is_match_policy_set () const;
-    bool is_match_format_set () const;
-    bool is_match_subsystems_set () const;
-    bool is_reserve_vtx_vec_set () const;
-    bool is_prune_filters_set () const;
-    bool is_update_interval_set () const;
-    bool is_traverser_policy_set () const;
 
     /*! Canonicalize the option set -- apply the general resource properties
      */
@@ -180,11 +115,19 @@ class resource_opts_t : public optmgr_parse_t {
    private:
     bool is_number (const std::string &num_str);
 
-    // default queue properties
-    resource_prop_t m_resource_prop;
+    const static std::map<std::string, opt_key_t> opt_key_map;
 
-    // mapping each option to an integer
-    std::map<std::string, int> m_tab;
+    // resource module options
+    std::optional<std::string> m_load_file;
+    std::optional<std::string> m_load_format;
+    std::optional<std::string> m_load_allowlist;
+    std::optional<std::string> m_match_policy;
+    std::optional<std::string> m_match_format;
+    std::optional<std::string> m_match_subsystems;
+    std::optional<int> m_reserve_vtx_vec;
+    std::optional<std::string> m_prune_filters;
+    std::optional<int> m_update_interval;
+    std::optional<std::string> m_traverser_policy;
 };
 
 }  // namespace opts_manager


### PR DESCRIPTION
This PR is tentative and only open to gather opinions.

Problem: `resource_match_opts.*` has two related classes, `resource_opts_t` and `resource_prop_t`, which both share setters and getters for every option in the resource module.  `resource_opts_t` has a `resource_prop_t` member variable and calls `m_resource_prop.get_...()` in its own `resource_opts_t::get_...()` functions, and likewise for its `set`-ters and `is_set`-ters. This causes half of `resource_match_opts.*` to be boilerplate and makes it more difficult to add new module options.

Solution: `Make resource_opts_t` inherit from `rsrc_prop_t`, and replace all `resource_opts_t` function calls with the inherited `resource_prop_t` implementations. Remove the duplicated functions in `resource_match_opts.*`.

Is there a useful semantic relationship this change destroys? Is the decoupling of the module property data from its parsing logic desirable here?
Or could we take it farther and completely merge `resource_opts_t` and `resource_prop_t`?