### PR TITLE
dfu: prevent prune errno from overtaking traversal

### DIFF
--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -246,30 +246,35 @@ int dfu_impl_t::prune (const jobmeta_t &meta,
                        vtx_t u,
                        const std::vector<Jobspec::Resource> &resources)
 {
-    int rc = 0;
-
-    if ((rc = by_status (meta, u)) == -1) {
+    if (by_status (meta, u) == -1) {
         errno = EBUSY;
-        return rc;
+        return -1;
     }
 
-    if ((rc = by_constraint (meta, u)) == -1) {
+    if (by_constraint (meta, u) == -1) {
         // Constraint mismatch on this vertex - set EBUSY not ENODEV
         // because it doesn't mean the job is globally unsatisfiable,
         // just that this particular vertex doesn't match
         errno = EBUSY;
-        return rc;
+        return -1;
     }
 
     // if rack has been allocated exclusively, no reason to descend further.
-    if ((rc = by_avail (meta, s, u, resources)) == -1) {
+    if (by_avail (meta, s, u, resources) == -1) {
         // errno already set by by_avail
-        return rc;
+        // Resource availability insufficient under this vertex, set EBUSY
+        // rather than ERANGE because prune should never decide unsatisfiability
+        if (errno == ERANGE)
+            errno = EBUSY;
+        return -1;
     }
 
-    if ((rc = prune_resources (meta, exclusive, s, u, resources)) == -1) {
+    if (prune_resources (meta, exclusive, s, u, resources) == -1) {
         // errno already set by prune_resources
-        return rc;
+        // Prevent Unsatisfiable from escaping from planner again
+        if (errno == ERANGE)
+            errno = EBUSY;
+        return -1;
     }
 
     return 0;

--- a/t/data/resource/jgfs/tiny_storage.json
+++ b/t/data/resource/jgfs/tiny_storage.json
@@ -1,0 +1,1372 @@
+{
+  "graph": {
+    "directed": false,
+    "nodes": [
+      {
+        "id": "0",
+        "metadata": {
+          "type": "cluster",
+          "name": "compute",
+          "paths": {
+            "containment": "/compute"
+          }
+        }
+      },
+      {
+        "id": "1",
+        "metadata": {
+          "type": "chassis",
+          "id": 0,
+          "properties": {
+            "rabbit": "kind-worker2",
+            "ssdcount": "36"
+          },
+          "paths": {
+            "containment": "/compute/chassis0"
+          }
+        }
+      },
+      {
+        "id": "2",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd0"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "3",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd1"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "4",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd2"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "5",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd3"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "6",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd4"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "7",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd5"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "8",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd6"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "9",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd7"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "10",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd8"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "11",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd9"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "12",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd10"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "13",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd11"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "14",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd12"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "15",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd13"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "16",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd14"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "17",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd15"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "18",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd16"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "19",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd17"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "20",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd18"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "21",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd19"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "22",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd20"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "23",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd21"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "24",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd22"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "25",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd23"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "26",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd24"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "27",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd25"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "28",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd26"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "29",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd27"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "30",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd28"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "31",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd29"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "32",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd30"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "33",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd31"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "34",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd32"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "35",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd33"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "36",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd34"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "37",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 739,
+          "paths": {
+            "containment": "/compute/chassis0/ssd35"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "38",
+        "metadata": {
+          "type": "node",
+          "name": "compute-01",
+          "rank": 0,
+          "paths": {
+            "containment": "/compute/chassis0/compute-01"
+          }
+        }
+      },
+      {
+        "id": "39",
+        "metadata": {
+          "type": "core",
+          "id": 0,
+          "rank": 0,
+          "paths": {
+            "containment": "/compute/chassis0/compute-01/core0"
+          }
+        }
+      },
+      {
+        "id": "40",
+        "metadata": {
+          "type": "core",
+          "id": 1,
+          "rank": 0,
+          "paths": {
+            "containment": "/compute/chassis0/compute-01/core1"
+          }
+        }
+      },
+      {
+        "id": "41",
+        "metadata": {
+          "type": "core",
+          "id": 2,
+          "rank": 0,
+          "paths": {
+            "containment": "/compute/chassis0/compute-01/core2"
+          }
+        }
+      },
+      {
+        "id": "42",
+        "metadata": {
+          "type": "core",
+          "id": 3,
+          "rank": 0,
+          "paths": {
+            "containment": "/compute/chassis0/compute-01/core3"
+          }
+        }
+      },
+      {
+        "id": "43",
+        "metadata": {
+          "type": "core",
+          "id": 4,
+          "rank": 0,
+          "paths": {
+            "containment": "/compute/chassis0/compute-01/core4"
+          }
+        }
+      },
+      {
+        "id": "44",
+        "metadata": {
+          "type": "core",
+          "id": 5,
+          "rank": 0,
+          "paths": {
+            "containment": "/compute/chassis0/compute-01/core5"
+          }
+        }
+      },
+      {
+        "id": "45",
+        "metadata": {
+          "type": "core",
+          "id": 6,
+          "rank": 0,
+          "paths": {
+            "containment": "/compute/chassis0/compute-01/core6"
+          }
+        }
+      },
+      {
+        "id": "46",
+        "metadata": {
+          "type": "core",
+          "id": 7,
+          "rank": 0,
+          "paths": {
+            "containment": "/compute/chassis0/compute-01/core7"
+          }
+        }
+      },
+      {
+        "id": "47",
+        "metadata": {
+          "type": "core",
+          "id": 8,
+          "rank": 0,
+          "paths": {
+            "containment": "/compute/chassis0/compute-01/core8"
+          }
+        }
+      },
+      {
+        "id": "48",
+        "metadata": {
+          "type": "core",
+          "id": 9,
+          "rank": 0,
+          "paths": {
+            "containment": "/compute/chassis0/compute-01/core9"
+          }
+        }
+      },
+      {
+        "id": "49",
+        "metadata": {
+          "type": "chassis",
+          "id": 1,
+          "properties": {
+            "rabbit": "kind-worker3",
+            "ssdcount": "36"
+          },
+          "paths": {
+            "containment": "/compute/chassis1"
+          }
+        }
+      },
+      {
+        "id": "50",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd0"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "51",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd1"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "52",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd2"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "53",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd3"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "54",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd4"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "55",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd5"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "56",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd6"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "57",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd7"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "58",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd8"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "59",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd9"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "60",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd10"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "61",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd11"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "62",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd12"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "63",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd13"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "64",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd14"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "65",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd15"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "66",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd16"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "67",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd17"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "68",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd18"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "69",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd19"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "70",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd20"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "71",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd21"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "72",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd22"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "73",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd23"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "74",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd24"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "75",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd25"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "76",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd26"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "77",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd27"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "78",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd28"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "79",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd29"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "80",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd30"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "81",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd31"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "82",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd32"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "83",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd33"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "84",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd34"
+          },
+          "status": 1
+        }
+      },
+      {
+        "id": "85",
+        "metadata": {
+          "type": "ssd",
+          "unit": "GiB",
+          "size": 1024,
+          "paths": {
+            "containment": "/compute/chassis1/ssd35"
+          },
+          "status": 1
+        }
+      }
+    ],
+    "edges": [
+      {
+        "source": "0",
+        "target": "1"
+      },
+      {
+        "source": "1",
+        "target": "2"
+      },
+      {
+        "source": "1",
+        "target": "3"
+      },
+      {
+        "source": "1",
+        "target": "4"
+      },
+      {
+        "source": "1",
+        "target": "5"
+      },
+      {
+        "source": "1",
+        "target": "6"
+      },
+      {
+        "source": "1",
+        "target": "7"
+      },
+      {
+        "source": "1",
+        "target": "8"
+      },
+      {
+        "source": "1",
+        "target": "9"
+      },
+      {
+        "source": "1",
+        "target": "10"
+      },
+      {
+        "source": "1",
+        "target": "11"
+      },
+      {
+        "source": "1",
+        "target": "12"
+      },
+      {
+        "source": "1",
+        "target": "13"
+      },
+      {
+        "source": "1",
+        "target": "14"
+      },
+      {
+        "source": "1",
+        "target": "15"
+      },
+      {
+        "source": "1",
+        "target": "16"
+      },
+      {
+        "source": "1",
+        "target": "17"
+      },
+      {
+        "source": "1",
+        "target": "18"
+      },
+      {
+        "source": "1",
+        "target": "19"
+      },
+      {
+        "source": "1",
+        "target": "20"
+      },
+      {
+        "source": "1",
+        "target": "21"
+      },
+      {
+        "source": "1",
+        "target": "22"
+      },
+      {
+        "source": "1",
+        "target": "23"
+      },
+      {
+        "source": "1",
+        "target": "24"
+      },
+      {
+        "source": "1",
+        "target": "25"
+      },
+      {
+        "source": "1",
+        "target": "26"
+      },
+      {
+        "source": "1",
+        "target": "27"
+      },
+      {
+        "source": "1",
+        "target": "28"
+      },
+      {
+        "source": "1",
+        "target": "29"
+      },
+      {
+        "source": "1",
+        "target": "30"
+      },
+      {
+        "source": "1",
+        "target": "31"
+      },
+      {
+        "source": "1",
+        "target": "32"
+      },
+      {
+        "source": "1",
+        "target": "33"
+      },
+      {
+        "source": "1",
+        "target": "34"
+      },
+      {
+        "source": "1",
+        "target": "35"
+      },
+      {
+        "source": "1",
+        "target": "36"
+      },
+      {
+        "source": "1",
+        "target": "37"
+      },
+      {
+        "source": "1",
+        "target": "38"
+      },
+      {
+        "source": "38",
+        "target": "39"
+      },
+      {
+        "source": "38",
+        "target": "40"
+      },
+      {
+        "source": "38",
+        "target": "41"
+      },
+      {
+        "source": "38",
+        "target": "42"
+      },
+      {
+        "source": "38",
+        "target": "43"
+      },
+      {
+        "source": "38",
+        "target": "44"
+      },
+      {
+        "source": "38",
+        "target": "45"
+      },
+      {
+        "source": "38",
+        "target": "46"
+      },
+      {
+        "source": "38",
+        "target": "47"
+      },
+      {
+        "source": "38",
+        "target": "48"
+      },
+      {
+        "source": "0",
+        "target": "49"
+      },
+      {
+        "source": "49",
+        "target": "50"
+      },
+      {
+        "source": "49",
+        "target": "51"
+      },
+      {
+        "source": "49",
+        "target": "52"
+      },
+      {
+        "source": "49",
+        "target": "53"
+      },
+      {
+        "source": "49",
+        "target": "54"
+      },
+      {
+        "source": "49",
+        "target": "55"
+      },
+      {
+        "source": "49",
+        "target": "56"
+      },
+      {
+        "source": "49",
+        "target": "57"
+      },
+      {
+        "source": "49",
+        "target": "58"
+      },
+      {
+        "source": "49",
+        "target": "59"
+      },
+      {
+        "source": "49",
+        "target": "60"
+      },
+      {
+        "source": "49",
+        "target": "61"
+      },
+      {
+        "source": "49",
+        "target": "62"
+      },
+      {
+        "source": "49",
+        "target": "63"
+      },
+      {
+        "source": "49",
+        "target": "64"
+      },
+      {
+        "source": "49",
+        "target": "65"
+      },
+      {
+        "source": "49",
+        "target": "66"
+      },
+      {
+        "source": "49",
+        "target": "67"
+      },
+      {
+        "source": "49",
+        "target": "68"
+      },
+      {
+        "source": "49",
+        "target": "69"
+      },
+      {
+        "source": "49",
+        "target": "70"
+      },
+      {
+        "source": "49",
+        "target": "71"
+      },
+      {
+        "source": "49",
+        "target": "72"
+      },
+      {
+        "source": "49",
+        "target": "73"
+      },
+      {
+        "source": "49",
+        "target": "74"
+      },
+      {
+        "source": "49",
+        "target": "75"
+      },
+      {
+        "source": "49",
+        "target": "76"
+      },
+      {
+        "source": "49",
+        "target": "77"
+      },
+      {
+        "source": "49",
+        "target": "78"
+      },
+      {
+        "source": "49",
+        "target": "79"
+      },
+      {
+        "source": "49",
+        "target": "80"
+      },
+      {
+        "source": "49",
+        "target": "81"
+      },
+      {
+        "source": "49",
+        "target": "82"
+      },
+      {
+        "source": "49",
+        "target": "83"
+      },
+      {
+        "source": "49",
+        "target": "84"
+      },
+      {
+        "source": "49",
+        "target": "85"
+      }
+    ]
+  }
+}

--- a/t/t1020-qmanager-feasibility.t
+++ b/t/t1020-qmanager-feasibility.t
@@ -28,47 +28,44 @@ test_expect_success 'feasibility: --plugins=feasibility works ' '
         | jq -e ".errnum != 0"
 '
 
+run_sat_unsat() {
+    local label="$1"
+
+    test_expect_success "feasibility: unsatisfiable jobs are rejected ($label): 170 cores" '
+       test_must_fail flux submit -n 170 hostname 2>"err_${label}_cores" &&
+       grep "Unsatisfiable request" err_${label}_cores
+    '
+
+    test_expect_success "feasibility: unsatisfiable jobs are rejected ($label): 2 nodes" '
+       test_must_fail flux submit -N 2 -n2 hostname 2>"err_${label}_nodes" &&
+       grep "Unsatisfiable request" err_${label}_nodes
+    '
+
+    test_expect_success "feasibility: unsatisfiable jobs are rejected ($label): 1 gpu" '
+       test_must_fail flux submit -g 1 hostname 2>"err_${label}_gpu" &&
+       grep "Unsatisfiable request" err_${label}_gpu
+    '
+
+    test_expect_success "feasibility: satisfiable jobs are accepted ($label)" '
+        jobid=$(flux submit -n 8 hostname) &&
+        flux job wait-event -t 10 ${jobid} start &&
+        flux job wait-event -t 10 ${jobid} finish &&
+        flux job wait-event -t 10 ${jobid} release &&
+        flux job wait-event -t 10 ${jobid} clean
+    '
+}
+
 test_expect_success 'feasibility: loading job-ingest with feasibilty works' '
     flux module reload job-ingest validator-plugins=feasibility
  '
 
- test_expect_success 'feasibility: unsatisfiable jobs are rejected' '
-    test_must_fail flux submit -n 170 hostname 2>err1 &&
-    grep "Unsatisfiable request" err1 &&
-    test_must_fail flux submit -N 2 -n2 hostname 2>err2 &&
-    grep "Unsatisfiable request" err2 &&
-    test_must_fail flux submit -g 1 hostname 2>err3 &&
-    grep -i "Unsatisfiable request" err3
- '
-
-test_expect_success 'feasibility: satisfiable jobs are accepted' '
-    jobid=$(flux submit -n 8 hostname) &&
-    flux job wait-event -t 10 ${jobid} start &&
-    flux job wait-event -t 10 ${jobid} finish &&
-    flux job wait-event -t 10 ${jobid} release &&
-    flux job wait-event -t 10 ${jobid} clean
-'
+run_sat_unsat feasibility
 
 test_expect_success 'feasibility: load job-ingest with two validators' '
     flux module reload job-ingest validator-plugins=feasibility,jobspec
  '
 
- test_expect_success 'feasibility: unsatisfiable jobs are rejected' '
-    test_must_fail flux submit -n 170 hostname 2>err4 &&
-    grep "Unsatisfiable request" err4 &&
-    test_must_fail flux submit -N 2 -n2 hostname 2>err5 &&
-    grep "Unsatisfiable request" err5 &&
-    test_must_fail flux submit -g 1 hostname 2>err6 &&
-    grep -i "Unsatisfiable request" err6
- '
-
-test_expect_success 'feasibility: satisfiable jobs are accepted' '
-    jobid=$(flux submit -n 8 hostname) &&
-    flux job wait-event -t 10 ${jobid} start &&
-    flux job wait-event -t 10 ${jobid} finish &&
-    flux job wait-event -t 10 ${jobid} release &&
-    flux job wait-event -t 10 ${jobid} clean
-'
+run_sat_unsat feasibility_jobspec
 
 test_expect_success 'feasibility: cleanup active jobs' '
     cleanup_active_jobs

--- a/t/t3015-resource-basic-jgf.t
+++ b/t/t3015-resource-basic-jgf.t
@@ -7,6 +7,7 @@ test_description='Test Scheduling On Tiny Machine Configuration in JGF'
 cmd_dir="${SHARNESS_TEST_SRCDIR}/data/resource/commands/basics"
 exp_dir="${SHARNESS_TEST_SRCDIR}/data/resource/expected/basics"
 jgf="${SHARNESS_TEST_SRCDIR}/data/resource/jgfs/tiny.json"
+storage_jgf="${SHARNESS_TEST_SRCDIR}/data/resource/jgfs/tiny_storage.json"
 query="../../resource/utilities/resource-query"
 
 #
@@ -219,5 +220,66 @@ test_expect_success "${test048_desc}" '
     ${query} -L ${jgf} -f jgf -S CA -P first -t 048.R.out < cmds048 &&
     test_cmp 048.R.out ${exp_dir}/048.R.out
 '
+
+test_expect_success_hd 'ensure we do not get a traverser error on match allocate with imbalanced resources #1490' <<EOF
+    cat > jobspec.json <<END &&
+{
+  "resources": [
+    {
+      "type": "slot",
+      "count": 1,
+      "label": "rabbit",
+      "with": [
+        {
+          "type": "node",
+          "count": 1,
+          "with": [
+            {
+              "type": "slot",
+              "count": 1,
+              "with": [
+                {
+                  "type": "core",
+                  "count": 1
+                }
+              ],
+              "label": "task"
+            }
+          ]
+        },
+        {
+          "type": "ssd",
+          "count": 10245,
+          "exclusive": true
+        }
+      ]
+    }
+  ],
+  "tasks": [
+    {
+      "command": [
+        "hostname"
+      ],
+      "slot": "task",
+      "count": {
+        "per_slot": 1
+      }
+    }
+  ],
+  "attributes": {
+    "system": {
+      "duration": 0,
+      "cwd": "/home/user/",
+      "dw": "#DW jobdw capacity=10TiB type=lustre name=project2"
+    }
+  },
+  "version": 1
+}
+END
+    echo -e "m allocate_orelse_reserve jobspec.json\nquit" |
+        ${query} -L "${storage_jgf}" -f jgf -S CA -P first 2>&1 |
+        tee imbalance.out &&
+        test_must_fail grep 'ERROR: traverser:' imbalance.out
+EOF
 
 test_done


### PR DESCRIPTION
problem: errno set as part of pruning can become the overall errno of a dfu traversal if resources are considered after the last resources selected.  This can cause inappropriate error codes to be set which can result in unsatisfiable being returned when the result should be failure to allocate but satisfiable.

solution: save and restore errno in the prune function while we work out how to appropriately aggregate error values across the traversal as a whole.


fixes #1508 

CC @washwor1