### PR TITLE
qmanager: support RFC 33 virtual queues

### DIFF
--- a/qmanager/modules/CMakeLists.txt
+++ b/qmanager/modules/CMakeLists.txt
@@ -13,3 +13,5 @@ target_link_libraries(sched-fluxion-qmanager PRIVATE
     cppwrappers
     match_op
     )
+
+add_subdirectory( test )

--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -141,13 +141,34 @@ static int process_config_file (std::shared_ptr<qmanager_ctx_t> &ctx)
     optmgr_kv_t<qmanager_opts_t> opts_store;
     std::string info_str = "";
     if (queues_conf) {
-        // workaround to satisfy RFC 33
-        std::string queues = classify_queues (queues_conf);
+        // workaround to satisfy RFC 33: split the queues config table into
+        // real (internal) queues and RFC 33 virtual queues. A malformed
+        // config is rejected here. Because ctx->opts is only updated on
+        // success at the end of this function, returning an error leaves
+        // the currently-loaded config in place -- matching flux-core,
+        // where a failed config reload is reported via the reload RPC and
+        // the running config is retained.
+        std::string queues;
+        std::string vqueue_parents;
+        std::string err;
+
+        if (classify_queues (queues_conf, queues, vqueue_parents, err) < 0) {
+            flux_log_error (ctx->h, "%s: %s", __FUNCTION__, err.c_str ());
+            return -1;
+        }
         if ((rc = opts_store.put ("queues", queues)) < 0) {
             flux_log_error (ctx->h,
                             "%s: optmgr_kv_t::put ('queues', %s)",
                             __FUNCTION__,
                             queues.c_str ());
+            return rc;
+        }
+        if (!vqueue_parents.empty ()
+            && (rc = opts_store.put ("vqueue-parents", vqueue_parents)) < 0) {
+            flux_log_error (ctx->h,
+                            "%s: optmgr_kv_t::put ('vqueue-parents', %s)",
+                            __FUNCTION__,
+                            vqueue_parents.c_str ());
             return rc;
         }
     }

--- a/qmanager/modules/qmanager.cpp
+++ b/qmanager/modules/qmanager.cpp
@@ -142,15 +142,12 @@ static int process_config_file (std::shared_ptr<qmanager_ctx_t> &ctx)
     std::string info_str = "";
     if (queues_conf) {
         // workaround to satisfy RFC 33
-        std::ostringstream queues;
-        json_object_foreach (queues_conf, k, v) {
-            queues << std::string (k) << " ";
-        }
-        if ((rc = opts_store.put ("queues", queues.str ())) < 0) {
+        std::string queues = classify_queues (queues_conf);
+        if ((rc = opts_store.put ("queues", queues)) < 0) {
             flux_log_error (ctx->h,
                             "%s: optmgr_kv_t::put ('queues', %s)",
                             __FUNCTION__,
-                            queues.str ().c_str ());
+                            queues.c_str ());
             return rc;
         }
     }

