### PR TITLE
traverser: support fractional durations

### DIFF
--- a/resource/traversers/dfu_impl.hpp
+++ b/resource/traversers/dfu_impl.hpp
@@ -13,6 +13,7 @@
 
 #include <cstdlib>
 #include <cstdint>
+#include <cmath>
 #include <memory>
 #include "resource/libjobspec/jobspec.hpp"
 #include "resource/config/system_defaults.hpp"
@@ -72,7 +73,8 @@ struct jobmeta_t {
                                  graph_duration.graph_end - graph_duration.graph_start)
                                  .count ();
 
-        if (g_duration <= 0) {
+        // check for valid durations, use ! >= to catch NaN
+        if (g_duration <= 0 || !(jobspec.attributes.system.duration >= 0)) {
             errno = EINVAL;
             return -1;
         }
@@ -80,14 +82,17 @@ struct jobmeta_t {
         // int64_t max () for comparison with at in dfu_traverser_t::run
         if ((jobspec.attributes.system.duration > static_cast<double> (g_duration))
             || (jobspec.attributes.system.duration
-                > static_cast<double> (std::numeric_limits<int64_t>::max ()))) {
+                > static_cast<double> (std::numeric_limits<int64_t>::max () - 1))) {
             errno = EINVAL;
             return -1;
         }
         if (jobspec.attributes.system.duration == 0.0f) {
             duration = g_duration;
         } else {
-            duration = (int64_t)jobspec.attributes.system.duration;
+            // Round up to the nearest second: better to pad out the duration a tiny bit, and
+            // a fractional duration in (0, 1) must not truncate to 0 (which the planner rejects
+            // with EINVAL)
+            duration = static_cast<int64_t> (std::ceil (jobspec.attributes.system.duration));
         }
         if (jobspec.attributes.system.queue != "") {
             m_queue = jobspec.attributes.system.queue;

--- a/resource/traversers/test/CMakeLists.txt
+++ b/resource/traversers/test/CMakeLists.txt
@@ -14,3 +14,24 @@ add_sanitizers(flexible_split_test)
 catch_discover_tests(flexible_split_test
   TEST_PREFIX "resource traversers "
   )
+
+add_executable(jobmeta_test
+  ${CMAKE_CURRENT_SOURCE_DIR}/jobmeta_test.cpp
+  )
+target_link_libraries(jobmeta_test PRIVATE resource Catch2::Catch2WithMain)
+target_include_directories(jobmeta_test PRIVATE
+  ${CMAKE_SOURCE_DIR}
+  ${CMAKE_SOURCE_DIR}/resource
+  )
+target_compile_definitions(jobmeta_test PRIVATE
+  CATCH_CONFIG_FAST_COMPILE=1
+  )
+add_sanitizers(jobmeta_test)
+# PRE_TEST discovery is required so the trailing space in TEST_PREFIX
+# survives: the default POST_BUILD mode forwards the prefix via `cmake -D`,
+# which strips trailing whitespace and glues the prefix onto the case name.
+# Embedding the target name in the prefix lets `ctest -R jobmeta_test` work.
+catch_discover_tests(jobmeta_test
+  TEST_PREFIX "resource traversers jobmeta_test: "
+  DISCOVERY_MODE PRE_TEST
+  )

--- a/resource/traversers/test/jobmeta_test.cpp
+++ b/resource/traversers/test/jobmeta_test.cpp
@@ -1,0 +1,180 @@
+/*****************************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+}
+
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <limits>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "resource/libjobspec/jobspec.hpp"
+#include "resource/store/resource_graph_store.hpp"
+#include "resource/traversers/dfu_impl.hpp"
+
+using Flux::resource_model::graph_duration_t;
+using Flux::resource_model::detail::jobmeta_t;
+using alloc_type_t = jobmeta_t::alloc_type_t;
+
+namespace {
+
+// A jobspec with the given duration and nothing else set.
+Flux::Jobspec::Jobspec make_jobspec (double duration)
+{
+    Flux::Jobspec::Jobspec js;
+    js.attributes.system.duration = duration;
+    return js;
+}
+
+// Default graph window is [0, SYSTEM_MAX_DURATION), i.e. ~100 years, so
+// g_duration is large enough not to interfere with the duration tests below.
+graph_duration_t default_graph_duration ()
+{
+    return graph_duration_t{};
+}
+
+// A graph window of exactly `seconds` seconds.
+graph_duration_t graph_duration_of (int64_t seconds)
+{
+    graph_duration_t gd;
+    gd.graph_start = std::chrono::system_clock::from_time_t (0);
+    gd.graph_end = std::chrono::system_clock::from_time_t (seconds);
+    return gd;
+}
+
+}  // namespace
+
+TEST_CASE ("integer duration is preserved", "[jobmeta]")
+{
+    jobmeta_t m;
+    auto js = make_jobspec (3600.0);
+    auto gd = default_graph_duration ();
+    REQUIRE (m.build (js, alloc_type_t::AT_ALLOC, 1, 0, gd) == 0);
+    REQUIRE (m.duration == 3600);
+}
+
+TEST_CASE ("fractional duration rounds up", "[jobmeta]")
+{
+    jobmeta_t m;
+    auto js = make_jobspec (1.2);
+    auto gd = default_graph_duration ();
+    REQUIRE (m.build (js, alloc_type_t::AT_ALLOC, 1, 0, gd) == 0);
+    REQUIRE (m.duration == 2);  // truncation would have given 1
+}
+
+TEST_CASE ("sub-second duration maps to 1, not 0", "[jobmeta]")
+{
+    // The planner rejects duration < 1 with EINVAL; before b11ff4b, 0.1
+    // truncated to 0 and the match failed.
+    jobmeta_t m;
+    auto js = make_jobspec (0.1);
+    auto gd = default_graph_duration ();
+    REQUIRE (m.build (js, alloc_type_t::AT_ALLOC, 1, 0, gd) == 0);
+    REQUIRE (m.duration == 1);
+}
+
+TEST_CASE ("zero duration falls back to the graph duration", "[jobmeta]")
+{
+    jobmeta_t m;
+    auto js = make_jobspec (0.0);
+    auto gd = graph_duration_of (1234);
+    REQUIRE (m.build (js, alloc_type_t::AT_ALLOC, 1, 0, gd) == 0);
+    REQUIRE (m.duration == 1234);
+}
+
+TEST_CASE ("NaN duration is rejected with EINVAL", "[jobmeta]")
+{
+    jobmeta_t m;
+    auto js = make_jobspec (std::numeric_limits<double>::quiet_NaN ());
+    auto gd = default_graph_duration ();
+    errno = 0;
+    REQUIRE (m.build (js, alloc_type_t::AT_ALLOC, 1, 0, gd) == -1);
+    REQUIRE (errno == EINVAL);
+}
+
+TEST_CASE ("inf duration is rejected with EINVAL", "[jobmeta]")
+{
+    jobmeta_t m;
+    auto js = make_jobspec (std::numeric_limits<double>::infinity ());
+    auto gd = default_graph_duration ();
+    errno = 0;
+    REQUIRE (m.build (js, alloc_type_t::AT_ALLOC, 1, 0, gd) == -1);
+    REQUIRE (errno == EINVAL);
+}
+
+TEST_CASE ("negative duration is rejected with EINVAL", "[jobmeta]")
+{
+    jobmeta_t m;
+    auto js = make_jobspec (-1.0);
+    auto gd = default_graph_duration ();
+    errno = 0;
+    REQUIRE (m.build (js, alloc_type_t::AT_ALLOC, 1, 0, gd) == -1);
+    REQUIRE (errno == EINVAL);
+}
+
+TEST_CASE ("duration longer than the graph window is rejected", "[jobmeta]")
+{
+    jobmeta_t m;
+    auto js = make_jobspec (20.0);
+    auto gd = graph_duration_of (10);
+    errno = 0;
+    REQUIRE (m.build (js, alloc_type_t::AT_ALLOC, 1, 0, gd) == -1);
+    REQUIRE (errno == EINVAL);
+}
+
+TEST_CASE ("duration too large is rejected with EINVAL", "[jobmeta]")
+{
+    jobmeta_t m;
+    auto js = make_jobspec (std::numeric_limits<int64_t>::max ());
+    auto gd = graph_duration_of (std::numeric_limits<int64_t>::max ());
+    errno = 0;
+    REQUIRE (m.build (js, alloc_type_t::AT_ALLOC, 1, 0, gd) == -1);
+    REQUIRE (errno == EINVAL);
+}
+
+TEST_CASE ("empty graph window is rejected with EINVAL", "[jobmeta]")
+{
+    jobmeta_t m;
+    auto js = make_jobspec (5.0);
+    auto gd = graph_duration_of (0);  // graph_start == graph_end
+    errno = 0;
+    REQUIRE (m.build (js, alloc_type_t::AT_ALLOC, 1, 0, gd) == -1);
+    REQUIRE (errno == EINVAL);
+}
+
+TEST_CASE ("build populates the non-duration fields", "[jobmeta]")
+{
+    jobmeta_t m;
+    auto js = make_jobspec (100.0);
+    js.attributes.system.queue = "batch";
+    auto gd = default_graph_duration ();
+    REQUIRE (m.build (js, alloc_type_t::AT_ALLOC_ORELSE_RESERVE, 42, 7, gd) == 0);
+    REQUIRE (m.jobid == 42);
+    REQUIRE (m.at == 7);
+    REQUIRE (m.now == 7);
+    REQUIRE (m.alloc_type == alloc_type_t::AT_ALLOC_ORELSE_RESERVE);
+    REQUIRE (m.is_queue_set ());
+    REQUIRE (m.get_queue () == "batch");
+}
+
+TEST_CASE ("queue is unset when jobspec has no queue", "[jobmeta]")
+{
+    jobmeta_t m;
+    auto js = make_jobspec (100.0);
+    auto gd = default_graph_duration ();
+    REQUIRE (m.build (js, alloc_type_t::AT_ALLOC, 1, 0, gd) == 0);
+    REQUIRE_FALSE (m.is_queue_set ());
+}

--- a/t/data/resource/jobspecs/duration/test003.yaml
+++ b/t/data/resource/jobspecs/duration/test003.yaml
@@ -1,0 +1,30 @@
+version: 9999
+resources:
+    - type: cluster
+      count: 1
+      with:
+        - type: rack
+          count: 1
+          with:
+            - type: node
+              count: 1
+              with:
+                  - type: slot
+                    count: 1
+                    label: default
+                    with:
+                      - type: socket
+                        count: 1
+                        with:
+                          - type: core
+                            count: 1
+# a sub-second (fractional) duration must round up to 1 second rather
+# than truncate to 0, which the planner rejects with EINVAL
+attributes:
+  system:
+    duration: 0.1
+tasks:
+  - command: [ "app" ]
+    slot: default
+    count:
+      per_slot: 1

--- a/t/data/resource/jobspecs/duration/test004.yaml
+++ b/t/data/resource/jobspecs/duration/test004.yaml
@@ -1,0 +1,30 @@
+version: 9999
+resources:
+    - type: cluster
+      count: 1
+      with:
+        - type: rack
+          count: 1
+          with:
+            - type: node
+              count: 1
+              with:
+                  - type: slot
+                    count: 1
+                    label: default
+                    with:
+                      - type: socket
+                        count: 1
+                        with:
+                          - type: core
+                            count: 1
+# a duration below int64_t min must be rejected rather than cast (UB).
+# Must be a float at this scale; YAML/JSON may reject integers > 32 bits.
+attributes:
+  system:
+    duration: -1.0E+30
+tasks:
+  - command: [ "app" ]
+    slot: default
+    count:
+      per_slot: 1

--- a/t/t4001-match-allocate.t
+++ b/t/t4001-match-allocate.t
@@ -13,6 +13,8 @@ jobspec="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/basics/test001.yaml"
 malform="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/basics/bad.yaml"
 duration_too_large="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/duration/test001.yaml"
 duration_negative="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/duration/test002.yaml"
+duration_fractional="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/duration/test003.yaml"
+duration_below_min="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/duration/test004.yaml"
 
 #
 # test_under_flux is under sharness.d/
@@ -63,11 +65,31 @@ test_expect_success 'handling of an invalid resource type works' '
 
 test_expect_success 'invalid duration is caught' '
     test_must_fail flux ion-resource match allocate ${duration_too_large} &&
-    test_must_fail flux ion-resource match allocate ${duration_negative}
+    test_must_fail flux ion-resource match allocate ${duration_negative} &&
+    test_must_fail flux ion-resource match allocate ${duration_below_min}
 '
 
-
 test_expect_success 'removing resource works' '
+    remove_resource
+'
+
+#
+# A sub-second (fractional) duration must round up to the planner's
+# minimum granularity of 1 second rather than truncate to 0, which the
+# planner would reject with EINVAL.  Reload the module to start from a
+# fully available machine.
+#
+test_expect_success 'reloading resource module works' '
+    load_resource \
+load-file=${grug} prune-filters=ALL:core \
+load-format=grug subsystems=containment policy=high
+'
+
+test_expect_success 'match-allocate accepts a fractional duration' '
+    flux ion-resource match allocate ${duration_fractional}
+'
+
+test_expect_success 'removing resource again works' '
     remove_resource
 '
 


### PR DESCRIPTION
Problem: submitting a jobspec with a fractional duration
(attributes.system.duration) is mishandled. jobmeta_t::build ()
converts the double duration into the planner's integer-second
representation with a C-style cast, which truncates toward zero. This
silently discards the fractional part of any non-integer duration
(e.g. 1.9 becomes 1). In the sub-second case it is fatal: a duration
such as 0.1 truncates to 0, which the planner rejects with EINVAL
(it requires duration >= 1), surfacing as a "match failed ... Invalid
argument" error. An integer duration such as 1 works.

Round the duration up with std::ceil () so a fractional duration is
never truncated away and any duration in (0, 1] maps to the planner's
minimum granularity of 1 second rather than to 0.