### PR TITLE
[WIP] emit matched per slot labels for per slot task command

### DIFF
--- a/resource/schema/ephemeral.cpp
+++ b/resource/schema/ephemeral.cpp
@@ -39,6 +39,22 @@ int ephemeral_t::insert (uint64_t epoch, const std::string &key, const std::stri
     return rc;
 }
 
+int ephemeral_t::set (uint64_t epoch, const std::string &key, const std::string &value)
+{
+    int rc = 0;
+
+    try {
+        check_and_clear_if_stale (epoch);
+        m_epoch = epoch;
+        m_store[key] = value;
+    } catch (std::bad_alloc &) {
+        errno = ENOMEM;
+        rc = -1;
+    }
+
+    return rc;
+}
+
 boost::optional<std::string> ephemeral_t::get (uint64_t epoch, const std::string &key)
 {
     if (check_and_clear_if_stale (epoch)) {

--- a/resource/schema/ephemeral.hpp
+++ b/resource/schema/ephemeral.hpp
@@ -21,6 +21,12 @@ namespace resource_model {
 class ephemeral_t {
    public:
     int insert (uint64_t epoch, const std::string &key, const std::string &value);
+    /*! Insert or overwrite key with value for the given epoch. Unlike insert (),
+     *  this does not fail with EEXIST when the key already exists in the current
+     *  epoch; the existing value is replaced. Stale data from an older epoch is
+     *  cleared first.
+     */
+    int set (uint64_t epoch, const std::string &key, const std::string &value);
     boost::optional<std::string> get (uint64_t epoch, const std::string &key);
     const std::map<std::string, std::string> &to_map (uint64_t epoch);
     const std::map<std::string, std::string> &to_map () const;

--- a/resource/traversers/dfu_flexible.cpp
+++ b/resource/traversers/dfu_flexible.cpp
@@ -472,6 +472,19 @@ int dfu_flexible_t::dom_slot (const jobmeta_t &meta,
                                    (*egroup_i).edges[0].edge);
                 score += (*egroup_i).score;
                 edg_group.edges.push_back (ev_edg);
+                // Tag each vertex consumed by this slot with the winning slot's
+                // label so it can be recovered from R (via the vertex's
+                // ephemeral data emitted under the "scheduling" key). This lets
+                // the shell select the task command bound to the matched slot
+                // label. Uses set () rather than insert () because a vertex may
+                // be revisited within a match (e.g. allocate_orelse_reserve
+                // retries) which reuse the same sequence number/epoch.
+                if (!slots[slot_index].label.empty ()) {
+                    vtx_t tgt = target ((*egroup_i).edges[0].edge, *m_graph);
+                    (*m_graph)[tgt].idata.ephemeral.set (m_sequence_number,
+                                                         "slot_label",
+                                                         slots[slot_index].label);
+                }
                 j += (*egroup_i).edges[0].count;
             }
         }

--- a/resource/traversers/dfu_impl_update.cpp
+++ b/resource/traversers/dfu_impl_update.cpp
@@ -275,6 +275,13 @@ int dfu_impl_t::upd_sched (vtx_t u,
         }
     }
     if (n > 0) {
+        // Drop any ephemeral data left from an older traversal before emitting
+        // this vertex. The emit path (jgf writer) serializes the raw ephemeral
+        // map without an epoch check, so a label (e.g. "slot_label") tagged by
+        // a previous job that reused this vertex would otherwise leak into this
+        // job's R. Tags written during this job's select () share the current
+        // m_sequence_number and so are preserved.
+        (*m_graph)[u].idata.ephemeral.check_and_clear_if_stale (m_sequence_number);
         if ((rc = emit_vtx (u, writers, needs, excl, excl_parent)) == -1) {
             m_err_msg += __FUNCTION__;
             m_err_msg += ": emit_vtx returned -1.\n";

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -81,6 +81,7 @@ set(ALL_TESTS
   t3040-jgf-shorthand-match-format.t
   t3041-jgf-shorthand-load-format.t
   t3042-storage-node.t
+  t3043-resource-slot-labels.t
   t3044-resource-rabbit-cancel.t
   t3300-system-dontblock.t
   t3301-system-latestart.t

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -103,6 +103,7 @@ set(ALL_TESTS
   t4015-notify-feasibility.t
   t4016-match-flexible.t
   t4017-match-without-allocating.t
+  t4018-match-slot-labels.t
   t5000-valgrind.t
   t5100-issues-test-driver.t
   t5200-jgf-load-no-parent-jgf.t

--- a/t/t3043-resource-slot-labels.t
+++ b/t/t3043-resource-slot-labels.t
@@ -1,0 +1,318 @@
+#!/bin/sh
+
+test_description='Test matched slot label emission into R scheduling data'
+
+. $(dirname $0)/sharness.sh
+
+jgf="${SHARNESS_TEST_SRCDIR}/data/resource/jgfs/tiny.json"
+grug_small="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/small.graphml"
+jobspec_dir="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/flexible"
+query="../../resource/utilities/resource-query"
+
+#
+# The flexible traverser tags each vertex consumed by a matched slot with the
+# winning slot's label in the vertex's ephemeral data, which the rv1 writer
+# emits under R's "scheduling" key as
+# scheduling.graph.nodes[].metadata.ephemeral.slot_label.  The shell uses this
+# to select the task command bound to the matched slot label.  These tests
+# assert the label reaches R and that stale labels do not leak across jobs.
+#
+
+if command -v jq >/dev/null 2>&1; then
+    test_set_prereq HAVE_JQ
+fi
+
+# Collect the set of distinct slot_label values present across all allocated
+# jobs in an rv1 test-output file (one JSON object per allocated job).
+labels_in() {
+    grep '^{' "$1" | jq -r '
+        .scheduling.graph.nodes[].metadata.ephemeral.slot_label // empty
+    ' | sort -u
+}
+
+# labels present in the Nth allocated job (1-indexed)
+labels_in_job() {
+    grep '^{' "$1" | sed -n "${2}p" | jq -r '
+        .scheduling.graph.nodes[].metadata.ephemeral.slot_label // empty
+    ' | sort -u
+}
+
+# The slot_label carried by vertices of a given resource type in the first
+# allocated job (used to check that the label lands on the expected leaves).
+label_on_type() {
+    grep '^{' "$1" | sed -n '1p' | jq -r --arg t "$2" '
+        .scheduling.graph.nodes[]
+        | select(.metadata.type == $t)
+        | .metadata.ephemeral.slot_label // empty
+    ' | sort -u
+}
+
+# A two-branch, two-task jobspec: one command bound to each xor_slot label.
+# tuolumne needs a gpu; tioga is cpu-only. Which branch matches (and hence
+# which label is tagged) depends on whether the target graph has gpus.
+write_multitask() {
+    cat >"$1" <<-EOF
+	version: 9999
+	resources:
+	  - type: xor_slot
+	    count: 1
+	    label: tuolumne
+	    with:
+	      - type: core
+	        count: 8
+	      - type: gpu
+	        count: 1
+	  - type: xor_slot
+	    count: 1
+	    label: tioga
+	    with:
+	      - type: core
+	        count: 16
+	attributes:
+	  system:
+	    duration: 3600
+	tasks:
+	  - command: [ "tuolumne_app" ]
+	    slot: tuolumne
+	    count:
+	      per_slot: 1
+	  - command: [ "tioga_app" ]
+	    slot: tioga
+	    count:
+	      per_slot: 1
+	EOF
+}
+
+test_expect_success HAVE_JQ 'xor-slot: matched branch label appears in R' '
+    cat >cmds_xor <<-EOF &&
+	match allocate ${jobspec_dir}/test010.yaml
+	quit
+	EOF
+    ${query} -L ${jgf} -f jgf -S CA -P first -T flexible -F rv1 \
+        -t xor.out < cmds_xor &&
+    labels_in xor.out > xor.labels &&
+    test $(wc -l < xor.labels) -eq 1 &&
+    grep -qx "small" xor.labels
+'
+
+test_expect_success HAVE_JQ 'or-slot: DP-selected branch label appears in R' '
+    cat >or.yaml <<-EOF &&
+	version: 9999
+	resources:
+	  - type: slot
+	    count: 1
+	    label: alpha
+	    with:
+	      - type: core
+	        count: 4
+	  - type: slot
+	    count: 1
+	    label: beta
+	    with:
+	      - type: core
+	        count: 2
+	      - type: gpu
+	        count: 1
+	attributes:
+	  system:
+	    duration: 3600
+	tasks:
+	  - command: [ "app" ]
+	    slot: alpha
+	    count:
+	      per_slot: 1
+	EOF
+    cat >cmds_or <<-EOF &&
+	match allocate or.yaml
+	quit
+	EOF
+    ${query} -L ${jgf} -f jgf -S CA -P first -T flexible -F rv1 \
+        -t or.out < cmds_or &&
+    labels_in or.out > or.labels &&
+    grep -qx "alpha" or.labels
+'
+
+test_expect_success HAVE_JQ 'unlabeled slot emits no slot_label' '
+    cat >nolabel.yaml <<-EOF &&
+	version: 9999
+	resources:
+	  - type: slot
+	    count: 1
+	    label: ""
+	    with:
+	      - type: core
+	        count: 4
+	attributes:
+	  system:
+	    duration: 3600
+	tasks:
+	  - command: [ "app" ]
+	    slot: ""
+	    count:
+	      per_slot: 1
+	EOF
+    cat >cmds_none <<-EOF &&
+	match allocate nolabel.yaml
+	quit
+	EOF
+    ${query} -L ${jgf} -f jgf -S CA -P first -T flexible -F rv1 \
+        -t none.out < cmds_none &&
+    labels_in none.out > none.labels &&
+    test ! -s none.labels
+'
+
+test_expect_success HAVE_JQ 'no stale label leaks into a later job on reused vertices' '
+    cat >cmds_stale <<-EOF &&
+	match allocate or.yaml
+	cancel 1
+	match allocate nolabel.yaml
+	quit
+	EOF
+    ${query} -L ${jgf} -f jgf -S CA -P first -T flexible -F rv1 \
+        -t stale.out < cmds_stale &&
+    labels_in_job stale.out 1 > stale.job1 &&
+    labels_in_job stale.out 2 > stale.job2 &&
+    grep -qx "alpha" stale.job1 &&
+    test ! -s stale.job2
+'
+
+#
+# Multiple-task jobspecs: each xor_slot label has its own task command. The
+# emitted label is the one the shell would use to pick that task's command.
+#
+
+test_expect_success HAVE_JQ 'multi-task: gpu graph tags the gpu branch label' '
+    write_multitask multitask.yaml &&
+    cat >cmds_mt_gpu <<-EOF &&
+	match allocate multitask.yaml
+	quit
+	EOF
+    ${query} -L ${jgf} -f jgf -S CA -P first -T flexible -F rv1 \
+        -t mt_gpu.out < cmds_mt_gpu &&
+    labels_in mt_gpu.out > mt_gpu.labels &&
+    test $(wc -l < mt_gpu.labels) -eq 1 &&
+    grep -qx "tuolumne" mt_gpu.labels
+'
+
+test_expect_success HAVE_JQ 'multi-task: same jobspec on gpu-free graph tags the cpu branch label' '
+    write_multitask multitask.yaml &&
+    cat >cmds_mt_cpu <<-EOF &&
+	match allocate multitask.yaml
+	quit
+	EOF
+    ${query} -L ${grug_small} -f grug -S CA -P first -T flexible -F rv1 \
+        -t mt_cpu.out < cmds_mt_cpu &&
+    labels_in mt_cpu.out > mt_cpu.labels &&
+    test $(wc -l < mt_cpu.labels) -eq 1 &&
+    grep -qx "tioga" mt_cpu.labels
+'
+
+test_expect_success HAVE_JQ 'multi-task: high policy tags the same matched branch' '
+    write_multitask multitask.yaml &&
+    cat >cmds_mt_high <<-EOF &&
+	match allocate multitask.yaml
+	quit
+	EOF
+    ${query} -L ${jgf} -f jgf -S CA -P high -T flexible -F rv1 \
+        -t mt_high.out < cmds_mt_high &&
+    labels_in mt_high.out > mt_high.labels &&
+    grep -qx "tuolumne" mt_high.labels
+'
+
+#
+# Nested xor_slots: the inner matched branch and the outer group both carry a
+# label. Both must be present, tagged on the vertices each level consumes.
+#
+
+test_expect_success HAVE_JQ 'nested xor: inner and outer labels both appear' '
+    cat >cmds_nested <<-EOF &&
+	match allocate ${jobspec_dir}/test012.yaml
+	quit
+	EOF
+    ${query} -L ${jgf} -f jgf -S CA -P first -T flexible -F rv1 \
+        -t nested.out < cmds_nested &&
+    labels_in nested.out > nested.labels &&
+    grep -qx "a1" nested.labels &&
+    grep -qx "default" nested.labels &&
+    label_on_type nested.out gpu > nested.gpu.label &&
+    grep -qx "a1" nested.gpu.label
+'
+
+#
+# A slot spanning several leaf types (including a multi-unit leaf like memory)
+# tags every consumed leaf, not just the first.
+#
+
+test_expect_success HAVE_JQ 'label tags every leaf type a slot consumes' '
+    cat >memslot.yaml <<-EOF &&
+	version: 9999
+	resources:
+	  - type: slot
+	    count: 1
+	    label: memslot
+	    with:
+	      - type: core
+	        count: 2
+	      - type: memory
+	        count: 4
+	attributes:
+	  system:
+	    duration: 3600
+	tasks:
+	  - command: [ "app" ]
+	    slot: memslot
+	    count:
+	      per_slot: 1
+	EOF
+    cat >cmds_mem <<-EOF &&
+	match allocate memslot.yaml
+	quit
+	EOF
+    ${query} -L ${jgf} -f jgf -S CA -P first -T flexible -F rv1 \
+        -t mem.out < cmds_mem &&
+    label_on_type mem.out core > mem.core.label &&
+    label_on_type mem.out memory > mem.memory.label &&
+    grep -qx "memslot" mem.core.label &&
+    grep -qx "memslot" mem.memory.label
+'
+
+#
+# Distinct labels across separate jobs: each job carries only its own label.
+#
+
+test_expect_success HAVE_JQ 'two labeled jobs each carry only their own label' '
+    write_multitask multitask.yaml &&
+    cat >single_beta.yaml <<-EOF &&
+	version: 9999
+	resources:
+	  - type: slot
+	    count: 1
+	    label: beta_only
+	    with:
+	      - type: core
+	        count: 4
+	attributes:
+	  system:
+	    duration: 3600
+	tasks:
+	  - command: [ "app" ]
+	    slot: beta_only
+	    count:
+	      per_slot: 1
+	EOF
+    cat >cmds_two <<-EOF &&
+	match allocate multitask.yaml
+	match allocate single_beta.yaml
+	quit
+	EOF
+    ${query} -L ${jgf} -f jgf -S CA -P first -T flexible -F rv1 \
+        -t two.out < cmds_two &&
+    labels_in_job two.out 1 > two.job1 &&
+    labels_in_job two.out 2 > two.job2 &&
+    grep -qx "tuolumne" two.job1 &&
+    test $(wc -l < two.job1) -eq 1 &&
+    grep -qx "beta_only" two.job2 &&
+    test $(wc -l < two.job2) -eq 1
+'
+
+test_done

--- a/t/t4018-match-slot-labels.t
+++ b/t/t4018-match-slot-labels.t
@@ -1,0 +1,130 @@
+#!/bin/sh
+
+test_description='Test matched slot label emission through the resource module
+
+Ensure that the flexible traverser, running inside sched-fluxion-resource,
+tags each vertex it allocates to a matched slot with that slot label and
+emits it in R under scheduling.graph.nodes[].metadata.ephemeral.slot_label
+(match-format=rv1). This is the module-level companion to t3043 (which drives
+resource-query directly) and t3044 (which submits full jobs).
+'
+
+. `dirname $0`/sharness.sh
+
+grug="${SHARNESS_TEST_SRCDIR}/data/resource/grugs/tiny.graphml"
+jobspec_dir="${SHARNESS_TEST_SRCDIR}/data/resource/jobspecs/flexible"
+
+#
+# test_under_flux is under sharness.d/
+#
+test_under_flux 1
+
+if command -v jq >/dev/null 2>&1; then
+    test_set_prereq HAVE_JQ
+fi
+
+# `flux ion-resource match allocate` prints a header followed by the R object;
+# the R is the single line beginning with '{'. Extract it for jq.
+extract_R() {
+    grep '^{'
+}
+
+# The sorted, unique, non-empty set of slot labels present in an R object read
+# on stdin.
+labels_of_R() {
+    jq -r '[.scheduling.graph.nodes[].metadata.ephemeral.slot_label // empty]
+           | map(select(. != ""))
+           | unique
+           | .[]'
+}
+
+test_expect_success 'load resource module with flexible traverser and rv1' '
+    load_resource \
+        load-file=${grug} load-format=grug prune-filters=ALL:core \
+        subsystems=containment policy=high traverser=flexible \
+        match-format=rv1
+'
+
+test_expect_success HAVE_JQ 'xor-slot: matched branch label appears in R' '
+    flux ion-resource match allocate ${jobspec_dir}/test010.yaml \
+        | extract_R > xor.R &&
+    labels_of_R < xor.R > xor.labels &&
+    test $(wc -l < xor.labels) -eq 1 &&
+    grep -qx "small" xor.labels
+'
+
+test_expect_success HAVE_JQ 'nested xor-slot: inner and outer labels appear' '
+    flux ion-resource match allocate ${jobspec_dir}/test012.yaml \
+        | extract_R > nested.R &&
+    labels_of_R < nested.R > nested.labels &&
+    grep -qx "a1" nested.labels &&
+    grep -qx "default" nested.labels
+'
+
+test_expect_success HAVE_JQ 'label lands on the gpu leaf of the matched branch' '
+    flux ion-resource match allocate ${jobspec_dir}/test010.yaml \
+        | extract_R > gpu.R &&
+    jq -r ".scheduling.graph.nodes[]
+           | select(.metadata.type == \"gpu\")
+           | .metadata.ephemeral.slot_label // empty" gpu.R \
+        | sort -u > gpu.label &&
+    grep -qx "small" gpu.label
+'
+
+test_expect_success 'generate an unlabeled flexible jobspec' '
+    cat >unlabeled.yaml <<-EOF
+	version: 9999
+	resources:
+	  - type: slot
+	    count: 1
+	    label: ""
+	    with:
+	      - type: core
+	        count: 4
+	attributes:
+	  system:
+	    duration: 3600
+	tasks:
+	  - command: [ "app" ]
+	    slot: ""
+	    count:
+	      per_slot: 1
+	EOF
+'
+
+test_expect_success HAVE_JQ 'unlabeled slot emits no slot_label' '
+    flux ion-resource match allocate unlabeled.yaml | extract_R > none.R &&
+    labels_of_R < none.R > none.labels &&
+    test ! -s none.labels
+'
+
+test_expect_success HAVE_JQ 'no stale label leaks onto a later job on reused vertices' '
+    out=$(flux ion-resource match allocate ${jobspec_dir}/test010.yaml) &&
+    jobid=$(echo "$out" | awk "NR==2{print \$1}") &&
+    echo "$out" | extract_R | labels_of_R > stale.job1 &&
+    grep -qx "small" stale.job1 &&
+    flux ion-resource cancel ${jobid} &&
+    flux ion-resource match allocate unlabeled.yaml \
+        | extract_R | labels_of_R > stale.job2 &&
+    test ! -s stale.job2
+'
+
+test_expect_success 'reload resource module with the default rv1_nosched format' '
+    remove_resource &&
+    load_resource \
+        load-file=${grug} load-format=grug prune-filters=ALL:core \
+        subsystems=containment policy=high traverser=flexible \
+        match-format=rv1_nosched
+'
+
+test_expect_success HAVE_JQ 'rv1_nosched: R has no scheduling key (feature inert)' '
+    flux ion-resource match allocate ${jobspec_dir}/test010.yaml \
+        | extract_R > nosched.R &&
+    test $(jq "has (\"scheduling\")" nosched.R) = "false"
+'
+
+test_expect_success 'remove resource module' '
+    remove_resource
+'
+
+test_done


### PR DESCRIPTION
  Problem

  A jobspec can express alternative resource shapes via xor_slot / or-slot
  alternatives, each carrying a label, alongside multiple tasks[] each bound to
  a slot via tasks[].slot (RFC 14). The flexible traverser matches exactly one
  alternative, but it discards which labeled slot won. Nothing downstream can
  tell which branch was selected, so the job shell cannot run the command bound
  to the matched slot — the whole point of per-slot task selection.

  Solution
  
  Tag each vertex the flexible traverser allocates to a matched slot with that
  slot's label, and surface it in R so a consumer (the job shell) can recover
  it.

  The label rides in the vertex's ephemeral data, which the JGF writer already
  serializes as node metadata, and which the rv1 writer already nests under R's
  scheduling key. So the label appears at:

  scheduling.graph.nodes[].metadata.ephemeral.slot_label

  with no writer changes. Under the default rv1_nosched format there is no
  scheduling key, so the label is simply absent and consumers fall back to
  tasks[0] — safe degradation.

  This is deliberately a per-vertex tag (not a job-wide scalar): it covers XOR,
  OR (a single traversal can select a mix of labeled slots), and is
  forward-compatible with a future logical-AND slot where different ranks run
  different commands. XOR/OR is the degenerate all-vertices-share-one-label
  case.

  Changes
  
  Feature (~42 lines across 4 files):
  - resource/schema/ephemeral.{hpp,cpp} — add set(), an overwrite variant of
  insert() (no EEXIST), since a vertex may be re-tagged within one match (e.g.
  allocate_orelse_reserve retries reuse the epoch).
  - resource/traversers/dfu_flexible.cpp — in dom_slot, tag each consumed vertex
  with the winning slot's label, inside the existing emission loop.
  - resource/traversers/dfu_impl_update.cpp — stale-clear a vertex's ephemeral
  data before emit in upd_sched, so a prior job's label can't leak into a later
  job's R when a vertex is reused (the emit path doesn't epoch-check).

  Tests:
  - t3043-resource-slot-labels.t — resource-query -F rv1 level: XOR/OR label
  present, nested XOR (inner + outer labels), multi-leaf-type tagging, unlabeled
  emits nothing, two-job staleness, distinct labels per job.
  - t4018-match-slot-labels.t — resource-module level via flux ion-resource 
  match allocate (companion to the t40xx match tests): same assertions through
  the real sched-fluxion-resource module, plus rv1_nosched emits no scheduling
  key.

  Verification

  All new tests pass (t3043 10/10, t4018 10/10); existing t3038/t4016
  flexible-traverser tests remain green (the label rides in ephemeral data those
  tests' pretty_simple golden files don't serialize).

  Notes / open items (WIP)
  
  - This is the scheduler half. The consumer is a companion flux-core shell
  change (parse full tasks[], read the label from R, select the matching
  command). [PR found here](https://github.com/flux-framework/flux-core/pull/7799)
  - Config dependency: the label only surfaces under match-format = rv1 (or
  rv1_shorthand); the production default rv1_nosched omits scheduling.
  - Known limitation (out of scope): for OR-slots whose alternatives contain
  non-leaf resources, the tag lands on the non-leaf vertex rather than the
  leaves. Fine for all XOR and leaf-only OR (the tested cases); the non-leaf OR
  case is part of the separate OR-slot engine work.
  - Depends conceptually on / composes cleanly with the nslots R-calculation
  work (needed for top-level xor_slot jobs to run, not just schedule) — no file
  conflicts.