--- a/qmanager/modules/qmanager_callbacks.cpp
+++ b/qmanager/modules/qmanager_callbacks.cpp
@@ -245,6 +245,9 @@ int qmanager_cb_t::jobmanager_hello_cb (flux_t *h, const flux_msg_t *msg, const 
         queue_name = qn_attr;
     else
         queue_name = ctx->opts.get_opt ().get_default_queue_name ();
+    // An RFC 33 virtual queue has no internal queue of its own, so look up
+    // its parent queue's internal queue instead.
+    queue_name = ctx->opts.get_opt ().resolve_queue_name (queue_name);
     if (ctx->queues.find (queue_name) == ctx->queues.end ()) {
         flux_log (h,
                   LOG_ERR,
@@ -386,6 +389,9 @@ void qmanager_cb_t::jobmanager_alloc_cb (flux_t *h, const flux_msg_t *msg, void 
         queue_name = jobspec_obj.attributes.system.queue;
     job->jobspec = jobspec_str;
     free (jobspec_str);
+    // An RFC 33 virtual queue has no internal queue of its own, so look up
+    // its parent queue's internal queue instead.
+    queue_name = ctx->opts.get_opt ().resolve_queue_name (queue_name);
     if (ctx->queues.find (queue_name) == ctx->queues.end ()) {
         snprintf (errbuf, sizeof (errbuf), "queue (%s) doesn't exist", queue_name.c_str ());
         if (schedutil_alloc_respond_deny (ctx->schedutil, msg, errbuf) < 0)

--- a/qmanager/modules/qmanager_opts.cpp
+++ b/qmanager/modules/qmanager_opts.cpp
@@ -14,10 +14,24 @@ extern "C" {
 #endif
 }
 
+#include <sstream>
+
 #include "qmanager_opts.hpp"
 
 using namespace Flux;
 using namespace Flux::opts_manager;
+
+std::string Flux::opts_manager::classify_queues (json_t *queues_conf)
+{
+    const char *k = nullptr;
+    json_t *v = nullptr;
+    std::ostringstream queues;
+
+    json_object_foreach (queues_conf, k, v) {
+        queues << k << " ";
+    }
+    return queues.str ();
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Private API for Queue Manager Option Class

--- a/qmanager/modules/qmanager_opts.cpp
+++ b/qmanager/modules/qmanager_opts.cpp
@@ -21,18 +21,6 @@ extern "C" {
 using namespace Flux;
 using namespace Flux::opts_manager;
 
-std::string Flux::opts_manager::classify_queues (json_t *queues_conf)
-{
-    const char *k = nullptr;
-    json_t *v = nullptr;
-    std::ostringstream queues;
-
-    json_object_foreach (queues_conf, k, v) {
-        queues << k << " ";
-    }
-    return queues.str ();
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // Private API for Queue Manager Option Class
 ////////////////////////////////////////////////////////////////////////////////
@@ -60,6 +48,61 @@ int qmanager_opts_t::parse_queues (const std::string &queues)
     }
 done:
     return rc;
+}
+
+int qmanager_opts_t::parse_vqueue_parents (const std::string &vqueue_parents)
+{
+    m_vqueue_parents.clear ();
+    return parse_multi_options (vqueue_parents, ' ', ':', m_vqueue_parents);
+}
+
+// Return the parent queue name if this queue config entry is an RFC 33
+// virtual queue (i.e., has a string "parent" key), or nullptr otherwise.
+// json_object_get() and json_is_string() both tolerate a nullptr argument,
+// so this is safe for a missing key or a null entry.
+static const char *vqueue_parent (json_t *entry)
+{
+    json_t *parent = json_object_get (entry, "parent");
+    return json_is_string (parent) ? json_string_value (parent) : nullptr;
+}
+
+int Flux::opts_manager::classify_queues (json_t *queues_conf,
+                                         std::string &queues,
+                                         std::string &vqueue_parents,
+                                         std::string &err)
+{
+    const char *k = nullptr;
+    json_t *v = nullptr;
+    std::ostringstream queues_ss;
+    std::ostringstream vqueue_parents_ss;
+
+    json_object_foreach (queues_conf, k, v) {
+        const char *parent = vqueue_parent (v);
+        if (!parent) {
+            queues_ss << k << " ";
+            continue;
+        }
+        // k is a virtual queue: its parent must be a configured queue that
+        // is not itself virtual. flux-core validation normally enforces
+        // this before the config reaches us, so a violation is a malformed
+        // config: reject it rather than silently reinterpreting the entry.
+        json_t *parent_entry = json_object_get (queues_conf, parent);
+        if (!parent_entry) {
+            err = std::string ("queue '") + k + "' names unknown parent queue '" + parent + "'";
+            errno = EINVAL;
+            return -1;
+        }
+        if (vqueue_parent (parent_entry)) {
+            err = std::string ("queue '") + k + "' names parent '" + parent
+                  + "' that is itself a virtual queue";
+            errno = EINVAL;
+            return -1;
+        }
+        vqueue_parents_ss << k << ":" << parent << " ";
+    }
+    queues = queues_ss.str ();
+    vqueue_parents = vqueue_parents_ss.str ();
+    return 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -176,6 +219,10 @@ qmanager_opts_t::qmanager_opts_t ()
                                      static_cast<int> (
                                          qmanager_opts_key_t::POLICY_PARAMS_PER_QUEUE)));
     inserted &= ret.second;
+    ret = m_tab.insert (
+        std::pair<std::string, int> ("vqueue-parents",
+                                     static_cast<int> (qmanager_opts_key_t::VQUEUE_PARENTS)));
+    inserted &= ret.second;
 
     if (!inserted)
         throw std::bad_alloc ();
@@ -226,6 +273,12 @@ const std::map<std::string, queue_prop_t> &qmanager_opts_t::get_per_queue_prop (
     return m_per_queue_prop;
 }
 
+std::string qmanager_opts_t::resolve_queue_name (const std::string &name) const
+{
+    auto i = m_vqueue_parents.find (name);
+    return (i == m_vqueue_parents.end ()) ? name : i->second;
+}
+
 bool qmanager_opts_t::is_queue_policy_set () const
 {
     return m_queue_prop.is_queue_policy_set ();
@@ -271,6 +324,8 @@ qmanager_opts_t &qmanager_opts_t::operator+= (const qmanager_opts_t &src)
         m_queue_prop.set_policy_params (src.m_queue_prop.get_policy_params ());
     if (!src.m_per_queue_prop.empty ())
         m_per_queue_prop = src.get_per_queue_prop ();
+    if (!src.m_vqueue_parents.empty ())
+        m_vqueue_parents = src.m_vqueue_parents;
     return *this;
 }
 
@@ -350,6 +405,11 @@ int qmanager_opts_t::parse (const std::string &k, const std::string &v, std::str
             break;
 
         case static_cast<int> (qmanager_opts_key_t::QUEUE_POLICY_PER_QUEUE):
+            // m_per_queue_prop only contains queues that have an internal
+            // queue (i.e., RFC 33 virtual queues are excluded), so this
+            // also rejects a queue-policy-per-queue entry that names a
+            // virtual queue, since a virtual queue cannot have its own
+            // scheduler policy.
             tmp_mp.clear ();
             if ((rc = parse_multi_options (v, ' ', ':', tmp_mp)) < 0)
                 break;
@@ -395,6 +455,10 @@ int qmanager_opts_t::parse (const std::string &k, const std::string &v, std::str
                 }
                 m_per_queue_prop[kv.first].set_policy_params (kv.second);
             }
+            break;
+
+        case static_cast<int> (qmanager_opts_key_t::VQUEUE_PARENTS):
+            rc = parse_vqueue_parents (v);
             break;
 
         default:

--- a/qmanager/modules/qmanager_opts.hpp
+++ b/qmanager/modules/qmanager_opts.hpp
@@ -146,6 +146,14 @@ class qmanager_opts_t : public optmgr_parse_t {
     std::map<std::string, int> m_tab;
 };
 
+/*! Build a space-separated list of the queue names in an RFC 33 "queues"
+ *  config table, suitable for use as the "queues" option value.
+ *
+ *  \param queues_conf   "queues" config table (json object).
+ *  \return              space-separated list of queue names.
+ */
+std::string classify_queues (json_t *queues_conf);
+
 }  // namespace opts_manager
 }  // namespace Flux
 

--- a/qmanager/modules/qmanager_opts.hpp
+++ b/qmanager/modules/qmanager_opts.hpp
@@ -63,6 +63,7 @@ class qmanager_opts_t : public optmgr_parse_t {
         QUEUE_POLICY_PER_QUEUE = 40,   // queue-policy-per_queue
         QUEUE_PARAMS_PER_QUEUE = 50,   // queue-params-per_queue
         POLICY_PARAMS_PER_QUEUE = 60,  // policy-params-per_queue
+        VQUEUE_PARENTS = 70,           // vqueue-parents (RFC 33 virtual queues)
         UNKNOWN = 5000
     };
 
@@ -84,6 +85,18 @@ class qmanager_opts_t : public optmgr_parse_t {
     const std::string &get_queue_params () const;
     const std::string &get_policy_params () const;
     const std::map<std::string, queue_prop_t> &get_per_queue_prop () const;
+
+    /*! Resolve a queue name to the name of the internal queue that it
+     *  should be scheduled in. An RFC 33 virtual queue (i.e., a queue
+     *  configured with a "parent" key) has no internal queue of its own,
+     *  so its jobs are scheduled as part of its parent queue's internal
+     *  queue instead. If "name" is not a known virtual queue, it is
+     *  returned unmodified.
+     *
+     *  \param name      queue name, as set on a job.
+     *  \return          the name of the internal queue to use.
+     */
+    std::string resolve_queue_name (const std::string &name) const;
 
     bool is_queue_policy_set () const;
     bool is_queue_params_set () const;
@@ -133,26 +146,48 @@ class qmanager_opts_t : public optmgr_parse_t {
 
    private:
     int parse_queues (const std::string &queues);
+    int parse_vqueue_parents (const std::string &vqueue_parents);
 
     std::string m_default_queue_name = "default";
 
     // default queue properties
     queue_prop_t m_queue_prop;
 
-    // properties of each queue
+    // properties of each queue that has an internal queue (i.e., excludes
+    // RFC 33 virtual queues)
     std::map<std::string, queue_prop_t> m_per_queue_prop;
+
+    // map of RFC 33 virtual queue name to parent queue name
+    std::map<std::string, std::string> m_vqueue_parents;
 
     // mapping each option to an integer
     std::map<std::string, int> m_tab;
 };
 
-/*! Build a space-separated list of the queue names in an RFC 33 "queues"
- *  config table, suitable for use as the "queues" option value.
+/*! Classify a queues config table into real (internal) queues and RFC 33
+ *  virtual queues.
  *
- *  \param queues_conf   "queues" config table (json object).
- *  \return              space-separated list of queue names.
+ *  A queue entry with a string "parent" key is a virtual queue whose jobs
+ *  are scheduled in the parent queue's internal queue. A virtual queue is
+ *  only valid when its named parent is a configured queue that is not
+ *  itself a virtual queue; flux-core normally enforces this, so a
+ *  violation is treated as a malformed config and rejected here.
+ *
+ *  \param queues_conf   RFC 33 "queues" config table (json object).
+ *  \param queues        On success, space-separated list of real queue
+ *                       names, suitable for the "queues" option.
+ *  \param vqueue_parents On success, space-separated "vqueue:parent"
+ *                       pairs, suitable for the "vqueue-parents" option
+ *                       (empty when there are no virtual queues).
+ *  \param err           On failure, a human-readable reason.
+ *  \return              0 on success; -1 on malformed config (errno set to
+ *                       EINVAL). On failure the output strings are
+ *                       unspecified and must not be used.
  */
-std::string classify_queues (json_t *queues_conf);
+int classify_queues (json_t *queues_conf,
+                     std::string &queues,
+                     std::string &vqueue_parents,
+                     std::string &err);
 
 }  // namespace opts_manager
 }  // namespace Flux

--- a/qmanager/modules/test/CMakeLists.txt
+++ b/qmanager/modules/test/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(qmanager_opts_test
+  ${CMAKE_CURRENT_SOURCE_DIR}/qmanager_opts_test.cpp
+  ${CMAKE_SOURCE_DIR}/qmanager/modules/qmanager_opts.cpp
+  )
+target_include_directories(qmanager_opts_test PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(qmanager_opts_test
+  PRIVATE Catch2::Catch2WithMain PkgConfig::JANSSON)
+add_sanitizers(qmanager_opts_test)
+flux_add_test(NAME qmanager_opts_test COMMAND qmanager_opts_test)

--- a/qmanager/modules/test/qmanager_opts_test.cpp
+++ b/qmanager/modules/test/qmanager_opts_test.cpp
@@ -1,0 +1,195 @@
+/*****************************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, LICENSE)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\*****************************************************************************/
+
+extern "C" {
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+}
+
+#include <string>
+#include <catch2/catch_test_macros.hpp>
+#include "qmanager/modules/qmanager_opts.hpp"
+
+using namespace Flux::opts_manager;
+
+// Test the resolution of an RFC 33 virtual queue name to its parent
+// queue's internal queue name -- this is the helper that qmanager uses
+// to decide which internal queue a job should be scheduled in.
+
+TEST_CASE ("resolve_queue_name is a no-op with no virtual queues", "[qmanager_opts]")
+{
+    qmanager_opts_t opts;
+
+    // With no "vqueue-parents" ever parsed, every name resolves to
+    // itself. This models current (pre-RFC33-vqueue) flux-core
+    // behavior, where this feature must be a strict no-op.
+    CHECK (opts.resolve_queue_name ("batch") == "batch");
+    CHECK (opts.resolve_queue_name ("default") == "default");
+}
+
+TEST_CASE ("resolve_queue_name maps a virtual queue to its parent", "[qmanager_opts]")
+{
+    qmanager_opts_t opts;
+    std::string info;
+
+    CHECK (opts.parse ("vqueue-parents", "expedite:batch", info) == 0);
+    CHECK (opts.resolve_queue_name ("expedite") == "batch");
+    CHECK (opts.resolve_queue_name ("batch") == "batch");
+    CHECK (opts.resolve_queue_name ("debug") == "debug");
+}
+
+TEST_CASE ("resolve_queue_name maps multiple virtual queues", "[qmanager_opts]")
+{
+    qmanager_opts_t opts;
+    std::string info;
+
+    CHECK (opts.parse ("vqueue-parents", "expedite:batch urgent:batch", info) == 0);
+    CHECK (opts.resolve_queue_name ("expedite") == "batch");
+    CHECK (opts.resolve_queue_name ("urgent") == "batch");
+}
+
+TEST_CASE ("queue-policy-per-queue rejects a virtual queue name", "[qmanager_opts]")
+{
+    qmanager_opts_t opts;
+    std::string info;
+
+    // Only "batch" is a real (internal) queue; "expedite" is an RFC 33
+    // virtual queue parented under "batch" and therefore has no internal
+    // queue of its own.
+    CHECK (opts.parse ("queues", "batch", info) == 0);
+    CHECK (opts.parse ("vqueue-parents", "expedite:batch", info) == 0);
+
+    // A per-queue policy naming the real queue succeeds.
+    info.clear ();
+    CHECK (opts.parse ("queue-policy-per-queue", "batch:fcfs", info) == 0);
+
+    // But naming the virtual queue is rejected: since a virtual queue is
+    // never inserted into m_per_queue_prop, it is reported as an unknown
+    // queue (a virtual queue cannot have its own scheduler policy).
+    info.clear ();
+    errno = 0;
+    CHECK (opts.parse ("queue-policy-per-queue", "expedite:fcfs", info) == -1);
+    CHECK (errno == ENOENT);
+    CHECK (info.find ("Unknown queue (expedite)") != std::string::npos);
+}
+
+TEST_CASE ("operator+= merges virtual queue parents", "[qmanager_opts]")
+{
+    qmanager_opts_t dst;
+    qmanager_opts_t src;
+    std::string info;
+
+    // This mirrors how qmanager applies parsed options: a freshly parsed
+    // opts object is merged into the live config via operator+=. Without
+    // that merge carrying m_vqueue_parents, resolution on the destination
+    // would silently fall back to a no-op.
+    CHECK (src.parse ("vqueue-parents", "expedite:batch", info) == 0);
+    CHECK (dst.resolve_queue_name ("expedite") == "expedite");
+
+    dst += src;
+    CHECK (dst.resolve_queue_name ("expedite") == "batch");
+}
+
+TEST_CASE ("operator+= leaves virtual queue parents intact when src has none", "[qmanager_opts]")
+{
+    qmanager_opts_t dst;
+    qmanager_opts_t src;
+    std::string info;
+
+    // A subsequent merge that does not itself set vqueue-parents must not
+    // clobber an already-resolved mapping (the merge only overwrites when
+    // the source is non-empty).
+    CHECK (dst.parse ("vqueue-parents", "expedite:batch", info) == 0);
+    CHECK (src.parse ("queue-policy", "fcfs", info) == 0);
+
+    dst += src;
+    CHECK (dst.resolve_queue_name ("expedite") == "batch");
+}
+
+// Classification of an RFC 33 queues config table into real queues and
+// virtual queues, including rejection of malformed configs. This is the
+// logic qmanager runs on (re)load before committing a new config.
+
+TEST_CASE ("classify_queues splits real and virtual queues", "[qmanager_opts]")
+{
+    // { "batch": { "requires": [...] }, "expedite": { "parent": "batch" } }
+    json_t *conf = json_pack ("{s:{s:[s]}, s:{s:s}}",
+                              "batch",
+                              "requires",
+                              "batch",
+                              "expedite",
+                              "parent",
+                              "batch");
+    REQUIRE (conf != nullptr);
+
+    std::string queues, vqueue_parents, err;
+    CHECK (classify_queues (conf, queues, vqueue_parents, err) == 0);
+    // Only the real queue appears in "queues"; the virtual queue maps to
+    // its parent in "vqueue-parents".
+    CHECK (queues == "batch ");
+    CHECK (vqueue_parents == "expedite:batch ");
+    json_decref (conf);
+}
+
+TEST_CASE ("classify_queues handles a config with no virtual queues", "[qmanager_opts]")
+{
+    json_t *conf = json_pack ("{s:{s:[s]}}", "batch", "requires", "batch");
+    REQUIRE (conf != nullptr);
+
+    std::string queues, vqueue_parents, err;
+    CHECK (classify_queues (conf, queues, vqueue_parents, err) == 0);
+    CHECK (queues == "batch ");
+    CHECK (vqueue_parents.empty ());
+    json_decref (conf);
+}
+
+TEST_CASE ("classify_queues rejects a parent that is not a queue", "[qmanager_opts]")
+{
+    // "expedite" names a parent "nope" that is not a configured queue.
+    json_t *conf = json_pack ("{s:{s:s}}", "expedite", "parent", "nope");
+    REQUIRE (conf != nullptr);
+
+    std::string queues, vqueue_parents, err;
+    errno = 0;
+    CHECK (classify_queues (conf, queues, vqueue_parents, err) == -1);
+    CHECK (errno == EINVAL);
+    CHECK (err.find ("unknown parent queue") != std::string::npos);
+    json_decref (conf);
+}
+
+TEST_CASE ("classify_queues rejects a parent that is itself virtual", "[qmanager_opts]")
+{
+    // "default" is a real queue, "batch" is a valid virtual queue parented
+    // under it, and "expedite" tries to parent under "batch" -- but a
+    // virtual queue may not be a parent, so this is rejected.
+    json_t *conf = json_pack ("{s:{s:[s]}, s:{s:s}, s:{s:s}}",
+                              "default",
+                              "requires",
+                              "default",
+                              "batch",
+                              "parent",
+                              "default",
+                              "expedite",
+                              "parent",
+                              "batch");
+    REQUIRE (conf != nullptr);
+
+    std::string queues, vqueue_parents, err;
+    errno = 0;
+    CHECK (classify_queues (conf, queues, vqueue_parents, err) == -1);
+    CHECK (errno == EINVAL);
+    CHECK (err.find ("itself a virtual queue") != std::string::npos);
+    json_decref (conf);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -35,6 +35,7 @@ set(ALL_TESTS
   t1030-rv1-shorthand.t
   t1031-add-remove-resources.t
   t1032-without-alloc-check.t
+  t1033-qmanager-vqueue.t
   t2317-resource-shrink.t
   t3000-jobspec.t
   t3001-resource-basic.t

--- a/t/t1033-qmanager-vqueue.t
+++ b/t/t1033-qmanager-vqueue.t
@@ -1,0 +1,148 @@
+#!/bin/sh
+
+test_description='Test RFC 33 virtual queue support in qmanager
+
+A queue configured with a "parent" key is a virtual queue: it has no
+internal queue of its own in qmanager, and its jobs are scheduled as
+part of the parent queue internal queue, in the parent queue priority
+order. This test requires a flux-core that accepts a "parent" key in
+a queue config table; on a flux-core without virtual queue support,
+all virtual-queue-specific tests are skipped.
+'
+
+. `dirname $0`/sharness.sh
+
+mkdir -p config
+
+export FLUX_SCHED_MODULE=none
+test_under_flux 1 full -o,--config-path=$(pwd)/config
+
+
+# Probe whether this flux-core accepts a "parent" key in a queue config
+# table (i.e., RFC 33 virtual queue support). Note this must fail on any
+# flux-core that predates virtual queues, since the "parent" key would
+# be left unpacked by the queue config table parser. Reset the config
+# afterwards so the probe queues do not linger.
+test_expect_success 'probe for RFC 33 virtual queue support' '
+	cat >vqueue_probe.toml <<-EOT &&
+	[queues.batch]
+	requires = ["batch"]
+	[queues.expedite]
+	parent = "batch"
+	EOT
+	if flux config load vqueue_probe.toml 2>probe.err; then
+		test_set_prereq HAVE_VQUEUES &&
+		flux config reload
+	else
+		grep parent probe.err
+	fi
+'
+
+# N.B. the "batch" property must be set before fluxion acquires
+# resources, since flux resource reload is refused while a scheduler
+# holds them.
+test_expect_success HAVE_VQUEUES 'set the "batch" property on resources' '
+	flux kvs get resource.R >R.orig &&
+	flux R set-property batch:0 <R.orig >R &&
+	flux resource reload R
+'
+
+test_expect_success 'load resource module' '
+	load_resource prune-filters=ALL:core subsystems=containment policy=low
+'
+
+test_expect_success HAVE_VQUEUES 'loading qmanager with a virtual queue' '
+	cat >config/queues.toml <<-EOT &&
+	[queues.batch]
+	requires = ["batch"]
+	[queues.expedite]
+	parent = "batch"
+
+	[policy.jobspec.defaults.system]
+	queue = "batch"
+	EOT
+	flux config reload &&
+	flux queue start --all &&
+	load_qmanager
+'
+
+test_expect_success HAVE_VQUEUES 'virtual queue has no internal queue' '
+	flux module stats sched-fluxion-qmanager >stats.out &&
+	jq -e ".queues.batch" stats.out &&
+	test_must_fail jq -e ".queues.expedite" stats.out
+'
+
+test_expect_success HAVE_VQUEUES 'job can be submitted to parent queue' '
+	flux run -n1 --queue=batch true
+'
+
+test_expect_success HAVE_VQUEUES 'job can be submitted to virtual queue' '
+	flux run -n1 --queue=expedite true
+'
+
+test_expect_success HAVE_VQUEUES 'virtual queue job did not create a phantom queue' '
+	flux module stats sched-fluxion-qmanager >stats2.out &&
+	test_must_fail jq -e ".queues.expedite" stats2.out
+'
+
+test_expect_success HAVE_VQUEUES 'fill the parent queue with a running job' '
+	flux resource list -no {ncores} >ncores &&
+	flux submit -n $(cat ncores) --queue=batch sleep 3600 >blocker.id &&
+	flux job wait-event -t 30 $(cat blocker.id) start
+'
+
+# Submit full-size jobs so that at most one can run at a time, with
+# urgencies chosen so that neither submit order nor queue name matches
+# priority order: the vqueue job B outranks the parent queue job A
+# submitted before it, which outranks the vqueue job C submitted after
+# it. If parent and vqueue jobs were ordered in separate queues, or in
+# submit order, the start order asserted below would differ.
+test_expect_success HAVE_VQUEUES 'submit competing jobs to parent and vqueue' '
+	flux submit -n $(cat ncores) --queue=batch --urgency=16 \
+	    sleep 3600 >jobA.id &&
+	flux submit -n $(cat ncores) --queue=expedite --urgency=17 \
+	    sleep 3600 >jobB.id &&
+	flux submit -n $(cat ncores) --queue=expedite --urgency=15 \
+	    sleep 3600 >jobC.id
+'
+
+test_expect_success HAVE_VQUEUES 'parent and vqueue jobs pend in one internal queue' '
+	flux module stats sched-fluxion-qmanager >stats3.out &&
+	jq -r ".queues.batch.pending_queues | .pending + .pending_provisional | .[]" \
+	    stats3.out >pending.out &&
+	grep $(flux job id --to=f58plain $(cat jobA.id)) pending.out &&
+	grep $(flux job id --to=f58plain $(cat jobB.id)) pending.out &&
+	grep $(flux job id --to=f58plain $(cat jobC.id)) pending.out
+'
+
+# Each job needs every core and never exits on its own, so "started"
+# means it won the priority comparison among all pending jobs: were the
+# order wrong, the awaited job could never start and wait-event would
+# time out.
+test_expect_success HAVE_VQUEUES 'jobs run in priority order across parent and vqueue' '
+	flux cancel $(cat blocker.id) &&
+	flux job wait-event -t 30 $(cat jobB.id) start &&
+	flux cancel $(cat jobB.id) &&
+	flux job wait-event -t 30 $(cat jobA.id) start &&
+	flux cancel $(cat jobA.id) &&
+	flux job wait-event -t 30 $(cat jobC.id) start &&
+	flux cancel $(cat jobC.id) &&
+	flux job wait-event -t 30 $(cat jobC.id) clean
+'
+
+test_expect_success HAVE_VQUEUES 'unload qmanager and deconfigure queues' '
+	remove_qmanager &&
+	cp /dev/null config/queues.toml &&
+	flux config reload
+'
+
+test_expect_success 'cleanup active jobs' '
+	cleanup_active_jobs
+'
+
+test_expect_success 'removing resource and qmanager modules' '
+	test_might_fail remove_qmanager &&
+	remove_resource
+'
+
+test_done


### PR DESCRIPTION
This adds support for RFC 33 virtual queues to qmanager, closing #1536.

A virtual queue is declared by a `parent` key in a `[queues]` entry: an alternate submission name over the parent queue's resources with different policy at ingest. Jobs keep the virtual queue name, but must be scheduled as part of the parent queue's single priority order. Without this change, qmanager would create a separate internal queue for each virtual queue.

`process_config_file()` now detects `parent` keys in the `[queues]` table, excludes virtual queues from the internal queue list, and records a vqueue->parent map that `resolve_queue_name()` consults in the hello and alloc callbacks to route a virtual queue's jobs to the parent's internal queue.

The vqueue->parent map travels into `qmanager_opts_t` as a synthesized `vqueue-parents` option, following the precedent of the synthesized `queues` option that already carries the internal queue list derived from the same `[queues]` table. This keeps both halves of the derived queue topology in one place and follows existing code precedent. If extending that pattern is not acceptable for the vqueues support, an alternative is to hold the map on the qmanager context directly with a plain lookup call in the callbacks. This would seem to break the options abstraction but removes the synthetic option used only to carry vqueues; happy to implement that instead if preferred (understandable because it would eliminate a lot of glue code I think).

Since `vqueue-parents` is only ever populated from a config table containing `parent` keys, this is a strict no-op with any flux-core that predates virtual queues. Associated tests will be skipped until the flux-core PR is merged.