### PR TITLE
Fix unguarded dereferences, improve exception safety and planner errno handling

### DIFF
--- a/resource/planner/c++/planner.cpp
+++ b/resource/planner/c++/planner.cpp
@@ -541,12 +541,18 @@ bool planner::trees_equal (const planner &o) const
 // Public Planner_t methods
 ////////////////////////////////////////////////////////////////////////////////
 
+// The wrapper constructors rethrow so that a planner_t can never be
+// observed with a null inner planner; `new planner_t (...)` either
+// succeeds completely or throws (operator new releases the wrapper
+// allocation automatically when the constructor throws).
+
 planner_t::planner_t ()
 {
     try {
         plan = new planner ();
     } catch (std::bad_alloc &e) {
         errno = ENOMEM;
+        throw;
     }
 }
 
@@ -556,6 +562,7 @@ planner_t::planner_t (const planner &o)
         plan = new planner (o);
     } catch (std::bad_alloc &e) {
         errno = ENOMEM;
+        throw;
     }
 }
 
@@ -568,6 +575,7 @@ planner_t::planner_t (const int64_t base_time,
         plan = new planner (base_time, duration, resource_totals, in_resource_type);
     } catch (std::bad_alloc &e) {
         errno = ENOMEM;
+        throw;
     }
 }
 

--- a/resource/planner/c++/planner.cpp
+++ b/resource/planner/c++/planner.cpp
@@ -104,6 +104,9 @@ planner &planner::operator= (const planner &o)
 {
     int rc = -1;
 
+    if (this == &o)
+        return *this;
+
     if ((rc = erase ()) != 0) {
         throw std::runtime_error ("ERROR erasing *this\n");
     }
@@ -564,6 +567,25 @@ planner_t::planner_t (const planner &o)
         errno = ENOMEM;
         throw;
     }
+}
+
+planner_t &planner_t::operator= (const planner_t &o)
+{
+    if (this != &o) {
+        // Copy-and-swap for the strong exception guarantee: build the
+        // replacement first so *this is untouched if the copy throws
+        // (bad_alloc, or runtime_error from planner's tree/map copies).
+        planner *tmp = nullptr;
+        try {
+            tmp = new planner (*o.plan);
+        } catch (std::bad_alloc &e) {
+            errno = ENOMEM;
+            throw;
+        }
+        delete plan;
+        plan = tmp;
+    }
+    return *this;
 }
 
 planner_t::planner_t (const int64_t base_time,

--- a/resource/planner/c++/planner.hpp
+++ b/resource/planner/c++/planner.hpp
@@ -122,6 +122,7 @@ struct planner_t {
                const uint64_t duration,
                const uint64_t resource_totals,
                const char *in_resource_type);
+    planner_t &operator= (const planner_t &o);
     ~planner_t ();
 
     planner *plan = nullptr;

--- a/resource/planner/c++/planner_multi.cpp
+++ b/resource/planner/c++/planner_multi.cpp
@@ -17,6 +17,7 @@ extern "C" {
 #include <cstdlib>
 #include <cerrno>
 #include <cstring>
+#include <memory>
 #include <vector>
 #include <map>
 
@@ -187,22 +188,26 @@ void planner_multi::add_planner (int64_t base_time,
                                  size_t i)
 {
     std::string type;
-    planner_t *p = nullptr;
+    std::unique_ptr<planner_t> p;
 
+    // Own the new planner via unique_ptr until it is safely inserted so
+    // that a failed map or multi-index insertion cannot leak it.
     try {
         type = std::string (resource_type);
-        p = new planner_t (base_time, duration, resource_total, resource_type);
+        p = std::make_unique<planner_t> (base_time, duration, resource_total, resource_type);
+        m_iter.counts[type] = 0;
+        if (i > m_types_totals_planners.size ())
+            m_types_totals_planners.push_back ({type, resource_total, p.get ()});
+        else {
+            auto it = m_types_totals_planners.begin () + i;
+            m_types_totals_planners.insert (it, planner_multi_meta{type, resource_total, p.get ()});
+        }
     } catch (std::bad_alloc &e) {
         errno = ENOMEM;
         throw std::bad_alloc ();
     }
-    m_iter.counts[type] = 0;
-    if (i > m_types_totals_planners.size ())
-        m_types_totals_planners.push_back ({type, resource_total, p});
-    else {
-        auto it = m_types_totals_planners.begin () + i;
-        m_types_totals_planners.insert (it, planner_multi_meta{type, resource_total, p});
-    }
+    // The container now references the planner; release ownership.
+    p.release ();
 }
 
 void planner_multi::delete_planners (const std::unordered_set<std::string> &rtypes)
@@ -334,12 +339,18 @@ void planner_multi::incr_span_counter ()
 // Public Planner_multi_t methods
 ////////////////////////////////////////////////////////////////////////////////
 
+// The wrapper constructors rethrow so that a planner_multi_t can never
+// be observed with a null inner planner_multi; `new planner_multi_t (...)`
+// either succeeds completely or throws (operator new releases the wrapper
+// allocation automatically when the constructor throws).
+
 planner_multi_t::planner_multi_t ()
 {
     try {
         plan_multi = new planner_multi ();
     } catch (std::bad_alloc &e) {
         errno = ENOMEM;
+        throw;
     }
 }
 
@@ -349,6 +360,7 @@ planner_multi_t::planner_multi_t (const planner_multi &o)
         plan_multi = new planner_multi (o);
     } catch (std::bad_alloc &e) {
         errno = ENOMEM;
+        throw;
     }
 }
 
@@ -362,6 +374,7 @@ planner_multi_t::planner_multi_t (int64_t base_time,
         plan_multi = new planner_multi (base_time, duration, resource_totals, resource_types, len);
     } catch (std::bad_alloc &e) {
         errno = ENOMEM;
+        throw;
     }
 }
 

--- a/resource/planner/c++/planner_multi.cpp
+++ b/resource/planner/c++/planner_multi.cpp
@@ -83,12 +83,19 @@ planner_multi::planner_multi (const planner_multi &o)
     }
     m_iter = o.m_iter;
     m_span_lookup = o.m_span_lookup;
-    m_span_lookup_iter = o.m_span_lookup_iter;
+    // o's iterator points into o's m_span_lookup; copying it would leave
+    // this object holding an iterator into another container.  Reset it to
+    // a defined state instead; users must call avail_time_first () before
+    // avail_time_next () anyway.
+    m_span_lookup_iter = m_span_lookup.end ();
     m_span_counter = o.m_span_counter;
 }
 
 planner_multi &planner_multi::operator= (const planner_multi &o)
 {
+    if (this == &o)
+        return *this;
+
     // Erase *this so the vectors are empty
     erase ();
 
@@ -120,7 +127,8 @@ planner_multi &planner_multi::operator= (const planner_multi &o)
     }
     m_iter = o.m_iter;
     m_span_lookup = o.m_span_lookup;
-    m_span_lookup_iter = o.m_span_lookup_iter;
+    // See the copy constructor: never adopt an iterator into o's container.
+    m_span_lookup_iter = m_span_lookup.end ();
     m_span_counter = o.m_span_counter;
 
     return *this;
@@ -362,6 +370,25 @@ planner_multi_t::planner_multi_t (const planner_multi &o)
         errno = ENOMEM;
         throw;
     }
