### PR TITLE
reapi: drop sat output param from satisfy interfaces

### DIFF
--- a/resource/reapi/bindings/c/reapi_cli.cpp
+++ b/resource/reapi/bindings/c/reapi_cli.cpp
@@ -240,28 +240,19 @@ extern "C" int reapi_cli_match_allocate (reapi_cli_ctx_t *ctx,
     return reapi_cli_match (ctx, match_op, jobspec, jobid, reserved, R, at, ov);
 }
 
-extern "C" int reapi_cli_match_satisfy (reapi_cli_ctx_t *ctx,
-                                        const char *jobspec,
-                                        bool *sat,
-                                        double *ov)
+extern "C" int reapi_cli_match_satisfy (reapi_cli_ctx_t *ctx, const char *jobspec, double *ov)
 {
     match_op_t match_op = match_op_t::MATCH_SATISFIABILITY;
     uint64_t jobid;
     bool reserved;
     char *R;
     int64_t at;
-    int ret;
-    *sat = true;
 
-    ret = reapi_cli_match (ctx, match_op, jobspec, &jobid, &reserved, &R, &at, ov);
-
-    // Not satisfiable if the match reported unsatisfiable (ENODEV) or failed
-    // for any other reason (e.g. a jobspec referencing an unknown resource
-    // type).  A nonzero return must never be reported as satisfiable.
-    if (ret != 0)
-        *sat = false;
-
-    return ret;
+    if (reapi_cli_match (ctx, match_op, jobspec, &jobid, &reserved, &R, &at, ov) == 0)
+        return 0;
+    // The traverser reports an unsatisfiable request as ENODEV; any other
+    // errno is a genuine error (errno is left set for the caller).
+    return (errno == ENODEV) ? 1 : -1;
 }
 
 extern "C" int reapi_cli_update_allocate (reapi_cli_ctx_t *ctx,

--- a/resource/reapi/bindings/c/reapi_cli.h
+++ b/resource/reapi/bindings/c/reapi_cli.h
@@ -170,21 +170,13 @@ int reapi_cli_match_allocate (reapi_cli_ctx_t *ctx,
                               int64_t *at,
                               double *ov);
 
-/*! Run Satisfiability check for jobspec.
- *  When sat is true, there is no error and the job is satisfiable.
- *  When sat is false and there is no error, the job is not satisfiable.
- *  When sat is false and there is an error, satisfiability is unknown.
- *
+/*! Run a satisfiability check for jobspec.
  *  \param ctx       reapi_cli_ctx_t context object
  *  \param jobspec   jobspec string.
- *  \param sat       bool sat into which to return if jobspec is
- *                   satisfiable.
- *  \param ov        Double into which to return performance overhead
- *                   in terms of elapse time needed to complete
- *                   the match operation.
- *  \return          0 on success; -1 on error.
+ *  \param ov        Double into which to return the match overhead.
+ *  \return          0 if satisfiable; 1 if not satisfiable; -1 on error.
  */
-int reapi_cli_match_satisfy (reapi_cli_ctx_t *ctx, const char *jobspec, bool *sat, double *ov);
+int reapi_cli_match_satisfy (reapi_cli_ctx_t *ctx, const char *jobspec, double *ov);
 
 /*! Update the resource state with R.
  *

--- a/resource/reapi/bindings/c/test/reapi_cli_test.c
+++ b/resource/reapi/bindings/c/test/reapi_cli_test.c
@@ -71,6 +71,14 @@ static const char *jobspec_absent_type =
     "\"tasks\": [{\"command\": [\"app\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}],"
     "\"attributes\": {\"system\": {\"duration\": 60.0}}}";
 
+static const char *jobspec_too_many_cores =
+    "{\"version\": 1,"
+    "\"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{"
+    "\"type\": \"slot\", \"count\": 1, \"label\": \"task\","
+    "\"with\": [{\"type\": \"core\", \"count\": 2}]}]}],"
+    "\"tasks\": [{\"command\": [\"app\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}],"
+    "\"attributes\": {\"system\": {\"duration\": 60.0}}}";
+
 static int test_clone ()
 {
     reapi_cli_ctx_t *ctx = reapi_cli_new ();
@@ -491,7 +499,7 @@ static int test_find ()
     return 0;
 }
 
-static int test_match_satisfy_absent_type ()
+static int test_match_satisfy ()
 {
     reapi_cli_ctx_t *ctx = reapi_cli_new ();
     if (!ctx)
@@ -503,15 +511,23 @@ static int test_match_satisfy_absent_type ()
 
     double ov = 0.0;
 
-    // Sanity: a satisfiable request is reported satisfiable.
+    // Satisfiable request -> 0.
     rc = reapi_cli_match_satisfy (ctx, simple_jobspec, &ov);
     ok (rc == 0, "reapi_cli_match_satisfy: satisfiable request -> 0");
 
-    // A request for a resource type absent from the graph fails with an errno
-    // other than ENODEV, so it is an error rather than a plain "not
-    // satisfiable" result.
+    // Valid request the graph cannot satisfy (more cores than exist) -> 1.
+    // The traverser signals this by setting errno to ENODEV.
+    errno = 0;
+    rc = reapi_cli_match_satisfy (ctx, jobspec_too_many_cores, &ov);
+    ok (rc == 1 && errno == ENODEV,
+        "reapi_cli_match_satisfy: unsatisfiable request -> 1 with errno=ENODEV");
+
+    // Request referencing a resource type absent from the graph -> -1 (error).
+    // Any errno other than ENODEV means satisfiability is unknown.
+    errno = 0;
     rc = reapi_cli_match_satisfy (ctx, jobspec_absent_type, &ov);
-    ok (rc == -1, "reapi_cli_match_satisfy: absent resource type -> -1");
+    ok (rc == -1 && errno != ENODEV,
+        "reapi_cli_match_satisfy: absent resource type -> -1 with errno!=ENODEV");
 
     reapi_cli_destroy (ctx);
     return 0;
@@ -528,7 +544,7 @@ int main (int argc, char *argv[])
     test_null_parameters ();
     test_cancel_ex ();
     test_find ();
-    test_match_satisfy_absent_type ();
+    test_match_satisfy ();
 
     done_testing ();
     return EXIT_SUCCESS;

--- a/resource/reapi/bindings/c/test/reapi_cli_test.c
+++ b/resource/reapi/bindings/c/test/reapi_cli_test.c
@@ -501,22 +501,17 @@ static int test_match_satisfy_absent_type ()
     if (rc < 0)
         BAIL_OUT ("reapi_cli_initialize failed: %s", reapi_cli_get_err_msg (ctx));
 
-    bool sat = false;
     double ov = 0.0;
 
     // Sanity: a satisfiable request is reported satisfiable.
-    sat = false;
-    rc = reapi_cli_match_satisfy (ctx, simple_jobspec, &sat, &ov);
-    ok (rc == 0 && sat, "reapi_cli_match_satisfy: satisfiable request -> satisfiable");
+    rc = reapi_cli_match_satisfy (ctx, simple_jobspec, &ov);
+    ok (rc == 0, "reapi_cli_match_satisfy: satisfiable request -> 0");
 
-    // A request for a resource type absent from the graph must NOT be reported
-    // satisfiable.  reapi_cli_match_satisfy used to default *sat=true and clear
-    // it only for ENODEV, so a jobspec referencing an unknown type (which fails
-    // with errno != ENODEV) was wrongly reported satisfiable.
-    sat = true;
-    errno = 0;
-    rc = reapi_cli_match_satisfy (ctx, jobspec_absent_type, &sat, &ov);
-    ok (rc != 0 && !sat, "reapi_cli_match_satisfy: absent resource type -> unsatisfiable");
+    // A request for a resource type absent from the graph fails with an errno
+    // other than ENODEV, so it is an error rather than a plain "not
+    // satisfiable" result.
+    rc = reapi_cli_match_satisfy (ctx, jobspec_absent_type, &ov);
+    ok (rc == -1, "reapi_cli_match_satisfy: absent resource type -> -1");
 
     reapi_cli_destroy (ctx);
     return 0;

--- a/resource/reapi/bindings/go/src/fluxcli/reapi_cli.go
+++ b/resource/reapi/bindings/go/src/fluxcli/reapi_cli.go
@@ -160,32 +160,23 @@ func (cli *ReapiClient) MatchAllocate(
 	return cli.Match(match_op, jobspec)
 }
 
-// MatchSatisfy runs satisfiability check on jobspec.
-//
-//	\param jobspec   jobspec string.
-//	\param jobid     jobid of the uint64_t type.
-//	\param reserved  Boolean into which to return true if this job has been
-//	                 reserved instead of allocated.
-//	\param R         String into which to return the resource set either
-//	                 allocated or reserved.
-//	\param at        If allocated, 0 is returned; if reserved, actual time
-//	                 at which the job is reserved.
-//	\param ov        Double into which to return performance overhead
-//	                 in terms of elapse time needed to complete
-//	                 the match operation.
-//	\return          0 on success; -1 on error.
+// MatchSatisfy runs a satisfiability check on jobspec.
+// Returns 0 if satisfiable, 1 if not satisfiable, -1 on error (err is set).
 func (cli *ReapiClient) MatchSatisfy(
 	jobspec string,
-) (sat bool, overhead float64, err error) {
+) (int, float64, error) {
+	var overhead float64
 	spec := C.CString(jobspec)
+	defer C.free(unsafe.Pointer(spec))
 
-	fluxerr := (int)(C.reapi_cli_match_satisfy((*C.struct_reapi_cli_ctx)(cli.ctx),
+	rc := (int)(C.reapi_cli_match_satisfy((*C.struct_reapi_cli_ctx)(cli.ctx),
 		spec,
-		(*C.bool)(&sat),
 		(*C.double)(&overhead)))
 
-	err = retvalToError(fluxerr, "issue resource api client matching satisfy")
-	return sat, overhead, err
+	if rc < 0 {
+		return rc, overhead, retvalToError(rc, "issue resource api client matching satisfy")
+	}
+	return rc, overhead, nil
 }
 
 // UpdateAllocate updates the resource state with R.

--- a/resource/reapi/bindings/go/src/fluxcli/reapi_cli_test.go
+++ b/resource/reapi/bindings/go/src/fluxcli/reapi_cli_test.go
@@ -12,10 +12,61 @@ package fluxcli
 
 import "testing"
 
+// A minimal resource graph: one cluster -> one node -> one core.
+const tinyJGF = `{"graph": {"nodes": [` +
+	`{"id": "0", "metadata": {"type": "cluster", "basename": "tiny", "name": "tiny0", "size": 1, "paths": {"containment": "/tiny0"}}},` +
+	`{"id": "1", "metadata": {"type": "node", "basename": "node", "name": "node0", "size": 1, "rank": 0, "paths": {"containment": "/tiny0/node0"}}},` +
+	`{"id": "2", "metadata": {"type": "core", "basename": "core", "name": "core0", "size": 1, "id": 0, "rank": 0, "paths": {"containment": "/tiny0/node0/core0"}}}` +
+	`], "edges": [{"source": "0", "target": "1"}, {"source": "1", "target": "2"}]}}`
+
+const tinyParams = `{"load_format": "jgf", "matcher_policy": "high", "match_format": "rv1", "matcher_name": "CA"}`
+
+// Fits the graph exactly (1 core): satisfiable.
+const satisfiableJobspec = `{"version": 1, "resources": [{"type": "node", "count": 1, "with": [` +
+	`{"type": "slot", "count": 1, "label": "task", "with": [{"type": "core", "count": 1}]}]}],` +
+	`"tasks": [{"command": ["sleep", "0"], "slot": "task", "count": {"per_slot": 1}}],` +
+	`"attributes": {"system": {"duration": 60.0}}}`
+
+// Valid but asks for more cores than exist: not satisfiable (traverser ENODEV).
+const unsatisfiableJobspec = `{"version": 1, "resources": [{"type": "node", "count": 1, "with": [` +
+	`{"type": "slot", "count": 1, "label": "task", "with": [{"type": "core", "count": 2}]}]}],` +
+	`"tasks": [{"command": ["app"], "slot": "task", "count": {"per_slot": 1}}],` +
+	`"attributes": {"system": {"duration": 60.0}}}`
+
+// References a resource type absent from the graph: a genuine error, not a
+// plain "not satisfiable" result (traverser errno is not ENODEV).
+const errorJobspec = `{"version": 1, "resources": [{"type": "node", "count": 1, "with": [` +
+	`{"type": "slot", "count": 1, "label": "task", "with": [{"type": "core", "count": 1}, {"type": "mpi", "count": 1}]}]}],` +
+	`"tasks": [{"command": ["app"], "slot": "task", "count": {"per_slot": 1}}],` +
+	`"attributes": {"system": {"duration": 60.0}}}`
+
 func TestFluxcli(t *testing.T) {
 	cli := NewReapiClient()
 	if !cli.HasContext() {
 		t.Errorf("Context is null")
 	}
+}
 
+// TestMatchSatisfy exercises the three-way result of MatchSatisfy: 0
+// (satisfiable), 1 (not satisfiable), and -1 (error).
+func TestMatchSatisfy(t *testing.T) {
+	cli := NewReapiClient()
+	if err := cli.InitContext(tinyJGF, tinyParams); err != nil {
+		t.Fatalf("InitContext failed: %v", err)
+	}
+
+	// Satisfiable request -> 0 with a nil error.
+	if code, _, err := cli.MatchSatisfy(satisfiableJobspec); code != 0 || err != nil {
+		t.Errorf("satisfiable jobspec: want (0, nil), got (%d, %v)", code, err)
+	}
+
+	// Unsatisfiable request -> 1 with a nil error (not a failure).
+	if code, _, err := cli.MatchSatisfy(unsatisfiableJobspec); code != 1 || err != nil {
+		t.Errorf("unsatisfiable jobspec: want (1, nil), got (%d, %v)", code, err)
+	}
+
+	// Genuine error -> -1 with a non-nil error.
+	if code, _, err := cli.MatchSatisfy(errorJobspec); code != -1 || err == nil {
+		t.Errorf("bad jobspec: want (-1, non-nil error), got (%d, %v)", code, err)
+	}
 }

--- a/resource/reapi/bindings/go/src/test/main.go
+++ b/resource/reapi/bindings/go/src/test/main.go
@@ -89,14 +89,9 @@ func main() {
 	}
 	printOutput(reserved, allocated, at, jobid, err)
 
-	sat, overhead, err := cli.MatchSatisfy(string(jobspec))
+	code, overhead, err := cli.MatchSatisfy(string(jobspec))
 	fmt.Println("Errors so far: \n", cli.GetErrMsg())
-
-	if err != nil {
-		fmt.Printf("Error in ReapiClient MatchAllocate: %v\n", err)
-		return
-	}
-	printSatOutput(sat, err)
+	printSatOutput(code, err)
 
 	err = cli.Cancel(1, false)
 	if err != nil {
@@ -126,7 +121,7 @@ func printOutput(reserved bool, allocated string, at int64, jobid uint64, err er
 	fmt.Printf("jobid: %d\nreserved: %t\nallocated: %s\nat: %d\nerror: %v\n", jobid, reserved, allocated, at, err)
 }
 
-func printSatOutput(sat bool, err error) {
+func printSatOutput(code int, err error) {
 	fmt.Println("\n\t----Match Satisfy output---")
-	fmt.Printf("satisfied: %t\nerror: %v\n", sat, err)
+	fmt.Printf("result (0=satisfiable, 1=not satisfiable, -1=error): %d\nerror: %v\n", code, err)
 }

--- a/resource/reapi/test/reapi_cli_test_c.cpp
+++ b/resource/reapi/test/reapi_cli_test_c.cpp
@@ -141,7 +141,7 @@ TEST_CASE ("Initialize REAPI CLI and test match, satisfy, and cancel",
                                  + "/data/resource/jobspecs/basics/test011.yaml");
     match_op_t match_op = match_op_t::MATCH_ALLOCATE;
     uint64_t jobid, jobid2, jobid3;
-    bool reserved, satisfiable;
+    bool reserved;
     char *R = nullptr, *mode = nullptr;
     int64_t at;
     double ov;
@@ -184,12 +184,10 @@ TEST_CASE ("Initialize REAPI CLI and test match, satisfy, and cancel",
     INFO (reapi_cli_get_err_msg (ctx));
 
     // Test satisfy
-    CHECK (reapi_cli_match_satisfy (ctx, jobspec.c_str (), &satisfiable, &ov) == 0);
-    CHECK (satisfiable == true);
+    CHECK (reapi_cli_match_satisfy (ctx, jobspec.c_str (), &ov) == 0);
 
     // Test satisfy with unsatisfiable jobspec
-    CHECK (reapi_cli_match_satisfy (ctx, jobspec2.c_str (), &satisfiable, &ov) != 0);
-    CHECK (satisfiable == false);
+    CHECK (reapi_cli_match_satisfy (ctx, jobspec2.c_str (), &ov) != 0);
 
     // Test info with valid jobid
     CHECK (reapi_cli_info (ctx, jobid2, &mode, &reserved, &at, &ov) == 0);


### PR DESCRIPTION
Problem: We currently return a sat boolean along with an error for our reapi satisfy interfaces. This is problematic as it introduces a matrix of possibly outcomes, where an outcome such as a satisfied job with an error becomes confusing.

Solution: return a single error code, where 0 == satisfied, 1 == not satisfied, and -1 == error (and satisfiability is unknown). This update changes the Go and C interfaces. We also update the C unit test, the Go example caller, and add a fluxcli unit test to cover all cases.

I realized that the called function `reapi_cli_match_satisfy` in the Go SDK itself was not returning the granularity we discussed - it was just a 0 or -1, and we could not determine a call that did not error but did not satisfy. I think to fix this we need to look for a -1 with the error `ENODEV` per [here](https://github.com/flux-framework/flux-sched/blob/7b7315a420ead319822028128a50d037de449764/resource/traversers/dfu.cpp#L47-L56) and [here](https://github.com/flux-framework/flux-sched/blob/7b7315a420ead319822028128a50d037de449764/resource/traversers/dfu.cpp#L84-L88).

- Follow up to https://github.com/flux-framework/flux-sched/pull/1522.
- I will keep rebase / push until testing issues pass.

We probably need to look at our go docstrings too. The [convention](https://go.dev/doc/comment#func) I see most often is like:

```go
// FuncName does this thing.
// It returns something else.
func FuncName(input []byte) (name string, size int, err error) {
	// ... function body
	return somethingElse, nil
}
```

e.g.,

```go
// ProcessData executes a specific operation on the provided input payload.
// It returns the newly generated unique identifier string, the calculated 
// total size of the output payload, and any processing error encountered.
// If the input byte slice is empty, it returns 0 and ErrInvalidPayload.
func ProcessData(input []byte) (id string, size int, err error) {
	// ... function body
	return id, size, nil
}
```

And not to have the entire repeated docstring with parameters again. I wrote satisfy for how I want to suggest it can be. 