### PR TITLE
t: increase timeouts in t1016, t1018, & t1028

### DIFF
--- a/t/t1016-nest-namespace.t
+++ b/t/t1016-nest-namespace.t
@@ -38,7 +38,7 @@ EOF
 EOF
     chmod u+x nest.sh &&
     jobid=$(flux batch --output=kvs -n1 -N1 -c22 -g2 ./nest.sh) &&
-    flux job wait-event -t10 ${jobid} release &&
+    flux job wait-event -t20 ${jobid} release &&
     flux job attach ${jobid} > out1.a &&
     tail -3 out1.a > out1.a.fin &&
     diff out1.a.fin exp1
@@ -47,7 +47,7 @@ EOF
 test_expect_success HAVE_GETXML 'namespace: parent CUDA_VISIBLE_DEVICES has no effect' '
     export CUDA_VISIBLE_DEVICES="0,1,2,3" &&
     jobid=$(flux batch --output=kvs -n1 -N1 -c22 -g2 ./nest.sh) &&
-    flux job wait-event -t10 ${jobid} release &&
+    flux job wait-event -t20 ${jobid} release &&
     flux job attach ${jobid} > out1.b &&
     tail -3 out1.b > out1.b.fin &&
     diff out1.b.fin exp1
@@ -69,7 +69,7 @@ test_expect_success HAVE_GETXML 'namespace: gpu id remapping works with hwloc (p
 	0,1
 EOF
     jobid=$(flux batch --output=kvs -n1 -N1 -c22 -g2 ./nest.sh) &&
-    flux job wait-event -t10 ${jobid} release &&
+    flux job wait-event -t20 ${jobid} release &&
     flux job attach ${jobid} > out2.a &&
     tail -3 out2.a > out2.a.fin &&
     diff out2.a.fin exp2
@@ -78,7 +78,7 @@ EOF
 test_expect_success HAVE_GETXML 'namespace: parent CUDA_VISIBLE_DEVICES has no effect' '
     export CUDA_VISIBLE_DEVICES=-1 &&
     jobid=$(flux batch --output=kvs -n1 -N1 -c22 -g2 ./nest.sh) &&
-    flux job wait-event -t10 ${jobid} release &&
+    flux job wait-event -t20 ${jobid} release &&
     flux job attach ${jobid} > out2.b &&
     tail -3 out2.b > out2.b.fin &&
     diff out2.b.fin exp2
@@ -107,7 +107,7 @@ EOF
 EOF
     chmod u+x nest2.sh &&
     jobid=$(flux batch --output=kvs -n1 -N1 -c22 -g2 ./nest2.sh) &&
-    flux job wait-event -t10 ${jobid} release &&
+    flux job wait-event -t20 ${jobid} release &&
     flux job attach ${jobid} > out3.a &&
     tail -1 out3.a > out3.a.fin &&
     diff out3.a.fin exp3
@@ -116,7 +116,7 @@ EOF
 test_expect_success 'namespace: parent CUDA_VISIBLE_DEVICES has no effect' '
     export CUDA_VISIBLE_DEVICES="0,1,2,3" &&
     jobid=$(flux batch --output=kvs -n1 -N1 -c22 -g2 ./nest2.sh) &&
-    flux job wait-event -t10 ${jobid} release &&
+    flux job wait-event -t20 ${jobid} release &&
     flux job attach ${jobid} > out3.b &&
     tail -1 out3.b > out3.b.fin &&
     diff out3.b.fin exp3
@@ -136,7 +136,7 @@ test_expect_success 'namespace: gpu id remapping works with rv1exec (pol=hi)' '
 	0,1
 EOF
     jobid=$(flux batch --output=kvs -n1 -N1 -c22 -g2 ./nest2.sh) &&
-    flux job wait-event -t10 ${jobid} release &&
+    flux job wait-event -t20 ${jobid} release &&
     flux job attach ${jobid} > out4.a &&
     tail -1 out4.a > out4.a.fin &&
     diff out4.a.fin exp4
@@ -145,7 +145,7 @@ EOF
 test_expect_success 'namespace: parent CUDA_VISIBLE_DEVICES has no effect' '
     export CUDA_VISIBLE_DEVICES="0,1,2,3" &&
     jobid=$(flux batch --output=kvs -n1 -N1 -c22 -g2 ./nest2.sh) &&
-    flux job wait-event -t10 ${jobid} release &&
+    flux job wait-event -t20 ${jobid} release &&
     flux job attach ${jobid} > out4.b &&
     tail -1 out4.b > out4.b.fin &&
     diff out4.b.fin exp4

--- a/t/t1018-rv1-bootstrap2.t
+++ b/t/t1018-rv1-bootstrap2.t
@@ -33,7 +33,7 @@ test_expect_success 'rv1-bootstrap2: creating a nested batch script' '
 load-allowlist=cluster,node,gpu,core match-format=rv1 policy=\$1
 	flux module load sched-fluxion-qmanager
 	nested_jobid=\$(flux submit -n\$2 -N\$3 -c\$4 -g\$5 sleep 0)
