### PR TITLE
doc: relax requirements.txt as documentation allows

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
-sphinx>=6.0.0
-sphinx-rtd-theme>=0.5.2
-docutils>=0.18
-jinja2>=3.1.0
-breathe>=4.35.0
+sphinx
+sphinx-rtd-theme
+docutils
+jinja2
+breathe>=4.32.0


### PR DESCRIPTION
Problem: the requirements.txt file for the documentation is more stringent than is necessary to build the docs.

Solution: relax the requirements.

Fixes #1529