### PR TITLE
reapi: reopen interners for constructor graph load

### DIFF
--- a/resource/reapi/bindings/c++/reapi_cli_impl.hpp
+++ b/resource/reapi/bindings/c++/reapi_cli_impl.hpp
@@ -1076,11 +1076,23 @@ resource_query_t::resource_query_t (const std::string &rgraph, const std::string
             m_err_msg += "WARN: allowlist unsupported\n";
     }
 
-    if (db->load (rgraph, rd) != 0) {
-        tmp_err = __FUNCTION__;
-        tmp_err += ": ERROR: " + rd->err_message () + "\n";
-        tmp_err += "ERROR: error generating resources\n";
-        throw std::runtime_error (tmp_err);
+    {
+        // The interner storages are process-global statics that this
+        // constructor finalizes below.  When more than one resource_query_t is
+        // created in a process (e.g. across test cases, or a re-init), an
+        // earlier instance will have already finalized them, so loading a graph
+        // that introduces a resource type or subsystem not yet interned would
+        // throw ("interner is finalized ...").  Reopen the storages across the
+        // load so new strings can be added, mirroring add_subgraph().
+        auto subsystem_open = subsystem_t::storage_t::open_for_scope ();
+        auto resource_open = resource_type_t::storage_t::open_for_scope ();
+
+        if (db->load (rgraph, rd) != 0) {
+            tmp_err = __FUNCTION__;
+            tmp_err += ": ERROR: " + rd->err_message () + "\n";
+            tmp_err += "ERROR: error generating resources\n";
+            throw std::runtime_error (tmp_err);
+        }
     }
 
     jobid_counter = 1;

--- a/resource/reapi/test/reapi_cli_test_cxx.cpp
+++ b/resource/reapi/test/reapi_cli_test_cxx.cpp
@@ -371,4 +371,58 @@ TEST_CASE ("Test the graph idempotence of certain match operations", "[match C++
     }
 }
 
+// Regression test for the interner scope guard in the resource_query_t
+// (rgraph, options) constructor.
+//
+// The subsystem_t and resource_type_t interners are process-global statics that
+// the constructor finalizes after loading its graph.  A second resource_query_t
+// built in the same process therefore inherits an already-finalized interner,
+// so loading a graph that introduces a resource type not yet interned used to
+// throw ("interner is finalized ... found new string: 'widget'").  The
+// constructor guards its load with open_for_scope() to allow this; without the
+// guard this test throws and fails.
+//
+// The interner is a process-global that accumulates across every test case in
+// this binary and is never reset, so the second graph must introduce a type
+// that NO other fixture in the suite loads -- otherwise an earlier case would
+// already have interned it and the finalized-interner path would never be hit,
+// making the test pass even without the fix (and dependent on case order).
+// node-widget-test.json uses the type "widget", which appears in no other
+// fixture here, so this second construction is always the first to intern it
+// regardless of Catch2's randomized case order.
+TEST_CASE ("Constructing a second resource_query_t with new types",
+           "[initialize C++][interner-finalize C++]")
+{
+    const std::string options = "{\"load_format\": \"jgf\"}";
+    const char *test_srcdir = std::getenv ("SHARNESS_TEST_SRCDIR");
+    REQUIRE (test_srcdir);
+    const std::string data = std::string (test_srcdir) + "/data/resource/jgfs/elastic/";
+
+    // First graph: finalizes the interners.  Any graph without a "widget" type
+    // works; node-test.json is cluster/rack/node/socket/core.
+    std::stringstream base_buf;
+    std::ifstream base_file (data + "node-test.json");
+    REQUIRE (base_file.is_open ());
+    base_buf << base_file.rdbuf ();
+    const std::string base_graph = base_buf.str ();
+
+    // Second graph: introduces the type "widget", not present in any other
+    // fixture loaded by this test binary.
+    std::stringstream widget_buf;
+    std::ifstream widget_file (data + "node-widget-test.json");
+    REQUIRE (widget_file.is_open ());
+    widget_buf << widget_file.rdbuf ();
+    const std::string widget_graph = widget_buf.str ();
+
+    std::shared_ptr<resource_query_t> first =
+        std::make_shared<resource_query_t> (base_graph, options);
+    REQUIRE (first);
+
+    // Before the fix this construction throws std::system_error because "widget"
+    // is a new string and the interner was finalized by the first construction.
+    std::shared_ptr<resource_query_t> second;
+    REQUIRE_NOTHROW (second = std::make_shared<resource_query_t> (widget_graph, options));
+    REQUIRE (second);
+}
+
 }  // namespace Flux::resource_model::detail

