### PR TITLE
reapi: fix match_satisfy reporting satisfiable on error

### DIFF
--- a/resource/reapi/bindings/c/reapi_cli.cpp
+++ b/resource/reapi/bindings/c/reapi_cli.cpp
@@ -244,8 +244,10 @@ extern "C" int reapi_cli_match_satisfy (reapi_cli_ctx_t *ctx,
 
     ret = reapi_cli_match (ctx, match_op, jobspec, &jobid, &reserved, &R, &at, ov);
 
-    // check for satisfiability
-    if (errno == ENODEV)
+    // Not satisfiable if the match reported unsatisfiable (ENODEV) or failed
+    // for any other reason (e.g. a jobspec referencing an unknown resource
+    // type).  A nonzero return must never be reported as satisfiable.
+    if (ret != 0)
         *sat = false;
 
     return ret;

--- a/resource/reapi/bindings/c/reapi_cli.h
+++ b/resource/reapi/bindings/c/reapi_cli.h
@@ -161,6 +161,9 @@ int reapi_cli_match_allocate (reapi_cli_ctx_t *ctx,
                               double *ov);
 
 /*! Run Satisfiability check for jobspec.
+ *  When sat is true, there is no error and the job is satisfiable.
+ *  When sat is false and there is no error, the job is not satisfiable.
+ *  When sat is false and there is an error, satisfiability is unknown.
  *
  *  \param ctx       reapi_cli_ctx_t context object
  *  \param jobspec   jobspec string.

--- a/resource/reapi/bindings/c/test/reapi_cli_test.c
+++ b/resource/reapi/bindings/c/test/reapi_cli_test.c
@@ -63,6 +63,14 @@ static const char *simple_jobspec =
     "\"attributes\": {\"system\": {\"duration\": 60.0}}"
     "}";
 
+static const char *jobspec_absent_type =
+    "{\"version\": 1,"
+    "\"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{"
+    "\"type\": \"slot\", \"count\": 1, \"label\": \"task\","
+    "\"with\": [{\"type\": \"core\", \"count\": 1}, {\"type\": \"mpi\", \"count\": 1}]}]}],"
+    "\"tasks\": [{\"command\": [\"app\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}],"
+    "\"attributes\": {\"system\": {\"duration\": 60.0}}}";
+
 static int test_clone ()
 {
     reapi_cli_ctx_t *ctx = reapi_cli_new ();
@@ -483,6 +491,37 @@ static int test_find ()
     return 0;
 }
 
+static int test_match_satisfy_absent_type ()
+{
+    reapi_cli_ctx_t *ctx = reapi_cli_new ();
+    if (!ctx)
+        BAIL_OUT ("reapi_cli_new failed");
+
+    int rc = reapi_cli_initialize (ctx, tiny_jgf, tiny_params);
+    if (rc < 0)
+        BAIL_OUT ("reapi_cli_initialize failed: %s", reapi_cli_get_err_msg (ctx));
+
+    bool sat = false;
+    double ov = 0.0;
+
+    // Sanity: a satisfiable request is reported satisfiable.
+    sat = false;
+    rc = reapi_cli_match_satisfy (ctx, simple_jobspec, &sat, &ov);
+    ok (rc == 0 && sat, "reapi_cli_match_satisfy: satisfiable request -> satisfiable");
+
+    // A request for a resource type absent from the graph must NOT be reported
+    // satisfiable.  reapi_cli_match_satisfy used to default *sat=true and clear
+    // it only for ENODEV, so a jobspec referencing an unknown type (which fails
+    // with errno != ENODEV) was wrongly reported satisfiable.
+    sat = true;
+    errno = 0;
+    rc = reapi_cli_match_satisfy (ctx, jobspec_absent_type, &sat, &ov);
+    ok (rc != 0 && !sat, "reapi_cli_match_satisfy: absent resource type -> unsatisfiable");
+
+    reapi_cli_destroy (ctx);
+    return 0;
+}
+
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
@@ -494,6 +533,7 @@ int main (int argc, char *argv[])
     test_null_parameters ();
     test_cancel_ex ();
     test_find ();
+    test_match_satisfy_absent_type ();
 
     done_testing ();
     return EXIT_SUCCESS;


### PR DESCRIPTION
This will fix https://github.com/flux-framework/flux-sched/issues/1521

Problem: reapi_cli_match_satisfy defaulted sat to true and only cleared it when errno == ENODEV. A jobspec that references a resource type absent from the graph fails in reapi_cli_match with a nonzero return and an errno other than ENODEV, so it was wrongly reported as satisfiable while the function also returned -1. If a user just checks sat, they are going to get back that a cluster can satisfy a type it does not even have.

Solution: I think the retval is closer to the source of truth. If an error happens, I do not see any case where this could be satisfied. So the change here reports sat=true only when the match is successful. I also added a C test.