### PR TITLE
dfu: Stop implicit subplan initialization for non-mutating match traversals

### DIFF
--- a/resource/readers/resource_reader_jgf.cpp
+++ b/resource/readers/resource_reader_jgf.cpp
@@ -20,6 +20,8 @@ extern "C" {
 #include <unistd.h>
 #include <regex>
 #include <jansson.h>
+#include <boost/optional/optional.hpp>
+
 #include "resource/readers/resource_reader_jgf.hpp"
 #include "resource/store/resource_graph_store.hpp"
 #include "resource/planner/c/planner.h"
@@ -752,7 +754,7 @@ int resource_reader_jgf_t::cancel_vtx (vtx_t vtx,
     int64_t xspan = -1;
     int64_t sched_span = -1;
     int64_t prev_occu = -1;
-    planner_multi_t *subtree_plan = NULL;
+    boost::optional<planner_multi_t *> opt_subtree_plan;
     planner_t *x_checker = NULL;
     planner_t *plans = NULL;
     auto &job2span = g[vtx].idata.job2span;
@@ -767,9 +769,10 @@ int resource_reader_jgf_t::cancel_vtx (vtx_t vtx,
     // remove from aggregate filter if present
     auto agg_span = job2span.find (update_data.jobid);
     if (agg_span != job2span.end ()) {
-        if ((subtree_plan = g[vtx].idata.subplans[containment_sub]) == NULL)
+        if (!(opt_subtree_plan = g[vtx].idata.subplans.try_at (containment_sub))
+            || *opt_subtree_plan == NULL)
             goto error;
-        if (planner_multi_rem_span (subtree_plan, agg_span->second) != 0)
+        if (planner_multi_rem_span (*opt_subtree_plan, agg_span->second) != 0)
             goto error;
         // Delete from job2span tracker
         job2span.erase (update_data.jobid);

--- a/resource/reapi/test/reapi_cli_test_cxx.cpp
+++ b/resource/reapi/test/reapi_cli_test_cxx.cpp
@@ -3,6 +3,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <resource/reapi/bindings/c++/reapi_cli.hpp>
 #include <resource/policies/base/match_op.h>
+#include <resource/schema/resource_graph.hpp>
 #include <fstream>
 #include <cstdlib>
 
@@ -101,7 +102,7 @@ TEST_CASE ("Match basic jobspec", "[match C++]")
     ctx = std::make_shared<resource_query_t> (rgraph, options);
     REQUIRE (ctx);
 
-    match_op_t match_op = match_op_t::MATCH_ALLOCATE;
+    match_op_t match_op = MATCH_ALLOCATE;
     bool reserved = false;
     std::string R = "";
     uint64_t jobid = 1;
@@ -152,6 +153,98 @@ TEST_CASE ("Initialize REAPI CLI and test add and remove", "[initialize-add-remo
     // Valid add then remove.
     CHECK (detail::reapi_cli_t::add_subgraph (ctx.get (), add_sgraph) == 0);
     CHECK (detail::reapi_cli_t::remove_subgraph (ctx.get (), remove_path) == 0);
+}
+
+TEST_CASE ("Test the graph idempotence of certain match operations", "[match C++]")
+{
+    int rc = -1;
+    const std::string options = "{}";
+    std::stringstream gbuffer, jbuffer;
+    const char *test_srcdir = std::getenv ("SHARNESS_TEST_SRCDIR");
+    REQUIRE (test_srcdir);
+
+    std::ifstream graphfile (std::string (test_srcdir) + "/data/resource/grugs/tiny.graphml");
+    REQUIRE (graphfile.is_open ());
+
+    gbuffer << graphfile.rdbuf ();
+    std::string rgraph = gbuffer.str ();
+
+    std::ifstream jobspecfile (std::string (test_srcdir)
+                               + "/data/resource/jobspecs/basics/test006.yaml");
+    REQUIRE (jobspecfile.is_open ());
+
+    jbuffer << jobspecfile.rdbuf ();
+    std::string jobspec = jbuffer.str ();
+
+    std::shared_ptr<resource_query_t> ctx = nullptr;
+    ctx = std::make_shared<resource_query_t> (rgraph, options);
+    REQUIRE (ctx);
+
+    // Store the initial state of the graph
+    std::map<vtx_t, pool_infra_t> idata_map;
+    std::map<vtx_t, schedule_t> sched_map;
+    vtx_iterator_t u, end;
+    for (boost::tuples::tie (u, end) = boost::vertices (ctx->db->resource_graph); u != end; u++) {
+        idata_map[*u] = ctx->db->resource_graph[*u].idata;
+        sched_map[*u] = ctx->db->resource_graph[*u].schedule;
+        REQUIRE (idata_map[*u] == ctx->db->resource_graph[*u].idata);
+        REQUIRE (sched_map[*u] == ctx->db->resource_graph[*u].schedule);
+    }
+
+    match_op_t match_op;
+    bool reserved = false;
+    std::string R = "";
+    uint64_t jobid = 1;
+    double ov = 0.0;
+    int64_t at = 0;
+
+    SECTION ("MATCH_SATISFIABILITY doesn't change the graph")
+    {
+        match_op = MATCH_SATISFIABILITY;
+        rc = detail::reapi_cli_t::match_allocate (ctx.get (),
+                                                  match_op,
+                                                  jobspec,
+                                                  jobid,
+                                                  reserved,
+                                                  R,
+                                                  at,
+                                                  ov);
+        CHECK (reserved == false);
+        CHECK (at == 0);
+        REQUIRE (rc == 0);
+
+        // Check that the post-MATCH_SATISFIABILITY graph state is the same as the initial state
+        for (boost::tuples::tie (u, end) = boost::vertices (ctx->db->resource_graph); u != end;
+             u++) {
+            CHECK (idata_map.at (*u).equal_except_color (ctx->db->resource_graph[*u].idata));
+            CHECK (sched_map.at (*u) == ctx->db->resource_graph[*u].schedule);
+        }
+    }
+
+    SECTION ("MATCH_ALLOCATE changes the graph")
+    {
+        match_op = MATCH_ALLOCATE;
+        rc = detail::reapi_cli_t::match_allocate (ctx.get (),
+                                                  match_op,
+                                                  jobspec,
+                                                  jobid,
+                                                  reserved,
+                                                  R,
+                                                  at,
+                                                  ov);
+        CHECK (reserved == false);
+        CHECK (at == 0);
+        REQUIRE (rc == 0);
+
+        // The graph state should have changed
+        bool changed = false;
+        for (boost::tuples::tie (u, end) = boost::vertices (ctx->db->resource_graph); u != end;
+             u++) {
+            changed |= !(idata_map.at (*u).equal_except_color (ctx->db->resource_graph[*u].idata));
+            changed |= !(sched_map.at (*u) == ctx->db->resource_graph[*u].schedule);
+        }
+        REQUIRE (changed == true);
+    }
 }
 
 }  // namespace Flux::resource_model::detail

--- a/resource/schema/infra_data.cpp
+++ b/resource/schema/infra_data.cpp
@@ -106,13 +106,22 @@ pool_infra_t &pool_infra_t::operator= (const pool_infra_t &o)
 
 bool pool_infra_t::operator== (const pool_infra_t &o) const
 {
+    if (!equal_except_color (o))
+        return false;
+    if (colors != o.colors)
+        return false;
+    return true;
+}
+
+// Two pool_infra_ts with different colors but all else equal will behave the
+// same in a traversal.
+bool pool_infra_t::equal_except_color (const pool_infra_t &o) const
+{
     if (tags != o.tags)
         return false;
     if (x_spans != o.x_spans)
         return false;
     if (job2span != o.job2span)
-        return false;
-    if (colors != o.colors)
         return false;
     if (!planners_equal (x_checker, o.x_checker))
         return false;

--- a/resource/schema/infra_data.hpp
+++ b/resource/schema/infra_data.hpp
@@ -39,6 +39,7 @@ struct pool_infra_t : public infra_base_t {
     pool_infra_t (const pool_infra_t &o);
     pool_infra_t &operator= (const pool_infra_t &o);
     bool operator== (const pool_infra_t &o) const;
+    bool equal_except_color (const pool_infra_t &o) const;
     virtual ~pool_infra_t ();
     virtual void scrub ();
 

--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -16,6 +16,7 @@ extern "C" {
 
 #include "resource/traversers/dfu_impl.hpp"
 #include <optional>
+#include <boost/optional/optional.hpp>
 #include <boost/iterator/transform_iterator.hpp>
 #include <chrono>
 
@@ -55,8 +56,11 @@ bool dfu_impl_t::stop_explore (edg_t e, subsystem_t subsystem) const
     // Return true if the target vertex has been visited (forward: black)
     // or being visited (cycle: gray).
     vtx_t u = target (e, *m_graph);
-    return (m_color.is_gray ((*m_graph)[u].idata.colors[subsystem])
-            || m_color.is_black ((*m_graph)[u].idata.colors[subsystem]));
+    boost::optional<uint64_t &> u_color = (*m_graph)[u].idata.colors.try_at (subsystem);
+
+    if (!u_color)
+        return false;
+    return m_color.is_gray (*u_color) || m_color.is_black (*u_color);
 }
 
 bool dfu_impl_t::exclusivity (const std::vector<Jobspec::Resource> &resources, vtx_t u)
@@ -161,9 +165,9 @@ int dfu_impl_t::by_subplan (const jobmeta_t &meta,
     int64_t at = meta.at;
     uint64_t d = meta.duration;
     std::vector<uint64_t> aggs;
-    planner_multi_t *p = (*m_graph)[u].idata.subplans[s];
+    boost::optional<planner_multi_t *&> opt_p = (*m_graph)[u].idata.subplans.try_at (s);
 
-    if (!p) {
+    if (!opt_p || !(*opt_p)) {
         // Subplan is null if u is a leaf.
         // TODO: handle the unlikely case
         // where the subplan is null for another
@@ -174,9 +178,9 @@ int dfu_impl_t::by_subplan (const jobmeta_t &meta,
         // If user_data is empty, no data is available to prune with.
         return 0;
     }
-    count_relevant_types (p, resource.user_data, aggs);
+    count_relevant_types (*opt_p, resource.user_data, aggs);
     len = aggs.size ();
-    if ((rc = planner_multi_avail_during (p, at, d, aggs.data (), len)) == -1) {
+    if ((rc = planner_multi_avail_during (*opt_p, at, d, aggs.data (), len)) == -1) {
         // Don't log ERANGE or EBUSY - these are expected conditions:
         // ERANGE: request exceeds capacity (unsatisfiable)
         // EBUSY: resources temporarily unavailable
@@ -876,6 +880,7 @@ int dfu_impl_t::dom_find_dfv (std::shared_ptr<match_writers_t> &w,
     Flux::resource_model::vtx_predicates_override_t p_overridden = p;
     p_overridden.set (down, allocated, reserved);
     std::map<std::string, std::string> agfilter_data;
+    boost::optional<planner_multi_t *&> opt_filter_plan;
     planner_multi_t *filter_plan = NULL;
 
     (*m_graph)[u].idata.colors[dom] = m_color.gray ();
@@ -910,8 +915,10 @@ int dfu_impl_t::dom_find_dfv (std::shared_ptr<match_writers_t> &w,
     }
     if (agfilter) {
         // Check if there's a pruning (aggregate) filter initialized
-        if ((filter_plan = (*m_graph)[u].idata.subplans[dom]) == NULL)
+        opt_filter_plan = (*m_graph)[u].idata.subplans.try_at (dom);
+        if (!opt_filter_plan || !(*opt_filter_plan))
             goto done;
+        filter_plan = *opt_filter_plan;
         if (jobid == 0) {  // jobid not specified; get totals
             auto now = std::chrono::system_clock::now ();
             int64_t now_epoch =
@@ -1219,6 +1226,7 @@ int dfu_impl_t::prime_pruning_filter (subsystem_t s,
     std::map<resource_type_t, int64_t> dfv;
     resource_type_t resource_type = (*m_graph)[u].type;
     std::vector<resource_type_t> out_prune_types;
+    boost::optional<planner_multi_t *&> opt_p;
 
     (*m_graph)[u].idata.colors[s] = m_color.gray ();
     accum_if (s, resource_type, (*m_graph)[u].size, to_parent);
@@ -1257,7 +1265,10 @@ int dfu_impl_t::prime_pruning_filter (subsystem_t s,
         goto done;
     }
 
-    if ((*m_graph)[u].idata.subplans[s] == NULL) {
+    opt_p = (*m_graph)[u].idata.subplans.try_at (s);
+    if (opt_p && *opt_p) {
+        planner_multi_update (*opt_p, avail.data (), types.data (), types.size ());
+    } else {
         planner_multi_t *p = NULL;
         if (!(p = subtree_plan (u, avail, types))) {
             m_err_msg += "prime: error initializing a multi-planner. ";
@@ -1266,11 +1277,6 @@ int dfu_impl_t::prime_pruning_filter (subsystem_t s,
             goto done;
         }
         (*m_graph)[u].idata.subplans[s] = p;
-    } else {
-        planner_multi_update ((*m_graph)[u].idata.subplans[s],
-                              avail.data (),
-                              types.data (),
-                              types.size ());
     }
     rc = 0;
 done:

--- a/resource/traversers/dfu_impl_update.cpp
+++ b/resource/traversers/dfu_impl_update.cpp
@@ -14,6 +14,8 @@ extern "C" {
 #endif
 }
 
+#include <boost/optional/optional.hpp>
+
 #include "resource/traversers/dfu_impl.hpp"
 
 using namespace Flux::Jobspec;
@@ -71,15 +73,15 @@ int dfu_impl_t::upd_agfilter (vtx_t u,
                               jobmeta_t jobmeta,
                               const std::map<resource_type_t, int64_t> &dfu)
 {
-    // idata subtree aggregate prunning filter
-    planner_multi_t *subtree_plan = (*m_graph)[u].idata.subplans[s];
-    if (subtree_plan && !dfu.empty ()) {
+    // idata subtree aggregate pruning filter
+    boost::optional<planner_multi_t *&> opt_subtree_plan = (*m_graph)[u].idata.subplans.try_at (s);
+    if (opt_subtree_plan && *opt_subtree_plan && !dfu.empty ()) {
         int64_t span = -1;
         std::vector<uint64_t> aggregate;
         // Update the subtree aggregate pruning filter of this vertex
         // using the new aggregates passed by dfu.
-        count_relevant_types (subtree_plan, dfu, aggregate);
-        span = planner_multi_add_span (subtree_plan,
+        count_relevant_types (*opt_subtree_plan, dfu, aggregate);
+        span = planner_multi_add_span (*opt_subtree_plan,
                                        jobmeta.at,
                                        jobmeta.duration,
                                        aggregate.data (),
@@ -114,9 +116,10 @@ int dfu_impl_t::upd_by_outedges (subsystem_t subsystem, jobmeta_t jobmeta, vtx_t
 {
     size_t len = 0;
     vtx_t tgt = target (e, *m_graph);
-    planner_multi_t *subplan = (*m_graph)[tgt].idata.subplans[subsystem];
-    if (subplan) {
-        if ((len = planner_multi_resources_len (subplan)) == 0)
+    boost::optional<planner_multi_t *&> opt_subplan =
+        (*m_graph)[tgt].idata.subplans.try_at (subsystem);
+    if (opt_subplan && *opt_subplan) {
+        if ((len = planner_multi_resources_len (*opt_subplan)) == 0)
             return -1;
 
         // Set dynamic traversing order based on the following heuristics:
@@ -124,9 +127,9 @@ int dfu_impl_t::upd_by_outedges (subsystem_t subsystem, jobmeta_t jobmeta, vtx_t
         //     2. Last pruning filter resource type (if additional
         //        pruning filter type was given, that's a good
         //        indication that it is the scarcest resource)
-        int64_t avail = planner_multi_avail_resources_at (subplan, jobmeta.now, len - 1);
+        int64_t avail = planner_multi_avail_resources_at (*opt_subplan, jobmeta.now, len - 1);
         // Special case to skip (e.g., leaf resource vertices)
-        if (avail == 0 && planner_multi_span_size (subplan) == 0)
+        if (avail == 0 && planner_multi_span_size (*opt_subplan) == 0)
             return 0;
 
         auto key = std::make_pair ((*m_graph)[e].idata.get_weight (), (*m_graph)[tgt].uniq_id);
@@ -430,13 +433,13 @@ int dfu_impl_t::mod_agfilter (vtx_t u,
 {
     int rc = 0;
     bool removed = false;
-    planner_multi_t *subtree_plan = NULL;
+    boost::optional<planner_multi_t *&> opt_subtree_plan;
     auto &job2span = (*m_graph)[u].idata.job2span;
     std::map<int64_t, int64_t>::iterator span_it;
 
-    if ((subtree_plan = (*m_graph)[u].idata.subplans[subsystem]) == NULL)
+    opt_subtree_plan = (*m_graph)[u].idata.subplans.try_at (subsystem);
+    if (!opt_subtree_plan || !(*opt_subtree_plan))
         goto done;
-
     span_it = job2span.find (jobid);
     if (span_it == job2span.end ()) {
         if (mod_data.mod_type == job_modify_t::PARTIAL_CANCEL)
@@ -448,7 +451,7 @@ int dfu_impl_t::mod_agfilter (vtx_t u,
         goto done;
     }
     if (mod_data.mod_type != job_modify_t::PARTIAL_CANCEL) {
-        if ((rc = planner_multi_rem_span (subtree_plan, span_it->second)) != 0) {
+        if ((rc = planner_multi_rem_span (*opt_subtree_plan, span_it->second)) != 0) {
             m_err_msg += __FUNCTION__;
             m_err_msg += ": planner_multi_rem_span returned -1.\n";
             m_err_msg += (*m_graph)[u].name + " " + strerror (errno) + ".\n";
@@ -468,7 +471,7 @@ int dfu_impl_t::mod_agfilter (vtx_t u,
                 reduced_types.push_back (t2ct_it.first.c_str ());
                 reduced_counts.push_back (t2ct_it.second);
             }
-            if ((rc = planner_multi_reduce_span (subtree_plan,
+            if ((rc = planner_multi_reduce_span (*opt_subtree_plan,
                                                  span_it->second,
                                                  reduced_counts.data (),
                                                  reduced_types.data (),
@@ -685,7 +688,7 @@ int dfu_impl_t::clear_vertex (vtx_t vtx, modify_data_t &mod_data)
     int64_t base_time = 0;
     int64_t duration = 0;
     planner_t *plans = NULL;
-    planner_multi_t *multi_plans = NULL;
+    boost::optional<planner_multi_t *&> opt_multi_plans;
 
     // Compute removed span counts
     plans = (*m_graph)[vtx].schedule.plans;
@@ -711,10 +714,11 @@ int dfu_impl_t::clear_vertex (vtx_t vtx, modify_data_t &mod_data)
         return -1;
     }
     // Reset planner_multi
-    if ((multi_plans = (*m_graph)[vtx].idata.subplans[dom]) != NULL) {
-        base_time = planner_multi_base_time (multi_plans);
-        duration = planner_multi_duration (multi_plans);
-        if (planner_multi_reset (multi_plans, base_time, duration) != 0) {
+    opt_multi_plans = (*m_graph)[vtx].idata.subplans.try_at (dom);
+    if (opt_multi_plans && *opt_multi_plans) {
+        base_time = planner_multi_base_time (*opt_multi_plans);
+        duration = planner_multi_duration (*opt_multi_plans);
+        if (planner_multi_reset (*opt_multi_plans, base_time, duration) != 0) {
             m_err_msg += __FUNCTION__;
             m_err_msg += ": planner_multi_reset failed.\n";
             m_err_msg += (*m_graph)[vtx].name + " " + strerror (errno) + ".\n";


### PR DESCRIPTION
Problem: Previously, the traverser used the index operator to access nodes' subplans, like `m_graph[u].subplans[s]`. Because the traversal to prime the pruning filters during graph initialization does not touch every node (it skips leaf nodes, which will never have pruning filters), generalized logic to access node subplans using `[]` in subsequent traversals can implicitly generate elements of the node's subplan list. This is not an issue for correctness since the elements are initialized to NULL, and the traverser always checks whether an element is null before using it.
However, this causes the graph's state to change in cases where it shouldn't. Specifically, this causes infra_data idempotence checks to fail, due to a change in the length of the subplan list, after running a MATCH_SATISFIABILITY request that does not actually add or remove any subplans.
The same is true of MATCH_WITHOUT_ALLOCATING requests (#1387).

Solution: Access node subplans in the traverser using `try_at` instead of `[]`.
Add a regression test that compares the state of the graph before and after running a MATCH_SATISFIABILITY request.