### PR TITLE
traverser: skip expansion when next is empty

### DIFF
--- a/resource/traversers/dfu_impl.cpp
+++ b/resource/traversers/dfu_impl.cpp
@@ -808,7 +808,7 @@ int dfu_impl_t::dom_dfv (const jobmeta_t &meta,
     (*m_graph)[u].idata.colors[dom] = m_color.gray ();
     if (sm == match_kind_t::SLOT_MATCH)
         dom_slot (meta, u, next, nslots, check_pres, &x_inout, dfu);
-    else
+    else if (!next.empty ())
         dom_exp (meta, u, next, check_pres, &x_inout, dfu);
     *excl = x_in;
     (*m_graph)[u].idata.colors[dom] = m_color.black ();


### PR DESCRIPTION
@milroy and I noticed that a bare `node[1]` jobspec with the firstnodex match policy produced 28 traversal events in resource-query for its first match on a Tuolumne-size resource graph, compared with only 6 for `node[1]` with `core[1]`, despite the bare node already satisfying the request. When the node matched, `test()` returned an empty next vector, but `dom_dfv()` still called `dom_exp()`, which interpreted that empty vector by iterating over every outgoing core edge. Each core failed to match but still incremented the preorder counter, and the normal early-exit logic was never reached because it only applies after a successful child match. The fix changes the unconditional `else` to `else if (!next.empty())`, so dynamic expansion occurs only when the matcher actually requests another resource level. The one-node `firstnodex` case now requires 4 traversal events instead of 28, and larger bare-node requests show similarly large traversal reductions without changing which jobs match. There was also a positive effect on other match policies with `lonodex` seeing 3818 pre-order visits in traversal for the first match, down from 119042 before the change. 

This change results in a significant performance improvement for the bare `node[1]` jobspec:

Before Patch:
<img width="2200" height="1400" alt="image" src="https://github.com/user-attachments/assets/fd680c85-8eda-406b-9948-81d11f795af6" />



After patch:
<img width="2200" height="1400" alt="image" src="https://github.com/user-attachments/assets/effbe10d-d433-421a-91a9-4fe07dbf52f6" />
