### PR TITLE
t: add valgrind suppression for hwloc after realloc

### DIFF
--- a/t/valgrind/valgrind.supp
+++ b/t/valgrind/valgrind.supp
@@ -111,6 +111,17 @@
    ...
 }
 {
+   <sched_issue_1531>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:realloc
+   ...
+   obj:*libhwloc.so.15.*.*
+   obj:*libhwloc.so.15.*.*
+   fun:hwloc_topology_load
+   ...
+}
+{
    <core_issue_3640>
    Memcheck:Leak
    match-leak-kinds: possible


### PR DESCRIPTION
Problem: the valgrind suppressions we borrowed from flux-core suppress several hwloc errors occurring after the `malloc` function is run, but not after the `realloc` function is run, allowing these same memory errors to slip through and become reported as Fluxion errors in CI.

Solution: add a suppression as suggested by @trws in our meeting.

Fixes #1531

Assisted-by: Claude:opus-4.8