### PR TITLE
qmanager: annotate jobs with `sched.selection_type` and update `t_estimate` for jobs

### DIFF
--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -110,12 +110,19 @@ int qmanager_cb_t::post_sched_loop (
             if (job->schedule.at == job->schedule.old_at)
                 continue;
             job->schedule.old_at = job->schedule.at;
+            // Reserved jobs receive a t_estimate annotation while they wait
+            // for their reserved time.  Report selection_type here too so that
+            // a job that is only ever reserved (and never allocated) still has
+            // its RFC 27 sched.selection_type recorded, rather than only being
+            // reported on the eventual alloc SUCCESS response.
             if (schedutil_alloc_respond_annotate_pack (schedutil,
                                                        job->msg,
-                                                       "{ s:{s:f} }",
+                                                       "{ s:{s:f s:s} }",
                                                        "sched",
                                                        "t_estimate",
-                                                       static_cast<double> (job->schedule.at))) {
+                                                       static_cast<double> (job->schedule.at),
+                                                       "selection_type",
+                                                       job_selection_type_str (job->schedule.selection_type))) {
                 flux_log_error (h, "%s: schedutil_alloc_respond_annotate_pack", __FUNCTION__);
                 goto out;
             }

--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -62,12 +62,23 @@ int qmanager_cb_t::post_sched_loop (
         const std::string &queue_name = kv.first;
         std::shared_ptr<queue_policy_base_t> &queue = kv.second;
         while ((job = queue->alloced_pop ()) != nullptr) {
+            // Record how the job was started (immediate, backfill, or
+            // reserved) as a scheduler annotation in the RFC 27 "sched"
+            // namespace.  Annotations carried on the alloc SUCCESS response
+            // are snapshotted into the job's "alloc" event and thus
+            // preserved in the job record.  t_estimate is nulled here to
+            // clear any volatile start-time estimate now that the job has
+            // been allocated.
             if (schedutil_alloc_respond_success_pack (schedutil,
                                                       job->msg,
                                                       job->schedule.R.c_str (),
-                                                      "{ s:{s:n} }",
+                                                      "{ s:{s:n s:s} }",
                                                       "sched",
-                                                      "t_estimate")
+                                                      "t_estimate",
+                                                      // NULL from format string
+                                                      "selection_type",
+                                                      job_selection_type_str (
+                                                          job->schedule.selection_type))
                 < 0) {
                 flux_log_error (h,
                                 "%s: schedutil_alloc_respond_pack (queue=%s)",

--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -106,25 +106,54 @@ int qmanager_cb_t::post_sched_loop (
         for (job = queue->pending_begin (), qd = 0;
              job != nullptr && qd < queue->get_queue_depth ();
              job = queue->pending_next (), qd++) {
-            // if old_at == at, then no reason to send this annotation again.
-            if (job->schedule.at == job->schedule.old_at)
-                continue;
-            job->schedule.old_at = job->schedule.at;
-            // Reserved jobs receive a t_estimate annotation while they wait
-            // for their reserved time.  Report selection_type here too so that
-            // a job that is only ever reserved (and never allocated) still has
-            // its RFC 27 sched.selection_type recorded, rather than only being
-            // reported on the eventual alloc SUCCESS response.
-            if (schedutil_alloc_respond_annotate_pack (schedutil,
-                                                       job->msg,
-                                                       "{ s:{s:f s:s} }",
-                                                       "sched",
-                                                       "t_estimate",
-                                                       static_cast<double> (job->schedule.at),
-                                                       "selection_type",
-                                                       job_selection_type_str (job->schedule.selection_type))) {
-                flux_log_error (h, "%s: schedutil_alloc_respond_annotate_pack", __FUNCTION__);
-                goto out;
+            // only send an annotation when the start-time estimate has
+            // changed since the last successfully transmitted one.
+            if (job->schedule.at != job->schedule.old_at) {
+                if (job->schedule.at > 0) {
+                    // Reserved jobs receive a t_estimate annotation while they
+                    // wait for their reserved time.  Report selection_type
+                    // here too so that a job that is only ever reserved (and
+                    // never allocated) still has its RFC 27
+                    // sched.selection_type recorded, rather than only being
+                    // reported on the eventual alloc SUCCESS response.
+                    if (schedutil_alloc_respond_annotate_pack (schedutil,
+                                                               job->msg,
+                                                               "{ s:{s:f s:s} }",
+                                                               "sched",
+                                                               "t_estimate",
+                                                               static_cast<double> (
+                                                                   job->schedule.at),
+                                                               "selection_type",
+                                                               job_selection_type_str (
+                                                                   job->schedule.selection_type))) {
+                        flux_log_error (h,
+                                        "%s: schedutil_alloc_respond_annotate_pack",
+                                        __FUNCTION__);
+                        goto out;
+                    }
+                } else {
+                    // The job lost its reservation this loop (it could be
+                    // neither allocated nor reserved), so its previously
+                    // reported start-time estimate is now stale.  A JSON null
+                    // value deletes the key in the job manager, so both
+                    // t_estimate and selection_type are cleared rather than
+                    // left displaying an incorrect eta (#1424).
+                    if (schedutil_alloc_respond_annotate_pack (schedutil,
+                                                               job->msg,
+                                                               "{ s:{s:n s:n} }",
+                                                               "sched",
+                                                               "t_estimate",
+                                                               "selection_type")) {
+                        flux_log_error (h,
+                                        "%s: schedutil_alloc_respond_annotate_pack",
+                                        __FUNCTION__);
+                        goto out;
+                    }
+                }
+                // record the transmitted value only after a successful send
+                // so that a failed annotation is retried on the next
+                // post_sched_loop rather than being silently dropped.
+                job->schedule.old_at = job->schedule.at;
             }
         }
         queue->reset_scheduled ();
@@ -515,7 +544,8 @@ void qmanager_cb_t::prep_watcher_cb (flux_reactor_t *r, flux_watcher_t *w, int r
     for (auto &kv : ctx->queues) {
         std::shared_ptr<queue_policy_base_t> &queue = kv.second;
         ctx->pls_sched_loop = ctx->pls_sched_loop || queue->is_schedulable ();
-        ctx->pls_post_loop = ctx->pls_post_loop || queue->is_scheduled ();
+        ctx->pls_post_loop =
+            ctx->pls_post_loop || queue->is_scheduled () || queue->is_annotation_dirty ();
     }
     if (ctx->pls_sched_loop || ctx->pls_post_loop)
         flux_watcher_start (ctx->idle);

--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -815,11 +815,22 @@ class queue_policy_base_t : public resource_model::queue_adapter_base_t {
         return m_scheduled;
     }
 
-    /*! Reset this queue's "scheduled" state.
+    /*! Return true if a job annotation has changed (e.g. a stale
+     *  t_estimate was cleared) and post_sched_loop must run to transmit
+     *  it, even though no job was scheduled.  Unlike is_scheduled (),
+     *  this does not cause the scheduling loop to be restarted.
+     */
+    bool is_annotation_dirty ()
+    {
+        return m_annotation_dirty;
+    }
+
+    /*! Reset this queue's "scheduled" and "annotation dirty" states.
      */
     void reset_scheduled ()
     {
         m_scheduled = false;
+        m_annotation_dirty = false;
     }
 
     /*! Implement queue_adapter_base_t's pure virtual method
@@ -1192,6 +1203,7 @@ class queue_policy_base_t : public resource_model::queue_adapter_base_t {
 
     bool m_schedulable = false;
     bool m_scheduled = false;
+    bool m_annotation_dirty = false;
     bool m_sched_loop_active = false;
     uint64_t m_pq_cnt = 0;
     uint64_t m_rq_cnt = 0;

--- a/qmanager/policies/base/queue_policy_base.hpp
+++ b/qmanager/policies/base/queue_policy_base.hpp
@@ -38,6 +38,20 @@ namespace queue_manager {
 
 enum class job_state_kind_t { INIT, PENDING, REJECTED, RUNNING, ALLOC_RUNNING, CANCELED, COMPLETE };
 
+/*! How a job was ultimately started by the scheduler.
+ *  UNKNOWN:   not yet allocated (or fcfs before allocation).
+ *  IMMEDIATE: allocated on the first scheduling attempt with no prior
+ *             reservations in the current backfill loop.
+ *  BACKFILL:  allocated after one or more other jobs had been reserved
+ *             ahead of it in the current loop.
+ *  RESERVED:  allocated from a previous reservation if in the ALLOC
+ *             state, or retained for a future reservation if annotation
+ *             shown in the SCHED state. Note this state can be posted,
+ *             then later cleared in the SCHED state if the reservation
+ *             is lost.
+ */
+enum class job_selection_type_t { UNKNOWN, IMMEDIATE, BACKFILL, RESERVED };
+
 /*! Type to store schedule information such as the
  *  allocated or reserved (for backfill) resource set (R).
  */
@@ -52,10 +66,29 @@ struct schedule_t {
     schedule_t &operator= (const schedule_t &s) = default;
     std::string R = "";
     bool reserved = false;
+    bool was_reserved = false;
+    job_selection_type_t selection_type = job_selection_type_t::UNKNOWN;
     int64_t at = 0;
     int64_t old_at = 0;
     double ov = 0.0f;
 };
+
+/*! Map a job_selection_type_t to the string reported in the RFC 27
+ *  sched.selection_type annotation on the alloc SUCCESS response.
+ */
+inline const char *job_selection_type_str (job_selection_type_t mode)
+{
+    switch (mode) {
+        case job_selection_type_t::IMMEDIATE:
+            return "immediate";
+        case job_selection_type_t::BACKFILL:
+            return "backfill";
+        case job_selection_type_t::RESERVED:
+            return "reserved";
+        default:
+            return "unknown";
+    }
+}
 
 /*! Type to store various time stamps for queuing
  */

--- a/qmanager/policies/queue_policy_bf_base_impl.hpp
+++ b/qmanager/policies/queue_policy_bf_base_impl.hpp
@@ -159,8 +159,11 @@ int queue_policy_bf_base_t<reapi_type>::handle_match_success (flux_jobid_t jobid
         // High-priority job has been reserved, continue.  Remember that this
         // job was reserved for a future time so that when it is ultimately
         // allocated (possibly in a later scheduling loop) it is categorized
-        // as "reserved" rather than "backfill" or "immediate".
+        // as "reserved" rather than "backfill" or "immediate".  Categorize it
+        // as "reserved" now as well so that the selection_type can be reported
+        // alongside the t_estimate annotation transmitted while the job waits.
         sched.was_reserved = true;
+        sched.selection_type = job_selection_type_t::RESERVED;
         m_reserved.insert (std::pair<uint64_t, flux_jobid_t> (m_oq_cnt++, job->id));
         m_reservation_cnt++;
         m_in_progress_iter++;

--- a/qmanager/policies/queue_policy_bf_base_impl.hpp
+++ b/qmanager/policies/queue_policy_bf_base_impl.hpp
@@ -156,13 +156,28 @@ int queue_policy_bf_base_t<reapi_type>::handle_match_success (flux_jobid_t jobid
     sched.at = at;
     sched.ov = ov;
     if (job->schedule.reserved) {
-        // High-priority job has been reserved, continue
+        // High-priority job has been reserved, continue.  Remember that this
+        // job was reserved for a future time so that when it is ultimately
+        // allocated (possibly in a later scheduling loop) it is categorized
+        // as "reserved" rather than "backfill" or "immediate".
+        sched.was_reserved = true;
         m_reserved.insert (std::pair<uint64_t, flux_jobid_t> (m_oq_cnt++, job->id));
         m_reservation_cnt++;
         m_in_progress_iter++;
         // reply with an annotation
         m_scheduled = true;
     } else {
+        // The job is being allocated now.  Categorize how it was started:
+        //   reserved  - this job had previously been reserved for the future
+        //   backfill  - a higher-priority job was reserved ahead of it in
+        //               this loop, so it was backfilled past that reservation
+        //   immediate - allocated with no reservations standing in its way
+        if (sched.was_reserved)
+            sched.selection_type = job_selection_type_t::RESERVED;
+        else if (m_reservation_cnt > 0)
+            sched.selection_type = job_selection_type_t::BACKFILL;
+        else
+            sched.selection_type = job_selection_type_t::IMMEDIATE;
         // move the job to the running queue and make sure the
         // job is enqueued into allocated job queue as well.
         // When this is used within a module, it allows the

--- a/qmanager/policies/queue_policy_bf_base_impl.hpp
+++ b/qmanager/policies/queue_policy_bf_base_impl.hpp
@@ -213,6 +213,35 @@ int queue_policy_bf_base_t<reapi_type>::handle_match_failure (flux_jobid_t jobid
 
         // copy iterator before we advance to avoid invalidation
         auto element_iter = m_in_progress_iter;
+        auto job_it = m_jobs.find (element_iter->second);
+        if (job_it == m_jobs.end ()) {
+            // The job is just missing, much worse
+            errno = ENOENT;
+            return -1;
+        }
+        // N.B. unlike handle_match_success, jobid cannot be validated here:
+        // the failure response does not carry a jobid (the callback receives
+        // its initialization value of -1), so only the in-progress iterator
+        // identifies the job.
+        auto &job = job_it->second;
+        // This job could be neither allocated nor reserved this loop, so it no
+        // longer has a valid start-time estimate.  Clear it so post_sched_loop
+        // detects the change and sends a null sched.t_estimate annotation,
+        // removing any stale eta that was reported while the job was previously
+        // reserved (issue #1424).  was_reserved is also cleared: the job lost
+        // its reservation, so its eventual allocation should be categorized by
+        // how it actually starts (reserved/backfill/immediate) rather than by
+        // the reservation it once held.  Flag m_annotation_dirty so the check
+        // watcher actually runs post_sched_loop after this loop ends; otherwise
+        // the clearing annotation would sit untransmitted until the next
+        // unrelated scheduling event.
+        auto &fsched = job->schedule;
+        if (fsched.at != 0) {
+            fsched.at = 0;
+            fsched.selection_type = job_selection_type_t::UNKNOWN;
+            fsched.was_reserved = false;
+            m_annotation_dirty = true;
+        }
         // if we are allocating and not trying to reserve, as in FCFS for
         // example, EBUSY means the request failed because not enough
         // resources are available right now.

--- a/qmanager/policies/queue_policy_fcfs_impl.hpp
+++ b/qmanager/policies/queue_policy_fcfs_impl.hpp
@@ -110,6 +110,8 @@ int queue_policy_fcfs_t<reapi_type>::handle_match_success (flux_jobid_t jobid,
     job->schedule.R = R;
     job->schedule.at = at;
     job->schedule.ov = ov;
+    // fcfs does not backfill or reserve, so any allocation is immediate.
+    job->schedule.selection_type = job_selection_type_t::IMMEDIATE;
     m_iter = to_running (m_iter, true);
     return 0;
 }

--- a/t/issues/t1424-t_estimate-lost-reservation.sh
+++ b/t/issues/t1424-t_estimate-lost-reservation.sh
@@ -1,0 +1,95 @@
+#!/bin/bash -e
+#
+#  Issue #1424: under the easy backfill policy, a reserved job advertises
+#  its start-time estimate via the sched.t_estimate annotation, which
+#  `flux jobs` displays as an eta.  If the job later loses its reservation
+#  because newly submitted higher-urgency jobs take the single reservation
+#  slot, the now-stale estimate must be cleared so `flux jobs` stops
+#  displaying an incorrect eta.
+#
+
+log() { printf "issue#1424: $@\n" >&2; }
+
+# Run in a fresh instance so we can swap schedulers freely
+if test "$ISSUE_1424_ACTIVE" != "t"; then
+    export ISSUE_1424_ACTIVE=t
+    log "Re-launching test script under flux-start"
+    exec flux start -Sbroker.module-nopanic=1 $0
+fi
+
+# `flux jobs` renders sched.t_estimate in the INFO column as "eta:<fsd>"
+# (or "eta:now" once the estimated time has passed) for jobs in SCHED state.
+eta() {
+    flux jobs -no "{contextual_info}" $1
+}
+
+has_eta() {
+    eta $1 | grep -q "eta:"
+}
+
+no_eta() {
+    ! has_eta $1
+}
+
+selection_type_absent() {
+    test "$(flux job list-ids "$1" |
+        jq -r '(.annotations.sched // {}) |
+               has("selection_type") | not')" = "true"
+}
+
+# Annotation updates are not posted to the eventlog, so poll.
+wait_for() {
+    local i=0
+    while ! "$@"; do
+        i=$((i+1))
+        test $i -ge 50 && return 1
+        sleep 0.2
+    done
+    return 0
+}
+
+log "loading fluxion with easy backfill policy"
+flux module remove sched-simple
+flux module load sched-fluxion-resource
+flux module load sched-fluxion-qmanager queue-policy=easy
+
+log "submitting squatter job to occupy the node"
+squatter=$(flux submit -x -N1 -n1 -t 600s --job-name=squatter sleep inf)
+flux job wait-event -t 30 ${squatter} start
+
+log "submitting low-urgency job (demoted), blocked behind squatter"
+demoted=$(flux submit --urgency=1 -x -N1 -n1 -t 60s --job-name=demoted sleep inf)
+
+log "waiting for demoted to be reserved and show an eta"
+wait_for has_eta ${demoted}
+log "demoted: '$(eta ${demoted})'"
+
+# With easy backfill the reservation depth is effectively 1, so once
+# highest and higher are submitted only the highest-urgency job should
+# hold the reservation and an eta; demoted's eta is now stale and must
+# be cleared, and higher is skipped without ever getting an eta.
+log "submitting higher-urgency jobs to displace demoted's reservation"
+highest=$(flux submit --urgency=6 -x -N1 -n1 -t 60s --job-name=highest sleep inf)
+higher=$(flux submit --urgency=4 -x -N1 -n1 -t 60s --job-name=higher sleep inf)
+
+log "waiting for demoted's stale eta to be cleared"
+wait_for no_eta ${demoted}
+log "verifying that selection_type was cleared when stale eta was cleared"
+selection_type_absent ${demoted}
+log "waiting for highest to gain an eta"
+wait_for has_eta ${highest}
+if has_eta ${higher}; then
+    log "ERROR: higher unexpectedly has an eta: '$(eta ${higher})'"
+    exit 1
+fi
+log "demoted: '$(eta ${demoted})' highest: '$(eta ${highest})' higher: '$(eta ${higher})'"
+
+flux jobs -ao "{id.f58:>12} {urgency:<3} {status_abbrev:<2} {contextual_info}" >&2
+
+log "cleaning up"
+flux cancel ${squatter} ${demoted} ${highest} ${higher}
+flux job wait-event -t 30 ${higher} clean
+
+flux module remove sched-fluxion-qmanager
+flux module remove sched-fluxion-resource
+flux module load sched-simple

--- a/t/t1004-qmanager-optimize.t
+++ b/t/t1004-qmanager-optimize.t
@@ -68,6 +68,12 @@ test_expect_success 'qmanager: selection_type is immediate and backfill' '
     test "$(selection_type ${jobid7})" = "backfill" &&
     test "$(selection_type ${jobid8})" = "backfill"
 '
+# jobid2 was reserved but has not started; its selection_type is now
+# transmitted alongside the t_estimate annotation while it waits, so it
+# reads "reserved" before it is ever allocated.
+test_expect_success 'qmanager: reserved job is annotated while pending' '
+    test "$(selection_type ${jobid2})" = "reserved"
+'
 test_expect_success 'qmanager: selection_type is reserved' '
     flux cancel ${jobid1} &&
     flux job wait-event -t 10 ${jobid2} start &&

--- a/t/t1004-qmanager-optimize.t
+++ b/t/t1004-qmanager-optimize.t
@@ -15,6 +15,25 @@ selection_type() {
     flux job list-ids $1 | jq -r ".annotations.sched.selection_type"
 }
 
+t_estimate() {
+    flux job list-ids $1 | jq -r ".annotations.sched.t_estimate"
+}
+
+selection_type_is() {
+    test "$(selection_type $1)" = "$2"
+}
+
+# Annotation updates are not posted to the eventlog, so poll.
+wait_for() {
+    wf_i=0
+    while ! "$@"; do
+        wf_i=$((wf_i+1))
+        test ${wf_i} -ge 50 && return 1
+        sleep 0.2
+    done
+    return 0
+}
+
 exec_test()     { ${jq} '.attributes.system.exec.test = {}'; }
 
 test_expect_success 'qmanager: generate jobspecs of varying requirements' '
@@ -80,6 +99,56 @@ test_expect_success 'qmanager: selection_type is reserved' '
     test "$(selection_type ${jobid2})" = "reserved"
 '
 test_expect_success 'qmanager: cleanup all active jobs' '
+    cleanup_active_jobs
+'
+# A reserved job advertises sched.selection_type=reserved and a
+# sched.t_estimate.  When a higher-urgency job takes the single easy
+# reservation slot, both annotations must be cleared (issue #1424), and
+# the displaced job is later categorized by how it actually starts.
+# Here both C08 jobs fit once the squatter is gone, so the displaced job
+# allocates with no reservations ahead of it: immediate.
+test_expect_success 'qmanager: displaced reservation ends up immediate' '
+    flux queue start --all &&
+    squat=$(flux job submit C10.T3600.json) &&
+    flux job wait-event -t 10 ${squat} start &&
+    resv=$(flux job submit C08.T3600.json) &&
+    wait_for selection_type_is ${resv} reserved &&
+    test "$(t_estimate ${resv})" != "null" &&
+    hi=$(flux job submit --urgency=20 C08.T3600.json) &&
+    wait_for selection_type_is ${hi} reserved &&
+    wait_for selection_type_is ${resv} null &&
+    test "$(t_estimate ${resv})" = "null" &&
+    flux cancel ${squat} &&
+    flux job wait-event -t 10 ${resv} start &&
+    test "$(selection_type ${resv})" = "immediate" &&
+    test "$(selection_type ${hi})" = "reserved"
+'
+test_expect_success 'qmanager: cleanup displaced-immediate jobs' '
+    cleanup_active_jobs
+'
+# Same displacement, but this time the higher-urgency job (C14) still
+# cannot run after the small squatter is cancelled, so it re-reserves at
+# squatA completion time.  The displaced job is short enough (T1800) to
+# finish before that reservation, so it is backfilled past it: backfill.
+test_expect_success 'qmanager: displaced reservation ends up backfill' '
+    flux queue start --all &&
+    flux run --job-name=12 --dry-run -n8 -t 30m hostname | exec_test > C08.T1800.json &&
+    squatA=$(flux job submit C08.T3600.json) &&
+    squatB=$(flux job submit C02.T3600.json) &&
+    flux job wait-event -t 10 ${squatB} start &&
+    resv=$(flux job submit C08.T1800.json) &&
+    wait_for selection_type_is ${resv} reserved &&
+    test "$(t_estimate ${resv})" != "null" &&
+    hi=$(flux job submit --urgency=20 C14.T3600.json) &&
+    wait_for selection_type_is ${hi} reserved &&
+    wait_for selection_type_is ${resv} null &&
+    test "$(t_estimate ${resv})" = "null" &&
+    flux cancel ${squatB} &&
+    flux job wait-event -t 10 ${resv} start &&
+    test "$(selection_type ${resv})" = "backfill" &&
+    test "$(selection_type ${hi})" = "reserved"
+'
+test_expect_success 'qmanager: cleanup displaced-backfill jobs' '
     cleanup_active_jobs
 '
 test_expect_success 'qmanager: loading with hybrid+queue-depth=5' '

--- a/t/t1004-qmanager-optimize.t
+++ b/t/t1004-qmanager-optimize.t
@@ -11,6 +11,10 @@ excl_1N1B="${hwloc_basepath}/001N/exclusive/01-brokers"
 export FLUX_SCHED_MODULE=none
 test_under_flux 1
 
+selection_type() {
+    flux job list-ids $1 | jq -r ".annotations.sched.selection_type"
+}
+
 exec_test()     { ${jq} '.attributes.system.exec.test = {}'; }
 
 test_expect_success 'qmanager: generate jobspecs of varying requirements' '
@@ -56,21 +60,32 @@ test_expect_success 'qmanager: EASY policy conforms to queue-depth=5' '
     flux cancel ${jobid7} &&
     flux job wait-event -t 10 ${jobid8} start &&
     test $(flux job list --states=active | wc -l) -eq 9 &&
-    test $(flux job list --states=running | wc -l) -eq 3 &&
-    active_jobs=$(flux job list --states=active | jq .id) &&
-    for job in ${active_jobs}; do flux cancel ${job}; done &&
-    for job in ${active_jobs}; do flux job wait-event -t 10 ${job} clean; done
+    test $(flux job list --states=running | wc -l) -eq 3
 '
-
+test_expect_success 'qmanager: selection_type is immediate and backfill' '
+    test "$(selection_type ${jobid1})" = "immediate" &&
+    test "$(selection_type ${jobid6})" = "backfill" &&
+    test "$(selection_type ${jobid7})" = "backfill" &&
+    test "$(selection_type ${jobid8})" = "backfill"
+'
+test_expect_success 'qmanager: selection_type is reserved' '
+    flux cancel ${jobid1} &&
+    flux job wait-event -t 10 ${jobid2} start &&
+    test "$(selection_type ${jobid2})" = "reserved"
+'
+test_expect_success 'qmanager: cleanup all active jobs' '
+    cleanup_active_jobs
+'
 test_expect_success 'qmanager: loading with hybrid+queue-depth=5' '
     remove_resource &&
     load_resource prune-filters=ALL:core subsystems=containment policy=low &&
     load_qmanager queue-policy=hybrid \
-queue-params=queue-depth=5 policy-params=reservation-depth=3
+queue-params=queue-depth=5 policy-params=reservation-depth=3 &&
+    flux queue start --all
 '
 
 test_expect_success 'qmanager: HYBRID policy conforms to queue-depth=5' '
-    jobid1=$(flux job submit C08.T3600.json) &&
+    jobid1=$(flux job submit C08.T3600.json) && # immediate
     jobid2=$(flux job submit C10.T3600.json) && # reserved
     jobid3=$(flux job submit C12.T3600.json) && # reserved
     jobid4=$(flux job submit C14.T3600.json) && # reserved
@@ -83,22 +98,35 @@ test_expect_success 'qmanager: HYBRID policy conforms to queue-depth=5' '
     jobid11=$(flux job submit C02.T3600.json) &&
 
     flux job wait-event -t 10 ${jobid1} start &&
-    flux jobs -a &&
     test $(flux job list --states=active | wc -l) -eq 11 &&
-    test $(flux job list --states=running| wc -l) -eq 1 &&
-    active_jobs=$(flux job list --states=active | jq .id) &&
-    for job in ${active_jobs}; do flux cancel ${job}; done &&
-    for job in ${active_jobs}; do flux job wait-event -t 10 ${job} clean; done
+    test $(flux job list --states=running| wc -l) -eq 1
 '
-
+# hybrid reserves up to reservation-depth jobs; jobid1 runs on the first
+# attempt (immediate).  With the reservations held, no later job can
+# backfill without delaying them, so nothing else starts.
+test_expect_success 'qmanager: HYBRID selection_type is immediate' '
+    test "$(selection_type ${jobid1})" = "immediate"
+'
+# Cancel jobid1 to free its cores so the reserved jobid2 can finally
+# start; because it had previously been reserved it is categorized as
+# reserved.
+test_expect_success 'qmanager: HYBRID selection_type is reserved' '
+    flux cancel ${jobid1} &&
+    flux job wait-event -t 10 ${jobid2} start &&
+    test "$(selection_type ${jobid2})" = "reserved"
+'
+test_expect_success 'cancel and cleanup active jobs' '
+    cleanup_active_jobs
+'
 test_expect_success 'qmanager: loading with conservative+queue-depth=5' '
     remove_resource &&
     load_resource prune-filters=ALL:core subsystems=containment policy=low &&
-    load_qmanager queue-policy=conservative queue-params=queue-depth=5
+    load_qmanager queue-policy=conservative queue-params=queue-depth=5 &&
+    flux queue start --all
 '
 
 test_expect_success 'qmanager: CONSERVATIVE policy conforms to queue-depth=5' '
-    jobid1=$(flux job submit C08.T3600.json) &&
+    jobid1=$(flux job submit C08.T3600.json) && # immediate
     jobid2=$(flux job submit C10.T3600.json) && # reserved
     jobid3=$(flux job submit C12.T3600.json) && # reserved
     jobid4=$(flux job submit C14.T3600.json) && # reserved
@@ -112,17 +140,39 @@ test_expect_success 'qmanager: CONSERVATIVE policy conforms to queue-depth=5' '
 
     flux job wait-event -t 10 ${jobid1} start &&
     test $(flux job list --states=active | wc -l) -eq 11 &&
-    test $(flux job list --states=running | wc -l) -eq 1 &&
+    test $(flux job list --states=running | wc -l) -eq 1
+'
+# conservative reserves every job it cannot run now, so jobid1 runs on the
+# first attempt (immediate) and nothing can backfill past the reservations.
+test_expect_success 'qmanager: CONSERVATIVE selection_type is immediate' '
+    test "$(selection_type ${jobid1})" = "immediate"
+'
+# Cancel jobid1 to free its cores so the reserved jobid2 can finally
+# start; because it had previously been reserved it is categorized as
+# reserved.
+test_expect_success 'qmanager: CONSERVATIVE selection_type is reserved' '
+    flux cancel ${jobid1} &&
+    flux job wait-event -t 10 ${jobid2} start &&
+    test "$(selection_type ${jobid2})" = "reserved"
+'
+test_expect_success 'cancel and cleanup active jobs' '
+    cleanup_active_jobs
+'
+test_expect_success 'qmanager: all jobs under fcfs have sched.selection_type=immediate' '
+    remove_qmanager &&
+    reload_resource prune-filters=ALL:core \
+subsystems=containment policy=low load-allowlist=cluster,node,core &&
+    load_qmanager &&
+    flux queue start --all &&
+    jobid1=$(flux submit -n 8 -t 360s sleep 300) &&
+    flux job wait-event -t 10 ${jobid1} start &&
+    test "$(selection_type ${jobid1})" = "immediate" &&
     active_jobs=$(flux job list --states=active | jq .id) &&
     for job in ${active_jobs}; do flux cancel ${job}; done &&
     for job in ${active_jobs}; do flux job wait-event -t 10 ${job} clean; done
 '
-
-test_expect_success 'cleanup active jobs' '
-    cleanup_active_jobs
-'
-
-test_expect_success 'removing resource and qmanager modules' '
+test_expect_success 'post-test cleanup' '
+    cleanup_active_jobs &&
     remove_qmanager &&
     remove_resource
 '


### PR DESCRIPTION
There is a separate PR open at flux-framework/rfc#529 if you have opinions on what the annotation should be called. I'll rename it in this branch to whatever we decide, but for this prototype, it is called `sched.start_method`.

This is a surprisingly simple amount of code that I believe fixes #1510. Though it may seem like unit tests would be more appropriate, the integration testsuite already has well-commented jobs that are marked "reserved" or "BF" (backfill), so repurposing those tests seems to be a win-win.