-	flux job wait-event -t10 \${nested_jobid} start
+	flux job wait-event -t20 \${nested_jobid} start
 	flux job info \${nested_jobid} R > \$6
 	sleep inf
 EOF

--- a/t/t1028-rv1-partial-release-across-racks.t
+++ b/t/t1028-rv1-partial-release-across-racks.t
@@ -78,8 +78,8 @@ test_expect_success 'successfully loads fluxion with sticky rank in rack0' '
 test_expect_success 'submit two jobs; the second allocates 2 nodes in rack1' '
 	jobid1=$(flux submit -N17 -n612 --exclusive sleep inf) &&
 	jobid2=$(flux submit --flags=waitable -N3 -n108 --exclusive true) &&
-	flux job wait-event -vt5 ${jobid2} alloc &&
-	flux job wait-event -vt5 ${jobid2} clean &&
+	flux job wait-event -vt20 ${jobid2} alloc &&
+	flux job wait-event -vt20 ${jobid2} clean &&
 	flux cancel ${jobid1}
 '
 
@@ -109,8 +109,8 @@ test_expect_success HAVE_PARTIAL_OK 'reload fluxion modules for lonodex' '
 test_expect_success 'submit two jobs; the second allocates 2 nodes in rack1' '
 	jobid1=$(flux submit -N17 -n612 --exclusive sleep inf) &&
 	jobid2=$(flux submit --flags=waitable -N3 -n108 --exclusive true) &&
-	flux job wait-event -vt5 ${jobid2} alloc &&
-	flux job wait-event -vt5 ${jobid2} clean &&
+	flux job wait-event -vt20 ${jobid2} alloc &&
+	flux job wait-event -vt20 ${jobid2} clean &&
 	flux cancel ${jobid1}
 '
 
@@ -140,8 +140,8 @@ test_expect_success HAVE_PARTIAL_OK 'reload fluxion modules, set up to node prun
 test_expect_success 'submit two jobs; the second allocates 2 nodes in rack1' '
 	jobid1=$(flux submit -N17 -n612 --exclusive sleep inf) &&
 	jobid2=$(flux submit --flags=waitable -N3 -n108 --exclusive true) &&
-	flux job wait-event -vt5 ${jobid2} alloc &&
-	flux job wait-event -vt5 ${jobid2} clean &&
+	flux job wait-event -vt20 ${jobid2} alloc &&
+	flux job wait-event -vt20 ${jobid2} clean &&
 	flux cancel ${jobid1}
 '
 
@@ -171,8 +171,8 @@ test_expect_success HAVE_PARTIAL_OK 'reload fluxion modules for lonodex, set up 
 test_expect_success 'submit two jobs; the second allocates 2 nodes in rack1' '
 	jobid1=$(flux submit -N17 -n612 --exclusive sleep inf) &&
 	jobid2=$(flux submit --flags=waitable -N3 -n108 --exclusive true) &&
-	flux job wait-event -vt5 ${jobid2} alloc &&
-	flux job wait-event -vt5 ${jobid2} clean &&
+	flux job wait-event -vt20 ${jobid2} alloc &&
+	flux job wait-event -vt20 ${jobid2} clean &&
 	flux cancel ${jobid1}
 '
 
@@ -202,8 +202,8 @@ test_expect_success HAVE_PARTIAL_OK 'reload fluxion modules, set leaf pruning fi
 test_expect_success 'submit two jobs; the second allocates 2 nodes in rack1' '
 	jobid1=$(flux submit -N17 -n612 --exclusive sleep inf) &&
 	jobid2=$(flux submit --flags=waitable -N3 -n108 --exclusive true) &&
-	flux job wait-event -vt5 ${jobid2} alloc &&
-	flux job wait-event -vt5 ${jobid2} clean &&
+	flux job wait-event -vt20 ${jobid2} alloc &&
+	flux job wait-event -vt20 ${jobid2} clean &&
 	flux cancel ${jobid1}
 '
 
@@ -233,8 +233,8 @@ test_expect_success HAVE_PARTIAL_OK 'reload fluxion modules for lonodex, set lea
 test_expect_success 'submit two jobs; the second allocates 2 nodes in rack1' '
 	jobid1=$(flux submit -N17 -n612 --exclusive sleep inf) &&
 	jobid2=$(flux submit --flags=waitable -N3 -n108 --exclusive true) &&
-	flux job wait-event -vt5 ${jobid2} alloc &&
-	flux job wait-event -vt5 ${jobid2} clean &&
+	flux job wait-event -vt20 ${jobid2} alloc &&
+	flux job wait-event -vt20 ${jobid2} clean &&
 	flux cancel ${jobid1}
 '
 


### PR DESCRIPTION
Problem: on a small number of systems, certain tests were consistently timing out, but succeed when allowed to just run slightly longer

Increase the timeouts to a consistent 20 seconds

Fixes https://github.com/flux-framework/flux-sched/issues/1384