--- a/t/data/resource/jgfs/elastic/node-widget-test.json
+++ b/t/data/resource/jgfs/elastic/node-widget-test.json
@@ -1,0 +1,97 @@
+{
+    "graph": {
+        "nodes": [
+            {
+                "id": "0",
+                "metadata": {
+                    "type": "cluster",
+                    "basename": "tiny",
+                    "name": "tiny0",
+                    "id": 0,
+                    "uniq_id": 0,
+                    "rank": -1,
+                    "exclusive": false,
+                    "unit": "",
+                    "size": 1,
+                    "paths": {
+                        "containment": "/tiny0"
+                    }
+                }
+            },
+            {
+                "id": "1",
+                "metadata": {
+                    "type": "rack",
+                    "basename": "rack",
+                    "name": "rack0",
+                    "id": 0,
+                    "uniq_id": 1,
+                    "rank": -1,
+                    "exclusive": false,
+                    "unit": "",
+                    "size": 1,
+                    "paths": {
+                        "containment": "/tiny0/rack0"
+                    }
+                }
+            },
+            {
+                "id": "2",
+                "metadata": {
+                    "type": "node",
+                    "basename": "node",
+                    "name": "node0",
+                    "id": 0,
+                    "uniq_id": 2,
+                    "rank": -1,
+                    "exclusive": true,
+                    "unit": "",
+                    "size": 1,
+                    "paths": {
+                        "containment": "/tiny0/rack0/node0"
+                    }
+                }
+            },
+            {
+                "id": "3",
+                "metadata": {
+                    "type": "widget",
+                    "basename": "widget",
+                    "name": "widget0",
+                    "id": 0,
+                    "uniq_id": 3,
+                    "rank": -1,
+                    "exclusive": true,
+                    "unit": "",
+                    "size": 1,
+                    "paths": {
+                        "containment": "/tiny0/rack0/node0/widget0"
+                    }
+                }
+            }
+        ],
+        "edges": [
+            {
+                "source": "0",
+                "target": "1",
+                "metadata": {
+                    "subsystem": "containment"
+                }
+            },
+            {
+                "source": "1",
+                "target": "2",
+                "metadata": {
+                    "subsystem": "containment"
+                }
+            },
+            {
+                "source": "2",
+                "target": "3",
+                "metadata": {
+                    "subsystem": "containment"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Problem: constructing a second resource_query_t in a process throws "This interner is finalized and must be open to add strings" whenever the new graph introduces a resource type or subsystem the first graph did not contain. The `subsystem_t` and `resource_type_t` interner storages are process-global statics, and the `resource_query_t` constructor finalizes them at the end of construction. A later instance therefore inherits an already-finalized interner and cannot intern any new string during its own graph load.

This surfaced as intermittent, order-dependent failures in the `reapi_cli_c_test` and `reapi_cli_cxx_test suites`: Catch2 randomizes test case order, so the failure fires only when a case whose fixture interns a smaller set of types runs before a case that loads a graph with new types (e.g. an elastic JGF base with no memory/gpu, followed by tiny.graphml which has both). Different seeds produced different symptoms, including a misleading grug "Invalid argument" message.

Wrap the constructor's `db->load` in subsystem_t and resource_type_t open_for_scope() guards, mirroring add_subgraph() and the module's grow/add-subgraph paths, so new strings can be interned during the load. The guards auto-close before the subsequent `finalize()` calls.

Fixes #1546 