+}
+
+planner_multi_t &planner_multi_t::operator= (const planner_multi_t &o)
+{
+    if (this != &o) {
+        // Copy-and-swap for the strong exception guarantee: build the
+        // replacement first so *this is untouched if the copy throws
+        // (bad_alloc, or runtime_error from the inner planner copies).
+        planner_multi *tmp = nullptr;
+        try {
+            tmp = new planner_multi (*o.plan_multi);
+        } catch (std::bad_alloc &e) {
+            errno = ENOMEM;
+            throw;
+        }
+        delete plan_multi;
+        plan_multi = tmp;
+    }
+    return *this;
 }
 
 planner_multi_t::planner_multi_t (int64_t base_time,

--- a/resource/planner/c++/planner_multi.hpp
+++ b/resource/planner/c++/planner_multi.hpp
@@ -125,6 +125,7 @@ struct planner_multi_t {
                      const uint64_t *resource_totals,
                      const char **resource_types,
                      size_t len);
+    planner_multi_t &operator= (const planner_multi_t &o);
     ~planner_multi_t ();
 
     planner_multi *plan_multi = nullptr;

--- a/resource/planner/c/planner.h
+++ b/resource/planner/c/planner.h
@@ -63,14 +63,17 @@ planner_t *planner_new_empty ();
  */
 planner_t *planner_copy (planner_t *p);
 
-/*! Assign a planner.
+/*! Assign a planner: copy the state of rhs into lhs.
+ *  On error, lhs is unmodified.
  *
- *  \param lhs          the base planner which will be assigned to rhs.
- *  \param rhs          the base planner which will be copied and returned as
- *                      a new planner context.
- *
+ *  \param lhs          planner context to assign into.
+ *  \param rhs          planner context whose state is copied into lhs.
+ *  \return             0 on success; -1 on an error with errno set as
+ *                      follows:
+ *                          EINVAL: invalid argument.
+ *                          ENOMEM: memory error.
  */
-void planner_assign (planner_t *lhs, planner_t *rhs);
+int planner_assign (planner_t *lhs, planner_t *rhs);
 
 /*! Reset the planner with a new time bound. Destroy all existing planned spans.
  *

--- a/resource/planner/c/planner_c_interface.cpp
+++ b/resource/planner/c/planner_c_interface.cpp
@@ -12,6 +12,7 @@
 #include <map>
 #include <list>
 #include <string>
+#include <stdexcept>
 
 #include "resource/planner/c++/planner.hpp"
 
@@ -340,6 +341,11 @@ extern "C" planner_t *planner_copy (planner_t *p)
         ctx = new planner_t (*(p->plan));
     } catch (std::bad_alloc &e) {
         errno = ENOMEM;
+    } catch (std::runtime_error &e) {
+        // planner's copy machinery reports allocation failures in its
+        // tree and map copies as runtime_error; it must not escape this
+        // extern "C" boundary.
+        errno = ENOMEM;
     }
 
     return ctx;
@@ -351,7 +357,15 @@ extern "C" void planner_assign (planner_t *lhs, planner_t *rhs)
         errno = EINVAL;
         return;
     }
-    (*(lhs->plan) = *(rhs->plan));
+    try {
+        (*(lhs->plan) = *(rhs->plan));
+    } catch (std::bad_alloc &e) {
+        errno = ENOMEM;
+    } catch (std::runtime_error &e) {
+        // See planner_copy: copy failures surface as runtime_error and
+        // must not escape this extern "C" boundary.
+        errno = ENOMEM;
+    }
 }
 
 extern "C" planner_t *planner_new_empty ()

--- a/resource/planner/c/planner_c_interface.cpp
+++ b/resource/planner/c/planner_c_interface.cpp
@@ -351,21 +351,25 @@ extern "C" planner_t *planner_copy (planner_t *p)
     return ctx;
 }
 
-extern "C" void planner_assign (planner_t *lhs, planner_t *rhs)
+extern "C" int planner_assign (planner_t *lhs, planner_t *rhs)
 {
     if (!lhs || !rhs) {
         errno = EINVAL;
-        return;
+        return -1;
     }
     try {
-        (*(lhs->plan) = *(rhs->plan));
+        *lhs = *rhs;
     } catch (std::bad_alloc &e) {
         errno = ENOMEM;
+        return -1;
     } catch (std::runtime_error &e) {
         // See planner_copy: copy failures surface as runtime_error and
-        // must not escape this extern "C" boundary.
+        // must not escape this extern "C" boundary.  planner_t's
+        // copy-and-swap assignment leaves lhs unmodified on throw.
         errno = ENOMEM;
+        return -1;
     }
+    return 0;
 }
 
 extern "C" planner_t *planner_new_empty ()

--- a/resource/planner/c/planner_c_interface.cpp
+++ b/resource/planner/c/planner_c_interface.cpp
@@ -331,6 +331,11 @@ extern "C" planner_t *planner_copy (planner_t *p)
 {
     planner_t *ctx = nullptr;
 
+    if (!p) {
+        errno = EINVAL;
+        return nullptr;
+    }
+
     try {
         ctx = new planner_t (*(p->plan));
     } catch (std::bad_alloc &e) {
@@ -342,6 +347,10 @@ extern "C" planner_t *planner_copy (planner_t *p)
 
 extern "C" void planner_assign (planner_t *lhs, planner_t *rhs)
 {
+    if (!lhs || !rhs) {
+        errno = EINVAL;
+        return;
+    }
     (*(lhs->plan) = *(rhs->plan));
 }
 
@@ -525,6 +534,10 @@ extern "C" int64_t planner_add_span (planner_t *ctx,
     scheduled_point_t *start_point = nullptr;
     scheduled_point_t *last_point = nullptr;
 
+    if (!ctx) {
+        errno = EINVAL;
+        return -1;
+    }
     if (!avail_during (ctx, start_time, duration, (int64_t)request)) {
         errno = EINVAL;
         return -1;
@@ -756,11 +769,22 @@ extern "C" int64_t planner_span_resource_count (planner_t *ctx, int64_t span_id)
 
 extern "C" bool planners_equal (planner_t *lhs, planner_t *rhs)
 {
+    // Covers the case where both are nullptr or the same object;
+    // planner members of vertex data are legitimately nullable, and two
+    // null planners must compare equal for operator== reflexivity.
+    if (lhs == rhs)
+        return true;
+    if (!lhs || !rhs)
+        return false;
     return (*(lhs->plan) == *(rhs->plan));
 }
 
 extern "C" int planner_update_total (planner_t *ctx, uint64_t resource_total)
 {
+    if (!ctx) {
+        errno = EINVAL;
+        return -1;
+    }
     return ctx->plan->update_total (resource_total);
 }
 

--- a/resource/planner/c/planner_multi.h
+++ b/resource/planner/c/planner_multi.h
@@ -69,14 +69,17 @@ planner_multi_t *planner_multi_empty ();
  */
 planner_multi_t *planner_multi_copy (planner_multi_t *mp);
 
-/*! Assign a planner_multi_t.
+/*! Assign a planner_multi: copy the state of rhs into lhs.
+ *  On error, lhs is unmodified.
  *
- *  \param lhs          the base planner_multi which will be assigned to rhs.
- *  \param rhs          the base planner_multi which will be copied and returned as
- *                      a new planner_multi context.
- *
+ *  \param lhs          planner_multi context to assign into.
+ *  \param rhs          planner_multi context whose state is copied into lhs.
+ *  \return             0 on success; -1 on an error with errno set as
+ *                      follows:
+ *                          EINVAL: invalid argument.
+ *                          ENOMEM: memory error.
  */
-void planner_multi_assign (planner_multi_t *lhs, planner_multi_t *rhs);
+int planner_multi_assign (planner_multi_t *lhs, planner_multi_t *rhs);
 
 /*! Getters:
  *  \return             -1 or NULL on an error with errno set as follows:

--- a/resource/planner/c/planner_multi_c_interface.cpp
+++ b/resource/planner/c/planner_multi_c_interface.cpp
@@ -15,6 +15,7 @@
 #include <vector>
 #include <map>
 #include <numeric>
+#include <stdexcept>
 
 #include "planner_multi.h"
 #include "resource/planner/c++/planner_multi.hpp"
@@ -103,6 +104,12 @@ extern "C" planner_multi_t *planner_multi_copy (planner_multi_t *mp)
     } catch (std::bad_alloc &e) {
         errno = ENOMEM;
         goto nomem_error;
+    } catch (std::runtime_error &e) {
+        // planner_multi's copy machinery reports inner planner copy
+        // failures as runtime_error; it must not escape this extern "C"
+        // boundary.
+        errno = ENOMEM;
+        goto nomem_error;
     }
     return ctx;
 
@@ -118,7 +125,15 @@ extern "C" void planner_multi_assign (planner_multi_t *lhs, planner_multi_t *rhs
         errno = EINVAL;
         return;
     }
-    (*(lhs->plan_multi) = *(rhs->plan_multi));
+    try {
+        (*(lhs->plan_multi) = *(rhs->plan_multi));
+    } catch (std::bad_alloc &e) {
+        errno = ENOMEM;
+    } catch (std::runtime_error &e) {
+        // See planner_multi_copy: copy failures surface as runtime_error
+        // and must not escape this extern "C" boundary.
+        errno = ENOMEM;
+    }
 }
 
 extern "C" int64_t planner_multi_base_time (planner_multi_t *ctx)
@@ -402,10 +417,19 @@ extern "C" int64_t planner_multi_add_span (planner_multi_t *ctx,
     }
 
     mspan = ctx->plan_multi->get_span_counter ();
-    auto res = ctx->plan_multi->get_span_lookup ().insert (
-        std::pair<int64_t, std::vector<int64_t>> (mspan, std::vector<int64_t> ()));
-    if (!res.second) {
-        errno = EEXIST;
+    try {
+        auto res = ctx->plan_multi->get_span_lookup ().insert (
+            std::pair<int64_t, std::vector<int64_t>> (mspan, std::vector<int64_t> ()));
+        if (!res.second) {
+            errno = EEXIST;
+            return -1;
+        }
+        // Reserve up front so the push_back below cannot throw after
+        // underlying planner spans have already been allocated.
+        res.first->second.reserve (len);
+    } catch (std::bad_alloc &e) {
+        ctx->plan_multi->get_span_lookup ().erase (mspan);
+        errno = ENOMEM;
         return -1;
     }
 
@@ -676,12 +700,19 @@ extern "C" int planner_multi_update (planner_multi_t *ctx,
         }
         rtypes.insert (resource_types[i]);
         if (!ctx->plan_multi->planner_at (resource_types[i])) {
-            // Assume base_time same as parent
-            ctx->plan_multi->add_planner (base_time,
-                                          static_cast<uint64_t> (duration),
-                                          resource_totals[i],
-                                          resource_types[i],
-                                          i);
+            try {
+                // Assume base_time same as parent
+                ctx->plan_multi->add_planner (base_time,
+                                              static_cast<uint64_t> (duration),
+                                              resource_totals[i],
+                                              resource_types[i],
+                                              i);
+            } catch (std::bad_alloc &e) {
+                // add_planner rethrows bad_alloc; it must not escape this
+                // extern "C" boundary.
+                errno = ENOMEM;
+                goto done;
+            }
         } else {
             // Index could have changed
             ctx->plan_multi->update_planner_index (resource_types[i], i);

--- a/resource/planner/c/planner_multi_c_interface.cpp
+++ b/resource/planner/c/planner_multi_c_interface.cpp
@@ -119,21 +119,25 @@ nomem_error:
     return ctx;
 }
 
-extern "C" void planner_multi_assign (planner_multi_t *lhs, planner_multi_t *rhs)
+extern "C" int planner_multi_assign (planner_multi_t *lhs, planner_multi_t *rhs)
 {
     if (!lhs || !rhs) {
         errno = EINVAL;
-        return;
+        return -1;
     }
     try {
-        (*(lhs->plan_multi) = *(rhs->plan_multi));
+        *lhs = *rhs;
     } catch (std::bad_alloc &e) {
         errno = ENOMEM;
+        return -1;
     } catch (std::runtime_error &e) {
         // See planner_multi_copy: copy failures surface as runtime_error
-        // and must not escape this extern "C" boundary.
+        // and must not escape this extern "C" boundary.  planner_multi_t's
+        // copy-and-swap assignment leaves lhs unmodified on throw.
         errno = ENOMEM;
+        return -1;
     }
+    return 0;
 }
 
 extern "C" int64_t planner_multi_base_time (planner_multi_t *ctx)

--- a/resource/planner/c/planner_multi_c_interface.cpp
+++ b/resource/planner/c/planner_multi_c_interface.cpp
@@ -312,10 +312,19 @@ extern "C" int64_t planner_multi_avail_time_next (planner_multi_t *ctx)
             break;
         for (i = 1; i < ctx->plan_multi->get_planners_size (); ++i) {
             type = ctx->plan_multi->get_resource_type_at (i);
+            auto count_it = ctx->plan_multi->get_iter ().counts.find (type);
+            // A resource type may be missing from the iterator request if the
+            // planner composition changed since the last call to
+            // planner_multi_avail_time_first; error out instead of throwing.
+            if (count_it == ctx->plan_multi->get_iter ().counts.end ()) {
+                errno = EINVAL;
+                t = -1;
+                goto done;
+            }
             if ((unmet = planner_avail_during (ctx->plan_multi->get_planner_at (i),
                                                t,
                                                ctx->plan_multi->get_iter ().duration,
-                                               ctx->plan_multi->get_iter ().counts.at (type)))
+                                               count_it->second))
                 == -1)
                 break;
         }
@@ -463,6 +472,15 @@ extern "C" int planner_multi_rem_span (planner_multi_t *ctx, int64_t span_id)
         errno = ENOENT;
         goto done;
     }
+    // The span lookup vector can be longer than the planner count if
+    // planners were deleted by planner_multi_update after the span was
+    // created; get_planner_at () would throw std::out_of_range below.
+    // Error out instead; keeping the span metadata aligned with the
+    // planner set across composition changes is future work.
+    if (it->second.size () > ctx->plan_multi->get_planners_size ()) {
+        errno = EINVAL;
+        goto done;
+    }
     for (i = 0; i < it->second.size (); ++i) {
         // If executed after partial cancel, depending on pruning filter settings
         // some spans may no longer exist. In that case the span_lookup value for
@@ -500,6 +518,14 @@ extern "C" int planner_multi_reduce_span (planner_multi_t *ctx,
     auto span_it = ctx->plan_multi->get_span_lookup ().find (span_id);
     if (span_it == ctx->plan_multi->get_span_lookup ().end ()) {
         errno = ENOENT;
+        return -1;
+    }
+    // The span lookup vector can be shorter than the planner count if
+    // planners were added by planner_multi_update after the span was
+    // created. Reject the reduction up front (rather than mid-loop) so a
+    // failed call leaves all planner state unchanged.
+    if (span_it->second.size () < ctx->plan_multi->get_planners_size ()) {
+        errno = EINVAL;
         return -1;
     }
     for (i = 0; i < len; ++i) {
@@ -601,6 +627,12 @@ extern "C" int64_t planner_multi_span_planned_at (planner_multi_t *ctx,
         errno = ENOENT;
         return -1;
     }
+    // The span vector can be shorter than the planner count if planners were
+    // added by planner_multi_update after the span was created. The span
+    // holds no allocation for such a type, so report a count of zero (also
+    // avoids letting .at () throw across the C boundary).
+    if (i >= span_it->second.size ())
+        return 0;
     int64_t p_span_id = span_it->second.at (i);
     // Span may have been removed during a partial cancel
     if (p_span_id == -1) {

--- a/resource/planner/c/planner_multi_c_interface.cpp
+++ b/resource/planner/c/planner_multi_c_interface.cpp
@@ -93,6 +93,11 @@ extern "C" planner_multi_t *planner_multi_copy (planner_multi_t *mp)
 {
     planner_multi_t *ctx = nullptr;
 
+    if (!mp) {
+        errno = EINVAL;
+        return nullptr;
+    }
+
     try {
         ctx = new planner_multi_t (*(mp->plan_multi));
     } catch (std::bad_alloc &e) {
@@ -109,12 +114,18 @@ nomem_error:
 
 extern "C" void planner_multi_assign (planner_multi_t *lhs, planner_multi_t *rhs)
 {
+    if (!lhs || !rhs) {
+        errno = EINVAL;
+        return;
+    }
     (*(lhs->plan_multi) = *(rhs->plan_multi));
 }
 
 extern "C" int64_t planner_multi_base_time (planner_multi_t *ctx)
 {
-    if (!ctx) {
+    // Guard against empty planner_multi (e.g. from planner_multi_empty ());
+    // get_planner_at (0) would otherwise throw std::out_of_range.
+    if (!ctx || ctx->plan_multi->get_planners_size () < 1) {
         errno = EINVAL;
         return -1;
     }
@@ -123,7 +134,9 @@ extern "C" int64_t planner_multi_base_time (planner_multi_t *ctx)
 
 extern "C" int64_t planner_multi_duration (planner_multi_t *ctx)
 {
-    if (!ctx) {
+    // Guard against empty planner_multi (e.g. from planner_multi_empty ());
+    // get_planner_at (0) would otherwise throw std::out_of_range.
+    if (!ctx || ctx->plan_multi->get_planners_size () < 1) {
         errno = EINVAL;
         return -1;
     }
@@ -141,7 +154,7 @@ extern "C" size_t planner_multi_resources_len (planner_multi_t *ctx)
 
 extern "C" const char *planner_multi_resource_type_at (planner_multi_t *ctx, unsigned int i)
 {
-    if (!ctx) {
+    if (!ctx || i >= ctx->plan_multi->get_planners_size ()) {
         errno = EINVAL;
         return nullptr;
     }
@@ -270,7 +283,9 @@ extern "C" int64_t planner_multi_avail_time_next (planner_multi_t *ctx)
     int64_t t = -1;
     std::string type;
 
-    if (!ctx) {
+    // Guard against empty planner_multi (e.g. from planner_multi_empty ());
+    // get_planner_at (0) would otherwise throw std::out_of_range.
+    if (!ctx || ctx->plan_multi->get_planners_size () < 1) {
         errno = EINVAL;
         goto done;
     }
@@ -381,8 +396,10 @@ extern "C" int64_t planner_multi_add_span (planner_multi_t *ctx,
     int64_t span = -1;
     int64_t mspan = -1;
 
-    if (!ctx || !resource_requests || len != ctx->plan_multi->get_planners_size ())
+    if (!ctx || !resource_requests || len != ctx->plan_multi->get_planners_size ()) {
+        errno = EINVAL;
         return -1;
+    }
 
     mspan = ctx->plan_multi->get_span_counter ();
     auto res = ctx->plan_multi->get_span_lookup ().insert (
@@ -573,21 +590,18 @@ extern "C" int64_t planner_multi_span_planned_at (planner_multi_t *ctx,
 
 extern "C" int64_t planner_multi_span_first (planner_multi_t *ctx)
 {
-    int64_t rc = -1;
-    std::map<uint64_t, std::vector<int64_t>>::iterator tmp_it =
-        ctx->plan_multi->get_span_lookup ().begin ();
     if (!ctx) {
         errno = EINVAL;
-        goto done;
+        return -1;
     }
+    std::map<uint64_t, std::vector<int64_t>>::iterator tmp_it =
+        ctx->plan_multi->get_span_lookup ().begin ();
     ctx->plan_multi->set_span_lookup_iter (tmp_it);
     if (ctx->plan_multi->get_span_lookup_iter () == ctx->plan_multi->get_span_lookup ().end ()) {
         errno = ENOENT;
-        goto done;
+        return -1;
     }
-    rc = ctx->plan_multi->get_span_lookup_iter ()->first;
-done:
-    return rc;
+    return ctx->plan_multi->get_span_lookup_iter ()->first;
 }
 
 extern "C" int64_t planner_multi_span_next (planner_multi_t *ctx)
@@ -618,6 +632,13 @@ extern "C" size_t planner_multi_span_size (planner_multi_t *ctx)
 
 extern "C" bool planner_multis_equal (planner_multi_t *lhs, planner_multi_t *rhs)
 {
+    // Covers the case where both are nullptr or the same object;
+    // planner_multi members of vertex data are legitimately nullable, and
+    // two null planners must compare equal for operator== reflexivity.
+    if (lhs == rhs)
+        return true;
+    if (!lhs || !rhs)
+        return false;
     return (*(lhs->plan_multi) == *(rhs->plan_multi));
 }
 
@@ -634,7 +655,10 @@ extern "C" int planner_multi_update (planner_multi_t *ctx,
     int64_t base_time = 0;
     int64_t duration = 0;
 
-    if (!ctx || !resource_totals || !resource_types) {
+    // The empty check also guards against an empty planner_multi (e.g. from
+    // planner_multi_empty ()); get_planner_at (0) would otherwise throw
+    // std::out_of_range.
+    if (!ctx || !resource_totals || !resource_types || ctx->plan_multi->get_planners_size () < 1) {
         errno = EINVAL;
         goto done;
     }

--- a/resource/planner/test/planner_errno_test.cpp
+++ b/resource/planner/test/planner_errno_test.cpp
@@ -16,6 +16,7 @@ extern "C" {
 
 #include <cerrno>
 #include "planner.h"
+#include "planner_multi.h"
 #include "src/common/libtap/tap.h"
 
 static int test_planner_avail_resources_at_errno ()
@@ -170,6 +171,349 @@ static int test_planner_avail_during_erange ()
     return 0;
 }
 
+static int test_planner_null_arg_guards ()
+{
+    planner_t *ctx = planner_new (0, 100, 10, "core");
+    ok (ctx != nullptr, "planner_new succeeded");
+
+    errno = 0;
+    ok (planner_copy (nullptr) == nullptr && errno == EINVAL,
+        "planner_copy (NULL) returns NULL with errno=EINVAL");
+
+    errno = 0;
+    planner_assign (nullptr, ctx);
+    ok (errno == EINVAL, "planner_assign (NULL lhs) sets errno=EINVAL");
+
+    errno = 0;
+    planner_assign (ctx, nullptr);
+    ok (errno == EINVAL, "planner_assign (NULL rhs) sets errno=EINVAL");
+
+    errno = 0;
+    ok (planner_add_span (nullptr, 0, 10, 5) == -1 && errno == EINVAL,
+        "planner_add_span (NULL ctx) returns -1 with errno=EINVAL");
+
+    errno = 0;
+    ok (planner_update_total (nullptr, 10) == -1 && errno == EINVAL,
+        "planner_update_total (NULL ctx) returns -1 with errno=EINVAL");
+
+    // Null planners must compare equal for operator== reflexivity of
+    // vertex data with nullable planner members
+    ok (planners_equal (nullptr, nullptr), "planners_equal (NULL, NULL) returns true");
+    ok (!planners_equal (ctx, nullptr), "planners_equal (ctx, NULL) returns false");
+    ok (!planners_equal (nullptr, ctx), "planners_equal (NULL, ctx) returns false");
+    ok (planners_equal (ctx, ctx), "planners_equal (ctx, ctx) returns true");
+
+    planner_destroy (&ctx);
+    return 0;
+}
+
+static int test_planner_multi_null_arg_guards ()
+{
+    const uint64_t totals[] = {10, 20};
+    const char *types[] = {"core", "memory"};
+    planner_multi_t *ctx = planner_multi_new (0, 100, totals, types, 2);
+    ok (ctx != nullptr, "planner_multi_new succeeded");
+
+    errno = 0;
+    ok (planner_multi_copy (nullptr) == nullptr && errno == EINVAL,
+        "planner_multi_copy (NULL) returns NULL with errno=EINVAL");
+
+    errno = 0;
+    planner_multi_assign (nullptr, ctx);
+    ok (errno == EINVAL, "planner_multi_assign (NULL lhs) sets errno=EINVAL");
+
+    errno = 0;
+    planner_multi_assign (ctx, nullptr);
+    ok (errno == EINVAL, "planner_multi_assign (NULL rhs) sets errno=EINVAL");
+
+    ok (planner_multis_equal (nullptr, nullptr), "planner_multis_equal (NULL, NULL) returns true");
+    ok (!planner_multis_equal (ctx, nullptr), "planner_multis_equal (ctx, NULL) returns false");
+    ok (!planner_multis_equal (nullptr, ctx), "planner_multis_equal (NULL, ctx) returns false");
+    ok (planner_multis_equal (ctx, ctx), "planner_multis_equal (ctx, ctx) returns true");
+
+    errno = 0;
+    ok (planner_multi_span_first (nullptr) == -1 && errno == EINVAL,
+        "planner_multi_span_first (NULL ctx) returns -1 with errno=EINVAL");
+
+    errno = 0;
+    ok (planner_multi_resource_type_at (ctx, 2) == nullptr && errno == EINVAL,
+        "planner_multi_resource_type_at (out-of-range index) returns NULL with errno=EINVAL");
+
+    const uint64_t requests[] = {1, 1};
+    errno = 0;
+    ok (planner_multi_add_span (nullptr, 0, 10, requests, 2) == -1 && errno == EINVAL,
+        "planner_multi_add_span (NULL ctx) returns -1 with errno=EINVAL");
+
+    errno = 0;
+    ok (planner_multi_add_span (ctx, 0, 10, requests, 1) == -1 && errno == EINVAL,
+        "planner_multi_add_span (mismatched len) returns -1 with errno=EINVAL");
+
+    planner_multi_destroy (&ctx);
+    return 0;
+}
+
+static int test_planner_multi_empty_guards ()
+{
+    planner_multi_t *ctx = planner_multi_empty ();
+    ok (ctx != nullptr, "planner_multi_empty succeeded");
+
+    // These would throw std::out_of_range across the C boundary without
+    // the empty-planner guards
+    errno = 0;
+    ok (planner_multi_base_time (ctx) == -1 && errno == EINVAL,
+        "planner_multi_base_time (empty planner) returns -1 with errno=EINVAL");
+
+    errno = 0;
+    ok (planner_multi_duration (ctx) == -1 && errno == EINVAL,
+        "planner_multi_duration (empty planner) returns -1 with errno=EINVAL");
+
+    errno = 0;
+    ok (planner_multi_avail_time_next (ctx) == -1 && errno == EINVAL,
+        "planner_multi_avail_time_next (empty planner) returns -1 with errno=EINVAL");
+
+    // planner_multi_update derives base_time and duration from the planner
+    // at index 0, which an empty planner_multi does not have
+    const uint64_t totals[] = {10};
+    const char *types[] = {"core"};
+    errno = 0;
+    ok (planner_multi_update (ctx, totals, types, 1) == -1 && errno == EINVAL,
+        "planner_multi_update (empty planner) returns -1 with errno=EINVAL");
+
+    planner_multi_destroy (&ctx);
+    return 0;
+}
+
+static int test_planner_self_assign ()
+{
+    planner_t *ctx = planner_new (0, 100, 10, "core");
+    ok (ctx != nullptr, "planner_new succeeded");
+
+    int64_t span_id = planner_add_span (ctx, 10, 10, 8);
+    ok (span_id >= 0, "planner_add_span succeeded");
+
+    // Self-assignment must be a no-op: without the guard, operator=
+    // first erases its own state and then copies from the erased state
+    planner_assign (ctx, ctx);
+    ok (planner_avail_resources_at (ctx, 15) == 2, "self-assign preserves span allocations");
+    ok (planner_span_resource_count (ctx, span_id) == 8, "self-assign preserves the span");
+
+    planner_destroy (&ctx);
+    return 0;
+}
+
+static int test_planner_multi_self_assign ()
+{
+    const uint64_t totals[] = {10, 20};
+    const char *types[] = {"core", "memory"};
+    planner_multi_t *ctx = planner_multi_new (0, 100, totals, types, 2);
+    ok (ctx != nullptr, "planner_multi_new succeeded");
+
+    const uint64_t requests[] = {5, 10};
+    int64_t span_id = planner_multi_add_span (ctx, 0, 10, requests, 2);
+    ok (span_id >= 0, "planner_multi_add_span succeeded");
+
+    // Self-assignment must be a no-op: without the guard, operator=
+    // first erases its own planners and then copies from the erased state
+    planner_multi_assign (ctx, ctx);
+    ok (planner_multi_resources_len (ctx) == 2, "self-assign preserves the planner set");
+    ok (planner_multi_span_planned_at (ctx, span_id, 0) == 5,
+        "self-assign preserves span allocations");
+    ok (planner_multi_avail_resources_at (ctx, 5, 0) == 5, "self-assign preserves availability");
+
+    planner_multi_destroy (&ctx);
+    return 0;
+}
+
+static int test_planner_multi_copy_iterator_independent ()
+{
+    const uint64_t totals[] = {10};
+    const char *types[] = {"core"};
+    planner_multi_t *orig = planner_multi_new (0, 100, totals, types, 1);
+    ok (orig != nullptr, "planner_multi_new succeeded");
+
+    const uint64_t requests[] = {1};
+    int64_t s0 = planner_multi_add_span (orig, 0, 10, requests, 1);
+    int64_t s1 = planner_multi_add_span (orig, 20, 10, requests, 1);
+    ok (s0 >= 0 && s1 >= 0, "added two spans");
+
+    // Position the source's span iterator mid-iteration, then copy
+    ok (planner_multi_span_first (orig) == s0, "planner_multi_span_first on the source");
+    planner_multi_t *copy = planner_multi_copy (orig);
+    ok (copy != nullptr, "planner_multi_copy succeeded");
+
+    // The copy iterates its own span map from the start, independent of
+    // the source's iterator position
+    ok (planner_multi_span_first (copy) == s0, "planner_multi_span_first on the copy");
+    ok (planner_multi_span_next (orig) == s1, "the source's iteration is unaffected by the copy");
+
+    // Destroy the source: the copy's iterator must not reference the
+    // source's (now freed) span map
+    planner_multi_destroy (&orig);
+    ok (planner_multi_span_next (copy) == s1, "the copy's iterator survives destroying the source");
+    errno = 0;
+    ok (planner_multi_span_next (copy) == -1 && errno == ENOENT,
+        "the copy's iteration ends cleanly");
+
+    planner_multi_destroy (&copy);
+    return 0;
+}
+
+static int test_planner_multi_rem_span_after_planner_delete ()
+{
+    const uint64_t totals[] = {10, 20};
+    const char *types[] = {"core", "memory"};
+    planner_multi_t *ctx = planner_multi_new (0, 100, totals, types, 2);
+    ok (ctx != nullptr, "planner_multi_new succeeded");
+
+    const uint64_t requests[] = {5, 10};
+    int64_t span_id = planner_multi_add_span (ctx, 0, 10, requests, 2);
+    ok (span_id >= 0, "planner_multi_add_span succeeded");
+
+    // Shrink the planner_multi to one resource type; the existing span's
+    // lookup vector is now longer than the planner count
+    const uint64_t new_totals[] = {10};
+    const char *new_types[] = {"core"};
+    ok (planner_multi_update (ctx, new_totals, new_types, 1) == 0,
+        "planner_multi_update to remove a resource type succeeded");
+
+    // Removing the span would index the lookup vector past the end of the
+    // planner set and throw std::out_of_range across the C boundary
+    // without the guard
+    errno = 0;
+    ok (planner_multi_rem_span (ctx, span_id) == -1 && errno == EINVAL,
+        "planner_multi_rem_span (span vector longer than planner set) returns -1 with "
+        "errno=EINVAL");
+
+    planner_multi_destroy (&ctx);
+    return 0;
+}
+
+static int test_planner_multi_avail_time_next_after_front_insert ()
+{
+    const uint64_t totals[] = {10};
+    const char *types[] = {"core"};
+    planner_multi_t *ctx = planner_multi_new (0, 100, totals, types, 1);
+    ok (ctx != nullptr, "planner_multi_new succeeded");
+
+    const uint64_t span_requests[] = {5};
+    int64_t span_id = planner_multi_add_span (ctx, 10, 10, span_requests, 1);
+    ok (span_id >= 0, "planner_multi_add_span succeeded");
+
+    const uint64_t requests[] = {10};
+    ok (planner_multi_avail_time_first (ctx, 0, 5, requests, 1) == 0,
+        "planner_multi_avail_time_first returns the earliest satisfiable time");
+
+    // Insert a new resource type at index 0 between avail_time_first and
+    // avail_time_next: the planner now leading the iteration is one whose
+    // availability iterator was never initialized by avail_time_first
+    const uint64_t new_totals[] = {30, 10};
+    const char *new_types[] = {"gpu", "core"};
+    ok (planner_multi_update (ctx, new_totals, new_types, 2) == 0,
+        "planner_multi_update to insert a resource type at index 0 succeeded");
+
+    // The contract is that iteration restarts with avail_time_first after
+    // a composition change; a stale continuation must fail cleanly with
+    // EINVAL (planner_avail_time_next on an uninitialized availability
+    // iterator) rather than crash or return stale data
+    errno = 0;
+    ok (planner_multi_avail_time_next (ctx) == -1 && errno == EINVAL,
+        "planner_multi_avail_time_next after front insertion returns -1 with errno=EINVAL");
+
+    // Restarting the iteration works
+    const uint64_t new_requests[] = {1, 10};
+    ok (planner_multi_avail_time_first (ctx, 0, 5, new_requests, 2) == 0,
+        "planner_multi_avail_time_first after the composition change succeeds");
+
+    planner_multi_destroy (&ctx);
+    return 0;
+}
+
+static int test_planner_multi_short_span_vector ()
+{
+    const uint64_t totals[] = {10};
+    const char *types[] = {"core"};
+    planner_multi_t *ctx = planner_multi_new (0, 100, totals, types, 1);
+    ok (ctx != nullptr, "planner_multi_new succeeded");
+
+    const uint64_t requests[] = {5};
+    int64_t span_id = planner_multi_add_span (ctx, 0, 10, requests, 1);
+    ok (span_id >= 0, "planner_multi_add_span succeeded");
+
+    // Grow the planner_multi by one resource type; the existing span's
+    // lookup vector is now shorter than the planner count
+    const uint64_t new_totals[] = {10, 20};
+    const char *new_types[] = {"core", "memory"};
+    ok (planner_multi_update (ctx, new_totals, new_types, 2) == 0,
+        "planner_multi_update to add a resource type succeeded");
+
+    // Accessing the added resource type index for the pre-existing span
+    // would throw std::out_of_range across the C boundary without the
+    // span vector bounds guard. The span holds no allocation of the type
+    // added after its creation, so the planned count is 0.
+    errno = 0;
+    ok (planner_multi_span_planned_at (ctx, span_id, 1) == 0,
+        "planner_multi_span_planned_at (type added after span creation) returns 0");
+
+    // An out-of-range index must still be an error
+    errno = 0;
+    ok (planner_multi_span_planned_at (ctx, span_id, 2) == -1 && errno == EINVAL,
+        "planner_multi_span_planned_at (out-of-range index) returns -1 with errno=EINVAL");
+
+    // Reducing a span whose lookup vector is shorter than the planner
+    // count must fail up front and leave planner state unchanged
+    const uint64_t reduced[] = {2};
+    const char *reduced_types[] = {"core"};
+    bool removed = true;
+    errno = 0;
+    ok (planner_multi_reduce_span (ctx, span_id, reduced, reduced_types, 1, removed) == -1
+            && errno == EINVAL && !removed,
+        "planner_multi_reduce_span (short span vector) returns -1 with errno=EINVAL");
+    ok (planner_multi_avail_resources_at (ctx, 5, 0) == 5,
+        "failed planner_multi_reduce_span leaves availability unchanged");
+    ok (planner_multi_span_planned_at (ctx, span_id, 0) == 5,
+        "failed planner_multi_reduce_span leaves the span's planned count unchanged");
+
+    planner_multi_destroy (&ctx);
+    return 0;
+}
+
+static int test_planner_multi_iterator_after_tail_growth ()
+{
+    const uint64_t totals[] = {10};
+    const char *types[] = {"core"};
+    planner_multi_t *ctx = planner_multi_new (0, 100, totals, types, 1);
+    ok (ctx != nullptr, "planner_multi_new succeeded");
+
+    // Occupy 5 cores in [10, 20) so a request for all 10 cores has a
+    // next satisfiable point (t=20) after the first (t=0)
+    const uint64_t span_requests[] = {5};
+    int64_t span_id = planner_multi_add_span (ctx, 10, 10, span_requests, 1);
+    ok (span_id >= 0, "planner_multi_add_span succeeded");
+
+    const uint64_t requests[] = {10};
+    ok (planner_multi_avail_time_first (ctx, 0, 5, requests, 1) == 0,
+        "planner_multi_avail_time_first returns the earliest satisfiable time");
+
+    // Grow the planner_multi between avail_time_first and avail_time_next;
+    // planner_multi_update registers the added type in the iterator request
+    // with a zero count
+    const uint64_t new_totals[] = {10, 20};
+    const char *new_types[] = {"core", "memory"};
+    ok (planner_multi_update (ctx, new_totals, new_types, 2) == 0,
+        "planner_multi_update to add a resource type succeeded");
+
+    // The iteration must survive the composition change (no exception across
+    // the C boundary) and treat the added type as a zero request: the next
+    // point at which all 10 cores are free is t=20 (span end)
+    errno = 0;
+    ok (planner_multi_avail_time_next (ctx) == 20,
+        "planner_multi_avail_time_next after planner_multi_update returns the next "
+        "satisfiable time");
+
+    planner_multi_destroy (&ctx);
+    return 0;
+}
+
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
@@ -180,6 +524,16 @@ int main (int argc, char *argv[])
     test_planner_rem_span_errno ();
     test_planner_avail_during_ebusy ();
     test_planner_avail_during_erange ();
+    test_planner_null_arg_guards ();
+    test_planner_multi_null_arg_guards ();
+    test_planner_multi_empty_guards ();
+    test_planner_self_assign ();
+    test_planner_multi_self_assign ();
+    test_planner_multi_copy_iterator_independent ();
+    test_planner_multi_rem_span_after_planner_delete ();
+    test_planner_multi_avail_time_next_after_front_insert ();
+    test_planner_multi_short_span_vector ();
+    test_planner_multi_iterator_after_tail_growth ();
 
     done_testing ();
     return EXIT_SUCCESS;

--- a/resource/planner/test/planner_errno_test.cpp
+++ b/resource/planner/test/planner_errno_test.cpp
@@ -181,12 +181,12 @@ static int test_planner_null_arg_guards ()
         "planner_copy (NULL) returns NULL with errno=EINVAL");
 
     errno = 0;
-    planner_assign (nullptr, ctx);
-    ok (errno == EINVAL, "planner_assign (NULL lhs) sets errno=EINVAL");
+    ok (planner_assign (nullptr, ctx) == -1 && errno == EINVAL,
+        "planner_assign (NULL lhs) returns -1 with errno=EINVAL");
 
     errno = 0;
-    planner_assign (ctx, nullptr);
-    ok (errno == EINVAL, "planner_assign (NULL rhs) sets errno=EINVAL");
+    ok (planner_assign (ctx, nullptr) == -1 && errno == EINVAL,
+        "planner_assign (NULL rhs) returns -1 with errno=EINVAL");
 
     errno = 0;
     ok (planner_add_span (nullptr, 0, 10, 5) == -1 && errno == EINVAL,
@@ -219,12 +219,12 @@ static int test_planner_multi_null_arg_guards ()
         "planner_multi_copy (NULL) returns NULL with errno=EINVAL");
 
     errno = 0;
-    planner_multi_assign (nullptr, ctx);
-    ok (errno == EINVAL, "planner_multi_assign (NULL lhs) sets errno=EINVAL");
+    ok (planner_multi_assign (nullptr, ctx) == -1 && errno == EINVAL,
+        "planner_multi_assign (NULL lhs) returns -1 with errno=EINVAL");
 
     errno = 0;
-    planner_multi_assign (ctx, nullptr);
-    ok (errno == EINVAL, "planner_multi_assign (NULL rhs) sets errno=EINVAL");
+    ok (planner_multi_assign (ctx, nullptr) == -1 && errno == EINVAL,
+        "planner_multi_assign (NULL rhs) returns -1 with errno=EINVAL");
 
     ok (planner_multis_equal (nullptr, nullptr), "planner_multis_equal (NULL, NULL) returns true");
     ok (!planner_multis_equal (ctx, nullptr), "planner_multis_equal (ctx, NULL) returns false");
@@ -293,7 +293,7 @@ static int test_planner_self_assign ()
 
     // Self-assignment must be a no-op: without the guard, operator=
     // first erases its own state and then copies from the erased state
-    planner_assign (ctx, ctx);
+    ok (planner_assign (ctx, ctx) == 0, "self-assign returns 0");
     ok (planner_avail_resources_at (ctx, 15) == 2, "self-assign preserves span allocations");
     ok (planner_span_resource_count (ctx, span_id) == 8, "self-assign preserves the span");
 
@@ -314,7 +314,7 @@ static int test_planner_multi_self_assign ()
 
     // Self-assignment must be a no-op: without the guard, operator=
     // first erases its own planners and then copies from the erased state
-    planner_multi_assign (ctx, ctx);
+    ok (planner_multi_assign (ctx, ctx) == 0, "self-assign returns 0");
     ok (planner_multi_resources_len (ctx) == 2, "self-assign preserves the planner set");
     ok (planner_multi_span_planned_at (ctx, span_id, 0) == 5,
         "self-assign preserves span allocations");

--- a/resource/planner/test/planner_test01.cpp
+++ b/resource/planner/test/planner_test01.cpp
@@ -688,8 +688,8 @@ static int test_constructors_and_overload ()
     bo = (bo || !planners_equal (ctx2, ctx3));
     ok (!bo, "empty planners should be equal");
 
-    planner_assign (ctx2, ctx);
-    planner_assign (ctx3, ctx2);
+    bo = (bo || planner_assign (ctx2, ctx) != 0);
+    bo = (bo || planner_assign (ctx3, ctx2) != 0);
     bo = (bo || !(planners_equal (ctx2, ctx3)));
     bo = (bo || !(planners_equal (ctx, ctx2)));
     ok (!bo, "test assignment overload");
@@ -709,7 +709,7 @@ static int test_constructors_and_overload ()
     bo = (bo || (planners_equal (ctx2, ctx4)) || rc == -1);
     ok (!bo, "compare planners after mutation");
 
-    planner_assign (ctx4, ctx2);
+    bo = (bo || planner_assign (ctx4, ctx2) != 0);
     bo = (bo || !(planners_equal (ctx2, ctx4)));
     ok (!bo, "assignment overload works on planners with state");
 

--- a/resource/planner/test/planner_test02.cpp
+++ b/resource/planner/test/planner_test02.cpp
@@ -571,7 +571,7 @@ static int test_constructors_and_overload ()
     ctx3 = planner_multi_empty ();
     bo = (bo || !planner_multis_equal (ctx2, ctx3));
 
-    planner_multi_assign (ctx2, ctx);
+    bo = (bo || planner_multi_assign (ctx2, ctx) != 0);
     bo = (bo || !(planner_multis_equal (ctx, ctx2)));
     ok (!bo, "test assignment overload");
 
@@ -590,7 +590,7 @@ static int test_constructors_and_overload ()
     size = planner_multi_span_size (ctx4);
     ok ((size == 3), "removing span doesn't change deep copy's size");
     // Assignment overload works on planners with state
-    planner_multi_assign (ctx4, ctx2);
+    bo = (bo || planner_multi_assign (ctx4, ctx2) != 0);
     size = planner_multi_span_size (ctx4);
     ok ((size == 2), "planner_multi 3 now has the size of planner_multi 2");
     bo = (bo || !(planner_multis_equal (ctx2, ctx4)));

--- a/resource/reapi/bindings/c/reapi_cli.cpp
+++ b/resource/reapi/bindings/c/reapi_cli.cpp
@@ -100,32 +100,33 @@ extern "C" void reapi_cli_destroy (reapi_cli_ctx_t *ctx)
 
 extern "C" int reapi_cli_initialize (reapi_cli_ctx_t *ctx, const char *rgraph, const char *options)
 {
-    int rc = -1;
+    resource_query_t *rqt = nullptr;
 
     if (!ctx || !rgraph || !options) {
         errno = EINVAL;
         return -1;
     }
-    ctx->rqt = nullptr;
 
+    // Construct into a local first so that a failed (re)initialization
+    // neither leaks a previously installed resource_query_t nor leaves
+    // the context pointing at destroyed state.
     try {
-        ctx->rqt = new resource_query_t (rgraph, options);
+        rqt = new resource_query_t (rgraph, options);
     } catch (std::bad_alloc &e) {
         ctx->err_msg += __FUNCTION__;
         ctx->err_msg += ": ERROR: can't allocate memory: " + std::string (e.what ()) + "\n";
         errno = ENOMEM;
-        goto out;
+        return -1;
     } catch (std::runtime_error &e) {
         ctx->err_msg += __FUNCTION__;
         ctx->err_msg += ": Runtime error: " + std::string (e.what ()) + "\n";
         errno = EPROTO;
-        goto out;
+        return -1;
     }
 
-    rc = 0;
-
-out:
-    return rc;
+    delete ctx->rqt;
+    ctx->rqt = rqt;
+    return 0;
 }
 
 extern "C" reapi_cli_ctx_t *reapi_cli_clone (reapi_cli_ctx_t *ctx)
@@ -249,7 +250,7 @@ extern "C" int reapi_cli_match_satisfy (reapi_cli_ctx_t *ctx,
     match_op_t match_op = match_op_t::MATCH_SATISFIABILITY;
     uint64_t jobid;
     bool reserved;
-    char *R;
+    char *R = nullptr;
     int64_t at;
     int ret;
 
@@ -262,6 +263,13 @@ extern "C" int reapi_cli_match_satisfy (reapi_cli_ctx_t *ctx,
     *sat = true;
 
     ret = reapi_cli_match (ctx, match_op, jobspec, &jobid, &reserved, &R, &at, ov);
+    // R is not part of a satisfiability response; free the strdup'd buffer.
+    // Preserve errno defensively across cleanup for compatibility with older
+    // or nonconforming allocation environments (POSIX.1-2024 requires that
+    // free () not modify errno; earlier editions did not).
+    int saved_errno = errno;
+    free (R);
+    errno = saved_errno;
 
     // Not satisfiable if the match reported unsatisfiable (ENODEV) or failed
     // for any other reason (e.g. a jobspec referencing an unknown resource

--- a/resource/reapi/bindings/c/reapi_cli.cpp
+++ b/resource/reapi/bindings/c/reapi_cli.cpp
@@ -113,13 +113,19 @@ extern "C" int reapi_cli_initialize (reapi_cli_ctx_t *ctx, const char *rgraph, c
     try {
         rqt = new resource_query_t (rgraph, options);
     } catch (std::bad_alloc &e) {
-        ctx->err_msg += __FUNCTION__;
-        ctx->err_msg += ": ERROR: can't allocate memory: " + std::string (e.what ()) + "\n";
+        // Keep this handler allocation-free: appending a diagnostic to
+        // err_msg allocates, and a second bad_alloc thrown while handling
+        // the first would escape this extern "C" boundary.
         errno = ENOMEM;
         return -1;
     } catch (std::runtime_error &e) {
-        ctx->err_msg += __FUNCTION__;
-        ctx->err_msg += ": Runtime error: " + std::string (e.what ()) + "\n";
+        try {
+            // Best effort: constructing the diagnostic allocates and must
+            // not let a secondary exception escape the C boundary.
+            ctx->err_msg += __FUNCTION__;
+            ctx->err_msg += ": Runtime error: " + std::string (e.what ()) + "\n";
+        } catch (...) {
+        }
         errno = EPROTO;
         return -1;
     }
@@ -142,23 +148,37 @@ extern "C" reapi_cli_ctx_t *reapi_cli_clone (reapi_cli_ctx_t *ctx)
         clone->err_msg = "";
         return clone.release ();
     } catch (std::bad_alloc &e) {
-        ctx->err_msg = __FUNCTION__;
-        ctx->err_msg += ": ERROR: can't allocate memory: " + std::string (e.what ()) + "\n";
+        // Keep this handler allocation-free: appending a diagnostic to
+        // err_msg allocates, and a second bad_alloc thrown while handling
+        // the first would escape this extern "C" boundary.
         errno = ENOMEM;
         return nullptr;
     } catch (std::system_error &e) {
-        ctx->err_msg = __FUNCTION__;
-        ctx->err_msg += ": ERROR: System error: " + std::string (e.what ()) + "\n";
+        try {
+            // Best effort: constructing the diagnostic allocates and must
+            // not let a secondary exception escape the C boundary.
+            ctx->err_msg = __FUNCTION__;
+            ctx->err_msg += ": ERROR: System error: " + std::string (e.what ()) + "\n";
+        } catch (...) {
+        }
         errno = e.code ().value ();
         return nullptr;
     } catch (std::runtime_error &e) {
-        ctx->err_msg = __FUNCTION__;
-        ctx->err_msg += ": ERROR: Runtime error: " + std::string (e.what ()) + "\n";
+        try {
+            // Best effort; see above.
+            ctx->err_msg = __FUNCTION__;
+            ctx->err_msg += ": ERROR: Runtime error: " + std::string (e.what ()) + "\n";
+        } catch (...) {
+        }
         errno = EPROTO;
         return nullptr;
     } catch (...) {
-        ctx->err_msg = __FUNCTION__;
-        ctx->err_msg += ": ERROR: unknown exception during clone\n";
+        try {
+            // Best effort; see above.
+            ctx->err_msg = __FUNCTION__;
+            ctx->err_msg += ": ERROR: unknown exception during clone\n";
+        } catch (...) {
+        }
         errno = EINVAL;
         return nullptr;
     }

--- a/resource/reapi/bindings/c/reapi_cli.cpp
+++ b/resource/reapi/bindings/c/reapi_cli.cpp
@@ -75,21 +75,22 @@ extern "C" reapi_cli_ctx_t *reapi_cli_new ()
     try {
         ctx = new reapi_cli_ctx_t;
     } catch (const std::bad_alloc &e) {
-        ctx->err_msg = __FUNCTION__;
-        ctx->err_msg += ": ERROR: can't allocate memory: " + std::string (e.what ()) + "\n";
+        // ctx is still nullptr here; an error message can't be stored in an
+        // object that failed to allocate.
         errno = ENOMEM;
-        goto out;
+        return nullptr;
     }
 
     ctx->rqt = nullptr;
     ctx->err_msg = "";
 
-out:
     return ctx;
 }
 
 extern "C" void reapi_cli_destroy (reapi_cli_ctx_t *ctx)
 {
+    if (!ctx)
+        return;
     int saved_errno = errno;
     if (ctx->rqt)
         delete ctx->rqt;
@@ -100,6 +101,11 @@ extern "C" void reapi_cli_destroy (reapi_cli_ctx_t *ctx)
 extern "C" int reapi_cli_initialize (reapi_cli_ctx_t *ctx, const char *rgraph, const char *options)
 {
     int rc = -1;
+
+    if (!ctx || !rgraph || !options) {
+        errno = EINVAL;
+        return -1;
+    }
     ctx->rqt = nullptr;
 
     try {
@@ -170,7 +176,7 @@ extern "C" int reapi_cli_match_with_jobid (reapi_cli_ctx_t *ctx,
     std::string R_buf = "";
     char *R_buf_c = nullptr;
 
-    if (!ctx || !ctx->rqt) {
+    if (!ctx || !ctx->rqt || !jobspec || !reserved || !R || !at || !ov) {
         errno = EINVAL;
         goto out;
     }
@@ -205,7 +211,7 @@ extern "C" int reapi_cli_match (reapi_cli_ctx_t *ctx,
 {
     int rc = -1;
 
-    if (!ctx || !ctx->rqt) {
+    if (!ctx || !ctx->rqt || !jobid) {
         errno = EINVAL;
         return -1;
     }
@@ -246,6 +252,13 @@ extern "C" int reapi_cli_match_satisfy (reapi_cli_ctx_t *ctx,
     char *R;
     int64_t at;
     int ret;
+
+    // Validate every pointer argument before the *sat write below;
+    // reapi_cli_match checks the rest (ctx->rqt, jobspec, ov).
+    if (!ctx || !jobspec || !sat || !ov) {
+        errno = EINVAL;
+        return -1;
+    }
     *sat = true;
 
     ret = reapi_cli_match (ctx, match_op, jobspec, &jobid, &reserved, &R, &at, ov);
@@ -408,7 +421,7 @@ extern "C" int reapi_cli_stat (reapi_cli_ctx_t *ctx,
                                double *max,
                                double *avg)
 {
-    if (!ctx || !ctx->rqt) {
+    if (!ctx || !ctx->rqt || !V || !E || !J || !load || !min || !max || !avg) {
         errno = EINVAL;
         return -1;
     }
@@ -432,6 +445,8 @@ extern "C" const char *reapi_cli_get_err_msg (reapi_cli_ctx_t *ctx)
 
 extern "C" void reapi_cli_clear_err_msg (reapi_cli_ctx_t *ctx)
 {
+    if (!ctx)
+        return;
     if (ctx->rqt)
         ctx->rqt->clear_resource_query_err_msg ();
     reapi_cli_t::clear_err_message ();

--- a/resource/reapi/bindings/c/reapi_module.cpp
+++ b/resource/reapi/bindings/c/reapi_module.cpp
@@ -60,7 +60,7 @@ extern "C" int reapi_module_match (reapi_module_ctx_t *ctx,
     std::string R_buf = "";
     char *R_buf_c = NULL;
 
-    if (!ctx || !ctx->h) {
+    if (!ctx || !ctx->h || !jobspec || !reserved || !R || !at || !ov) {
         errno = EINVAL;
         goto out;
     }
@@ -98,11 +98,19 @@ extern "C" int reapi_module_match_satisfy (reapi_module_ctx_t *ctx, const char *
 {
     match_op_t match_op = match_op_t::MATCH_SATISFIABILITY;
     const uint64_t jobid = 0;
-    bool *reserved;
-    char **R;
-    int64_t *at;
+    bool reserved = false;
+    char *R = NULL;
+    int64_t at = -1;
+    int rc;
 
-    return reapi_module_match (ctx, match_op, jobspec, jobid, reserved, R, at, ov);
+    rc = reapi_module_match (ctx, match_op, jobspec, jobid, &reserved, &R, &at, ov);
+    // Preserve errno defensively across cleanup for compatibility with older
+    // or nonconforming allocation environments (POSIX.1-2024 requires that
+    // free () not modify errno; earlier editions did not).
+    int saved_errno = errno;
+    free (R);
+    errno = saved_errno;
+    return rc;
 }
 
 extern "C" int reapi_module_update_allocate (reapi_module_ctx_t *ctx,
@@ -160,7 +168,7 @@ extern "C" int reapi_module_info (reapi_module_ctx_t *ctx,
                                   int64_t *at,
                                   double *ov)
 {
-    if (!ctx || !ctx->h) {
+    if (!ctx || !ctx->h || !reserved || !at || !ov) {
         errno = EINVAL;
         return -1;
     }
@@ -185,7 +193,7 @@ extern "C" int reapi_module_stat (reapi_module_ctx_t *ctx,
                                   double *max,
                                   double *avg)
 {
-    if (!ctx || !ctx->h) {
+    if (!ctx || !ctx->h || !V || !E || !J || !load || !min || !max || !avg) {
         errno = EINVAL;
         return -1;
     }

--- a/resource/reapi/test/reapi_cli_test_c.cpp
+++ b/resource/reapi/test/reapi_cli_test_c.cpp
@@ -2,10 +2,24 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <resource/reapi/bindings/c/reapi_cli.h>
+#include <cerrno>
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
+#include <string>
 
 namespace Flux::resource_model::detail {
+
+// reapi_cli_get_err_msg () returns a strdup'd buffer on every path; take
+// ownership into a std::string and free the buffer so streaming the message
+// into INFO does not leak the allocation.
+static std::string take_err_msg (reapi_cli_ctx_t *ctx)
+{
+    char *msg = const_cast<char *> (reapi_cli_get_err_msg (ctx));
+    std::string res = msg ? msg : "";
+    free (msg);
+    return res;
+}
 
 TEST_CASE ("Initialize REAPI CLI", "[initialize C]")
 {
@@ -100,29 +114,33 @@ TEST_CASE ("Initialize REAPI CLI and test match, satisfy, and cancel",
     const std::string jobspec2 = buffer3.str ();
 
     reapi_cli_ctx_t *ctx = reapi_cli_new ();
+    int rc = -1;
 
-    // Test initialize with invalid params
-    REQUIRE (reapi_cli_initialize (ctx, "", "") != 0);
-    INFO (reapi_cli_get_err_msg (ctx));
+    // Test initialize with invalid params.  Install the diagnostic before
+    // the assertion so a failure is annotated with the error message.
+    rc = reapi_cli_initialize (ctx, "", "");
+    INFO (take_err_msg (ctx));
+    REQUIRE (rc != 0);
 
     // Test match with empty resource graph
     REQUIRE (reapi_cli_match (ctx, match_op, jobspec.c_str (), &jobid, &reserved, &R, &at, &ov)
              != 0);
 
     // Test initialization with valid params
-    REQUIRE (reapi_cli_initialize (ctx, rgraph.c_str (), options.c_str ()) == 0);
-    INFO (reapi_cli_get_err_msg (ctx));
+    rc = reapi_cli_initialize (ctx, rgraph.c_str (), options.c_str ());
+    INFO (take_err_msg (ctx));
+    REQUIRE (rc == 0);
 
     // Test match with populated resource graph
-    CHECK (reapi_cli_match (ctx, match_op, jobspec.c_str (), &jobid2, &reserved, &R, &at, &ov)
-           == 0);
+    rc = reapi_cli_match (ctx, match_op, jobspec.c_str (), &jobid2, &reserved, &R, &at, &ov);
+    INFO (take_err_msg (ctx));
+    CHECK (rc == 0);
     CHECK (reserved == false);
-    INFO (reapi_cli_get_err_msg (ctx));
 
     // Test match_allocate with orelse_reserve = true
-    CHECK (reapi_cli_match_allocate (ctx, true, jobspec.c_str (), &jobid3, &reserved, &R, &at, &ov)
-           == 0);
-    INFO (reapi_cli_get_err_msg (ctx));
+    rc = reapi_cli_match_allocate (ctx, true, jobspec.c_str (), &jobid3, &reserved, &R, &at, &ov);
+    INFO (take_err_msg (ctx));
+    CHECK (rc == 0);
 
     // Test satisfy
     CHECK (reapi_cli_match_satisfy (ctx, jobspec.c_str (), &satisfiable, &ov) == 0);
@@ -137,12 +155,14 @@ TEST_CASE ("Initialize REAPI CLI and test match, satisfy, and cancel",
     CHECK (std::string (mode) == "ALLOCATED");
 
     // Test cancel with invalid jobid
-    CHECK (reapi_cli_cancel (ctx, jobid3 + 1, false) != 0);
-    INFO (reapi_cli_get_err_msg (ctx));
+    rc = reapi_cli_cancel (ctx, jobid3 + 1, false);
+    INFO (take_err_msg (ctx));
+    CHECK (rc != 0);
 
     // Test cancel with valid jobid
-    CHECK (reapi_cli_cancel (ctx, jobid2, false) == 0);
-    INFO (reapi_cli_get_err_msg (ctx));
+    rc = reapi_cli_cancel (ctx, jobid2, false);
+    INFO (take_err_msg (ctx));
+    CHECK (rc == 0);
 
     reapi_cli_destroy (ctx);
 }
@@ -234,8 +254,179 @@ TEST_CASE ("Add subgraph introducing a new resource type", "[add-subgraph-new-ty
     // returns non-zero or lets the interner's std::system_error escape, and the test
     // fails either way.
     int rc = reapi_cli_add_subgraph (ctx, add_sgraph.c_str ());
-    INFO ("reapi_cli_add_subgraph rc=" << rc << " err='" << reapi_cli_get_err_msg (ctx) << "'");
+    INFO ("reapi_cli_add_subgraph rc=" << rc << " err='" << take_err_msg (ctx) << "'");
     CHECK (rc == 0);
+
+    reapi_cli_destroy (ctx);
+}
+
+TEST_CASE ("REAPI CLI C binding null argument guards", "[null-guards C]")
+{
+    // NULL ctx must be a no-op rather than a crash, and must leave errno
+    // unchanged
+    errno = ENOENT;
+    reapi_cli_destroy (nullptr);
+    CHECK (errno == ENOENT);
+
+    errno = ENOENT;
+    reapi_cli_clear_err_msg (nullptr);
+    CHECK (errno == ENOENT);
+
+    errno = 0;
+    REQUIRE (reapi_cli_initialize (nullptr, "{}", "{}") == -1);
+    REQUIRE (errno == EINVAL);
+
+    reapi_cli_ctx_t *ctx = reapi_cli_new ();
+    REQUIRE (ctx);
+
+    errno = 0;
+    REQUIRE (reapi_cli_initialize (ctx, nullptr, "{}") == -1);
+    REQUIRE (errno == EINVAL);
+
+    errno = 0;
+    REQUIRE (reapi_cli_initialize (ctx, "{}", nullptr) == -1);
+    REQUIRE (errno == EINVAL);
+
+    reapi_cli_destroy (ctx);
+}
+
+// Every CLI match binding must reject each null required pointer argument
+// with EINVAL before dereferencing it (or writing through an output).
+TEST_CASE ("REAPI CLI match functions reject null pointer arguments", "[match-null-guards C]")
+{
+    const std::string options = "{}";
+    std::stringstream gbuffer, jbuffer;
+    const char *test_srcdir = std::getenv ("SHARNESS_TEST_SRCDIR");
+    REQUIRE (test_srcdir);
+
+    std::ifstream graphfile (std::string (test_srcdir) + "/data/resource/grugs/tiny.graphml");
+    REQUIRE (graphfile.is_open ());
+    gbuffer << graphfile.rdbuf ();
+    std::string rgraph = gbuffer.str ();
+
+    std::ifstream jobspecfile (std::string (test_srcdir)
+                               + "/data/resource/jobspecs/basics/test006.yaml");
+    REQUIRE (jobspecfile.is_open ());
+    jbuffer << jobspecfile.rdbuf ();
+    std::string jobspec = jbuffer.str ();
+
+    // Initialize a valid context so the pointer-argument guards -- not the
+    // null-context guard -- are what each assertion exercises.
+    reapi_cli_ctx_t *ctx = reapi_cli_new ();
+    REQUIRE (ctx);
+    REQUIRE (reapi_cli_initialize (ctx, rgraph.c_str (), options.c_str ()) == 0);
+
+    match_op_t match_op = match_op_t::MATCH_ALLOCATE;
+    bool reserved = false;
+    bool sat = false;
+    char *R = nullptr;
+    uint64_t jobid = 0;
+    double ov = 0.0;
+    int64_t at = 0;
+
+    struct {
+        const char *jobspec;
+        uint64_t *jobid;
+        bool *reserved;
+        char **R;
+        int64_t *at;
+        double *ov;
+    } args[] = {
+        {nullptr, &jobid, &reserved, &R, &at, &ov},
+        {jobspec.c_str (), nullptr, &reserved, &R, &at, &ov},
+        {jobspec.c_str (), &jobid, nullptr, &R, &at, &ov},
+        {jobspec.c_str (), &jobid, &reserved, nullptr, &at, &ov},
+        {jobspec.c_str (), &jobid, &reserved, &R, nullptr, &ov},
+        {jobspec.c_str (), &jobid, &reserved, &R, &at, nullptr},
+    };
+    for (auto &a : args) {
+        errno = 0;
+        CHECK (reapi_cli_match (ctx, match_op, a.jobspec, a.jobid, a.reserved, a.R, a.at, a.ov)
+               == -1);
+        CHECK (errno == EINVAL);
+    }
+
+    // reapi_cli_match_with_jobid takes the jobid by value; check the rest.
+    for (auto &a : args) {
+        if (!a.jobid)
+            continue;
+        errno = 0;
+        CHECK (reapi_cli_match_with_jobid (ctx, match_op, a.jobspec, 1, a.reserved, a.R, a.at, a.ov)
+               == -1);
+        CHECK (errno == EINVAL);
+    }
+
+    errno = 0;
+    CHECK (reapi_cli_match_satisfy (nullptr, jobspec.c_str (), &sat, &ov) == -1);
+    CHECK (errno == EINVAL);
+    errno = 0;
+    CHECK (reapi_cli_match_satisfy (ctx, nullptr, &sat, &ov) == -1);
+    CHECK (errno == EINVAL);
+    errno = 0;
+    CHECK (reapi_cli_match_satisfy (ctx, jobspec.c_str (), nullptr, &ov) == -1);
+    CHECK (errno == EINVAL);
+    errno = 0;
+    CHECK (reapi_cli_match_satisfy (ctx, jobspec.c_str (), &sat, nullptr) == -1);
+    CHECK (errno == EINVAL);
+
+    // A match must still succeed after the rejected calls (no state damage).
+    errno = 0;
+    CHECK (reapi_cli_match (ctx, match_op, jobspec.c_str (), &jobid, &reserved, &R, &at, &ov) == 0);
+    free (R);
+
+    reapi_cli_destroy (ctx);
+}
+
+TEST_CASE ("REAPI CLI repeated and failed initialization", "[reinitialize C]")
+{
+    const std::string options = "{}";
+    std::stringstream gbuffer, jbuffer;
+    const char *test_srcdir = std::getenv ("SHARNESS_TEST_SRCDIR");
+    REQUIRE (test_srcdir);
+
+    std::ifstream graphfile (std::string (test_srcdir) + "/data/resource/grugs/tiny.graphml");
+    REQUIRE (graphfile.is_open ());
+
+    gbuffer << graphfile.rdbuf ();
+    std::string rgraph = gbuffer.str ();
+
+    std::ifstream jobspecfile (std::string (test_srcdir)
+                               + "/data/resource/jobspecs/basics/test006.yaml");
+    REQUIRE (jobspecfile.is_open ());
+
+    jbuffer << jobspecfile.rdbuf ();
+    std::string jobspec = jbuffer.str ();
+
+    reapi_cli_ctx_t *ctx = reapi_cli_new ();
+    REQUIRE (ctx);
+
+    REQUIRE (reapi_cli_initialize (ctx, rgraph.c_str (), options.c_str ()) == 0);
+
+    // Re-initialization must replace the prior resource_query_t (without
+    // leaking it) and succeed
+    REQUIRE (reapi_cli_initialize (ctx, rgraph.c_str (), options.c_str ()) == 0);
+
+    // A failed re-initialization must leave the previously initialized
+    // context untouched and usable
+    REQUIRE (reapi_cli_initialize (ctx, "", "") != 0);
+
+    match_op_t match_op = match_op_t::MATCH_ALLOCATE;
+    bool reserved = false;
+    char *R = nullptr;
+    uint64_t jobid = 0;
+    double ov = 0.0;
+    int64_t at = 0;
+    int mrc = reapi_cli_match (ctx, match_op, jobspec.c_str (), &jobid, &reserved, &R, &at, &ov);
+    INFO (take_err_msg (ctx));
+    CHECK (mrc == 0);
+    free (R);
+
+    // stat with a null output parameter must fail with EINVAL
+    int64_t E, J;
+    double load, min, max, avg;
+    errno = 0;
+    CHECK (reapi_cli_stat (ctx, nullptr, &E, &J, &load, &min, &max, &avg) == -1);
+    CHECK (errno == EINVAL);
 
     reapi_cli_destroy (ctx);
 }

--- a/resource/schema/infra_data.cpp
+++ b/resource/schema/infra_data.cpp
@@ -15,6 +15,7 @@ extern "C" {
 }
 
 #include <limits>
+#include <stdexcept>
 #include "resource/schema/infra_data.hpp"
 
 namespace Flux {
@@ -71,7 +72,8 @@ pool_infra_t::pool_infra_t (const pool_infra_t &o) : infra_base_t (o)
         if (!x_checker) {
             x_checker = planner_copy (o.x_checker);
         } else {
-            planner_assign (x_checker, o.x_checker);
+            if (planner_assign (x_checker, o.x_checker) != 0)
+                throw std::runtime_error ("ERROR assigning x_checker planner\n");
         }
     }
 }
@@ -98,7 +100,8 @@ pool_infra_t &pool_infra_t::operator= (const pool_infra_t &o)
         if (!x_checker) {
             x_checker = planner_copy (o.x_checker);
         } else {
-            planner_assign (x_checker, o.x_checker);
+            if (planner_assign (x_checker, o.x_checker) != 0)
+                throw std::runtime_error ("ERROR assigning x_checker planner\n");
         }
     }
     return *this;

--- a/resource/schema/sched_data.cpp
+++ b/resource/schema/sched_data.cpp
@@ -28,7 +28,8 @@ schedule_t::schedule_t (const schedule_t &o)
 
     if (plans) {
         if (o.plans) {
-            planner_assign (plans, o.plans);
+            if (planner_assign (plans, o.plans) != 0)
+                throw std::runtime_error ("ERROR assigning planners\n");
         } else {
             planner_destroy (&plans);
         }
@@ -50,7 +51,8 @@ schedule_t &schedule_t::operator= (const schedule_t &o)
 
     if (plans) {
         if (o.plans) {
-            planner_assign (plans, o.plans);
+            if (planner_assign (plans, o.plans) != 0)
+                throw std::runtime_error ("ERROR assigning planners\n");
         } else {
             planner_destroy (&plans);
         }


### PR DESCRIPTION
Reviewing PR #1534 revealed one case of unguarded pointer dereferencing in `planner`. I had Fable 5 scan the entire codebase for similar problems. Unsurprisingly, it found many and also found issues with exception safety and `errno` reporting.

This PR fixes those cases, and is assisted by Claude. It lays a foundation for planner test improvement and eventual refactor of the planner API.